### PR TITLE
Fix redirected URLs in vignette; bump to 1.5.2 (#20)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.5.1
+Version: 1.5.2
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # NEWS
 
+## Version 1.5.2 (2026-05-10)
+
+- Fixed two redirected URLs in the main vignette (`vignettes/vignette.Rmd`)
+  that pointed at a bookdown.org domain now 301-redirecting to Posit
+  Connect cloud. Resolves #20.
+
 ## Version 1.5.1 (2026-05-10)
 
 - Output of `getTes()` is now an S3 object of class `FETWFE_tes` with

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.5.1",
+  note    = "R package version 1.5.2",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -23,6 +23,7 @@ YYYYMM
 YYYYMMDD
 bacondecomp
 betwfe
+bookdown
 doi
 econometricians
 etwfe

--- a/vignettes/vignette.Rmd
+++ b/vignettes/vignette.Rmd
@@ -26,9 +26,9 @@ Feel free to skip to the "Package Usage" section if you want to jump right in to
 
 ## Background
 
-This vignette is written under the assumption that you're at least vaguely familiar with developments in [difference-in-differences](https://en.wikipedia.org/wiki/Difference_in_differences) with [staggered adoptions](https://bookdown.org/mike/data_analysis/sec-difference-in-differences.html#sec-multiple-periods-and-variation-in-treatment-timing) since about 2018. Just to make sure we're on the same page, the brief recap is:
+This vignette is written under the assumption that you're at least vaguely familiar with developments in [difference-in-differences](https://en.wikipedia.org/wiki/Difference_in_differences) with [staggered adoptions](https://mike-data-analysis.share.connect.posit.cloud/sec-difference-in-differences.html#sec-multiple-periods-and-variation-in-treatment-timing) since about 2018. Just to make sure we're on the same page, the brief recap is:
 
-- Historically, under staggered adoptions researchers used the [standard two-way fixed effects estimator](https://bookdown.org/mike/data_analysis/sec-difference-in-differences.html#sec-two-way-fixed-effects) and interpreted the coefficient on the treatment dummy as an average treatment effect on the treated units.
+- Historically, under staggered adoptions researchers used the [standard two-way fixed effects estimator](https://mike-data-analysis.share.connect.posit.cloud/sec-difference-in-differences.html#sec-two-way-fixed-effects) and interpreted the coefficient on the treatment dummy as an average treatment effect on the treated units.
 - In the late 2010s, econometricians formally checked what this estimator was doing and found that in fact, this coefficient was not any kind of reasonable average treatment effect estimator.
 - Since then, a number of new difference-in-differences estimators that are asymptotically unbiased under staggered adoptions have been developed.
 


### PR DESCRIPTION
Resolves #20. Two URLs in `vignettes/vignette.Rmd` (lines 29 and 31) pointed at a `bookdown.org` domain that now 301-redirects to a Posit Connect cloud URL. Replaced the host portion with the canonical destination; anchor fragments (`#sec-multiple-periods-and-variation-in-treatment-timing` and `#sec-two-way-fixed-effects`) preserved verbatim — both verified to exist on the new domain. No R source touched.

Patch version bump 1.5.1 → 1.5.2 in `DESCRIPTION` / `NEWS.md` / `inst/CITATION`. Adds `bookdown` to `inst/WORDLIST` so `devtools::spell_check()` stays clean (the new NEWS bullet references the domain by name).

Per-PR CRAN gate clean: `devtools::check(args = "--as-cran")` 0/0/0; `devtools::test()` 1065/1065 PASS; `devtools::spell_check()` empty; `urlchecker::url_check()` all 19 URLs reachable; `devtools::build_vignettes()` rebuilt cleanly with the new URLs in the rendered HTML.

Two subagent review rounds (round 1 plan-review on the draft plan, round 2 post-execution review on commit `53aeb94`): both LGTM, no action items.