### PR TITLE
Resolve 11 roxygen link-resolution warnings; bump to 1.5.3 (#21)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.5.2
+Version: 1.5.3
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # NEWS
 
+## Version 1.5.3 (2026-05-10)
+
+- Resolved 11 "Could not resolve link to topic" warnings from
+  `devtools::document()` against `R/fetwfe_core.R` and `R/etwfe_core.R`
+  by replacing internal-helper Markdown link forms `[func()]` with
+  `\code{func()}`, plus one LaTeX-in-`@return` fix to use `\eqn{}`
+  instead of `\(...\)`. Internal cleanup; no behavior change. Resolves
+  #21.
+
 ## Version 1.5.2 (2026-05-10)
 
 - Fixed two redirected URLs in the main vignette (`vignettes/vignette.Rmd`)

--- a/R/etwfe_core.R
+++ b/R/etwfe_core.R
@@ -634,7 +634,7 @@ etwfe_core <- function(
 #' `etwfe_core()`, `twfeCovs_core()`, and related fitting routines.  The function
 #' (i) keeps only the relevant variables, (ii) one-hot-encodes or otherwise
 #' expands any *factor* covariates, (iii) builds the stacked design matrix
-#' `X_ints` and centred response `y` via [`prepXints()`], and (iv) performs a
+#' `X_ints` and centred response `y` via \code{prepXints()}, and (iv) performs a
 #' battery of **sanity checks** on cohort counts before estimation proceeds.
 #'
 #' @param pdata A **data.frame** in long (unit x time) format containing at

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -78,12 +78,12 @@
 #' `att_var_1 + att_var_2 + 2sqrt(att_var_1*att_var_2)`.
 #'
 #' All matrices required for Term 2 are produced upstream:
-#' * `psi_mat` from [getCohortATTsFinal()]
+#' * `psi_mat` from \code{getCohortATTsFinal()}
 #' * `d_inv_treat_sel` from the same routine
 #' * the Jacobian \(J\) is built in
-#'   [getSecondVarTermDataApp()] using `d_inv_treat_sel`
+#'   \code{getSecondVarTermDataApp()} using `d_inv_treat_sel`
 #' @inheritParams getTeResults2
-#' @seealso [getSecondVarTermDataApp()]
+#' @seealso \code{getSecondVarTermDataApp()}
 #' @keywords internal
 #' @noRd
 getTeResults2 <- function(
@@ -330,7 +330,7 @@ checkFetwfeInputs <- function(
 #'   1 x 1 or 1 x *`k`* shape so that higher-level code can
 #'   `rbind()` the blocks without special cases.
 #' @inheritParams getPsiRFused
-#' @seealso [getCohortATTsFinal()]
+#' @seealso \code{getCohortATTsFinal()}
 #' @keywords internal
 #' @noRd
 getPsiRFused <- function(
@@ -1270,7 +1270,7 @@ fetwfe_core <- function(
 #' @return
 #' A numeric matrix `X_mod` with the **same dimensions** as `X_int` but whose
 #' columns are the transformed regressors
-#' \(\bigl[\tilde{\boldsymbol Z}\,\boldsymbol D_N^{-1}\bigr]_{NT\times p}\).
+#' \eqn{[\tilde{\boldsymbol Z}\,\boldsymbol D_N^{-1}]_{NT\times p}}.
 #'
 #' @seealso
 #' * `genBackwardsInvFusionTransformMat()`
@@ -1888,7 +1888,7 @@ genInvFusionTransformMat <- function(n_vars) {
 #' `d_inv_treat_sel` and the cohort probabilities, then plugs everything into
 #' the quadratic form above and finally rescales by \(T/(N T)=1/N\).
 #' @inheritParams getSecondVarTermDataApp
-#' @seealso [getTeResults2()]
+#' @seealso \code{getTeResults2()}
 #' @keywords internal
 #' @noRd
 getSecondVarTermDataApp <- function(
@@ -2164,7 +2164,7 @@ genInvTwoWayFusionTransformMat <- function(n_vars, first_inds, R) {
 #' \(\widehat{\tau}_{\text{ATT},r}=\psi_r^{\!\top}\widehat\theta\).
 #' The function
 #'
-#' * constructs every \(\psi_r\) (via [getPsiRFused()])
+#' * constructs every \(\psi_r\) (via \code{getPsiRFused()})
 #' * builds the Gram inverse
 #'   \(\bigl((NT)^{-1}X_{\hat{\mathcal S}}^{\top}X_{\hat{\mathcal S}}\bigr)^{-1}\)
 #'   for the *selected* treatment-effect columns
@@ -2231,9 +2231,9 @@ genInvTwoWayFusionTransformMat <- function(n_vars, first_inds, R) {
 #' block `d_inv_treat_sel` -
 #' the sub-matrix of \(D^{(2)}(\mathcal R)^{-1}\) with
 #' **all rows** but **only the selected columns**.
-#' This block is later required by [getSecondVarTermDataApp()]
+#' This block is later required by \code{getSecondVarTermDataApp()}
 #' to propagate sampling noise in the cohort-probability estimates.
-#' @seealso [getPsiRFused()], [getTeResults2()]
+#' @seealso \code{getPsiRFused()}, \code{getTeResults2()}
 #' @keywords internal
 #' @noRd
 getCohortATTsFinal <- function(

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.5.2",
+  note    = "R package version 1.5.3",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )


### PR DESCRIPTION
Resolves #21. `devtools::document()` previously emitted 11 "Could not resolve link to topic" warnings against `R/fetwfe_core.R` (10 of them) and `R/etwfe_core.R` (1). Issue body literally listed only 3, but the underlying motivation ("warnings appear on every documentation rebuild") is only fully met by clearing all 11.

Two categories of fix:

- **10 link-form swaps:** each `[func()]` Markdown auto-link pointing at an internal helper (`prepXints`, `getCohortATTsFinal`, `getSecondVarTermDataApp`, `getTeResults2`, `getPsiRFused`) replaced with `\code{func()}`. The helpers are all `@noRd`, so no roxygen topic exists for the auto-link to resolve to; `\code{}` is the established repo convention for naming an internal helper without trying to link to its (nonexistent) help page.
- **1 LaTeX-in-`@return` fix at `R/fetwfe_core.R:1270`:** the inline math `\(\bigl[\tilde{\boldsymbol Z}\,\boldsymbol D_N^{-1}\bigr]_{NT\times p}\)` confused roxygen's Markdown parser (it interpreted the `[...]` brackets as a link target). Rewritten as `\eqn{[\tilde{\boldsymbol Z}\,\boldsymbol D_N^{-1}]_{NT\times p}}` so the body is treated as raw LaTeX rather than Markdown. `\bigl`/`\bigr` size modifiers dropped; default-size brackets in `\eqn{}` are equivalent for an inline expression with no tall content.

Internal-only: no behavior change, no NAMESPACE change, no `man/*.Rd` regeneration (all affected helpers are `@noRd`, so no `.Rd` content was ever being produced for them — the warnings fired at parse time only).

Patch version bump 1.5.2 → 1.5.3 in `DESCRIPTION` / `NEWS.md` / `inst/CITATION`.

Per-PR CRAN gate clean: `devtools::document()` 11 → 0 warnings; `devtools::check(args = "--as-cran")` 0/0/0; `devtools::test()` 1065/1065 PASS; `devtools::spell_check()` empty; `urlchecker::url_check()` all 19 URLs reachable.

Two subagent review rounds (round 1 plan-review, round 2 post-execution review on commit `a581817`): both LGTM, no action items beyond two cosmetic plan-text clarifications applied between rounds.