### PR TITLE
Support panels with no never-treated units; bump to 1.5.6

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.5.5
+Version: 1.5.6
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # NEWS
 
+## Version 1.5.6 (2026-05-11)
+
+- The four estimators (`fetwfe()`, `betwfe()`, `etwfe()`, `twfeCovs()`)
+  and their `*WithSimulatedData()` wrappers now accept a new
+  `allow_no_never_treated = TRUE` argument. When the input panel has
+  zero never-treated units (previously a hard error), the package
+  auto-truncates the panel by dropping time periods at and after the
+  latest cohort's start time --- the units in that latest cohort then
+  serve as the never-treated comparison group in the retained
+  sub-panel --- and issues a clear warning naming the dropped periods.
+  Pass `allow_no_never_treated = FALSE` to restore the previous
+  hard-error behavior. The argument has no effect when the input
+  already contains never-treated units.
+
 ## Version 1.5.5 (2026-05-11)
 
 - `fetwfe()`, `betwfe()`, `etwfe()`, and `twfeCovs()` now surface a

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -91,6 +91,14 @@
 #' @param add_ridge (Optional.) Logical; if TRUE, adds a small amount of ridge
 #' regularization to the (untransformed) coefficients to stabilize estimation.
 #' Default is FALSE.
+#' @param allow_no_never_treated (Optional.) Logical; if `TRUE` (default) and
+#' the input panel contains no never-treated units, the panel is auto-truncated
+#' by dropping time periods at and after the latest cohort's start time --- the
+#' units in that latest cohort then serve as the never-treated comparison group
+#' in the retained sub-panel --- with a warning naming the dropped periods. If
+#' `FALSE`, the estimator stops with an error in this case (the package's
+#' behavior prior to version 1.5.6). The argument has no effect when the input
+#' already contains never-treated units. Default is `TRUE`.
 #' @return An object of class \code{betwfe} containing the following elements:
 #' \item{att_hat}{The
 #' estimated overall average treatment effect for a randomly selected treated
@@ -229,7 +237,8 @@ betwfe <- function(
 	q = 0.5,
 	verbose = FALSE,
 	alpha = 0.05,
-	add_ridge = FALSE
+	add_ridge = FALSE,
+	allow_no_never_treated = TRUE
 ) {
 	# Check inputs
 	ret <- checkFetwfeInputs(
@@ -255,6 +264,14 @@ betwfe <- function(
 	indep_count_data_available = ret$indep_count_data_available
 
 	rm(ret)
+
+	pdata <- .truncate_if_no_never_treated(
+		pdata,
+		time_var = time_var,
+		unit_var = unit_var,
+		treat_var = treatment,
+		allow_no_never_treated = allow_no_never_treated
+	)
 
 	res1 <- prep_for_etwfe_core(
 		pdata = pdata,
@@ -411,6 +428,14 @@ betwfe <- function(
 #' @param add_ridge (Optional.) Logical; if TRUE, adds a small amount of ridge
 #' regularization to the (untransformed) coefficients to stabilize estimation.
 #' Default is FALSE.
+#' @param allow_no_never_treated (Optional.) Logical; if `TRUE` (default) and
+#' the input panel contains no never-treated units, the panel is auto-truncated
+#' by dropping time periods at and after the latest cohort's start time --- the
+#' units in that latest cohort then serve as the never-treated comparison group
+#' in the retained sub-panel --- with a warning naming the dropped periods. If
+#' `FALSE`, the estimator stops with an error in this case (the package's
+#' behavior prior to version 1.5.6). The argument has no effect when the input
+#' already contains never-treated units. Default is `TRUE`.
 #' @return An object of class \code{betwfe} containing the following elements:
 #' \item{att_hat}{The
 #' estimated overall average treatment effect for a randomly selected treated
@@ -503,7 +528,8 @@ betwfeWithSimulatedData <- function(
 	q = 0.5,
 	verbose = FALSE,
 	alpha = 0.05,
-	add_ridge = FALSE
+	add_ridge = FALSE,
+	allow_no_never_treated = TRUE
 ) {
 	if (!inherits(simulated_obj, "FETWFE_simulated")) {
 		stop("simulated_obj must be an object of class 'FETWFE_simulated'")
@@ -535,7 +561,8 @@ betwfeWithSimulatedData <- function(
 		q = q,
 		verbose = verbose,
 		alpha = alpha,
-		add_ridge = add_ridge
+		add_ridge = add_ridge,
+		allow_no_never_treated = allow_no_never_treated
 	)
 
 	return(res)

--- a/R/etwfe_core.R
+++ b/R/etwfe_core.R
@@ -16,6 +16,14 @@
 #' @param add_ridge (Optional.) Logical; if TRUE, adds a small amount of ridge
 #' regularization to the (untransformed) coefficients to stabilize estimation.
 #' Default is FALSE.
+#' @param allow_no_never_treated (Optional.) Logical; if `TRUE` (default) and
+#' the input panel contains no never-treated units, the panel is auto-truncated
+#' by dropping time periods at and after the latest cohort's start time --- the
+#' units in that latest cohort then serve as the never-treated comparison group
+#' in the retained sub-panel --- with a warning naming the dropped periods. If
+#' `FALSE`, the estimator stops with an error in this case (the package's
+#' behavior prior to version 1.5.6). The argument has no effect when the input
+#' already contains never-treated units. Default is `TRUE`.
 #' @return An object of class \code{etwfe} containing the following elements:
 #' \item{att_hat}{The
 #' estimated overall average treatment effect for a randomly selected treated
@@ -78,7 +86,8 @@ etwfeWithSimulatedData <- function(
 	simulated_obj,
 	verbose = FALSE,
 	alpha = 0.05,
-	add_ridge = FALSE
+	add_ridge = FALSE,
+	allow_no_never_treated = TRUE
 ) {
 	if (!inherits(simulated_obj, "FETWFE_simulated")) {
 		stop("simulated_obj must be an object of class 'FETWFE_simulated'")
@@ -106,7 +115,8 @@ etwfeWithSimulatedData <- function(
 		sig_eps_c_sq = sig_eps_c_sq,
 		verbose = verbose,
 		alpha = alpha,
-		add_ridge = add_ridge
+		add_ridge = add_ridge,
+		allow_no_never_treated = allow_no_never_treated
 	)
 
 	return(res)

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -94,6 +94,14 @@
 #' @param add_ridge (Optional.) Logical; if TRUE, adds a small amount of ridge
 #' regularization to the (untransformed) coefficients to stabilize estimation.
 #' Default is FALSE.
+#' @param allow_no_never_treated (Optional.) Logical; if `TRUE` (default) and
+#' the input panel contains no never-treated units, the panel is auto-truncated
+#' by dropping time periods at and after the latest cohort's start time --- the
+#' units in that latest cohort then serve as the never-treated comparison group
+#' in the retained sub-panel --- with a warning naming the dropped periods. If
+#' `FALSE`, the estimator stops with an error in this case (the package's
+#' behavior prior to version 1.5.6). The argument has no effect when the input
+#' already contains never-treated units. Default is `TRUE`.
 #' @return An object of class \code{fetwfe} containing the following elements:
 #' \item{att_hat}{The estimated overall average treatment effect for a randomly selected treated unit.}
 #' \item{att_se}{If `q < 1`, a standard error for the ATT. If `indep_counts` was provided, this standard error is asymptotically exact; if not, it is asymptotically conservative. If `q >= 1`, this will be NA.}
@@ -181,7 +189,8 @@ fetwfe <- function(
 	q = 0.5,
 	verbose = FALSE,
 	alpha = 0.05,
-	add_ridge = FALSE
+	add_ridge = FALSE,
+	allow_no_never_treated = TRUE
 ) {
 	# Check inputs
 	ret <- checkFetwfeInputs(
@@ -207,6 +216,14 @@ fetwfe <- function(
 	indep_count_data_available = ret$indep_count_data_available
 
 	rm(ret)
+
+	pdata <- .truncate_if_no_never_treated(
+		pdata,
+		time_var = time_var,
+		unit_var = unit_var,
+		treat_var = treatment,
+		allow_no_never_treated = allow_no_never_treated
+	)
 
 	res1 <- prep_for_etwfe_core(
 		pdata = pdata,
@@ -372,6 +389,14 @@ fetwfe <- function(
 #' @param add_ridge (Optional.) Logical; if TRUE, adds a small amount of ridge
 #' regularization to the (untransformed) coefficients to stabilize estimation.
 #' Default is FALSE.
+#' @param allow_no_never_treated (Optional.) Logical; if `TRUE` (default) and
+#' the input panel contains no never-treated units, the panel is auto-truncated
+#' by dropping time periods at and after the latest cohort's start time --- the
+#' units in that latest cohort then serve as the never-treated comparison group
+#' in the retained sub-panel --- with a warning naming the dropped periods. If
+#' `FALSE`, the estimator stops with an error in this case (the package's
+#' behavior prior to version 1.5.6). The argument has no effect when the input
+#' already contains never-treated units. Default is `TRUE`.
 #' @return An object of class \code{fetwfe} containing the following elements:
 #' \item{att_hat}{The estimated overall average treatment effect for a randomly selected treated unit.}
 #' \item{att_se}{If `q < 1`, a standard error for the ATT. If `indep_counts` was provided, this standard error is asymptotically exact; if not, it is asymptotically conservative. If `q >= 1`, this will be NA.}
@@ -430,7 +455,8 @@ fetwfeWithSimulatedData <- function(
 	q = 0.5,
 	verbose = FALSE,
 	alpha = 0.05,
-	add_ridge = FALSE
+	add_ridge = FALSE,
+	allow_no_never_treated = TRUE
 ) {
 	if (!inherits(simulated_obj, "FETWFE_simulated")) {
 		stop("simulated_obj must be an object of class 'FETWFE_simulated'")
@@ -462,7 +488,8 @@ fetwfeWithSimulatedData <- function(
 		q = q,
 		verbose = verbose,
 		alpha = alpha,
-		add_ridge = add_ridge
+		add_ridge = add_ridge,
+		allow_no_never_treated = allow_no_never_treated
 	)
 
 	return(res)
@@ -536,6 +563,14 @@ fetwfeWithSimulatedData <- function(
 #' @param add_ridge (Optional.) Logical; if TRUE, adds a small amount of ridge
 #' regularization to the (untransformed) coefficients to stabilize estimation.
 #' Default is FALSE.
+#' @param allow_no_never_treated (Optional.) Logical; if `TRUE` (default) and
+#' the input panel contains no never-treated units, the panel is auto-truncated
+#' by dropping time periods at and after the latest cohort's start time --- the
+#' units in that latest cohort then serve as the never-treated comparison group
+#' in the retained sub-panel --- with a warning naming the dropped periods. If
+#' `FALSE`, the estimator stops with an error in this case (the package's
+#' behavior prior to version 1.5.6). The argument has no effect when the input
+#' already contains never-treated units. Default is `TRUE`.
 #' @return An object of class \code{etwfe} containing the following elements:
 #' \item{att_hat}{The
 #' estimated overall average treatment effect for a randomly selected treated
@@ -600,7 +635,8 @@ etwfe <- function(
 	sig_eps_c_sq = NA,
 	verbose = FALSE,
 	alpha = 0.05,
-	add_ridge = FALSE
+	add_ridge = FALSE,
+	allow_no_never_treated = TRUE
 ) {
 	# Check inputs
 	ret <- checkEtwfeInputs(
@@ -622,6 +658,14 @@ etwfe <- function(
 	indep_count_data_available = ret$indep_count_data_available
 
 	rm(ret)
+
+	pdata <- .truncate_if_no_never_treated(
+		pdata,
+		time_var = time_var,
+		unit_var = unit_var,
+		treat_var = treatment,
+		allow_no_never_treated = allow_no_never_treated
+	)
 
 	res1 <- prep_for_etwfe_core(
 		pdata = pdata,

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -71,6 +71,14 @@
 #' @param add_ridge (Optional.) Logical; if TRUE, adds a small amount of ridge
 #' regularization to the (untransformed) coefficients to stabilize estimation.
 #' Default is FALSE.
+#' @param allow_no_never_treated (Optional.) Logical; if `TRUE` (default) and
+#' the input panel contains no never-treated units, the panel is auto-truncated
+#' by dropping time periods at and after the latest cohort's start time --- the
+#' units in that latest cohort then serve as the never-treated comparison group
+#' in the retained sub-panel --- with a warning naming the dropped periods. If
+#' `FALSE`, the estimator stops with an error in this case (the package's
+#' behavior prior to version 1.5.6). The argument has no effect when the input
+#' already contains never-treated units. Default is `TRUE`.
 #' @return A named list with the following elements: \item{att_hat}{The
 #' estimated overall average treatment effect for a randomly selected treated
 #' unit.} \item{att_se}{A standard error for the ATT. If the Gram matrix is not
@@ -134,7 +142,8 @@ twfeCovs <- function(
 	sig_eps_c_sq = NA,
 	verbose = FALSE,
 	alpha = 0.05,
-	add_ridge = FALSE
+	add_ridge = FALSE,
+	allow_no_never_treated = TRUE
 ) {
 	# Check inputs
 	ret <- checkEtwfeInputs(
@@ -156,6 +165,14 @@ twfeCovs <- function(
 	indep_count_data_available = ret$indep_count_data_available
 
 	rm(ret)
+
+	pdata <- .truncate_if_no_never_treated(
+		pdata,
+		time_var = time_var,
+		unit_var = unit_var,
+		treat_var = treatment,
+		allow_no_never_treated = allow_no_never_treated
+	)
 
 	res1 <- prep_for_etwfe_core(
 		pdata = pdata,
@@ -282,6 +299,14 @@ twfeCovs <- function(
 #' @param add_ridge (Optional.) Logical; if TRUE, adds a small amount of ridge
 #' regularization to the (untransformed) coefficients to stabilize estimation.
 #' Default is FALSE.
+#' @param allow_no_never_treated (Optional.) Logical; if `TRUE` (default) and
+#' the input panel contains no never-treated units, the panel is auto-truncated
+#' by dropping time periods at and after the latest cohort's start time --- the
+#' units in that latest cohort then serve as the never-treated comparison group
+#' in the retained sub-panel --- with a warning naming the dropped periods. If
+#' `FALSE`, the estimator stops with an error in this case (the package's
+#' behavior prior to version 1.5.6). The argument has no effect when the input
+#' already contains never-treated units. Default is `TRUE`.
 #' @return A named list with the following elements: \item{att_hat}{The
 #' estimated overall average treatment effect for a randomly selected treated
 #' unit.} \item{att_se}{If `q < 1`, a standard error for the ATT. If
@@ -345,7 +370,8 @@ twfeCovsWithSimulatedData <- function(
 	simulated_obj,
 	verbose = FALSE,
 	alpha = 0.05,
-	add_ridge = FALSE
+	add_ridge = FALSE,
+	allow_no_never_treated = TRUE
 ) {
 	if (!inherits(simulated_obj, "FETWFE_simulated")) {
 		stop("simulated_obj must be an object of class 'FETWFE_simulated'")
@@ -373,7 +399,8 @@ twfeCovsWithSimulatedData <- function(
 		sig_eps_c_sq = sig_eps_c_sq,
 		verbose = verbose,
 		alpha = alpha,
-		add_ridge = add_ridge
+		add_ridge = add_ridge,
+		allow_no_never_treated = allow_no_never_treated
 	)
 
 	return(res)

--- a/R/utility.R
+++ b/R/utility.R
@@ -512,3 +512,136 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 		NA_real_
 	)
 }
+
+#' @title Auto-truncate a panel that has no never-treated units
+#'
+#' @description
+#' Internal helper called by the four public estimator entry points
+#' (`fetwfe()`, `etwfe()`, `betwfe()`, `twfeCovs()`) when their
+#' `allow_no_never_treated` argument is TRUE (default). Detects whether
+#' the input panel `pdata` contains any never-treated units; if so,
+#' returns `pdata` unchanged. If not, identifies the latest cohort start
+#' time and drops rows at or after that time, issues a warning naming the
+#' dropped time periods, and returns the truncated panel. If
+#' `allow_no_never_treated = FALSE` and there are no never-treated units,
+#' stops with an informative error. If truncation is structurally
+#' impossible (would leave fewer than 2 time periods or fewer than 2
+#' treated cohorts), stops regardless of the argument.
+#'
+#' @param pdata A balanced panel `data.frame`.
+#' @param time_var Character string; name of the time variable column.
+#' @param unit_var Character string; name of the unit identifier column.
+#' @param treat_var Character string; name of the treatment indicator column.
+#' @param allow_no_never_treated Logical; if `FALSE`, stops with an error
+#'   when there are no never-treated units. If `TRUE` (default), auto-
+#'   truncates.
+#' @details The helper trusts the package's documented absorbing-state
+#'   assumption for the treatment column. If a unit's treatment is
+#'   non-absorbing (e.g., 0 -> 1 -> 0 -> 1), and the rows that violate
+#'   absorbing would be dropped by truncation, this helper will not catch
+#'   the violation (the truncated panel sees a clean absorbing history).
+#'   Users supplying non-absorbing data are already violating the
+#'   package's input contract; the responsibility for catching that sits
+#'   at `idCohorts` in the standard pipeline.
+#' @return The (possibly truncated) `pdata` data.frame.
+#' @keywords internal
+#' @noRd
+.truncate_if_no_never_treated <- function(
+	pdata,
+	time_var,
+	unit_var,
+	treat_var,
+	allow_no_never_treated = TRUE
+) {
+	stopifnot(is.logical(allow_no_never_treated))
+	stopifnot(length(allow_no_never_treated) == 1)
+	stopifnot(!is.na(allow_no_never_treated))
+
+	# Detect never-treated units.
+	treated_any <- tapply(
+		pdata[[treat_var]],
+		pdata[[unit_var]],
+		function(x) any(x == 1)
+	)
+	if (any(!treated_any)) {
+		return(pdata)
+	}
+
+	# All units are eventually treated.
+	if (!isTRUE(allow_no_never_treated)) {
+		stop(
+			"No never-treated units detected in data to fit model; ",
+			"estimating treatment effects is not possible. Set ",
+			"`allow_no_never_treated = TRUE` to enable automatic panel ",
+			"truncation, which drops time periods at and after the latest ",
+			"cohort's start time so the latest-cohort units become the ",
+			"never-treated comparison group."
+		)
+	}
+
+	# Identify each unit's first-treatment time.
+	unit_first_treat <- tapply(
+		seq_len(nrow(pdata)),
+		pdata[[unit_var]],
+		function(idx) {
+			treated_rows <- idx[pdata[[treat_var]][idx] == 1]
+			min(pdata[[time_var]][treated_rows])
+		}
+	)
+	r_max <- max(unit_first_treat)
+	times_sorted <- sort(unique(pdata[[time_var]]))
+
+	# If `r_max == times[1]`, every unit was treated from the very first
+	# time period (otherwise `r_max` would be larger). There is no
+	# pre-treatment period to retain; the existing pipeline's first-period
+	# filter in `idCohorts()` already reports this case with a clearer
+	# message ("All units were treated in the first time period..."), so
+	# defer to it rather than rewrite the diagnostic.
+	if (r_max <= times_sorted[1]) {
+		return(pdata)
+	}
+
+	retained_times <- times_sorted[times_sorted < r_max]
+	dropped_times <- times_sorted[times_sorted >= r_max]
+
+	# Impossible-truncation guards.
+	if (length(retained_times) < 2) {
+		stop(
+			"Cannot estimate treatment effects: panel has no never-treated ",
+			"units, and truncating to the largest sub-panel where any ",
+			"units are still untreated would leave only ",
+			length(retained_times),
+			" time period(s) (need at least 2)."
+		)
+	}
+
+	# After truncation, retained cohorts are those with r_i < r_max.
+	# prep_for_etwfe_core() downstream requires R >= 2 (at least two
+	# treated cohorts), so the guard here matches that constraint.
+	retained_cohorts <- setdiff(unique(unit_first_treat), r_max)
+	if (length(retained_cohorts) < 2) {
+		stop(
+			"Cannot estimate treatment effects: panel has no never-treated ",
+			"units, and the truncated panel would have only ",
+			length(retained_cohorts),
+			" treated cohort(s). FETWFE/ETWFE/BETWFE/twfeCovs each require ",
+			"at least 2 treated cohorts."
+		)
+	}
+
+	# Truncate.
+	truncated <- pdata[pdata[[time_var]] %in% retained_times, , drop = FALSE]
+	warning(
+		"No never-treated units in input data; auto-truncated panel by ",
+		"dropping time periods at or after ",
+		r_max,
+		" (dropped: ",
+		paste(dropped_times, collapse = ", "),
+		"). The units that started treatment at ",
+		r_max,
+		" serve as the never-treated comparison group in the truncated ",
+		"panel. Set `allow_no_never_treated = FALSE` to disable this ",
+		"behavior."
+	)
+	truncated
+}

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.5.5",
+  note    = "R package version 1.5.6",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/man/betwfe.Rd
+++ b/man/betwfe.Rd
@@ -20,7 +20,8 @@ betwfe(
   q = 0.5,
   verbose = FALSE,
   alpha = 0.05,
-  add_ridge = FALSE
+  add_ridge = FALSE,
+  allow_no_never_treated = TRUE
 )
 }
 \arguments{
@@ -126,6 +127,15 @@ for the cohort average treatment effects that will be returned in \code{catt_df}
 \item{add_ridge}{(Optional.) Logical; if TRUE, adds a small amount of ridge
 regularization to the (untransformed) coefficients to stabilize estimation.
 Default is FALSE.}
+
+\item{allow_no_never_treated}{(Optional.) Logical; if \code{TRUE} (default) and
+the input panel contains no never-treated units, the panel is auto-truncated
+by dropping time periods at and after the latest cohort's start time --- the
+units in that latest cohort then serve as the never-treated comparison group
+in the retained sub-panel --- with a warning naming the dropped periods. If
+\code{FALSE}, the estimator stops with an error in this case (the package's
+behavior prior to version 1.5.6). The argument has no effect when the input
+already contains never-treated units. Default is \code{TRUE}.}
 }
 \value{
 An object of class \code{betwfe} containing the following elements:

--- a/man/betwfeWithSimulatedData.Rd
+++ b/man/betwfeWithSimulatedData.Rd
@@ -12,7 +12,8 @@ betwfeWithSimulatedData(
   q = 0.5,
   verbose = FALSE,
   alpha = 0.05,
-  add_ridge = FALSE
+  add_ridge = FALSE,
+  allow_no_never_treated = TRUE
 )
 }
 \arguments{
@@ -58,6 +59,15 @@ for the cohort average treatment effects that will be returned in \code{catt_df}
 \item{add_ridge}{(Optional.) Logical; if TRUE, adds a small amount of ridge
 regularization to the (untransformed) coefficients to stabilize estimation.
 Default is FALSE.}
+
+\item{allow_no_never_treated}{(Optional.) Logical; if \code{TRUE} (default) and
+the input panel contains no never-treated units, the panel is auto-truncated
+by dropping time periods at and after the latest cohort's start time --- the
+units in that latest cohort then serve as the never-treated comparison group
+in the retained sub-panel --- with a warning naming the dropped periods. If
+\code{FALSE}, the estimator stops with an error in this case (the package's
+behavior prior to version 1.5.6). The argument has no effect when the input
+already contains never-treated units. Default is \code{TRUE}.}
 }
 \value{
 An object of class \code{betwfe} containing the following elements:

--- a/man/etwfe.Rd
+++ b/man/etwfe.Rd
@@ -16,7 +16,8 @@ etwfe(
   sig_eps_c_sq = NA,
   verbose = FALSE,
   alpha = 0.05,
-  add_ridge = FALSE
+  add_ridge = FALSE,
+  allow_no_never_treated = TRUE
 )
 }
 \arguments{
@@ -92,6 +93,15 @@ for the cohort average treatment effects that will be returned in \code{catt_df}
 \item{add_ridge}{(Optional.) Logical; if TRUE, adds a small amount of ridge
 regularization to the (untransformed) coefficients to stabilize estimation.
 Default is FALSE.}
+
+\item{allow_no_never_treated}{(Optional.) Logical; if \code{TRUE} (default) and
+the input panel contains no never-treated units, the panel is auto-truncated
+by dropping time periods at and after the latest cohort's start time --- the
+units in that latest cohort then serve as the never-treated comparison group
+in the retained sub-panel --- with a warning naming the dropped periods. If
+\code{FALSE}, the estimator stops with an error in this case (the package's
+behavior prior to version 1.5.6). The argument has no effect when the input
+already contains never-treated units. Default is \code{TRUE}.}
 }
 \value{
 An object of class \code{etwfe} containing the following elements:

--- a/man/etwfeWithSimulatedData.Rd
+++ b/man/etwfeWithSimulatedData.Rd
@@ -8,7 +8,8 @@ etwfeWithSimulatedData(
   simulated_obj,
   verbose = FALSE,
   alpha = 0.05,
-  add_ridge = FALSE
+  add_ridge = FALSE,
+  allow_no_never_treated = TRUE
 )
 }
 \arguments{
@@ -24,6 +25,15 @@ for the cohort average treatment effects that will be returned in \code{catt_df}
 \item{add_ridge}{(Optional.) Logical; if TRUE, adds a small amount of ridge
 regularization to the (untransformed) coefficients to stabilize estimation.
 Default is FALSE.}
+
+\item{allow_no_never_treated}{(Optional.) Logical; if \code{TRUE} (default) and
+the input panel contains no never-treated units, the panel is auto-truncated
+by dropping time periods at and after the latest cohort's start time --- the
+units in that latest cohort then serve as the never-treated comparison group
+in the retained sub-panel --- with a warning naming the dropped periods. If
+\code{FALSE}, the estimator stops with an error in this case (the package's
+behavior prior to version 1.5.6). The argument has no effect when the input
+already contains never-treated units. Default is \code{TRUE}.}
 }
 \value{
 An object of class \code{etwfe} containing the following elements:

--- a/man/fetwfe.Rd
+++ b/man/fetwfe.Rd
@@ -20,7 +20,8 @@ fetwfe(
   q = 0.5,
   verbose = FALSE,
   alpha = 0.05,
-  add_ridge = FALSE
+  add_ridge = FALSE,
+  allow_no_never_treated = TRUE
 )
 }
 \arguments{
@@ -126,6 +127,15 @@ for the cohort average treatment effects that will be returned in \code{catt_df}
 \item{add_ridge}{(Optional.) Logical; if TRUE, adds a small amount of ridge
 regularization to the (untransformed) coefficients to stabilize estimation.
 Default is FALSE.}
+
+\item{allow_no_never_treated}{(Optional.) Logical; if \code{TRUE} (default) and
+the input panel contains no never-treated units, the panel is auto-truncated
+by dropping time periods at and after the latest cohort's start time --- the
+units in that latest cohort then serve as the never-treated comparison group
+in the retained sub-panel --- with a warning naming the dropped periods. If
+\code{FALSE}, the estimator stops with an error in this case (the package's
+behavior prior to version 1.5.6). The argument has no effect when the input
+already contains never-treated units. Default is \code{TRUE}.}
 }
 \value{
 An object of class \code{fetwfe} containing the following elements:

--- a/man/fetwfeWithSimulatedData.Rd
+++ b/man/fetwfeWithSimulatedData.Rd
@@ -12,7 +12,8 @@ fetwfeWithSimulatedData(
   q = 0.5,
   verbose = FALSE,
   alpha = 0.05,
-  add_ridge = FALSE
+  add_ridge = FALSE,
+  allow_no_never_treated = TRUE
 )
 }
 \arguments{
@@ -58,6 +59,15 @@ for the cohort average treatment effects that will be returned in \code{catt_df}
 \item{add_ridge}{(Optional.) Logical; if TRUE, adds a small amount of ridge
 regularization to the (untransformed) coefficients to stabilize estimation.
 Default is FALSE.}
+
+\item{allow_no_never_treated}{(Optional.) Logical; if \code{TRUE} (default) and
+the input panel contains no never-treated units, the panel is auto-truncated
+by dropping time periods at and after the latest cohort's start time --- the
+units in that latest cohort then serve as the never-treated comparison group
+in the retained sub-panel --- with a warning naming the dropped periods. If
+\code{FALSE}, the estimator stops with an error in this case (the package's
+behavior prior to version 1.5.6). The argument has no effect when the input
+already contains never-treated units. Default is \code{TRUE}.}
 }
 \value{
 An object of class \code{fetwfe} containing the following elements:

--- a/man/twfeCovs.Rd
+++ b/man/twfeCovs.Rd
@@ -17,7 +17,8 @@ twfeCovs(
   sig_eps_c_sq = NA,
   verbose = FALSE,
   alpha = 0.05,
-  add_ridge = FALSE
+  add_ridge = FALSE,
+  allow_no_never_treated = TRUE
 )
 }
 \arguments{
@@ -93,6 +94,15 @@ for the cohort average treatment effects that will be returned in \code{catt_df}
 \item{add_ridge}{(Optional.) Logical; if TRUE, adds a small amount of ridge
 regularization to the (untransformed) coefficients to stabilize estimation.
 Default is FALSE.}
+
+\item{allow_no_never_treated}{(Optional.) Logical; if \code{TRUE} (default) and
+the input panel contains no never-treated units, the panel is auto-truncated
+by dropping time periods at and after the latest cohort's start time --- the
+units in that latest cohort then serve as the never-treated comparison group
+in the retained sub-panel --- with a warning naming the dropped periods. If
+\code{FALSE}, the estimator stops with an error in this case (the package's
+behavior prior to version 1.5.6). The argument has no effect when the input
+already contains never-treated units. Default is \code{TRUE}.}
 }
 \value{
 A named list with the following elements: \item{att_hat}{The

--- a/man/twfeCovsWithSimulatedData.Rd
+++ b/man/twfeCovsWithSimulatedData.Rd
@@ -8,7 +8,8 @@ twfeCovsWithSimulatedData(
   simulated_obj,
   verbose = FALSE,
   alpha = 0.05,
-  add_ridge = FALSE
+  add_ridge = FALSE,
+  allow_no_never_treated = TRUE
 )
 }
 \arguments{
@@ -24,6 +25,15 @@ for the cohort average treatment effects that will be returned in \code{catt_df}
 \item{add_ridge}{(Optional.) Logical; if TRUE, adds a small amount of ridge
 regularization to the (untransformed) coefficients to stabilize estimation.
 Default is FALSE.}
+
+\item{allow_no_never_treated}{(Optional.) Logical; if \code{TRUE} (default) and
+the input panel contains no never-treated units, the panel is auto-truncated
+by dropping time periods at and after the latest cohort's start time --- the
+units in that latest cohort then serve as the never-treated comparison group
+in the retained sub-panel --- with a warning naming the dropped periods. If
+\code{FALSE}, the estimator stops with an error in this case (the package's
+behavior prior to version 1.5.6). The argument has no effect when the input
+already contains never-treated units. Default is \code{TRUE}.}
 }
 \value{
 A named list with the following elements: \item{att_hat}{The

--- a/tests/testthat/test-betwfe.R
+++ b/tests/testthat/test-betwfe.R
@@ -393,7 +393,7 @@ test_that("betwfe errors when all units are treated in the first period", {
 # Test 11: Error when there are no never-treated units.
 # ------------------------------------------------------------------------------
 
-test_that("betwfe errors with a panel having no never-treated units", {
+test_that("betwfe errors with a panel having no never-treated units when allow_no_never_treated = FALSE", {
 	df_bad <- generate_bad_panel_data(N = 30, T = 10, seed = 123)
 
 	expect_error(
@@ -404,9 +404,10 @@ test_that("betwfe errors with a panel having no never-treated units", {
 			treatment = "treatment",
 			covs = c("cov1", "cov2"),
 			response = "y",
-			verbose = FALSE
+			verbose = FALSE,
+			allow_no_never_treated = FALSE
 		)),
-		"No never-treated units detected in data to fit model; estimating treatment effects is not possible"
+		"allow_no_never_treated"
 	)
 })
 
@@ -1217,4 +1218,60 @@ test_that("order_by = 'pvalue' sorts CATT by ascending P_value with NAs last", {
 		1
 	)
 	expect_equal(first_tokens, expected_cohorts)
+})
+
+# ------------------------------------------------------------------------------
+# Test: betwfe auto-truncates a no-never-treated panel (default)
+# ------------------------------------------------------------------------------
+test_that("betwfe auto-truncates a panel with no never-treated units (default)", {
+	df_bad <- generate_bad_panel_data(N = 200, T = 10, seed = 123)
+
+	expect_warning(
+		res <- betwfe(
+			pdata = df_bad,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			verbose = FALSE
+		),
+		"auto-truncated"
+	)
+	expect_s3_class(res, "betwfe")
+	expect_true(is.finite(res$att_hat))
+	expect_s3_class(res$catt_df, "data.frame")
+})
+
+# ------------------------------------------------------------------------------
+# Test: betwfe errors cleanly when truncation would yield < 2 retained cohorts
+# ------------------------------------------------------------------------------
+test_that("betwfe errors cleanly when no-never-treated truncation would yield < 2 cohorts", {
+	N <- 5
+	T_periods <- 6
+	r_single <- 4
+	df_single <- data.frame(
+		time = rep(seq_len(T_periods), times = N),
+		unit = rep(paste0("u", seq_len(N)), each = T_periods),
+		treatment = rep(
+			c(rep(0L, r_single - 1L), rep(1L, T_periods - r_single + 1L)),
+			times = N
+		),
+		cov1 = rep(rnorm(N, mean = 0), each = T_periods),
+		cov2 = rep(rnorm(N, mean = 0), each = T_periods),
+		y = rnorm(N * T_periods)
+	)
+
+	expect_error(
+		suppressWarnings(betwfe(
+			pdata = df_single,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			verbose = FALSE
+		)),
+		"treated cohort"
+	)
 })

--- a/tests/testthat/test-etwfe.R
+++ b/tests/testthat/test-etwfe.R
@@ -386,7 +386,7 @@ test_that("etwfe errors when all units are treated in the first period", {
 # Test 11: Error when there are no never-treated units.
 # ------------------------------------------------------------------------------
 
-test_that("etwfe errors with a panel having no never-treated units", {
+test_that("etwfe errors with a panel having no never-treated units when allow_no_never_treated = FALSE", {
 	df_bad <- generate_bad_panel_data(N = 30, T = 10, seed = 123)
 
 	expect_error(
@@ -397,9 +397,10 @@ test_that("etwfe errors with a panel having no never-treated units", {
 			treatment = "treatment",
 			covs = c("cov1", "cov2"),
 			response = "y",
-			verbose = FALSE
+			verbose = FALSE,
+			allow_no_never_treated = FALSE
 		)),
-		"No never-treated units detected in data to fit model; estimating treatment effects is not possible"
+		"allow_no_never_treated"
 	)
 })
 
@@ -1026,4 +1027,60 @@ test_that("etwfe surfaces P_value but not selected in catt_df", {
 	non_na <- !is.na(res$catt_df$P_value)
 	expect_true(all(res$catt_df$P_value[non_na] >= 0))
 	expect_true(all(res$catt_df$P_value[non_na] <= 1))
+})
+
+# ------------------------------------------------------------------------------
+# Test: etwfe auto-truncates a no-never-treated panel (default)
+# ------------------------------------------------------------------------------
+test_that("etwfe auto-truncates a panel with no never-treated units (default)", {
+	df_bad <- generate_bad_panel_data(N = 200, T = 10, seed = 123)
+
+	expect_warning(
+		res <- etwfe(
+			pdata = df_bad,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			verbose = FALSE
+		),
+		"auto-truncated"
+	)
+	expect_s3_class(res, "etwfe")
+	expect_true(is.finite(res$att_hat))
+	expect_s3_class(res$catt_df, "data.frame")
+})
+
+# ------------------------------------------------------------------------------
+# Test: etwfe errors cleanly when truncation would yield < 2 retained cohorts
+# ------------------------------------------------------------------------------
+test_that("etwfe errors cleanly when no-never-treated truncation would yield < 2 cohorts", {
+	N <- 5
+	T_periods <- 6
+	r_single <- 4
+	df_single <- data.frame(
+		time = rep(seq_len(T_periods), times = N),
+		unit = rep(paste0("u", seq_len(N)), each = T_periods),
+		treatment = rep(
+			c(rep(0L, r_single - 1L), rep(1L, T_periods - r_single + 1L)),
+			times = N
+		),
+		cov1 = rep(rnorm(N, mean = 0), each = T_periods),
+		cov2 = rep(rnorm(N, mean = 0), each = T_periods),
+		y = rnorm(N * T_periods)
+	)
+
+	expect_error(
+		suppressWarnings(etwfe(
+			pdata = df_single,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			verbose = FALSE
+		)),
+		"treated cohort"
+	)
 })

--- a/tests/testthat/test-fetwfe.R
+++ b/tests/testthat/test-fetwfe.R
@@ -390,7 +390,7 @@ test_that("fetwfe errors when all units are treated in the first period", {
 # Test 11: Error when there are no never-treated units.
 # ------------------------------------------------------------------------------
 
-test_that("fetwfe errors with a panel having no never-treated units", {
+test_that("fetwfe errors with a panel having no never-treated units when allow_no_never_treated = FALSE", {
 	df_bad <- generate_bad_panel_data(N = 30, T = 10, seed = 123)
 
 	expect_error(
@@ -401,9 +401,10 @@ test_that("fetwfe errors with a panel having no never-treated units", {
 			treatment = "treatment",
 			covs = c("cov1", "cov2"),
 			response = "y",
-			verbose = FALSE
+			verbose = FALSE,
+			allow_no_never_treated = FALSE
 		)),
-		"No never-treated units detected in data to fit model; estimating treatment effects is not possible"
+		"allow_no_never_treated"
 	)
 })
 
@@ -1153,4 +1154,64 @@ test_that("order_by = 'pvalue' sorts CATT by ascending P_value with NAs last", {
 		as.character(res$catt_df$Cohort)
 	)]
 	expect_equal(printed_p_values, sort(printed_p_values))
+})
+
+# ------------------------------------------------------------------------------
+# Test: fetwfe auto-truncates a no-never-treated panel (default)
+# ------------------------------------------------------------------------------
+test_that("fetwfe auto-truncates a panel with no never-treated units (default)", {
+	df_bad <- generate_bad_panel_data(N = 200, T = 10, seed = 123)
+
+	expect_warning(
+		res <- fetwfe(
+			pdata = df_bad,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			verbose = FALSE
+		),
+		"auto-truncated"
+	)
+	expect_s3_class(res, "fetwfe")
+	expect_true(is.finite(res$att_hat))
+	expect_s3_class(res$catt_df, "data.frame")
+	expect_true(res$T < 10)
+	expect_true(res$R < 9)
+})
+
+# ------------------------------------------------------------------------------
+# Test: fetwfe errors cleanly when truncation would yield < 2 retained cohorts
+# ------------------------------------------------------------------------------
+test_that("fetwfe errors cleanly when no-never-treated truncation would yield < 2 cohorts", {
+	# All units share a single cohort start time, no never-treated.
+	# Five units, six time periods, every unit starts treatment at t = 4.
+	N <- 5
+	T_periods <- 6
+	r_single <- 4
+	df_single <- data.frame(
+		time = rep(seq_len(T_periods), times = N),
+		unit = rep(paste0("u", seq_len(N)), each = T_periods),
+		treatment = rep(
+			c(rep(0L, r_single - 1L), rep(1L, T_periods - r_single + 1L)),
+			times = N
+		),
+		cov1 = rep(rnorm(N, mean = 0), each = T_periods),
+		cov2 = rep(rnorm(N, mean = 0), each = T_periods),
+		y = rnorm(N * T_periods)
+	)
+
+	expect_error(
+		suppressWarnings(fetwfe(
+			pdata = df_single,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			verbose = FALSE
+		)),
+		"treated cohort"
+	)
 })

--- a/tests/testthat/test-twfeCovs.R
+++ b/tests/testthat/test-twfeCovs.R
@@ -386,7 +386,7 @@ test_that("twfeCovs errors when all units are treated in the first period", {
 # Test 11: Error when there are no never-treated units.
 # ------------------------------------------------------------------------------
 
-test_that("twfeCovs errors with a panel having no never-treated units", {
+test_that("twfeCovs errors with a panel having no never-treated units when allow_no_never_treated = FALSE", {
 	df_bad <- generate_bad_panel_data(N = 30, T = 10, seed = 123)
 
 	expect_error(
@@ -397,9 +397,10 @@ test_that("twfeCovs errors with a panel having no never-treated units", {
 			treatment = "treatment",
 			covs = c("cov1", "cov2"),
 			response = "y",
-			verbose = FALSE
+			verbose = FALSE,
+			allow_no_never_treated = FALSE
 		)),
-		"No never-treated units detected in data to fit model; estimating treatment effects is not possible"
+		"allow_no_never_treated"
 	)
 })
 
@@ -1023,4 +1024,60 @@ test_that("twfeCovs surfaces P_value but not selected in catt_df", {
 	non_na <- !is.na(res$catt_df$P_value)
 	expect_true(all(res$catt_df$P_value[non_na] >= 0))
 	expect_true(all(res$catt_df$P_value[non_na] <= 1))
+})
+
+# ------------------------------------------------------------------------------
+# Test: twfeCovs auto-truncates a no-never-treated panel (default)
+# ------------------------------------------------------------------------------
+test_that("twfeCovs auto-truncates a panel with no never-treated units (default)", {
+	df_bad <- generate_bad_panel_data(N = 200, T = 10, seed = 123)
+
+	expect_warning(
+		res <- twfeCovs(
+			pdata = df_bad,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			verbose = FALSE
+		),
+		"auto-truncated"
+	)
+	expect_true(is.list(res))
+	expect_true(is.finite(res$att_hat))
+	expect_s3_class(res$catt_df, "data.frame")
+})
+
+# ------------------------------------------------------------------------------
+# Test: twfeCovs errors cleanly when truncation would yield < 2 retained cohorts
+# ------------------------------------------------------------------------------
+test_that("twfeCovs errors cleanly when no-never-treated truncation would yield < 2 cohorts", {
+	N <- 5
+	T_periods <- 6
+	r_single <- 4
+	df_single <- data.frame(
+		time = rep(seq_len(T_periods), times = N),
+		unit = rep(paste0("u", seq_len(N)), each = T_periods),
+		treatment = rep(
+			c(rep(0L, r_single - 1L), rep(1L, T_periods - r_single + 1L)),
+			times = N
+		),
+		cov1 = rep(rnorm(N, mean = 0), each = T_periods),
+		cov2 = rep(rnorm(N, mean = 0), each = T_periods),
+		y = rnorm(N * T_periods)
+	)
+
+	expect_error(
+		suppressWarnings(twfeCovs(
+			pdata = df_single,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			verbose = FALSE
+		)),
+		"treated cohort"
+	)
 })

--- a/vignettes/vignette.Rmd
+++ b/vignettes/vignette.Rmd
@@ -192,6 +192,13 @@ set.seed(23451)
 # 
 # The `fetwfe()` function will automatically take care of removing units that were treated in the
 # first time period.
+#
+# If your panel has no never-treated units at all (every unit is eventually
+# treated), `fetwfe()` will auto-truncate the panel by dropping the latest
+# time periods so that the latest-cohort units serve as the never-treated
+# comparison group, and issue a warning naming the dropped periods. Pass
+# `allow_no_never_treated = FALSE` if you would rather have the estimator
+# error out in that situation.
 
 # Call the estimator
 res <- fetwfe(


### PR DESCRIPTION
Adds an `allow_no_never_treated = TRUE` argument to `fetwfe()`, `betwfe()`, `etwfe()`, `twfeCovs()` and their `*WithSimulatedData()` wrappers. When the input panel has zero never-treated units, the package now auto-truncates the panel by dropping time periods at and after the latest cohort's start time (the units in that latest cohort then serve as the never-treated comparison group in the retained sub-panel) and issues a clear warning naming the dropped periods. Pass `allow_no_never_treated = FALSE` for the previous hard-error behavior.

The truncation is purely pre-processing: paper Assumption F2 (positive probability of never being treated, paper line 389) holds within the truncated sub-panel by construction, so the estimator's variance and consistency guarantees apply unchanged. A new internal helper `.truncate_if_no_never_treated()` in `R/utility.R` is called from each public entry point after `checkXxxInputs()` and before `prep_for_etwfe_core()`. Impossible-truncation edge cases (fewer than 2 retained time periods OR fewer than 2 retained treated cohorts) error cleanly with explanatory messages. The pre-existing "all units treated at time 1" error path is preserved via an early-return in the helper.