### PR TITLE
Add no-covariate showcase + test (1.6.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.6.0
+Version: 1.6.1
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # NEWS
 
+## Version 1.6.1 (2026-05-12)
+
+- Added a no-covariate side-by-side demonstration of `etwfe()` and
+  `fetwfe()` to `vignettes/etwfe_betwfe_vignette.Rmd`. The main
+  vignette `vignettes/vignette.Rmd` now points readers at that
+  section near the divorce-data application. An explicit
+  `covs = c()` end-to-end test of the public `fetwfe()` entry point
+  was added to `tests/testthat/test-fetwfe.R`. The package already
+  supported the no-covariate case (the simulator's `d = 0` path is
+  exercised by `tests/testthat/test-genCoefs.R` and
+  `tests/testthat/test-simulateData.R`); this release closes the
+  showcase gap.
+
 ## Version 1.6.0 (2026-05-12)
 
 - Added an experimental `se_type = c("default", "cluster")` argument to

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.6.0",
+  note    = "R package version 1.6.1",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-fetwfe.R
+++ b/tests/testthat/test-fetwfe.R
@@ -1314,3 +1314,53 @@ test_that("fetwfe $se_type slot reflects the argument value", {
 	expect_identical(res_def$se_type, "default")
 	expect_identical(res_cls$se_type, "cluster")
 })
+
+# ------------------------------------------------------------------------------
+# Test: fetwfe runs end-to-end with zero covariates (covs = c() path).
+# The package's d = 0 path is exercised by test-genCoefs.R and
+# test-simulateData.R at the simulator level; this test surfaces the same
+# capability via the public fetwfeWithSimulatedData wrapper, matching the
+# referee request (Report.pdf points 12-13) for a no-covariate
+# demonstration alongside the with-covariates tests in this file.
+# ------------------------------------------------------------------------------
+test_that("fetwfe runs and gives sensible output with zero covariates", {
+	set.seed(2026)
+	sim_coefs <- genCoefs(
+		R = 3,
+		T = 6,
+		d = 0,
+		density = 0.5,
+		eff_size = 2,
+		seed = 2026
+	)
+	sim_data <- simulateData(
+		sim_coefs,
+		N = 120,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5
+	)
+
+	res <- fetwfeWithSimulatedData(sim_data)
+
+	expect_s3_class(res, "fetwfe")
+	expect_true(is.finite(res$att_hat))
+	expect_true(is.finite(res$att_se))
+	expect_gt(res$att_se, 0)
+	expect_length(res$catt_hats, 3)
+	expect_length(res$catt_ses, 3)
+	expect_s3_class(res$catt_df, "data.frame")
+	expect_true(all(
+		c(
+			"Cohort",
+			"Estimated TE",
+			"SE",
+			"ConfIntLow",
+			"ConfIntHigh",
+			"P_value",
+			"selected"
+		) %in%
+			colnames(res$catt_df)
+	))
+	# The covariate-related slots should reflect d = 0:
+	expect_identical(res$d, 0L)
+})

--- a/vignettes/etwfe_betwfe_vignette.Rmd
+++ b/vignettes/etwfe_betwfe_vignette.Rmd
@@ -103,6 +103,62 @@ cat("betwfe sq. error:", (res_betwfe$att_hat - true_tes$att_true)^2, "\n")
 
 The bridge penalty in `betwfe()` shrinks the estimate toward zero relative to `etwfe()`. On this regime, that produces a noticeable bias — the textbook bias-variance trade-off in action. In other regimes (sparser true effects, or noisier data), the bias from regularization is more than offset by reduced variance, and `betwfe()` outperforms `etwfe()`.
 
+# No-covariate setting
+
+The examples above use a panel with `d = 2` time-invariant covariates. The package equally supports the no-covariate case by passing `covs = c()` to any estimator (or by generating data with `genCoefs(d = 0, ...)`). This section runs the same simulated regime with no covariates, side-by-side, so a user can see what `etwfe()` and `fetwfe()` look like in the simpler setting.
+
+```{r}
+sim_coefs_d0 <- genCoefs(
+  R         = 3,
+  T         = 6,
+  d         = 0,
+  density   = 0.5,
+  eff_size  = 2,
+  seed      = 20260510
+)
+
+sim_data_d0 <- simulateData(
+  sim_coefs_d0,
+  N            = 120,
+  sig_eps_sq   = 1,
+  sig_eps_c_sq = 1
+)
+
+true_tes_d0 <- getTes(sim_coefs_d0)
+cat("True overall ATT (no covariates):", true_tes_d0$att_true, "\n")
+```
+
+`etwfe()` in the no-covariate setting:
+
+```{r}
+res_etwfe_d0 <- etwfeWithSimulatedData(sim_data_d0)
+summary(res_etwfe_d0)
+```
+
+`fetwfe()` in the no-covariate setting:
+
+```{r}
+res_fetwfe_d0 <- fetwfeWithSimulatedData(sim_data_d0)
+summary(res_fetwfe_d0)
+```
+
+Side-by-side overall ATT estimates against the truth:
+
+```{r}
+cat("True ATT:        ", true_tes_d0$att_true, "\n")
+cat("etwfe() ATT:     ", res_etwfe_d0$att_hat, "\n")
+cat("fetwfe() ATT:    ", res_fetwfe_d0$att_hat, "\n")
+cat("etwfe sq. error: ", (res_etwfe_d0$att_hat - true_tes_d0$att_true)^2, "\n")
+cat("fetwfe sq. error:", (res_fetwfe_d0$att_hat - true_tes_d0$att_true)^2, "\n")
+```
+
+Two qualitative differences to note in the no-covariate regime:
+
+- **Smaller design matrix.** Without covariates and their cohort/time/treatment interactions, the underlying regression has many fewer columns, so both estimators converge faster and `etwfe()` becomes rank-stable at smaller cohort sizes (the `(d + 1)`-units-per-cohort floor that `etwfe()` enforces drops to just one unit per cohort).
+- **Standard errors typically widen.** Covariates that explain residual variance are absent, so the idiosyncratic-noise variance `sig_eps_sq` enters the SEs without that explanatory cushion. The signal-to-noise ratio on the treatment-effect coefficients drops, which is the trade-off for the simpler model.
+
+The package handles `covs = c()` end-to-end without any special-casing on the user's side: the data-prep pipeline (`prep_for_etwfe_core` in `R/etwfe_core.R`) dispatches on `d == 0` and skips the covariate-interaction columns automatically. The same applies to `betwfe()` and `twfeCovs()`.
+
 # When to use which
 
 `fetwfe()` is the recommended estimator for production use; `etwfe()` and `betwfe()` are useful as comparisons or as building blocks for understanding what `fetwfe()` is doing.

--- a/vignettes/vignette.Rmd
+++ b/vignettes/vignette.Rmd
@@ -239,6 +239,8 @@ catt_df_pct
 
 For the data application, FETWFE yielded an overall ATT of approximately –1.84% change in the female suicide rate, similar to other estimates in the literature. In addition, the output table (stored in `result_emp$catt_df`) displays the cohort-specific estimates. (Note that standard errors for the individual cohort estimates are less reliable when the number of units per cohort is small.)
 
+The divorce-data analysis above uses three covariates. The package also supports the no-covariate case — pass `covs = c()` to any estimator, or generate data with `genCoefs(d = 0, ...)`. For a worked side-by-side comparison of `etwfe()` and `fetwfe()` with no covariates, see the "No-covariate setting" section of the companion vignette `etwfe_betwfe_vignette`.
+
 ## Testing the zero-effect null
 
 Empirical users of difference-in-differences routinely want to ask "is this treatment effect statistically distinguishable from zero?". The confidence intervals in `catt_df` answer that implicitly --- a CI that excludes 0 corresponds to rejecting `H_0: tau = 0` at level `alpha`. The package also surfaces a `P_value` column (two-sided `2 * pnorm(-|estimate / se|)`) and, for `fetwfe()` and `betwfe()`, a `selected` logical flag, both at the overall ATT level and per-cohort.


### PR DESCRIPTION
Closes the referee request from `Report.pdf` points 12-13 ("comparisons between FETWFE and ETWFE without covariates"). Adds a worked `etwfe()` / `fetwfe()` side-by-side in the no-covariate setting (`covs = c()` / `d = 0`) as a new "No-covariate setting" section of `vignettes/etwfe_betwfe_vignette.Rmd`, a 2-sentence pointer in the main `vignettes/vignette.Rmd` near the divorce-data example, and an explicit `covs = c()` end-to-end test of the public `fetwfe()` entry point in `tests/testthat/test-fetwfe.R`. The package already supported the no-covariate path (the simulator's `d = 0` branch is exercised by `test-genCoefs.R` and `test-simulateData.R`); this release closes the showcase gap. Pure docs/tests; no methodology change.

Version 1.6.0 → 1.6.1. All 1230 tests pass (1221 prior + 9 new expects in the new test). `R CMD check --as-cran` clean: 0 errors, 0 warnings, 1 NOTE (the persistent environmental "unable to verify current time" NOTE).