### PR TITLE
Fix BETWFE SE miscalibration under partial selection (factor `k_full / k_sel`)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.1
+Version: 1.9.2
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,33 @@
 # NEWS
 
+## Version 1.9.2 (2026-05-16)
+
+- Fixed a bug in `betwfe()`'s standard-error calculation under partial
+  selection. The internal `getPsiRUnfused()` helper was normalizing the
+  weight vector `psi_r` by `k_sel` (the count of *selected* coefficients
+  in a cohort's treatment block) rather than `k_full` (the full block
+  size). The cohort point estimate
+  `cohort_tes[r] = mean(tes[first_ind_r:last_ind_r])` averages over the
+  full block (unselected entries are exact zeros post-bridge), so the
+  variance formula's `psi_r` weighting targeted the wrong estimand
+  whenever the bridge solver zeroed out some-but-not-all of a cohort's
+  coefficients. The bug violated BETWFE's documented "asymptotically
+  exact, non-conservative" SE promise. Effect on user-visible output: on
+  panels with partial selection, `betwfe()`'s reported `catt_df$SE`,
+  `catt_df$ConfIntLow`, `catt_df$ConfIntHigh`, and `catt_df$P_value`
+  shift — per-cohort SEs shrink by factor `k_full / k_sel`. The overall
+  `att_se` direction is counterintuitive: it can *grow*, because the
+  corrected per-cohort CATT vector is more dispersed across cohorts than
+  the pre-fix mean-over-selected-only version, and the `att_var_2`
+  component is a quadratic form in cohort dispersion. Empirical
+  magnitudes are ~2× shifts in either direction on representative
+  partial-selection panels. Point estimates (`att_hat`,
+  `catt_df$Estimated TE`) are unaffected. FETWFE, ETWFE, and `twfeCovs()`
+  are unaffected (FETWFE uses a different `psi_r` constructor; ETWFE and
+  twfeCovs never partial-select). Users with `se_type = "cluster"` also
+  see SEs shift on partial-selection BETWFE fits (the cluster-robust
+  path uses the same `psi_r` weighting).
+
 ## Version 1.9.1 (2026-05-15)
 
 - Fixed two coupled bugs in the internal variance-component estimator

--- a/R/ols_calcs.R
+++ b/R/ols_calcs.R
@@ -510,11 +510,11 @@ getSecondVarTermOLS <- function(
 #'   fusion penalization is applied to the treatment effects (or when calculating
 #'   SEs as if it were an OLS on selected variables). This vector is used in
 #'   standard error calculations for the cohort's Average Treatment Effect on
-#'   the Treated (ATT). In particular, this vector contains the constants
-#'   `1 / (T - r + 1)` that are multiplied by the cohort treatment effects
-#'   at each time, then summed, to get the average treatment effect for cohort
-#'   `r`. The vector `psi_r` places these constants in the correct positions so
-#'   that the inner product works as intended.
+#'   the Treated (ATT). Specifically, `psi_r` places the constant
+#'   `1 / k_full` (where `k_full = last_ind_r - first_ind_r + 1` is the
+#'   cohort's full treatment-block size) at each position corresponding to a
+#'   selected treatment effect in cohort `r`, and zero elsewhere — so that
+#'   `t(psi_r) %*% theta_hat_treat_sel == cohort_tes[r]`.
 #' @param first_ind_r Integer; the index of the first treatment effect for
 #'   cohort `r` within the `num_treats` block of treatment effects.
 #' @param last_ind_r Integer; the index of the last treatment effect for
@@ -523,16 +523,24 @@ getSecondVarTermOLS <- function(
 #'   treatment effects within the `num_treats` block, shifted to start from 1.
 #' @param gram_inv Numeric matrix; the inverse of the Gram matrix for the
 #'   selected treatment effect features.
-#' @return A numeric vector `psi_r` of length equal to
-#'   `length(sel_treat_inds_shifted)`. It contains weights (typically 1/k for
-#'   k selected effects in cohort r, 0 otherwise) to average the selected
-#'   treatment effect coefficients for cohort `r`.
-#' @details The function identifies which of the `sel_treat_inds_shifted` fall
-#'   within the range `[first_ind_r, last_ind_r]`. For these identified
-#'   indices in `psi_r`, it assigns a value of 1. `psi_r` is then normalized by
-#'   dividing by its sum, effectively creating an averaging vector for the
-#'   selected treatment effects belonging to cohort `r`. If no treatment effects
-#'   for cohort `r` were selected, `psi_r` will be a zero vector.
+#' @return A numeric vector `psi_r` of length
+#'   `length(sel_treat_inds_shifted)`. Positions corresponding to selected
+#'   treatment effects in cohort `r` carry `1 / k_full`; other positions are
+#'   zero. Returns a zero vector if no coefficients in cohort `r`'s block are
+#'   selected.
+#' @details The function identifies which of `sel_treat_inds_shifted` fall
+#'   within the cohort-r block `[first_ind_r, last_ind_r]`. For those
+#'   identified indices, `psi_r` is set to `1 / k_full`, where
+#'   `k_full = last_ind_r - first_ind_r + 1` is the cohort's full
+#'   treatment-block size. This normalization (rather than dividing by the
+#'   *selected* count `k_sel`) is what makes
+#'   `t(psi_r) %*% theta_hat_treat_sel == cohort_tes[r]`, since the
+#'   cohort point estimate `cohort_tes[r] = mean(tes[first_ind_r:last_ind_r])`
+#'   averages over the full block (unselected entries are exact zeros
+#'   post-bridge). If no coefficients in cohort r's block are selected,
+#'   `psi_r` is a zero vector. For ETWFE / `twfeCovs()` callers
+#'   (which pass `sel_treat_inds_shifted = 1:num_treats`, so `k_sel = k_full`),
+#'   this is bit-identical to the previous divide-by-sum normalization.
 #' @keywords internal
 #' @noRd
 getPsiRUnfused <- function(
@@ -541,6 +549,9 @@ getPsiRUnfused <- function(
 	sel_treat_inds_shifted,
 	gram_inv
 ) {
+	k_full <- last_ind_r - first_ind_r + 1
+	stopifnot(k_full >= 1)
+
 	which_inds_ir <- sel_treat_inds_shifted %in% (first_ind_r:last_ind_r)
 
 	psi_r <- rep(0, length(sel_treat_inds_shifted))
@@ -559,11 +570,7 @@ getPsiRUnfused <- function(
 		stopifnot(max(inds_r) <= ncol(gram_inv))
 		stopifnot(min(inds_r) >= 0)
 
-		psi_r[inds_r] <- 1
-
-		stopifnot(sum(psi_r) > 0)
-
-		psi_r <- psi_r / sum(psi_r)
+		psi_r[inds_r] <- 1 / k_full
 	}
 
 	return(psi_r)

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.1",
+  note    = "R package version 1.9.2",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -90,3 +90,6 @@ un
 ΔBIC
 ε
 σ
+counterintuitive
+estimand
+unselected

--- a/tests/testthat/test-betwfe-se-fix.R
+++ b/tests/testthat/test-betwfe-se-fix.R
@@ -1,0 +1,107 @@
+# Tests for the BETWFE partial-selection SE fix.
+#
+# Background: prior to v1.9.2, getPsiRUnfused() normalized psi_r by k_sel
+# (count of *selected* coefficients in cohort r's treatment block) rather
+# than k_full (the full block size). The cohort point estimate
+# cohort_tes[r] = mean(tes[first_ind_r:last_ind_r]) averages over the full
+# block (unselected entries are exact zeros post-bridge), so the variance
+# formula targeted the wrong estimand whenever the bridge solver zeroed
+# out some-but-not-all of a cohort's coefficients. Per-cohort SEs were
+# inflated by factor k_full / k_sel; overall att_se shifted (direction
+# depends on cohort-dispersion structure). See
+# .plans/follow-ups/issue-draft-betwfe-se-partial-selection.md.
+
+test_that("getPsiRUnfused invariant: t(psi_r) %*% theta_sel == cohort_tes[r]", {
+	# Constructed scenario: cohort 1 occupies indices 1..4 (k_full = 4); the
+	# bridge selected positions 1, 2, 5 across all cohorts, so within cohort
+	# 1 only positions 1 and 2 are selected (k_sel = 2). theta_hat_treat_sel
+	# has 3 entries (length of sel_treat_inds_shifted).
+	psi_r <- fetwfe:::getPsiRUnfused(
+		first_ind_r = 1,
+		last_ind_r = 4,
+		sel_treat_inds_shifted = c(1L, 2L, 5L),
+		gram_inv = diag(3)
+	)
+	# Post-fix: psi_r = c(1/4, 1/4, 0).
+	expect_equal(psi_r, c(0.25, 0.25, 0))
+
+	# Invariant: psi_r %*% theta_sel matches cohort_tes[r] for a full
+	# cohort-block tes vector (zeros at unselected positions).
+	theta_sel <- c(1.0, 2.0, 3.0) # the bridge-selected coefficient values
+	# cohort_tes[1] = mean(tes[1:4]) where tes = c(1, 2, 0, 0)
+	# (positions 3-4 unselected → 0).
+	cohort_te_expected <- (1.0 + 2.0 + 0 + 0) / 4
+	expect_equal(as.numeric(psi_r %*% theta_sel), cohort_te_expected)
+})
+
+test_that("getPsiRUnfused is bit-identical to pre-fix on full-selection (ETWFE/twfeCovs path)", {
+	# When sel_treat_inds_shifted = 1:num_treats (the ETWFE / twfeCovs call
+	# shape), every index is "selected", so k_sel = k_full. The post-fix
+	# psi_r[inds_r] <- 1 / k_full equals the pre-fix
+	# psi_r[inds_r] <- 1; psi_r <- psi_r / sum(psi_r) = 1 / k_full.
+	num_treats <- 7L
+	psi_r <- fetwfe:::getPsiRUnfused(
+		first_ind_r = 1,
+		last_ind_r = 4,
+		sel_treat_inds_shifted = seq_len(num_treats),
+		gram_inv = diag(num_treats)
+	)
+	# Cohort 1 occupies indices 1..4 (k_full=4), all selected.
+	expect_equal(psi_r, c(0.25, 0.25, 0.25, 0.25, 0, 0, 0))
+})
+
+test_that("BETWFE SE/SD ratio is ~1 under partial selection (MC)", {
+	skip_on_cran()
+
+	# A DGP where cohort 1 reliably has partial selection: cohort_betas
+	# of c(4, 4, 0, 0) so bridge selects positions 1-2 but zeros 3-4 at
+	# this signal-to-noise level. Two cohorts (R=2), short panel (T=5).
+	# `density = 0.5` controls the sparsity in genCoefs internally; the
+	# `eff_size = 4` and `sig_eps_sq = 1` combination gives a clear SNR.
+	#
+	# Critical: simulateData(coefs_obj) reads coefs_obj$seed and calls
+	# set.seed() internally. Wrapping the loop in set.seed(i) does NOT
+	# vary noise across reps. Must mutate coefs_obj$seed.
+	coefs_template <- genCoefs(
+		R = 2,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 4,
+		seed = 42
+	)
+
+	n_reps <- 30
+	catt_hat_1 <- numeric(n_reps)
+	catt_se_1 <- numeric(n_reps)
+	att_hat <- numeric(n_reps)
+	att_se <- numeric(n_reps)
+
+	for (i in seq_len(n_reps)) {
+		coefs_i <- coefs_template
+		coefs_i$seed <- 8000L + i
+		sim <- simulateData(
+			coefs_i,
+			N = 300,
+			sig_eps_sq = 1,
+			sig_eps_c_sq = 1
+		)
+		res <- betwfeWithSimulatedData(sim)
+		catt_hat_1[i] <- res$catt_df[["Estimated TE"]][1]
+		catt_se_1[i] <- res$catt_df$SE[1]
+		att_hat[i] <- res$att_hat
+		att_se[i] <- res$att_se
+	}
+
+	# Per-cohort SE/SD ratio should be ~1 post-fix (pre-fix it was ~2).
+	# Allow generous slack against MC noise on 30 reps.
+	cohort1_ratio <- mean(catt_se_1, na.rm = TRUE) / sd(catt_hat_1)
+	expect_gt(cohort1_ratio, 0.7)
+	expect_lt(cohort1_ratio, 1.5)
+
+	# Overall att_se/sd ratio is also informative but the direction effect
+	# is more complex (att_var_2 can grow under the fix). Sanity bounds.
+	att_ratio <- mean(att_se, na.rm = TRUE) / sd(att_hat)
+	expect_gt(att_ratio, 0.5)
+	expect_lt(att_ratio, 3.0)
+})


### PR DESCRIPTION
Resolves #52 . `R/ols_calcs.R::getPsiRUnfused()` was normalizing the `psi_r` weight vector by `sum(psi_r) = k_sel` (count of *selected* coefficients in cohort r's treatment block), but the cohort point estimate `cohort_tes[r] = mean(tes[first_ind_r:last_ind_r])` averages over the *full* block `k_full = last_ind_r - first_ind_r + 1` (unselected entries are exact zeros post-bridge). The variance formula `sqrt(sig_eps_sq * t(psi_r) %*% gram_inv %*% psi_r / (N*T))` therefore targeted the wrong estimand whenever the bridge solver zeroed some-but-not-all of a cohort's coefficients. Two-line fix: compute `k_full` inside the function and set `psi_r[inds_r] <- 1 / k_full`. No signature change; both callers (the ETWFE/twfeCovs path and the BETWFE path) are bit-identical pre/post-fix where `k_sel = k_full` (which is always true for ETWFE/twfeCovs since they don't select).

Discovered during the May 2026 internal code review (`.plans/code-review-2026-05-15/01-estimator-cores.md` § Bug 1); MC at N=600, k_full=4 / k_sel=2 confirmed reported SE / empirical SD ≈ 2.05, matching the predicted ratio of 2.0. Issue draft at `.plans/follow-ups/issue-draft-betwfe-se-partial-selection.md`.

**User-visible impact: only BETWFE is affected.** FETWFE uses a different `psi_r` constructor (`getPsiRFused()`) and is unchanged. ETWFE and `twfeCovs()` never partial-select. On BETWFE panels with partial selection, per-cohort `catt_df$SE` shrinks by factor `k_full / k_sel`, but the overall `att_se` direction is counterintuitive — it can *grow*, because the corrected per-cohort CATT vector is more dispersed across cohorts than the pre-fix mean-over-selected-only version, and the `att_var_2` component is a quadratic form in cohort dispersion. NEWS bullet acknowledges both directions. Empirical magnitudes on representative panels are ~2× shifts (in either direction depending on the SE level). Point estimates (`att_hat`, `catt_df$Estimated TE`) are unaffected.

Cluster-robust SE path (`se_type = "cluster"`) also uses `psi_r` weighting, so it shifts on partial-selection BETWFE fits by the same factor.

Tests in new `tests/testthat/test-betwfe-se-fix.R`: (a) deterministic invariant `t(psi_r) %*% theta_sel == cohort_tes[r]` (fails pre-fix at factor `k_full / k_sel`); (b) bit-identical assertion on the ETWFE/twfeCovs call shape; (c) 30-rep MC verifying SE/SD ratio ≈ 1 (pre-fix would be ≈ 2). Test (c) uses the `coefs_obj$seed` mutation pattern since `simulateData()` ignores `set.seed()`.

`devtools::check(args = "--as-cran")` 0/0/0; `spell_check` empty after `counterintuitive`, `estimand`, `unselected` added to WORDLIST; `url_check` clean. 1379/1379 tests pass (1372 baseline + 7 new).
