### PR TITLE
Fix lexicographic cohort sort in `.truncate_catt` and `tidy.<class>` (#53)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.2
+Version: 1.9.3
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,23 @@
 # NEWS
 
+## Version 1.9.3 (2026-05-16)
+
+- Fixed a latent bug in two internal helpers — `.truncate_catt()`
+  (`R/class_helpers.R`) and `.tidy_estimator_output()`
+  (`R/broom_methods.R`) — both of which sorted `catt_df` rows via
+  `order(catt_df$Cohort)`. The `Cohort` column is character, so R's
+  default `order()` sorted lexicographically: `"10"` and `"11"` came
+  before `"2"` and `"3"`. Two visible consequences on panels with
+  ≥ 10 unique cohort adoption times: (a) `tidy.<class>()` row order was
+  alphabetical rather than chronological; (b) `print.<class>()` and
+  `summary.<class>()` (which call `.truncate_catt()` with
+  `max_cohorts`) silently dropped the wrong cohorts — the *earliest*
+  ones, treated as "later" alphabetically. Both helpers now use a
+  composite key `order(suppressWarnings(as.numeric(.)), .)` that
+  sorts numerically with a character tiebreak. Behavior on panels with
+  ≤ 9 cohorts (every existing test fixture) is bit-identical to
+  pre-fix. Resolves GitHub #53.
+
 ## Version 1.9.2 (2026-05-16)
 
 - Fixed a bug in `betwfe()`'s standard-error calculation under partial

--- a/R/broom_methods.R
+++ b/R/broom_methods.R
@@ -54,7 +54,16 @@ NULL
 	att_pvalue <- x$att_p_value
 
 	catt <- x$catt_df
-	catt <- catt[order(catt$Cohort), , drop = FALSE]
+	# Composite sort key: numeric-cohort-time first, character tiebreak.
+	# See R/class_helpers.R::.truncate_catt for the rationale.
+	catt <- catt[
+		order(
+			suppressWarnings(as.numeric(catt$Cohort)),
+			catt$Cohort
+		),
+		,
+		drop = FALSE
+	]
 	cohort_terms <- paste0("Cohort ", catt$Cohort)
 	cohort_estimates <- catt[["Estimated TE"]]
 	cohort_ses <- catt$SE

--- a/R/class_helpers.R
+++ b/R/class_helpers.R
@@ -37,7 +37,15 @@
 
 	idx <- switch(
 		order_by,
-		cohort = order(catt_df$Cohort),
+		# Composite sort key: numeric-cohort-time first, character as
+		# tiebreak. The character fallback only matters if some labels
+		# aren't numerically coercible (hypothetical -- catt_df$Cohort is
+		# always as.character(integer time) given the package's
+		# `is.integer(time_var)` input validation).
+		cohort = order(
+			suppressWarnings(as.numeric(catt_df$Cohort)),
+			catt_df$Cohort
+		),
 		estimate = order(catt_df$`Estimated TE`),
 		abs_estimate = order(abs(catt_df$`Estimated TE`), decreasing = TRUE),
 		pvalue = order(catt_df$P_value),

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.2",
+  note    = "R package version 1.9.3",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -93,3 +93,4 @@ un
 counterintuitive
 estimand
 unselected
+lexicographically

--- a/tests/testthat/test-broom-methods.R
+++ b/tests/testthat/test-broom-methods.R
@@ -74,9 +74,14 @@ test_that("tidy.fetwfe returns broom-schema columns with selected", {
 	expect_equal(nrow(td), res$R + 1L)
 	expect_equal(td$term[1], "ATT")
 	expect_match(td$term[-1], "^Cohort ")
-	# Cohort rows are sorted ascending by cohort label.
+	# Cohort rows are sorted ascending by NUMERIC cohort label. Note
+	# `sort()` on character is lexicographic, which would give the wrong
+	# answer for cohort labels ≥ 10 (see GitHub #53, fixed in v1.9.3 by
+	# the composite numeric-first sort key). Assert numeric ordering
+	# explicitly so this test catches any future regression on panels
+	# with ≥ 10 cohorts.
 	cohort_labels <- sub("^Cohort ", "", td$term[-1])
-	expect_equal(cohort_labels, sort(cohort_labels))
+	expect_equal(as.numeric(cohort_labels), sort(as.numeric(cohort_labels)))
 })
 
 test_that("tidy.etwfe has no selected column (no regularized selection)", {

--- a/tests/testthat/test-lex-cohort-sort.R
+++ b/tests/testthat/test-lex-cohort-sort.R
@@ -1,0 +1,92 @@
+# Tests for the lexicographic-vs-numeric cohort sort fix.
+#
+# Background: prior to v1.9.3, .truncate_catt() (R/class_helpers.R:40)
+# and .tidy_estimator_output() (R/broom_methods.R:57) both used
+# order(catt$Cohort) on a character column. R's default order() on
+# character is lexicographic, so for cohorts ≥ 10 the output came back
+# as "10","11","12","2","3" rather than "2","3","10","11","12". For
+# .truncate_catt(), the worst consequence is that print()/summary() with
+# max_cohorts truncation dropped the *earliest* cohorts as if they were
+# "later" alphabetically. See GitHub issue #53.
+
+# Build a 11-row catt_df with mixed-digit-count cohort labels to exercise
+# the bug. Without the fix, both order() outputs would be lex-sorted.
+.make_catt_df_11 <- function() {
+	data.frame(
+		Cohort = as.character(2:12),
+		`Estimated TE` = seq(0.01, 0.11, length.out = 11),
+		SE = rep(0.005, 11),
+		ConfIntLow = seq(0.0, 0.10, length.out = 11),
+		ConfIntHigh = seq(0.02, 0.12, length.out = 11),
+		P_value = rep(0.05, 11),
+		selected = rep(TRUE, 11),
+		check.names = FALSE,
+		stringsAsFactors = FALSE
+	)
+}
+
+test_that(".truncate_catt sorts cohorts numerically and drops the right cohort on truncation", {
+	df <- .make_catt_df_11()
+
+	# Truncate to 10 — should keep cohorts 2..11 (the earliest 10) and
+	# drop "12". Under the pre-fix lex sort, the kept rows would be
+	# "10","11","12","2","3","4","5","6","7","8" and the dropped cohort
+	# would be "9" (wrong).
+	res <- fetwfe:::.truncate_catt(
+		df,
+		max_cohorts = 10,
+		order_by = "cohort"
+	)
+	expect_equal(res$Cohort, as.character(2:11))
+	expect_true(isTRUE(attr(res, "truncated")))
+	expect_equal(attr(res, "n_discarded"), 1L)
+
+	# Confirm the dropped cohort is "12" (the largest), not "9" (which
+	# would be the pre-fix result).
+	expect_false("12" %in% res$Cohort)
+	expect_true("9" %in% res$Cohort)
+})
+
+test_that(".truncate_catt full-output sort order is numeric (no truncation)", {
+	df <- .make_catt_df_11()
+	res <- fetwfe:::.truncate_catt(
+		df,
+		max_cohorts = 20,
+		order_by = "cohort"
+	)
+	expect_equal(res$Cohort, as.character(2:12))
+	expect_false(isTRUE(attr(res, "truncated")))
+})
+
+test_that("tidy.<class> sorts cohorts numerically when labels include >= 10", {
+	skip_if_not_installed("broom")
+
+	# Build a minimal fetwfe-classed object with a catt_df containing
+	# cohorts >= 10. This bypasses the full estimator pipeline; we only
+	# need .tidy_estimator_output to be exercised.
+	obj <- list(
+		att_hat = 0.05,
+		att_se = 0.01,
+		att_p_value = 0.001,
+		att_selected = TRUE,
+		alpha = 0.05,
+		catt_df = .make_catt_df_11(),
+		N = 100,
+		T = 13,
+		R = 11,
+		d = 2,
+		p = 50
+	)
+	class(obj) <- "fetwfe"
+
+	td <- broom::tidy(obj)
+	cohort_rows <- td[td$term != "ATT", ]
+	cohort_labels <- sub("^Cohort ", "", cohort_rows$term)
+
+	# Numeric sort: "2","3",...,"12".
+	expect_equal(cohort_labels, as.character(2:12))
+
+	# Negative check: confirm this is NOT the lex-sort outcome
+	# ("10","11","12","2","3",...).
+	expect_false(identical(cohort_labels, sort(as.character(2:12))))
+})


### PR DESCRIPTION
Resolves #53. Two internal helpers — `R/class_helpers.R::.truncate_catt()` and `R/broom_methods.R::.tidy_estimator_output()` — sorted `catt_df` rows via `order(catt$Cohort)`. The `Cohort` column is character, so R's default sort was lexicographic: `"10"` and `"11"` came before `"2"` and `"3"`. Two visible consequences on panels with ≥ 10 unique cohort adoption times: `tidy.<class>()` row order was alphabetical rather than chronological; `print.<class>()` and `summary.<class>()` (which call `.truncate_catt()` with `max_cohorts`) silently dropped the *earliest* cohorts when truncating (treated them as "later" alphabetically). Both helpers now use a composite key `order(suppressWarnings(as.numeric(.)), .)` that sorts numerically with a character tiebreak for the (currently hypothetical) non-numeric-label case.

Latent before this fix because all existing tests asserted on cohort row order via `sort()` on a character vector (also lexicographic, so the assertion was trivially true even when the bug fired). The package-level fixtures use `R = 9` with cohorts at times `"2".."10"`, so the bug was actually triggered every test run but unobserved. Tightened the assertion in `tests/testthat/test-broom-methods.R:79` to numeric ordering so future regressions can't hide. New `tests/testthat/test-lex-cohort-sort.R` (3 test_thats, 9 assertions) constructs `catt_df` with `Cohort = as.character(2:12)` and verifies (a) `.truncate_catt` returns rows in numeric order, (b) `max_cohorts = 10` truncation drops `"12"` (largest) rather than `"9"` (which the pre-fix would have dropped), (c) `broom::tidy()` emits cohort terms in numeric order.

Behavior on panels with ≤ 9 cohorts (every existing fixture) is bit-identical to pre-fix (the composite key reduces to numeric sort when all labels coerce cleanly, and on `2..9` numeric sort matches lex sort).

`devtools::check(args = "--as-cran")` 0/0/0; `spell_check` empty after adding `lexicographically` to WORDLIST; `url_check` clean. Test suite: 1388/1388 (1379 baseline + 9 new). No public API change. Patch version bump 1.9.2 → 1.9.3.
