### PR TITLE
Small consistency cleanups bundled from May 15 review (#56, 1.9.5)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.4
+Version: 1.9.5
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,54 @@
 # NEWS
 
+## Version 1.9.5 (2026-05-16)
+
+- Small consistency cleanups surfaced by an internal code review;
+  bundled as one PR. None of these fire under current package usage,
+  but each is wrong on inspection and would bite a future refactor of
+  the surrounding machinery. Resolves GitHub #56.
+- (Item 1) `R/event_study.R::.assemble_event_study_df()` now calls
+  the canonical `.compute_p_values()` helper (`R/utility.R:508`)
+  rather than re-implementing the p-value computation inline. The
+  previous inline form used `is.na(ses) | ses == 0` to mask NA / zero
+  SEs; the canonical helper additionally masks negative SEs. The
+  package's own SE machinery never produces negative SEs (everything
+  comes out of `sqrt(...)`), so on every code path users currently
+  exercise the output is bit-identical. The change is a defensive
+  alignment against future refactors of the SE machinery.
+- (Item 2) `R/fetwfe_core.R::getSecondVarTermDataApp()` line 2022
+  relaxes `stopifnot(length(sel_inds[[r]]) < length(sel_inds[[r-1]]))`
+  to `<=`, matching the OLS analogue at `R/ols_calcs.R:449`. Both
+  assertions guard the same invariant; under the package's standard
+  cohort layout (`first_inds = getFirstInds(R, T)`) block sizes are
+  strictly decreasing and both forms pass. Behavior unchanged on
+  current usage; the relaxation is a no-op except for any future
+  non-standard cohort layout.
+- (Item 3) `R/ols_calcs.R::getSecondVarTermOLS()` line 465 changes
+  the `Sigma_pi_hat`-degeneracy threshold literal from `10e-6`
+  (= 1e-5) to `1e-6`. The previous literal reads naturally as `1e-6`
+  to an R reader who hasn't done the arithmetic; the change aligns
+  the typed literal with that reading. The assertion is
+  `stopifnot(sum(cohort_probs_overall) < 1 - eps)` and the change
+  *loosens* the rejection band from width `1e-5` to width `1e-6`.
+  The relaxed band is still well above floating-point precision, and
+  the guard is unreachable in normal operation: under
+  `allow_no_never_treated = TRUE` (default) the panel is auto-truncated
+  so `sum(cohort_probs_overall) <= (N-1)/N`, with margin `>= 1/N`
+  for `N >= 50`. The symmetric guard
+  (`stopifnot(length(cohort_probs_overall) == R)` and
+  `stopifnot(sum(cohort_probs_overall) < 1 - 1e-6)`) is added to the
+  FETWFE analogue `R/fetwfe_core.R::getSecondVarTermDataApp()`,
+  which previously had no such guard.
+- (Item 4) `R/utility.R::idCohorts()` panel-balance `stop()` message
+  now has balanced parentheses. The previous message read
+  `"Panel does not appear to be balanced (unit X does not have
+  exactly T observations for T = 3"` — the open parenthesis after
+  "balanced" was never closed. Cosmetic.
+- One additional item from the same review — `idCohorts()` collects
+  all malformed units rather than stopping on the first — is deferred
+  to a follow-up because it changes user-visible error wording in a
+  way that deserves its own framing.
+
 ## Version 1.9.4 (2026-05-16)
 
 - Fixed a latent bug in `augment.fetwfe()` / `augment.etwfe()` /

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -498,11 +498,7 @@ event_study <- function(x, alpha = NULL) {
 ) {
 	ci_low <- estimates - z * ses
 	ci_high <- estimates + z * ses
-	p_value <- ifelse(
-		is.na(ses) | ses == 0,
-		NA_real_,
-		2 * stats::pnorm(-abs(estimates / ses))
-	)
+	p_value <- .compute_p_values(estimates, ses)
 	out <- data.frame(
 		event_time = as.integer(event_times),
 		n_cohorts = as.integer(n_cohorts),

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -2019,10 +2019,13 @@ getSecondVarTermDataApp <- function(
 			sel_inds[[r]] <- first_ind_r:last_ind_r
 			if (r > 1) {
 				stopifnot(min(sel_inds[[r]]) > max(sel_inds[[r - 1]]))
-				stopifnot(length(sel_inds[[r]]) < length(sel_inds[[r - 1]]))
+				stopifnot(length(sel_inds[[r]]) <= length(sel_inds[[r - 1]]))
 			}
 		}
 		stopifnot(all.equal(unlist(sel_inds), 1:num_treats))
+
+		stopifnot(length(cohort_probs_overall) == R)
+		stopifnot(sum(cohort_probs_overall) < 1 - 1e-6)
 
 		for (r in 1:R) {
 			## diagonal contribution

--- a/R/ols_calcs.R
+++ b/R/ols_calcs.R
@@ -462,7 +462,7 @@ getSecondVarTermOLS <- function(
 	)
 
 	stopifnot(length(cohort_probs_overall) == R)
-	stopifnot(sum(cohort_probs_overall) < 1 - 10e-6)
+	stopifnot(sum(cohort_probs_overall) < 1 - 1e-6)
 
 	for (r in 1:R) {
 		# All terms in rth column have the same value except the diagonal term

--- a/R/utility.R
+++ b/R/utility.R
@@ -74,11 +74,14 @@ idCohorts <- function(df, time_var, unit_var, treat_var, covs) {
 		df_s <- df[df[, unit_var] == s, ]
 		# Assume this is a balanced panel
 		if (nrow(df_s) != T) {
-			stop(paste(
-				"Panel does not appear to be balanced (unit",
-				s,
-				"does not have exactly T observations for T =",
-				T
+			stop(paste0(
+				paste(
+					"Panel does not appear to be balanced (unit",
+					s,
+					"does not have exactly T observations for T =",
+					T
+				),
+				")"
 			))
 		}
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.4",
+  note    = "R package version 1.9.5",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-soft-bugs-56.R
+++ b/tests/testthat/test-soft-bugs-56.R
@@ -1,0 +1,159 @@
+# Tests for the small-consistency cleanups bundled in issue #56 (v1.9.5).
+#
+# Items covered in this file:
+#   1. R/event_study.R p-value mask: replace inline `is.na(ses) | ses == 0`
+#      mask with a call to the canonical .compute_p_values() (the canonical
+#      mask also handles negative SE — unreachable from package code paths
+#      but a defensive guard against future refactors).
+#   3. R/ols_calcs.R + R/fetwfe_core.R threshold: change `10e-6` (= 1e-5)
+#      to `1e-6` to match the typed-intent literal. The change *loosens*
+#      the rejection band from width 1e-5 to width 1e-6 — both are well
+#      above floating-point roundoff and the guard is unreachable in
+#      normal operation either way. Also adds the symmetric guard to
+#      R/fetwfe_core.R::getSecondVarTermDataApp() (which previously had
+#      no such guard).
+#   4. R/utility.R::idCohorts() panel-balance error message paren balance.
+#
+# Item 2 (R/fetwfe_core.R:2022, `<` -> `<=`) is not tested here. The
+# assertion is structural; under `first_inds = getFirstInds(R, T)` block
+# sizes are strictly decreasing so both forms pass. test-fetwfe-var2-fix.R
+# already exercises the surrounding function on a standard fixture, so
+# any regression in the relaxation would surface there.
+
+# ------------------------------------------------------------------------------
+# Item 1: .assemble_event_study_df() canonical NA mask for zero / negative SE.
+# ------------------------------------------------------------------------------
+
+test_that(".assemble_event_study_df masks zero and negative SEs to NA p-value", {
+	out <- fetwfe:::.assemble_event_study_df(
+		event_times = 0:3,
+		n_cohorts = c(2L, 2L, 1L, 1L),
+		estimates = c(0.5, -0.3, 0.2, 0.1),
+		ses = c(0.2, 0, -0.1, 0.15),
+		z = stats::qnorm(0.975)
+	)
+	# ses > 0: finite p-value.
+	expect_false(is.na(out$p_value[1]))
+	expect_false(is.na(out$p_value[4]))
+	# ses == 0 and ses < 0: NA p-value. The negative-SE row is unreachable
+	# from the package's own SE machinery (`sqrt(...)` is non-negative); the
+	# test exercises the defensive guard.
+	expect_true(is.na(out$p_value[2]))
+	expect_true(is.na(out$p_value[3]))
+})
+
+# ------------------------------------------------------------------------------
+# Item 3 — OLS path: getSecondVarTermOLS() asserts sum(cohort_probs_overall)
+# < 1 - 1e-6 (the post-fix typed-intent literal).
+# ------------------------------------------------------------------------------
+
+.minimal_ols_call <- function(cohort_probs_overall) {
+	# Minimal valid call shape for getSecondVarTermOLS: R=2, num_treats=3,
+	# first_inds = c(1, 3) so sel_inds = list(1:2, 3:3) and unlist = 1:3.
+	fetwfe:::getSecondVarTermOLS(
+		psi_mat = matrix(c(0.5, 0.5, 0, 0, 0, 1), nrow = 3, ncol = 2),
+		tes = c(1, 2, 3),
+		cohort_probs_overall = cohort_probs_overall,
+		first_inds = c(1L, 3L),
+		num_treats = 3L,
+		N = 100L,
+		T = 3L,
+		R = 2L
+	)
+}
+
+test_that("getSecondVarTermOLS fires the post-fix guard for sums in the new rejection band", {
+	# sum = 1 - 5e-7 is inside the new [1 - 1e-6, 1) rejection band.
+	cpo <- c(0.5, 0.5 - 5e-7)
+	stopifnot(abs(sum(cpo) - (1 - 5e-7)) < 1e-12)
+	expect_error(
+		.minimal_ols_call(cpo),
+		"1 - 1e-06",
+		fixed = TRUE
+	)
+})
+
+test_that("getSecondVarTermOLS does NOT fire on sums inside the old (loose) band but outside the new (loose) one", {
+	# sum = 1 - 5e-6 was inside the OLD rejection band (10e-6 = 1e-5);
+	# under the new threshold it is NOT in the [1 - 1e-6, 1) band, so the
+	# guard must NOT fire. This documents the loosening explicitly so a
+	# future reverter sees the looser behavior is intended.
+	cpo <- c(0.5, 0.5 - 5e-6)
+	stopifnot(abs(sum(cpo) - (1 - 5e-6)) < 1e-12)
+	expect_silent(.minimal_ols_call(cpo))
+})
+
+# ------------------------------------------------------------------------------
+# Item 3 — FETWFE path: getSecondVarTermDataApp() gains the same guard.
+# ------------------------------------------------------------------------------
+
+.minimal_fetwfe_call <- function(cohort_probs_overall) {
+	# Minimal valid call shape for getSecondVarTermDataApp: R=2, num_treats=3,
+	# first_inds = c(1, 3) so sel_inds = list(1:2, 3:3) and unlist = 1:3.
+	# d_inv_treat_sel is the inverse fusion-transform matrix (3x3 for these
+	# dimensions); we build it via the package's helper so it has the right
+	# structure.
+	d_inv <- fetwfe:::genInvTwoWayFusionTransformMat(
+		n_vars = 3L,
+		first_inds = c(1L, 3L),
+		R = 2L
+	)
+	fetwfe:::getSecondVarTermDataApp(
+		psi_mat = matrix(0, nrow = 3L, ncol = 2L),
+		sel_treat_inds_shifted = 1:3,
+		tes = c(1, 2, 3),
+		cohort_probs_overall = cohort_probs_overall,
+		first_inds = c(1L, 3L),
+		theta_hat_treat_sel = c(0.1, 0.2, 0.3),
+		num_treats = 3L,
+		N = 100L,
+		T = 3L,
+		R = 2L,
+		fused = TRUE,
+		d_inv_treat_sel = d_inv
+	)
+}
+
+test_that("getSecondVarTermDataApp fires the new symmetric guard for sums in the new rejection band", {
+	cpo <- c(0.5, 0.5 - 5e-7)
+	expect_error(
+		.minimal_fetwfe_call(cpo),
+		"1 - 1e-06",
+		fixed = TRUE
+	)
+})
+
+test_that("getSecondVarTermDataApp does NOT fire for sums outside the new rejection band", {
+	cpo <- c(0.5, 0.5 - 5e-6)
+	expect_silent(.minimal_fetwfe_call(cpo))
+})
+
+# ------------------------------------------------------------------------------
+# Item 4: idCohorts() unbalanced-panel error message has balanced parens.
+# ------------------------------------------------------------------------------
+
+test_that("idCohorts unbalanced-panel error message has balanced parens", {
+	df <- data.frame(
+		unit = c("A", "A", "A", "B", "B"),
+		time = c(1, 2, 3, 1, 2),
+		treat = c(0, 0, 1, 0, 1)
+	)
+	err <- tryCatch(
+		fetwfe:::idCohorts(
+			df = df,
+			time_var = "time",
+			unit_var = "unit",
+			treat_var = "treat",
+			covs = NULL
+		),
+		error = function(e) conditionMessage(e)
+	)
+	# Sanity: the canonical message text is preserved.
+	expect_match(err, "Panel does not appear to be balanced")
+	# Parens balance. Counting via nchar(gsub(non-paren-chars-removed))
+	# avoids gregexpr's "-1 with length 1 on no match" gotcha.
+	expect_equal(
+		nchar(gsub("[^(]", "", err)),
+		nchar(gsub("[^)]", "", err))
+	)
+})


### PR DESCRIPTION
Resolves #56. Five small latent inconsistencies surfaced by the May 15 internal code review. Four ship in this PR; the fifth is deferred to a follow-up issue.

None of these fire under current package usage — they are wrong on inspection and would bite a future refactor of the surrounding machinery.

- **Item 1 — `R/event_study.R::.assemble_event_study_df()`** now calls the canonical `.compute_p_values()` helper (`R/utility.R:508`) rather than re-implementing the p-value mask inline. The canonical mask also catches negative SEs, unreachable from the package's own SE machinery (everything comes out of `sqrt(...)`) but a defensive guard against future refactors.
- **Item 2 — `R/fetwfe_core.R:2022`** relaxes `stopifnot(length(sel_inds[[r]]) < length(sel_inds[[r - 1]]))` from `<` to `<=`, matching the OLS analogue at `R/ols_calcs.R:449`. Both forms pass on the standard cohort layout (`first_inds = getFirstInds(R, T)` produces strictly-decreasing block sizes); the relaxation is a no-op except for future non-standard layouts.
- **Item 3 — `R/ols_calcs.R:465`** changes the `Sigma_pi_hat`-degeneracy threshold literal from `10e-6` (= 1e-5) to `1e-6`. The previous literal reads naturally as `1e-6` to an R reader who hasn't done the arithmetic; the change aligns the typed literal with that reading. **Note:** the assertion is `stopifnot(sum(cohort_probs_overall) < 1 - eps)` and the change *loosens* the rejection band from width `1e-5` to width `1e-6`. The relaxed band is still well above floating-point precision and the guard is unreachable in normal operation (under `allow_no_never_treated = TRUE` the panel is auto-truncated so `sum(cohort_probs_overall) <= (N - 1)/N`). The symmetric guard is also added to the FETWFE analogue `R/fetwfe_core.R::getSecondVarTermDataApp()`, which previously had no such guard.
- **Item 4 — `R/utility.R::idCohorts()`** panel-balance `stop()` message now has balanced parentheses. The previous message left the `(` after "balanced" unclosed. Cosmetic.
- **Deferred:** `idCohorts()` should collect all malformed units rather than stopping on the first. Changes user-visible error wording and deserves its own framing — follow-up issue to be filed.

Point estimates, standard errors, the no-trim augment path, and every user-visible numerical output of the estimators are unchanged.