### PR TITLE
Collect all malformed-unit violations in idCohorts (#64, 1.9.6)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.5
+Version: 1.9.6
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,26 @@
 # NEWS
 
+## Version 1.9.6 (2026-05-16)
+
+- `R/utility.R::idCohorts()` now reports every malformed unit at once
+  rather than stopping on the first. Previously a user with multiple
+  malformed units had to fix one, re-run, hit the next stop, fix
+  again, re-run — one error round-trip per bad unit. After this
+  change, both the balance check (every unit must appear in exactly
+  T periods) and the absorbing-state check (treatment, once 1, must
+  stay 1) collect violations across the entire unit loop and produce
+  a single grouped error message with all offending units listed
+  alphabetically (lexicographically; the unit name column is required
+  to be character). Listings over 20 entries per bucket are truncated with
+  a trailing summary count. The error message wording starts with
+  the canonical prefixes "Panel does not appear to be balanced" and
+  "Treatment does not appear to be an absorbing state" so downstream
+  grep-based consumers still match. The cohort-level stops at
+  `R/utility.R:191-195` ("all units treated in the first period") and
+  `:211-214` are end-of-loop validation, not per-unit, and remain
+  unchanged. Resolves GitHub #64. This was item 5 of #56, deferred
+  from v1.9.5 because it changes user-visible error wording.
+
 ## Version 1.9.5 (2026-05-16)
 
 - Small consistency cleanups surfaced by an internal code review;

--- a/R/utility.R
+++ b/R/utility.R
@@ -70,19 +70,25 @@ idCohorts <- function(df, time_var, unit_var, treat_var, covs) {
 	}
 	names(cohorts) <- times
 
+	# Collect per-unit violations across BOTH balance and absorbing-state
+	# checks, then stop() once at the end with a grouped listing. Previously
+	# each check stop()-ed on the first offending unit, forcing the user
+	# into one error round-trip per malformed unit. See issue #64.
+	balance_violations <- character(0)
+	absorbing_violations <- character(0)
+
 	for (s in units) {
 		df_s <- df[df[, unit_var] == s, ]
-		# Assume this is a balanced panel
+
+		# Balance check (gates the absorbing-state check on the same unit;
+		# we can't trust the per-period treatment vector when observations
+		# are missing).
 		if (nrow(df_s) != T) {
-			stop(paste0(
-				paste(
-					"Panel does not appear to be balanced (unit",
-					s,
-					"does not have exactly T observations for T =",
-					T
-				),
-				")"
-			))
+			balance_violations <- c(
+				balance_violations,
+				paste0("unit ", s, " has ", nrow(df_s), " observations")
+			)
+			next
 		}
 
 		if (any(df_s[, treat_var] == 1)) {
@@ -97,23 +103,65 @@ idCohorts <- function(df, time_var, unit_var, treat_var, covs) {
 				time_var
 			]
 
-			# Make sure treatment is absorbing
+			# Absorbing-state check.
 			# Check from the actual_treat_time onwards in the original df for unit s
 			original_unit_times_from_treatment <- df[
 				(df[, unit_var] == s) & (df[, time_var] >= actual_treat_time),
 				treat_var
 			]
 			if (any(original_unit_times_from_treatment != 1)) {
-				stop(paste(
-					"Treatment does not appear to be an absorbing state for unit",
-					s
-				))
+				absorbing_violations <- c(absorbing_violations, as.character(s))
+				# Do NOT append to cohorts: only units that pass BOTH the
+				# balance and absorbing-state checks contribute to cohort
+				# membership. (load-bearing: without `next`, this unit would
+				# leak into the cohorts list before stop() fires below.)
+				next
 			}
 			cohorts[[as.character(actual_treat_time)]] <- c(
 				cohorts[[as.character(actual_treat_time)]],
 				s
 			)
 		}
+	}
+
+	if (
+		length(balance_violations) > 0 ||
+			length(absorbing_violations) > 0
+	) {
+		# unit_var is required to be character (enforced at the public
+		# entry points; see e.g. R/etwfe_core.R:208), so sort() is
+		# lexicographic. For unit names like "unit10" / "unit2", the
+		# ordering is "unit10" < "unit2" < "unit3"; that's the same
+		# lex order as v1.9.3's cohort-sort caveat (#53).
+		msgs <- character(0)
+		if (length(balance_violations) > 0) {
+			msgs <- c(
+				msgs,
+				paste0(
+					"Panel does not appear to be balanced (expected T = ",
+					T,
+					" observations per unit). Violations:\n  ",
+					paste(
+						.truncate_violations(sort(balance_violations)),
+						collapse = "\n  "
+					)
+				)
+			)
+		}
+		if (length(absorbing_violations) > 0) {
+			msgs <- c(
+				msgs,
+				paste0(
+					"Treatment does not appear to be an absorbing state. ",
+					"Violations (units whose treatment was 1 and later 0):\n  ",
+					paste(
+						.truncate_violations(sort(absorbing_violations)),
+						collapse = "\n  "
+					)
+				)
+			)
+		}
+		stop(paste(msgs, collapse = "\n"))
 	}
 
 	stopifnot(length(unlist(cohorts)) <= N)
@@ -175,6 +223,29 @@ idCohorts <- function(df, time_var, unit_var, treat_var, covs) {
 	stopifnot(length(unlist(cohorts)) <= N)
 
 	return(list(df = df, cohorts = cohorts, units = units, times = times))
+}
+
+#' @title Truncate a violations listing for an error message
+#' @description Used by `idCohorts()` to cap a long list of per-unit
+#'   violations at a small representative sample, so a user with hundreds
+#'   of malformed units does not get a multi-page error message. Returns
+#'   the first `max_show` entries verbatim followed by `"... and N more"`
+#'   when the input exceeds `max_show`; returns the input unchanged
+#'   otherwise.
+#' @param xs Character vector of violation descriptions.
+#' @param max_show Integer scalar; maximum number of entries to show
+#'   verbatim before truncating. Defaults to 20.
+#' @return Character vector of length `min(length(xs), max_show + 1)`.
+#' @keywords internal
+#' @noRd
+.truncate_violations <- function(xs, max_show = 20L) {
+	if (length(xs) <= max_show) {
+		return(xs)
+	}
+	c(
+		xs[seq_len(max_show)],
+		paste0("... and ", length(xs) - max_show, " more")
+	)
 }
 
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.5",
+  note    = "R package version 1.9.6",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-idcohorts-collect-violations.R
+++ b/tests/testthat/test-idcohorts-collect-violations.R
@@ -1,0 +1,186 @@
+# Tests for the idCohorts() multi-unit-violation collection (v1.9.6, #64).
+#
+# Before this PR, idCohorts() stop()-ed on the FIRST offending unit for
+# both the balance check (unit doesn't appear in T periods) and the
+# absorbing-state check (treatment, once 1, must stay 1). A user with
+# multiple malformed units had to fix one, re-run, hit the next stop(),
+# fix again, re-run — one round-trip per bad unit.
+#
+# After this PR, idCohorts() collects violations across the whole loop
+# into two buckets (balance + absorbing-state) and stop()-s once at the
+# end with a grouped, lex-sorted listing, truncated to 20 entries per
+# bucket. The error message wording starts with the canonical prefix
+# ("Panel does not appear to be balanced" / "Treatment does not appear
+# to be an absorbing state") so downstream grep-based consumers still
+# match; the post-prefix content is the new listing.
+
+# ------------------------------------------------------------------------------
+# Test helpers
+# ------------------------------------------------------------------------------
+
+# Build a balanced T=3 panel with `n_good` well-behaved units, then mutate
+# selected units to introduce balance / absorbing-state violations. Returns
+# a data.frame with columns (unit, time, treat).
+.make_panel <- function(n_good = 3L) {
+	good_units <- sprintf("good%02d", seq_len(n_good))
+	data.frame(
+		unit = rep(good_units, each = 3L),
+		time = rep(c(1L, 2L, 3L), times = n_good),
+		treat = rep(c(0L, 0L, 0L), times = n_good),
+		stringsAsFactors = FALSE
+	)
+}
+
+# Capture conditionMessage from a stop() inside idCohorts.
+.catch_idcohorts <- function(df) {
+	tryCatch(
+		fetwfe:::idCohorts(
+			df = df,
+			time_var = "time",
+			unit_var = "unit",
+			treat_var = "treat",
+			covs = NULL
+		),
+		error = function(e) conditionMessage(e)
+	)
+}
+
+# ------------------------------------------------------------------------------
+# .truncate_violations() direct unit test
+# ------------------------------------------------------------------------------
+
+test_that(".truncate_violations returns xs unchanged when below max_show", {
+	xs <- letters[1:5]
+	expect_identical(fetwfe:::.truncate_violations(xs, max_show = 20L), xs)
+})
+
+test_that(".truncate_violations truncates and appends '... and N more' when above max_show", {
+	xs <- as.character(1:25)
+	out <- fetwfe:::.truncate_violations(xs, max_show = 20L)
+	expect_equal(length(out), 21L)
+	expect_equal(out[1:20], as.character(1:20))
+	expect_equal(out[21], "... and 5 more")
+})
+
+test_that(".truncate_violations boundary: length equal to max_show returns unchanged", {
+	xs <- letters[1:20]
+	expect_identical(fetwfe:::.truncate_violations(xs, max_show = 20L), xs)
+})
+
+# ------------------------------------------------------------------------------
+# Balance violations: single unit (sanity / wording-compat with v1.9.5).
+# ------------------------------------------------------------------------------
+
+test_that("idCohorts: single balance violation produces canonical-prefix message", {
+	df <- .make_panel(n_good = 2L)
+	# Drop one row of good01 → only 2 observations.
+	df <- df[!(df$unit == "good01" & df$time == 3L), ]
+	err <- .catch_idcohorts(df)
+	expect_match(err, "Panel does not appear to be balanced")
+	expect_match(err, "good01 has 2 observations", fixed = TRUE)
+})
+
+# ------------------------------------------------------------------------------
+# Balance violations: multiple units — error message names ALL of them.
+# ------------------------------------------------------------------------------
+
+test_that("idCohorts: 3 balance violations reported together (lex-ordered)", {
+	# Use lex-visible names ("unit10" < "unit2") to make the sort order
+	# observable; mirrors the v1.9.3 lex-cohort-sort caveat (#53).
+	df <- rbind(
+		data.frame(
+			unit = rep(c("unit2", "unit3", "unit10"), each = 3L),
+			time = rep(c(1L, 2L, 3L), times = 3L),
+			treat = 0L
+		),
+		data.frame(
+			unit = "good01",
+			time = 1L:3L,
+			treat = 0L
+		),
+		stringsAsFactors = FALSE
+	)
+	# Truncate one row from each of unit2, unit3, unit10.
+	df <- df[!(df$unit == "unit2" & df$time == 3L), ]
+	df <- df[!(df$unit == "unit3" & df$time == 3L), ]
+	df <- df[!(df$unit == "unit10" & df$time == 3L), ]
+	err <- .catch_idcohorts(df)
+	# All three names appear.
+	expect_match(err, "unit2 has 2 observations", fixed = TRUE)
+	expect_match(err, "unit3 has 2 observations", fixed = TRUE)
+	expect_match(err, "unit10 has 2 observations", fixed = TRUE)
+	# Ordering is lexicographic (unit10 < unit2 < unit3, the v1.9.3 trap).
+	pos_10 <- regexpr("unit10 has", err, fixed = TRUE)
+	pos_2 <- regexpr("unit2 has", err, fixed = TRUE)
+	pos_3 <- regexpr("unit3 has", err, fixed = TRUE)
+	expect_true(pos_10 < pos_2)
+	expect_true(pos_2 < pos_3)
+})
+
+# ------------------------------------------------------------------------------
+# Absorbing-state violations: multiple units.
+# ------------------------------------------------------------------------------
+
+test_that("idCohorts: multiple absorbing-state violations reported together", {
+	# Build a balanced panel where two units have treatment that turns on
+	# at time=2 and then off at time=3 (non-absorbing).
+	df <- data.frame(
+		unit = rep(c("absA", "absB", "good01"), each = 3L),
+		time = rep(c(1L, 2L, 3L), times = 3L),
+		treat = c(0L, 1L, 0L, 0L, 1L, 0L, 0L, 0L, 0L),
+		stringsAsFactors = FALSE
+	)
+	err <- .catch_idcohorts(df)
+	expect_match(err, "Treatment does not appear to be an absorbing state")
+	expect_match(err, "absA")
+	expect_match(err, "absB")
+	expect_false(grepl("good01", err, fixed = TRUE))
+})
+
+# ------------------------------------------------------------------------------
+# Both kinds of violations simultaneously: error message has both sections.
+# ------------------------------------------------------------------------------
+
+test_that("idCohorts: balance + absorbing violations both surfaced in one message", {
+	df <- data.frame(
+		unit = rep(c("badA", "badB", "good01"), each = 3L),
+		time = rep(c(1L, 2L, 3L), times = 3L),
+		treat = c(0L, 0L, 0L, 0L, 1L, 0L, 0L, 0L, 0L),
+		stringsAsFactors = FALSE
+	)
+	# Drop one row from badA → balance violation.
+	df <- df[!(df$unit == "badA" & df$time == 3L), ]
+	err <- .catch_idcohorts(df)
+	expect_match(err, "Panel does not appear to be balanced")
+	expect_match(err, "badA has 2 observations", fixed = TRUE)
+	expect_match(err, "Treatment does not appear to be an absorbing state")
+	expect_match(err, "badB")
+})
+
+# ------------------------------------------------------------------------------
+# Truncation: 25 balance violations → first 20 + "... and 5 more".
+# ------------------------------------------------------------------------------
+
+test_that("idCohorts: more than 20 balance violations are truncated to 20 + summary", {
+	# Build 26 units, all balanced (3 rows each), then drop the third row
+	# from 25 of them so they fail balance.
+	n_bad <- 25L
+	unit_names <- sprintf("u%03d", seq_len(n_bad + 1L))
+	df <- data.frame(
+		unit = rep(unit_names, each = 3L),
+		time = rep(c(1L, 2L, 3L), times = length(unit_names)),
+		treat = 0L,
+		stringsAsFactors = FALSE
+	)
+	bad_units <- unit_names[seq_len(n_bad)]
+	df <- df[!(df$unit %in% bad_units & df$time == 3L), ]
+	err <- .catch_idcohorts(df)
+	expect_match(err, "Panel does not appear to be balanced")
+	# Summary tail.
+	expect_match(err, "... and 5 more", fixed = TRUE)
+	# Spot-check: the first lex-sorted bad unit is "u001"; the 20th is
+	# "u020"; "u025" should NOT appear (it's in the truncated tail).
+	expect_match(err, "u001 has 2 observations", fixed = TRUE)
+	expect_match(err, "u020 has 2 observations", fixed = TRUE)
+	expect_false(grepl("u025 has 2 observations", err, fixed = TRUE))
+})


### PR DESCRIPTION
Resolves #64 . `R/utility.R::idCohorts()` validates each unit in the input panel for two per-unit invariants:
- **Balance:** every unit must appear in exactly `T` time periods.
- **Absorbing-state:** treatment, once 1, must stay 1.

Both previously stopped on the first offending unit, forcing users with multiple malformed units into one error round-trip per bad unit.

This PR refactors the unit loop to collect violations across the whole loop into two buckets (balance + absorbing-state), then `stop()`s once at the end with a grouped, lexicographically-sorted listing, truncated to 20 entries per bucket with a trailing `"... and N more"` summary. The error message prefixes (`"Panel does not appear to be balanced"` and `"Treatment does not appear to be an absorbing state"`) are preserved so downstream grep-based consumers still match; the post-prefix content is the new listing.

The two per-unit checks are restructured together because they share the same loop and the same UX value. The cohort-level stops at `R/utility.R:191-195` and `:211-214` are end-of-loop validation, not per-unit, and remain unchanged.

This was item 5 of #56, deferred from v1.9.5 because it changes user-visible error wording.