### PR TITLE
Drop vestigial params, dead code, and a typo rename (#59, 1.9.7)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.6
+Version: 1.9.7
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,32 @@
 # NEWS
 
+## Version 1.9.7 (2026-05-16)
+
+- Internal cleanup pass: dropped four unused parameters from internal
+  helpers, removed one block of redundant self-validating assertions,
+  and corrected a typo in an internal helper name. No public API
+  changes; no behavior changes. Resolves GitHub #59.
+- `idCohorts()` (`R/utility.R`) no longer accepts the unused `covs`
+  argument. Two internal call sites updated.
+- `genTreatVarsSim()` (`R/gen_funcs.R`) no longer accepts the unused
+  `d` argument. One internal call site updated.
+- `getPsiRUnfused()` (`R/ols_calcs.R`) no longer accepts the unused
+  `gram_inv` argument. Three internal assertions on `gram_inv`
+  dimensions were redundant with conditions already enforced
+  upstream and have been removed. Two source call sites and two
+  test call sites updated.
+- `checkFetwfeInputs()` (`R/fetwfe_core.R`) no longer accepts the
+  unused `nlambda` argument. Three call sites updated. `nlambda`
+  itself remains unchanged on the public entry points (`fetwfe()`,
+  `betwfe()`, `twfeCovs()`) where it is forwarded to `gBridge`.
+- `getFirstInds()` (`R/utility.R`) no longer runs a block of
+  assertions that re-derived its own closed-form formula and
+  compared the result to itself. The first three assertions on the
+  cardinality of `f_inds` are preserved.
+- Renamed the internal helper `prep_for_etwfe_regresion` to
+  `prep_for_etwfe_regression` (typo correction). The function is
+  `@noRd`, not exported, so the rename is internal.
+
 ## Version 1.9.6 (2026-05-16)
 
 - `R/utility.R::idCohorts()` now reports every malformed unit at once

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -286,7 +286,6 @@ betwfe <- function(
 		sig_eps_c_sq = sig_eps_c_sq,
 		lambda.max = lambda.max,
 		lambda.min = lambda.min,
-		nlambda = nlambda,
 		q = q,
 		verbose = verbose,
 		alpha = alpha,
@@ -807,7 +806,7 @@ betwfe_core <- function(
 	stopifnot(q > 0)
 	stopifnot(q <= 2)
 
-	res <- prep_for_etwfe_regresion(
+	res <- prep_for_etwfe_regression(
 		verbose = verbose,
 		sig_eps_sq = sig_eps_sq,
 		sig_eps_c_sq = sig_eps_c_sq,

--- a/R/broom_methods.R
+++ b/R/broom_methods.R
@@ -230,8 +230,7 @@ NULL
 			df = data,
 			time_var = x$time_var,
 			unit_var = x$unit_var,
-			treat_var = x$treatment,
-			covs = x$covs
+			treat_var = x$treatment
 		)
 		# idCohorts() filters first-period-treated units at the UNIT level
 		# (R/utility.R:126) and drops the treat_var column. Augment needs the

--- a/R/core_funcs.R
+++ b/R/core_funcs.R
@@ -85,7 +85,7 @@
 #'   }
 #' @keywords internal
 #' @noRd
-prep_for_etwfe_regresion <- function(
+prep_for_etwfe_regression <- function(
 	verbose,
 	sig_eps_sq,
 	sig_eps_c_sq,

--- a/R/etwfe_core.R
+++ b/R/etwfe_core.R
@@ -442,7 +442,7 @@ etwfe_core <- function(
 
 	stopifnot(length(c_names) == R)
 
-	res <- prep_for_etwfe_regresion(
+	res <- prep_for_etwfe_regression(
 		verbose = verbose,
 		sig_eps_sq = sig_eps_sq,
 		sig_eps_c_sq = sig_eps_c_sq,
@@ -1026,8 +1026,7 @@ prepXints <- function(
 		df = data,
 		time_var = time_var,
 		unit_var = unit_var,
-		treat_var = treatment,
-		covs = covs
+		treat_var = treatment
 	)
 
 	data <- ret$df

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -246,7 +246,6 @@ fetwfe <- function(
 		sig_eps_c_sq = sig_eps_c_sq,
 		lambda.max = lambda.max,
 		lambda.min = lambda.min,
-		nlambda = nlambda,
 		q = q,
 		verbose = verbose,
 		alpha = alpha,

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -224,7 +224,6 @@ getTeResults2 <- function(
 #'   Default `NA`.
 #' @param lambda.max Numeric or NA; maximum lambda for `gBridge`. Default `NA`.
 #' @param lambda.min Numeric or NA; minimum lambda for `gBridge`. Default `NA`.
-#' @param nlambda Integer; number of lambdas for `gBridge`. Default `100`.
 #' @param q Numeric; Lq penalty exponent for `gBridge`. Default `0.5`.
 #' @param verbose Logical; if TRUE, print progress. Default `FALSE`.
 #' @param alpha Numeric; significance level for confidence intervals. Default `0.05`.
@@ -260,7 +259,6 @@ checkFetwfeInputs <- function(
 	sig_eps_c_sq = NA,
 	lambda.max = NA,
 	lambda.min = NA,
-	nlambda = 100,
 	q = 0.5,
 	verbose = FALSE,
 	alpha = 0.05,
@@ -765,7 +763,7 @@ fetwfe_core <- function(
 		first_inds = first_inds
 	)
 
-	res <- prep_for_etwfe_regresion(
+	res <- prep_for_etwfe_regression(
 		verbose = verbose,
 		sig_eps_sq = sig_eps_sq,
 		sig_eps_c_sq = sig_eps_c_sq,
@@ -2487,8 +2485,7 @@ getCohortATTsFinal <- function(
 				psi_r <- getPsiRUnfused(
 					first_ind_r,
 					last_ind_r,
-					sel_treat_inds_shifted,
-					gram_inv
+					sel_treat_inds_shifted
 				)
 			}
 

--- a/R/gen_funcs.R
+++ b/R/gen_funcs.R
@@ -616,8 +616,7 @@ simulateDataCore <- function(
 		assignments,
 		cohort_inds,
 		N_UNTREATED = assignments[1],
-		first_inds_test = first_inds_test,
-		d = d
+		first_inds_test = first_inds_test
 	)
 	treat_mat_long <- res_treat$treat_mat_long
 	first_inds <- res_treat$first_inds
@@ -734,7 +733,6 @@ simulateDataCore <- function(
 		sig_eps_c_sq = sig_eps_c_sq,
 		lambda.max = NA,
 		lambda.min = NA,
-		nlambda = 100,
 		q = 0.5,
 		verbose = FALSE,
 		alpha = 0.05,
@@ -1267,7 +1265,6 @@ genAssignments <- function(N, R, guarantee_rank_condition = FALSE, d = NA) {
 #' @param N_UNTREATED Integer. Number of never-treated units.
 #' @param first_inds_test Integer vector. Pre-calculated indices of the first treatment
 #'   effect for each cohort (used for assertion).
-#' @param d Integer. Number of covariates (used for assertions within context, not directly in logic here).
 #'
 #' @return A list containing:
 #'   \item{treat_mat_long}{An NT x n_treats matrix of treatment dummy variables.
@@ -1285,8 +1282,7 @@ genTreatVarsSim <- function(
 	assignments,
 	cohort_inds,
 	N_UNTREATED,
-	first_inds_test,
-	d
+	first_inds_test
 ) {
 	# Treatment indicators
 	treat_mat_long <- matrix(0, N * T, n_treats)

--- a/R/ols_calcs.R
+++ b/R/ols_calcs.R
@@ -142,8 +142,7 @@ getCohortATTsFinalOLS <- function(
 		psi_r <- getPsiRUnfused(
 			first_ind_r,
 			last_ind_r,
-			sel_treat_inds_shifted = 1:num_treats,
-			gram_inv = gram_inv
+			sel_treat_inds_shifted = 1:num_treats
 		)
 
 		stopifnot(length(psi_r) == num_treats)
@@ -521,8 +520,6 @@ getSecondVarTermOLS <- function(
 #'   cohort `r` within the `num_treats` block.
 #' @param sel_treat_inds_shifted Integer vector; indices of all selected
 #'   treatment effects within the `num_treats` block, shifted to start from 1.
-#' @param gram_inv Numeric matrix; the inverse of the Gram matrix for the
-#'   selected treatment effect features.
 #' @return A numeric vector `psi_r` of length
 #'   `length(sel_treat_inds_shifted)`. Positions corresponding to selected
 #'   treatment effects in cohort `r` carry `1 / k_full`; other positions are
@@ -546,8 +543,7 @@ getSecondVarTermOLS <- function(
 getPsiRUnfused <- function(
 	first_ind_r,
 	last_ind_r,
-	sel_treat_inds_shifted,
-	gram_inv
+	sel_treat_inds_shifted
 ) {
 	k_full <- last_ind_r - first_ind_r + 1
 	stopifnot(k_full >= 1)
@@ -565,10 +561,6 @@ getPsiRUnfused <- function(
 		stopifnot(length(inds_r) == length(unique(inds_r)))
 		stopifnot(length(inds_r) <= length(sel_treat_inds_shifted))
 		stopifnot(all(inds_r %in% 1:length(sel_treat_inds_shifted)))
-
-		stopifnot(max(inds_r) <= nrow(gram_inv))
-		stopifnot(max(inds_r) <= ncol(gram_inv))
-		stopifnot(min(inds_r) >= 0)
 
 		psi_r[inds_r] <- 1 / k_full
 	}

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -616,7 +616,7 @@ twfeCovs_core <- function(
 
 	stopifnot(length(c_names) == R)
 
-	res <- prep_for_etwfe_regresion(
+	res <- prep_for_etwfe_regression(
 		verbose = verbose,
 		sig_eps_sq = sig_eps_sq,
 		sig_eps_c_sq = sig_eps_c_sq,

--- a/R/utility.R
+++ b/R/utility.R
@@ -25,7 +25,6 @@
 #' @param time_var Character string; name of the time variable column.
 #' @param unit_var Character string; name of the unit identifier column.
 #' @param treat_var Character string; name of the treatment indicator column.
-#' @param covs Character vector; names of covariate columns (used for subsetting `df`).
 #'
 #' @details
 #' The function iterates through each unit to determine its cohort assignment based
@@ -52,7 +51,7 @@
 #'     present in the original data.}
 #' @keywords internal
 #' @noRd
-idCohorts <- function(df, time_var, unit_var, treat_var, covs) {
+idCohorts <- function(df, time_var, unit_var, treat_var) {
 	stopifnot(time_var %in% colnames(df))
 	stopifnot(unit_var %in% colnames(df))
 	stopifnot(treat_var %in% colnames(df))
@@ -430,32 +429,7 @@ getP <- function(R, T, d, num_treats) {
 #' The formula for the starting index of the `r`-th cohort's treatment effects
 #' (1-indexed `r` from 1 to `R`):
 #' `f_inds[r] = 1 + sum_{k=1}^{r-1} (T - k) = 1 + (r-1)T - (r-1)r/2`.
-#'
-#' Gemini check:
-#' The paper's formula `1 + (r - 1)*(2*T - r)/2` seems to be for a slightly
-#' different definition of `num_treats` or indexing. This function should align
-#' with how `treat_var_mat` is constructed in `addDummies` and `num_treats`
-#' is calculated there.
-#' Let's re-evaluate the formula based on typical DiD setups:
-#' Cohort 1 (starts at time 2) has T-1 effects.
-#' Cohort 2 (starts at time 3) has T-2 effects.
-#' ...
-#' Cohort R (starts at time R+1) has T-R effects.
-#' `first_inds[1] = 1`
-#' `first_inds[2] = (T-1) + 1`
-#' `first_inds[3] = (T-1) + (T-2) + 1`
-#' So, `first_inds[r] = 1 + sum_{j=1}^{r-1} (T-j)`.
-#'
-#' The current code uses: `f_inds[r] <- 1 + (r - 1)*(2*T - r)/2`.
-#' Let's test this formula:
-#' r=1: 1
-#' r=2: 1 + 1*(2T-2)/2 = 1 + T - 1 = T
-#' r=3: 1 + 2*(2T-3)/2 = 1 + 2T - 3 = 2T - 2
-#' This implies the number of effects for cohort 1 is T-1 (indices 1 to T-1).
-#' Number of effects for cohort 2 is (2T-2) - T = T-2.
-#' This seems to match the sequence T-1, T-2, ..., T-R.
-#' Total number of treats (`num_treats`) from `getNumTreats(R,T)` is `T*R - R*(R+1)/2`.
-#' This is `sum_{j=1 to R} (T-j)`. This is consistent.
+#' Equivalently, `1 + (r - 1)*(2*T - r)/2` (algebraic restatement).
 #'
 #' @return An integer vector of length `R`, where `f_inds[r]` is the 1-based
 #'   starting index of the `r`-th cohort's treatment effects in the combined block.
@@ -488,39 +462,6 @@ getFirstInds <- function(R, T) {
 	# Last cohort has T - R treatment effects to estimate. So last first_ind
 	# should be at position num_treats - (T - R) + 1 = num_treats - T + R + 1.
 	stopifnot(f_inds[R] == n_treats - T + R + 1)
-
-	# Additional checks from Gemini below
-
-	stopifnot(all(f_inds <= n_treats) || R == 0)
-	if (R > 0) {
-		stopifnot(f_inds[1] == 1)
-	}
-
-	# Last first_ind: f_inds[R] = 1 + sum_{j=1}^{R-1} (T-j)
-	# Total effects = sum_{j=1}^{R} (T-j) = n_treats
-	# Last block of effects for cohort R has T-R effects.
-	# So f_inds[R] should be n_treats - (T-R) + 1.
-	if (R > 0) {
-		stopifnot(f_inds[R] == n_treats - (T - R) + 1)
-	}
-
-	# The original formula was: `1 + (r - 1)*(2*T - r)/2`
-	# Let's re-check the paper's formula logic, it implies number of effects for cohort `k` (1-indexed) is `T-k`.
-	# sum_{j=1}^{r-1} (T-j) = (r-1)T - (r-1)r/2. So f_inds[r] = 1 + (r-1)T - r(r-1)/2.
-	# (r-1)*(2T-r)/2 = (r-1)T - r(r-1)/2. Yes, they are the same.
-
-	# Using the paper's original loop for safety, assuming it's correct with getNumTreats
-	f_inds_paper <- integer(R)
-	if (R > 0) {
-		for (r_val in 1:R) {
-			# r_val is 1-indexed cohort number
-			f_inds_paper[r_val] <- 1 + (r_val - 1) * (2 * T - r_val) / 2 # This is not sum of T-k, but related to cumulative sum for triangular numbers.
-			# This formula is sum_{k=0}^{r-2} (T-1-k) if T-1 is max effects
-			# Or sum_{j=0}^{r-1-1} ( (T-1) - j )
-			# Let's use the direct sum formulation which is clearer.
-		}
-		stopifnot(f_inds == f_inds_paper) # Verify my derivation matches paper's formula
-	}
 
 	return(f_inds)
 }

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.6",
+  note    = "R package version 1.9.7",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-betwfe-se-fix.R
+++ b/tests/testthat/test-betwfe-se-fix.R
@@ -19,8 +19,7 @@ test_that("getPsiRUnfused invariant: t(psi_r) %*% theta_sel == cohort_tes[r]", {
 	psi_r <- fetwfe:::getPsiRUnfused(
 		first_ind_r = 1,
 		last_ind_r = 4,
-		sel_treat_inds_shifted = c(1L, 2L, 5L),
-		gram_inv = diag(3)
+		sel_treat_inds_shifted = c(1L, 2L, 5L)
 	)
 	# Post-fix: psi_r = c(1/4, 1/4, 0).
 	expect_equal(psi_r, c(0.25, 0.25, 0))
@@ -43,8 +42,7 @@ test_that("getPsiRUnfused is bit-identical to pre-fix on full-selection (ETWFE/t
 	psi_r <- fetwfe:::getPsiRUnfused(
 		first_ind_r = 1,
 		last_ind_r = 4,
-		sel_treat_inds_shifted = seq_len(num_treats),
-		gram_inv = diag(num_treats)
+		sel_treat_inds_shifted = seq_len(num_treats)
 	)
 	# Cohort 1 occupies indices 1..4 (k_full=4), all selected.
 	expect_equal(psi_r, c(0.25, 0.25, 0.25, 0.25, 0, 0, 0))

--- a/tests/testthat/test-idcohorts-collect-violations.R
+++ b/tests/testthat/test-idcohorts-collect-violations.R
@@ -38,8 +38,7 @@
 			df = df,
 			time_var = "time",
 			unit_var = "unit",
-			treat_var = "treat",
-			covs = NULL
+			treat_var = "treat"
 		),
 		error = function(e) conditionMessage(e)
 	)

--- a/tests/testthat/test-soft-bugs-56.R
+++ b/tests/testthat/test-soft-bugs-56.R
@@ -143,8 +143,7 @@ test_that("idCohorts unbalanced-panel error message has balanced parens", {
 			df = df,
 			time_var = "time",
 			unit_var = "unit",
-			treat_var = "treat",
-			covs = NULL
+			treat_var = "treat"
 		),
 		error = function(e) conditionMessage(e)
 	)


### PR DESCRIPTION
Resolves #59 . A code-review pass turned up several internal function parameters that appear in signatures but are never used, a block of self-validating assertions that re-derived its own formula and compared the result to itself, and a typo in an internal helper's name. None of these affect behavior; each is wrong on inspection and would mislead a future reader or trip up a refactor. Bundled as one low-risk cleanup PR. Resolves #59.

**Six items shipped:**

- **`idCohorts(..., covs)` param dropped** from `R/utility.R:55`. The body never references `covs`. Updated 2 source call sites (`R/etwfe_core.R`, `R/broom_methods.R`) and 2 test call sites.
- **`genTreatVarsSim(..., d)` param dropped** from `R/gen_funcs.R`. The body never references `d` (the docstring even admits this). Updated 1 call site.
- **`getPsiRUnfused(..., gram_inv)` param dropped** from `R/ols_calcs.R`. After the v1.9.2 BETWFE SE fix, `gram_inv` was used only by three dimension `stopifnot()`s; those checks were redundant with the upstream condition already asserted at line 567 of the function. Both the param and the three stopifnots are removed. Updated 2 source call sites + 2 test call sites.
- **`checkFetwfeInputs(..., nlambda)` param dropped** from `R/fetwfe_core.R`. The function validates `lambda.max`, `lambda.min`, `q`, and `add_ridge`; `nlambda` flowed through the signature but was never inspected. `nlambda` IS load-bearing downstream, but those flows go through `fetwfe / betwfe / twfeCovs` to `gBridge` directly, not through `checkFetwfeInputs`'s return value. Updated 3 call sites.
- **`getFirstInds()`'s "Gemini check" block** at `R/utility.R:492-523` plus its 25-line embedded docstring at lines 434-458 removed. The block re-derived the same closed-form formula and asserted equality with itself. The 3 cardinality `stopifnot`s at lines 486-490 (which check a real invariant) are preserved.
- **Typo rename: `prep_for_etwfe_regresion` → `prep_for_etwfe_regression`.** Internal helper (`@noRd`), so the rename is local. Updated definition in `R/core_funcs.R` plus 4 call sites.

**Two items from the original issue body are skipped** because the code evolved past their references:
- `genTreatVarsRealData::interaction(...)` — no longer exists in `R/gen_funcs.R`.
- `estOmegaSqrtInv()` in-place demeaning — removed entirely by the v1.9.1 REML rewrite.