### PR TITLE
Documentation sweep: stale @return blocks, missing @examples (#55, 1.9.8)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.7
+Version: 1.9.8
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,32 @@
 # NEWS
 
+## Version 1.9.8 (2026-05-16)
+
+- Documentation sweep: refreshed `@return` blocks on `etwfe()`,
+  `betwfe()`, `twfeCovs()`, and their `*WithSimulatedData()` wrappers
+  to match current slot inventories (slots added since v1.5.5 /
+  v1.7.0 / v1.9.0 were missing from the docs). Also added the
+  `theta_hat` sub-slot to the `internal` listing for `fetwfe()` and
+  `fetwfeWithSimulatedData()`. Added `@examples` blocks to `etwfe()`
+  and `twfeCovs()` (the other public estimator entry points already
+  had them). Removed copy-paste references to a bridge-penalty `q`
+  parameter from `twfeCovs.R` and `etwfe_core.R` docs (neither
+  function takes a `q` argument; both are pure OLS). Removed a
+  self-referential `@inheritParams getTeResults2` line from
+  `getTeResults2`'s own documentation block. Cleaned up `etwfe_core()` and
+  `twfeCovs_core()` `@return` blocks, which previously listed
+  bridge-only slots (`theta_hat`, `lambda.*`) those functions never
+  return. Updated a stale mock value in `test-class-helpers.R`
+  (`se_type = "standard"` → `"default"` to mirror the live
+  `match.arg()` choice). Resolves GitHub #55.
+- `attgtToFetwfeDf()` and `etwfeToFetwfeDf()` gain a `verbose = FALSE`
+  argument; the previously-unconditional "Dropped N unit-period(s)
+  treated in the first period" message is now gated on `verbose`.
+  Default-silenced to match the project convention that
+  non-interactive code paths should not emit console output without
+  opt-in. Users who want the message back can call with
+  `verbose = TRUE`.
+
 ## Version 1.9.7 (2026-05-16)
 
 - Internal cleanup pass: dropped four unused parameters from internal

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -190,6 +190,16 @@
 #' a user-supplied panel to the fitted design.}
 #' \item{covs}{Character vector; the original `covs` argument (pre-factor-
 #' expansion). Consumed by `augment.betwfe()`.}
+#' \item{alpha}{The alpha level used for confidence intervals.}
+#' \item{calc_ses}{Logical indicating whether standard errors were calculated.}
+#' \item{cohort_probs_overall}{A vector of the estimated cohort probabilities
+#' on the overall sample (treated and untreated), used in computing the
+#' variance of the overall ATT.}
+#' \item{indep_counts_used}{Logical scalar; `TRUE` if a valid `indep_counts`
+#' argument was provided and used for asymptotically-exact ATT inference,
+#' `FALSE` otherwise.}
+#' \item{se_type}{Character scalar; the `se_type` argument the user passed
+#' (`"default"` or `"cluster"`).}
 #' @author Gregory Faletto
 #' @references
 #' Faletto, G (2025). Fused Extended Two-Way Fixed Effects for
@@ -560,6 +570,25 @@ betwfe <- function(
 #' have been removed because they contained missing values or all contained the
 #' same value for every unit).} \item{p}{The final number of columns in the full
 #' set of covariates used to estimate the model.}
+#' \item{alpha}{The alpha level used for confidence intervals.}
+#' \item{calc_ses}{Logical indicating whether standard errors were calculated.}
+#' \item{cohort_probs_overall}{A vector of the estimated cohort probabilities
+#' on the overall sample (treated and untreated), used in computing the
+#' variance of the overall ATT.}
+#' \item{indep_counts_used}{Logical scalar; `TRUE` if a valid `indep_counts`
+#' argument was provided and used for asymptotically-exact ATT inference,
+#' `FALSE` otherwise.}
+#' \item{se_type}{Character scalar; the `se_type` argument the user passed
+#' (`"default"` or `"cluster"`).}
+#' \item{y_mean}{Numeric scalar; mean of the original (pre-centering) response.
+#' Stored so downstream methods (`augment()`, `predict()`) can return fitted
+#' values on the original-response scale.}
+#' \item{response_col_name}{Character scalar; the response column name in
+#' the original `pdata`. Consumed by `augment.betwfe()`.}
+#' \item{time_var, unit_var, treatment}{Character scalars; the corresponding
+#' arguments the user passed.}
+#' \item{covs}{Character vector; the original `covs` argument (pre-factor-
+#' expansion).}
 #'
 #' @examples
 #' \dontrun{

--- a/R/convert_dfs.R
+++ b/R/convert_dfs.R
@@ -35,6 +35,9 @@
 #'   treatment = "treatment", response = "y")`. Override if you prefer
 #'   different names (for instance, to keep the original `yname`). The vector
 #'   *must* contain exactly these four names.
+#' @param verbose Logical. If `TRUE`, a `message()` reports the count of
+#'   first-period-treated unit-period rows dropped when
+#'   `drop_first_period_treated = TRUE`. Default `FALSE` (silent).
 #'
 #' @return A `data.frame` with columns `time`, `unit`, `treatment`, `y`, and any
 #'   covariates requested in `covars`, ready to be fed to
@@ -88,14 +91,16 @@ attgtToFetwfeDf <- function(
 		unit = "unit_var",
 		treatment = "treatment",
 		response = "response"
-	)
+	),
+	verbose = FALSE
 ) {
 	.fetwfe_df_core(
 		data = data,
 		vars = list(y = yname, t = tname, id = idname, g = gname),
 		covars = covars,
 		drop_first_period_treated = drop_first_period_treated,
-		out_names = out_names
+		out_names = out_names,
+		verbose = verbose
 	)
 }
 
@@ -127,6 +132,9 @@ attgtToFetwfeDf <- function(
 #' @param out_names Named list giving the column names that the returned dataframe should have.
 #'   The default (`time`, `unit`, `treatment`, `y`) matches the arguments usually supplied to
 #'   `fetwfe()`. **Do not change the *names* of this list** – only the *values* – and keep all four.
+#' @param verbose Logical. If `TRUE`, a `message()` reports the count of
+#'   first-period-treated unit-period rows dropped when
+#'   `drop_first_period_treated = TRUE`. Default `FALSE` (silent).
 #'
 #' @return A tidy `data.frame` with (in this order)
 #'   * `time`       integer,
@@ -182,14 +190,16 @@ etwfeToFetwfeDf <- function(
 		unit = "unit_var",
 		treatment = "treatment",
 		response = "response"
-	)
+	),
+	verbose = FALSE
 ) {
 	.fetwfe_df_core(
 		data = data,
 		vars = list(y = yvar, t = tvar, id = idvar, g = gvar),
 		covars = covars,
 		drop_first_period_treated = drop_first_period_treated,
-		out_names = out_names
+		out_names = out_names,
+		verbose = verbose
 	)
 }
 
@@ -228,6 +238,9 @@ etwfeToFetwfeDf <- function(
 #'   in the returned data frame.  Defaults are
 #'   `list(time = "time_var", unit = "unit_var", treatment = "treatment",
 #'	 response = "response")`.
+#' @param verbose Logical. If `TRUE`, a `message()` reports the count of
+#'   first-period-treated unit-period rows dropped when
+#'   `drop_first_period_treated = TRUE`. Default `FALSE` (silent).
 #'
 #' @return A tidy `data.frame` with columns, in this order:
 #' \itemize{
@@ -263,7 +276,8 @@ etwfeToFetwfeDf <- function(
 		unit = "unit_var",
 		treatment = "treatment",
 		response = "response"
-	)
+	),
+	verbose = FALSE
 ) {
 	stopifnot(is.data.frame(data))
 	required <- unlist(vars, use.names = FALSE)
@@ -314,11 +328,13 @@ etwfeToFetwfeDf <- function(
 		treated_first <- df[[vars$g]] != 0 & df[[vars$g]] <= first_period
 		if (any(treated_first)) {
 			df <- df[!treated_first, ]
-			message(
-				"Dropped ",
-				sum(treated_first),
-				" unit-period(s) treated in the first period."
-			)
+			if (isTRUE(verbose)) {
+				message(
+					"Dropped ",
+					sum(treated_first),
+					" unit-period(s) treated in the first period."
+				)
+			}
 		}
 	}
 

--- a/R/etwfe_core.R
+++ b/R/etwfe_core.R
@@ -75,6 +75,26 @@
 #' have been removed because they contained missing values or all contained the
 #' same value for every unit).} \item{p}{The final number of columns in the full
 #' set of covariates used to estimate the model.}
+#' \item{alpha}{The alpha level used for confidence intervals.}
+#' \item{calc_ses}{Logical indicating whether standard errors were calculated.}
+#' \item{cohort_probs_overall}{A vector of the estimated cohort probabilities
+#' on the overall sample (treated and untreated), used in computing the
+#' variance of the overall ATT.}
+#' \item{indep_counts_used}{Logical scalar; `TRUE` if a valid `indep_counts`
+#' argument was provided and used for asymptotically-exact ATT inference,
+#' `FALSE` otherwise.}
+#' \item{se_type}{Character scalar; the `se_type` argument the user passed
+#' (`"default"` or `"cluster"`).}
+#' \item{y_mean}{Numeric scalar; the mean of the original (pre-centering)
+#'   response. Stored so downstream methods (`augment()`, `predict()`) can
+#'   return fitted values on the original-response scale.}
+#' \item{response_col_name}{Character scalar; the name of the response
+#'   column in the original `pdata`. Consumed by `augment.<class>()`.}
+#' \item{time_var, unit_var, treatment}{Character scalars; the
+#'   `time_var` / `unit_var` / `treatment` arguments the user passed.}
+#' \item{covs}{Character vector; the original `covs` argument the user
+#'   passed (before any factor expansion the estimator performed
+#'   internally).}
 #'
 #' @examples
 #' \dontrun{
@@ -361,7 +381,8 @@ checkEtwfeInputs <- function(
 #'       \item Extracts cohort-specific average treatment effects (CATTs) from
 #'         `beta_hat`.
 #'       \item Calls `getCohortATTsFinal` to calculate CATT point estimates,
-#'         standard errors (if `q < 1`), and confidence intervals. This involves
+#'         standard errors (when the Gram matrix is invertible), and
+#'         confidence intervals. This involves
 #'         computing the Gram matrix and related quantities.
 #'     }
 #'   \item **Overall ATT Calculation:** Calls `getTeResultsOLS` to calculate the
@@ -370,8 +391,8 @@ checkEtwfeInputs <- function(
 #'     if `indep_counts` were provided.
 #' }
 #' The standard errors for CATTs are asymptotically exact. For ATT, if
-#' `indep_counts` are provided, the SE is asymptotically exact; otherwise, it's
-#' asymptotically conservative (if `q < 1`).
+#' `indep_counts` are provided, the SE is asymptotically exact; otherwise, it
+#' is asymptotically conservative.
 #'
 #' @return A list containing detailed estimation results:
 #'   \item{in_sample_att_hat}{Estimated overall ATT using in-sample cohort probabilities.}
@@ -380,25 +401,20 @@ checkEtwfeInputs <- function(
 #'   \item{indep_att_hat}{Estimated overall ATT using `indep_counts` cohort probabilities (NA if `indep_counts` not provided).}
 #'   \item{indep_att_se}{Standard error for `indep_att_hat` (NA if not applicable).}
 #'   \item{catt_hats}{A named vector of estimated CATTs for each cohort.}
-#'   \item{catt_ses}{A named vector of SEs for `catt_hats` (NA if `q >= 1`).}
+#'   \item{catt_ses}{A named vector of SEs for `catt_hats` (NA when the Gram matrix is not invertible).}
 #'   \item{catt_df}{A data.frame summarizing CATTs, SEs, and confidence intervals.}
-#'   \item{theta_hat}{The vector of estimated coefficients in the *transformed* (fused) space, including the intercept as the first element.}
-#'   \item{beta_hat}{The vector of estimated coefficients in the *original* space (after untransforming `theta_hat`, excluding intercept).}
+#'   \item{beta_hat}{The vector of estimated coefficients in the *original*
+#'     space (no bridge fusion transformation; etwfe is pure OLS).}
 #'   \item{treat_inds}{Indices in `beta_hat` corresponding to base treatment effects.}
 #'   \item{treat_int_inds}{Indices in `beta_hat` corresponding to treatment-covariate interactions.}
 #'   \item{cohort_probs}{Estimated cohort probabilities conditional on being treated, from `in_sample_counts`.}
 #'   \item{indep_cohort_probs}{Estimated cohort probabilities from `indep_counts` (NA if not provided).}
 #'   \item{sig_eps_sq}{The (possibly estimated) variance of observation-level noise.}
 #'   \item{sig_eps_c_sq}{The (possibly estimated) variance of unit-level random effects.}
-#'   \item{lambda.max}{The maximum lambda value used in `grpreg`.}
-#'   \item{lambda.max_model_size}{Model size for `lambda.max`.}
-#'   \item{lambda.min}{The minimum lambda value used in `grpreg`.}
-#'   \item{lambda.min_model_size}{Model size for `lambda.min`.}
-#'   \item{lambda_star}{The lambda value selected by BIC.}
-#'   \item{lambda_star_model_size}{Model size for `lambda_star`.}
 #'   \item{X_ints}{The original input design matrix from `prepXints`.}
 #'   \item{y}{The original input centered response vector from `prepXints`.}
-#'   \item{X_final}{The design matrix after fusion transformation and GLS weighting.}
+#'   \item{X_final}{The design matrix after GLS weighting (no fusion
+#'     transformation for `etwfe_core`).}
 #'   \item{y_final}{The response vector after GLS weighting.}
 #'   \item{N, T, R, d, p}{Dimensions used in estimation.}
 #' @keywords internal

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -138,6 +138,14 @@
 #' \item{d}{The final number of covariates that appear in the final data set (after any covariates may have been removed because they contained missing values or all contained the same value for every unit).}
 #' \item{p}{The final number of columns in the full set of covariates used to estimate the model.}
 #' \item{alpha}{The alpha level used for confidence intervals.}
+#' \item{cohort_probs_overall}{A vector of the estimated cohort probabilities
+#' on the overall sample (treated and untreated), used in computing the
+#' variance of the overall ATT.}
+#' \item{indep_counts_used}{Logical scalar; `TRUE` if a valid `indep_counts`
+#' argument was provided and used for asymptotically-exact ATT inference,
+#' `FALSE` otherwise.}
+#' \item{se_type}{Character scalar; the `se_type` argument the user passed
+#' (`"default"` or `"cluster"`).}
 #' \item{y_mean}{Numeric scalar; the mean of the original (pre-centering)
 #'   response. Stored so downstream methods (`augment()`, `predict()`)
 #'   can return fitted values on the original-response scale.}
@@ -158,6 +166,7 @@
 #'     \item{y}{The vector of responses, containing `nrow(X_ints)` entries.}
 #'     \item{X_final}{The design matrix after applying the change in coordinates to fit the model and also multiplying on the left by the square root inverse of the estimated covariance matrix for each unit.}
 #'     \item{y_final}{The final response after multiplying on the left by the square root inverse of the estimated covariance matrix for each unit.}
+#'     \item{theta_hat}{The vector of estimated coefficients in the transformed (fused) space, including the intercept as the first element.}
 #'     \item{calc_ses}{Logical indicating whether standard errors were calculated.}
 #'   }
 #' }
@@ -485,6 +494,14 @@ fetwfe <- function(
 #' \item{d}{The final number of covariates that appear in the final data set (after any covariates may have been removed because they contained missing values or all contained the same value for every unit).}
 #' \item{p}{The final number of columns in the full set of covariates used to estimate the model.}
 #' \item{alpha}{The alpha level used for confidence intervals.}
+#' \item{cohort_probs_overall}{A vector of the estimated cohort probabilities
+#' on the overall sample (treated and untreated), used in computing the
+#' variance of the overall ATT.}
+#' \item{indep_counts_used}{Logical scalar; `TRUE` if a valid `indep_counts`
+#' argument was provided and used for asymptotically-exact ATT inference,
+#' `FALSE` otherwise.}
+#' \item{se_type}{Character scalar; the `se_type` argument the user passed
+#' (`"default"` or `"cluster"`).}
 #' \item{y_mean}{Numeric scalar; the mean of the original (pre-centering)
 #'   response. Stored so downstream methods (`augment()`, `predict()`)
 #'   can return fitted values on the original-response scale.}
@@ -505,6 +522,7 @@ fetwfe <- function(
 #'     \item{y}{The vector of responses, containing `nrow(X_ints)` entries.}
 #'     \item{X_final}{The design matrix after applying the change in coordinates to fit the model and also multiplying on the left by the square root inverse of the estimated covariance matrix for each unit.}
 #'     \item{y_final}{The final response after multiplying on the left by the square root inverse of the estimated covariance matrix for each unit.}
+#'     \item{theta_hat}{The vector of estimated coefficients in the transformed (fused) space, including the intercept as the first element.}
 #'     \item{calc_ses}{Logical indicating whether standard errors were calculated.}
 #'   }
 #' }
@@ -704,6 +722,28 @@ fetwfeWithSimulatedData <- function(
 #' have been removed because they contained missing values or all contained the
 #' same value for every unit).} \item{p}{The final number of columns in the full
 #' set of covariates used to estimate the model.}
+#' \item{alpha}{The alpha level used for confidence intervals.}
+#' \item{calc_ses}{Logical indicating whether standard errors were calculated.}
+#' \item{cohort_probs_overall}{A vector of the estimated cohort probabilities
+#' on the overall sample (treated and untreated), used in computing the
+#' variance of the overall ATT.}
+#' \item{indep_counts_used}{Logical scalar; `TRUE` if a valid `indep_counts`
+#' argument was provided and used for asymptotically-exact ATT inference,
+#' `FALSE` otherwise.}
+#' \item{se_type}{Character scalar; the `se_type` argument the user passed
+#' (`"default"` or `"cluster"`).}
+#' \item{y_mean}{Numeric scalar; the mean of the original (pre-centering)
+#'   response. Stored so downstream methods (`augment()`, `predict()`)
+#'   can return fitted values on the original-response scale.}
+#' \item{response_col_name}{Character scalar; the name of the response
+#'   column in the original `pdata`. Consumed by `augment.<class>()`.}
+#' \item{time_var, unit_var, treatment}{Character scalars; the
+#'   `time_var` / `unit_var` / `treatment` arguments the user passed.
+#'   Consumed by `augment.<class>()` when auto-aligning a user-supplied
+#'   panel to the fitted design.}
+#' \item{covs}{Character vector; the original `covs` argument the user
+#'   passed (before any factor expansion the estimator performed
+#'   internally). Consumed by `augment.<class>()`.}
 #' @author Gregory Faletto
 #' @references
 #' Wooldridge, J. M. (2021). Two-way fixed effects, the two-way mundlak
@@ -721,6 +761,30 @@ fetwfeWithSimulatedData <- function(
 #'
 #' Pinheiro, J. C., & Bates, D. M. (2000). \emph{Mixed-Effects Models in
 #' S and S-PLUS}. Springer.
+#' @examples
+#' \dontrun{
+#' set.seed(23451)
+#'
+#' library(bacondecomp)
+#'
+#' data(divorce)
+#'
+#' # No `covs` here: etwfe is pure OLS (no bridge penalty), so it cannot
+#' # handle the rank-deficient design that the bacondecomp::divorce panel
+#' # produces when small cohorts and three covariates are combined.
+#' res <- etwfe(
+#'     pdata = divorce[divorce$sex == 2, ],
+#'     time_var = "year",
+#'     unit_var = "st",
+#'     treatment = "changed",
+#'     response = "suiciderate_elast_jag",
+#'     sig_eps_sq = 0.0344,
+#'     sig_eps_c_sq = 0.1507,
+#'     verbose = TRUE)
+#'
+#' # Print results
+#' print(res, max_cohorts = Inf)
+#' }
 #' @export
 etwfe <- function(
 	pdata,

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -96,7 +96,6 @@
 #' * `d_inv_treat_sel` from the same routine
 #' * the Jacobian \(J\) is built in
 #'   \code{getSecondVarTermDataApp()} using `d_inv_treat_sel`
-#' @inheritParams getTeResults2
 #' @seealso \code{getSecondVarTermDataApp()}
 #' @keywords internal
 #' @noRd

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -49,8 +49,8 @@
 #' that this might not work out, maybe your data set is on the small side and
 #' it's best to just leave your full data set in `pdata`). The sum of all the
 #' counts in `indep_counts` must match the total number of units in `pdata`.
-#' Default is NA (in which case conservative standard errors will be calculated
-#' if `q < 1`.)
+#' Default is NA (in which case the conservative standard error formula will
+#' be used).
 #' @param sig_eps_sq (Optional.) Numeric; the variance of the row-level IID
 #' noise assumed to apply to each observation. See Section 2 of Faletto (2025)
 #' for details. It is best to provide this variance if it is known (for example,
@@ -140,6 +140,15 @@
 #' arguments the user passed.}
 #' \item{covs}{Character vector; the original `covs` argument (pre-factor-
 #' expansion).}
+#' \item{calc_ses}{Logical indicating whether standard errors were calculated.}
+#' \item{cohort_probs_overall}{A vector of the estimated cohort probabilities
+#' on the overall sample (treated and untreated), used in computing the
+#' variance of the overall ATT.}
+#' \item{indep_counts_used}{Logical scalar; `TRUE` if a valid `indep_counts`
+#' argument was provided and used for asymptotically-exact ATT inference,
+#' `FALSE` otherwise.}
+#' \item{se_type}{Character scalar; the `se_type` argument the user passed
+#' (`"default"` or `"cluster"`).}
 #' @author Gregory Faletto
 #' @references
 #' Faletto, G (2025). Fused Extended Two-Way Fixed Effects for
@@ -157,6 +166,30 @@
 #'
 #' Pinheiro, J. C., & Bates, D. M. (2000). \emph{Mixed-Effects Models in
 #' S and S-PLUS}. Springer.
+#' @examples
+#' \dontrun{
+#' set.seed(23451)
+#'
+#' library(bacondecomp)
+#'
+#' data(divorce)
+#'
+#' # No `covs` here: twfeCovs is pure OLS (no bridge penalty), so it cannot
+#' # handle the rank-deficient design that the bacondecomp::divorce panel
+#' # produces when small cohorts and three covariates are combined.
+#' res <- twfeCovs(
+#'     pdata = divorce[divorce$sex == 2, ],
+#'     time_var = "year",
+#'     unit_var = "st",
+#'     treatment = "changed",
+#'     response = "suiciderate_elast_jag",
+#'     sig_eps_sq = 0.0344,
+#'     sig_eps_c_sq = 0.1507,
+#'     verbose = TRUE)
+#'
+#' # Print results
+#' print(res, max_cohorts = Inf)
+#' }
 #' @export
 twfeCovs <- function(
 	pdata,
@@ -361,17 +394,19 @@ twfeCovs <- function(
 #' Default is `"default"`.
 #' @return A named list with the following elements: \item{att_hat}{The
 #' estimated overall average treatment effect for a randomly selected treated
-#' unit.} \item{att_se}{If `q < 1`, a standard error for the ATT. If
-#' `indep_counts` was provided, this standard error is asymptotically exact; if
-#' not, it is asymptotically conservative. If `q >= 1`, this will be NA.}
+#' unit.} \item{att_se}{A standard error for the ATT. If `indep_counts` was
+#' provided, this standard error is asymptotically exact; otherwise, it is
+#' asymptotically conservative. If the Gram matrix is not invertible, this
+#' will be NA.}
 #' \item{att_p_value}{A two-sided p-value for the overall ATT against the
 #' null `H_0: tau = 0`, computed as `2 * pnorm(-|att_hat / att_se|)`. `NA` if
 #' `att_se` is zero or `NA`. Standard post-OLS interpretation; `twfeCovs` does
 #' not perform selection.}
 #' \item{catt_hats}{A named vector containing the estimated average treatment
-#' effects for each cohort.} \item{catt_ses}{If `q < 1`, a named vector
-#' containing the (asymptotically exact, non-conservative) standard errors for
-#' the estimated average treatment effects within each cohort.}
+#' effects for each cohort.} \item{catt_ses}{A named vector containing the
+#' (asymptotically exact, non-conservative) standard errors for the estimated
+#' average treatment effects within each cohort. If the Gram matrix is not
+#' invertible, the entries are NA.}
 #' \item{cohort_probs}{A vector of the estimated probabilities of being in each
 #' cohort conditional on being treated, which was used in calculating `att_hat`.
 #' If `indep_counts` was provided, `cohort_probs` was calculated from that;
@@ -405,6 +440,24 @@ twfeCovs <- function(
 #' have been removed because they contained missing values or all contained the
 #' same value for every unit).} \item{p}{The final number of columns in the full
 #' set of covariates used to estimate the model.}
+#' \item{calc_ses}{Logical indicating whether standard errors were calculated.}
+#' \item{cohort_probs_overall}{A vector of the estimated cohort probabilities
+#' on the overall sample (treated and untreated), used in computing the
+#' variance of the overall ATT.}
+#' \item{indep_counts_used}{Logical scalar; `TRUE` if a valid `indep_counts`
+#' argument was provided and used for asymptotically-exact ATT inference,
+#' `FALSE` otherwise.}
+#' \item{se_type}{Character scalar; the `se_type` argument the user passed
+#' (`"default"` or `"cluster"`).}
+#' \item{y_mean}{Numeric scalar; mean of the original (pre-centering) response.
+#' Stored so downstream methods (`augment()`, `predict()`) can return fitted
+#' values on the original-response scale.}
+#' \item{response_col_name}{Character scalar; the response column name in
+#' the original `pdata`.}
+#' \item{time_var, unit_var, treatment}{Character scalars; the corresponding
+#' arguments the user passed.}
+#' \item{covs}{Character vector; the original `covs` argument (pre-factor-
+#' expansion).}
 #'
 #' @examples
 #' \dontrun{
@@ -541,7 +594,8 @@ twfeCovsWithSimulatedData <- function(
 #'       \item Extracts cohort-specific average treatment effects (CATTs) from
 #'         `beta_hat`.
 #'       \item Calls `getCohortATTsFinal` to calculate CATT point estimates,
-#'         standard errors (if `q < 1`), and confidence intervals. This involves
+#'         standard errors (when the Gram matrix is invertible), and
+#'         confidence intervals. This involves
 #'         computing the Gram matrix and related quantities.
 #'     }
 #'   \item **Overall ATT Calculation:** Calls `getTeResultsOLS` to calculate the
@@ -550,8 +604,8 @@ twfeCovsWithSimulatedData <- function(
 #'     if `indep_counts` were provided.
 #' }
 #' The standard errors for CATTs are asymptotically exact. For ATT, if
-#' `indep_counts` are provided, the SE is asymptotically exact; otherwise, it's
-#' asymptotically conservative (if `q < 1`).
+#' `indep_counts` are provided, the SE is asymptotically exact; otherwise, it
+#' is asymptotically conservative.
 #'
 #' @return A list containing detailed estimation results:
 #'   \item{in_sample_att_hat}{Estimated overall ATT using in-sample cohort probabilities.}
@@ -560,10 +614,10 @@ twfeCovsWithSimulatedData <- function(
 #'   \item{indep_att_hat}{Estimated overall ATT using `indep_counts` cohort probabilities (NA if `indep_counts` not provided).}
 #'   \item{indep_att_se}{Standard error for `indep_att_hat` (NA if not applicable).}
 #'   \item{catt_hats}{A named vector of estimated CATTs for each cohort.}
-#'   \item{catt_ses}{A named vector of SEs for `catt_hats` (NA if `q >= 1`).}
+#'   \item{catt_ses}{A named vector of SEs for `catt_hats` (NA when the Gram matrix is not invertible).}
 #'   \item{catt_df}{A data.frame summarizing CATTs, SEs, confidence intervals, and per-cohort p-values (`P_value`).}
-#'   \item{theta_hat}{The vector of estimated coefficients in the *transformed* (fused) space, including the intercept as the first element.}
-#'   \item{beta_hat}{The vector of estimated coefficients in the *original* space (after untransforming `theta_hat`, excluding intercept).}
+#'   \item{beta_hat}{The vector of estimated coefficients in the *original*
+#'     space (no bridge fusion transformation; `twfeCovs` is pure OLS).}
 #'   \item{treat_inds}{Indices in `beta_hat` corresponding to base treatment effects.}
 #'   \item{treat_int_inds}{Indices in `beta_hat` corresponding to treatment-covariate interactions.}
 #'   \item{cohort_probs}{Estimated cohort probabilities conditional on being treated, from `in_sample_counts`.}
@@ -572,7 +626,8 @@ twfeCovsWithSimulatedData <- function(
 #'   \item{sig_eps_c_sq}{The (possibly estimated) variance of unit-level random effects.}
 #'   \item{X_ints}{The original input design matrix from `prepXints`.}
 #'   \item{y}{The original input centered response vector from `prepXints`.}
-#'   \item{X_final}{The design matrix after fusion transformation and GLS weighting.}
+#'   \item{X_final}{The design matrix after GLS weighting (no fusion
+#'     transformation for `twfeCovs_core`).}
 #'   \item{y_final}{The response vector after GLS weighting.}
 #'   \item{N, T, R, d, p}{Dimensions used in estimation.}
 #' @keywords internal

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.7",
+  note    = "R package version 1.9.8",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/man/attgtToFetwfeDf.Rd
+++ b/man/attgtToFetwfeDf.Rd
@@ -13,7 +13,8 @@ attgtToFetwfeDf(
   covars = character(0),
   drop_first_period_treated = TRUE,
   out_names = list(time = "time_var", unit = "unit_var", treatment = "treatment",
-    response = "response")
+    response = "response"),
+  verbose = FALSE
 )
 }
 \arguments{
@@ -47,6 +48,10 @@ dropping them here keeps the returned dataframe cleaner.}
 resulting dataframe. Defaults are \code{list(time = "time", unit = "unit", treatment = "treatment", response = "y")}. Override if you prefer
 different names (for instance, to keep the original \code{yname}). The vector
 \emph{must} contain exactly these four names.}
+
+\item{verbose}{Logical. If \code{TRUE}, a \code{message()} reports the count of
+first-period-treated unit-period rows dropped when
+\code{drop_first_period_treated = TRUE}. Default \code{FALSE} (silent).}
 }
 \value{
 A \code{data.frame} with columns \code{time}, \code{unit}, \code{treatment}, \code{y}, and any

--- a/man/betwfe.Rd
+++ b/man/betwfe.Rd
@@ -231,6 +231,16 @@ arguments the user passed. Consumed by \code{augment.betwfe()} when auto-alignin
 a user-supplied panel to the fitted design.}
 \item{covs}{Character vector; the original \code{covs} argument (pre-factor-
 expansion). Consumed by \code{augment.betwfe()}.}
+\item{alpha}{The alpha level used for confidence intervals.}
+\item{calc_ses}{Logical indicating whether standard errors were calculated.}
+\item{cohort_probs_overall}{A vector of the estimated cohort probabilities
+on the overall sample (treated and untreated), used in computing the
+variance of the overall ATT.}
+\item{indep_counts_used}{Logical scalar; \code{TRUE} if a valid \code{indep_counts}
+argument was provided and used for asymptotically-exact ATT inference,
+\code{FALSE} otherwise.}
+\item{se_type}{Character scalar; the \code{se_type} argument the user passed
+(\code{"default"} or \code{"cluster"}).}
 }
 \description{
 Implementation of extended two-way fixed effects with a bridge

--- a/man/betwfeWithSimulatedData.Rd
+++ b/man/betwfeWithSimulatedData.Rd
@@ -151,6 +151,25 @@ of covariates that appear in the final data set (after any covariates may
 have been removed because they contained missing values or all contained the
 same value for every unit).} \item{p}{The final number of columns in the full
 set of covariates used to estimate the model.}
+\item{alpha}{The alpha level used for confidence intervals.}
+\item{calc_ses}{Logical indicating whether standard errors were calculated.}
+\item{cohort_probs_overall}{A vector of the estimated cohort probabilities
+on the overall sample (treated and untreated), used in computing the
+variance of the overall ATT.}
+\item{indep_counts_used}{Logical scalar; \code{TRUE} if a valid \code{indep_counts}
+argument was provided and used for asymptotically-exact ATT inference,
+\code{FALSE} otherwise.}
+\item{se_type}{Character scalar; the \code{se_type} argument the user passed
+(\code{"default"} or \code{"cluster"}).}
+\item{y_mean}{Numeric scalar; mean of the original (pre-centering) response.
+Stored so downstream methods (\code{augment()}, \code{predict()}) can return fitted
+values on the original-response scale.}
+\item{response_col_name}{Character scalar; the response column name in
+the original \code{pdata}. Consumed by \code{augment.betwfe()}.}
+\item{time_var, unit_var, treatment}{Character scalars; the corresponding
+arguments the user passed.}
+\item{covs}{Character vector; the original \code{covs} argument (pre-factor-
+expansion).}
 }
 \description{
 This function runs the bridge-penalized extended two-way fixed effects estimator (\code{betwfe()}) on

--- a/man/etwfe.Rd
+++ b/man/etwfe.Rd
@@ -159,11 +159,58 @@ of covariates that appear in the final data set (after any covariates may
 have been removed because they contained missing values or all contained the
 same value for every unit).} \item{p}{The final number of columns in the full
 set of covariates used to estimate the model.}
+\item{alpha}{The alpha level used for confidence intervals.}
+\item{calc_ses}{Logical indicating whether standard errors were calculated.}
+\item{cohort_probs_overall}{A vector of the estimated cohort probabilities
+on the overall sample (treated and untreated), used in computing the
+variance of the overall ATT.}
+\item{indep_counts_used}{Logical scalar; \code{TRUE} if a valid \code{indep_counts}
+argument was provided and used for asymptotically-exact ATT inference,
+\code{FALSE} otherwise.}
+\item{se_type}{Character scalar; the \code{se_type} argument the user passed
+(\code{"default"} or \code{"cluster"}).}
+\item{y_mean}{Numeric scalar; the mean of the original (pre-centering)
+response. Stored so downstream methods (\code{augment()}, \code{predict()})
+can return fitted values on the original-response scale.}
+\item{response_col_name}{Character scalar; the name of the response
+column in the original \code{pdata}. Consumed by \verb{augment.<class>()}.}
+\item{time_var, unit_var, treatment}{Character scalars; the
+\code{time_var} / \code{unit_var} / \code{treatment} arguments the user passed.
+Consumed by \verb{augment.<class>()} when auto-aligning a user-supplied
+panel to the fitted design.}
+\item{covs}{Character vector; the original \code{covs} argument the user
+passed (before any factor expansion the estimator performed
+internally). Consumed by \verb{augment.<class>()}.}
 }
 \description{
 Implementation of extended two-way fixed effects.
 Estimates overall ATT as well as CATT (cohort average treatment effects on
 the treated units).
+}
+\examples{
+\dontrun{
+set.seed(23451)
+
+library(bacondecomp)
+
+data(divorce)
+
+# No `covs` here: etwfe is pure OLS (no bridge penalty), so it cannot
+# handle the rank-deficient design that the bacondecomp::divorce panel
+# produces when small cohorts and three covariates are combined.
+res <- etwfe(
+    pdata = divorce[divorce$sex == 2, ],
+    time_var = "year",
+    unit_var = "st",
+    treatment = "changed",
+    response = "suiciderate_elast_jag",
+    sig_eps_sq = 0.0344,
+    sig_eps_c_sq = 0.1507,
+    verbose = TRUE)
+
+# Print results
+print(res, max_cohorts = Inf)
+}
 }
 \references{
 Wooldridge, J. M. (2021). Two-way fixed effects, the two-way mundlak

--- a/man/etwfeToFetwfeDf.Rd
+++ b/man/etwfeToFetwfeDf.Rd
@@ -14,7 +14,8 @@ etwfeToFetwfeDf(
   covars = character(0),
   drop_first_period_treated = TRUE,
   out_names = list(time = "time_var", unit = "unit_var", treatment = "treatment",
-    response = "response")
+    response = "response"),
+  verbose = FALSE
 )
 }
 \arguments{
@@ -39,6 +40,10 @@ here keeps the returned dataframe clean.)  Default \code{TRUE}.}
 \item{out_names}{Named list giving the column names that the returned dataframe should have.
 The default (\code{time}, \code{unit}, \code{treatment}, \code{y}) matches the arguments usually supplied to
 \code{fetwfe()}. \strong{Do not change the \emph{names} of this list} – only the \emph{values} – and keep all four.}
+
+\item{verbose}{Logical. If \code{TRUE}, a \code{message()} reports the count of
+first-period-treated unit-period rows dropped when
+\code{drop_first_period_treated = TRUE}. Default \code{FALSE} (silent).}
 }
 \value{
 A tidy \code{data.frame} with (in this order)

--- a/man/etwfeWithSimulatedData.Rd
+++ b/man/etwfeWithSimulatedData.Rd
@@ -89,6 +89,26 @@ of covariates that appear in the final data set (after any covariates may
 have been removed because they contained missing values or all contained the
 same value for every unit).} \item{p}{The final number of columns in the full
 set of covariates used to estimate the model.}
+\item{alpha}{The alpha level used for confidence intervals.}
+\item{calc_ses}{Logical indicating whether standard errors were calculated.}
+\item{cohort_probs_overall}{A vector of the estimated cohort probabilities
+on the overall sample (treated and untreated), used in computing the
+variance of the overall ATT.}
+\item{indep_counts_used}{Logical scalar; \code{TRUE} if a valid \code{indep_counts}
+argument was provided and used for asymptotically-exact ATT inference,
+\code{FALSE} otherwise.}
+\item{se_type}{Character scalar; the \code{se_type} argument the user passed
+(\code{"default"} or \code{"cluster"}).}
+\item{y_mean}{Numeric scalar; the mean of the original (pre-centering)
+response. Stored so downstream methods (\code{augment()}, \code{predict()}) can
+return fitted values on the original-response scale.}
+\item{response_col_name}{Character scalar; the name of the response
+column in the original \code{pdata}. Consumed by \verb{augment.<class>()}.}
+\item{time_var, unit_var, treatment}{Character scalars; the
+\code{time_var} / \code{unit_var} / \code{treatment} arguments the user passed.}
+\item{covs}{Character vector; the original \code{covs} argument the user
+passed (before any factor expansion the estimator performed
+internally).}
 }
 \description{
 This function runs the extended two-way fixed effects estimator (\code{etwfe()}) on

--- a/man/fetwfe.Rd
+++ b/man/fetwfe.Rd
@@ -176,6 +176,14 @@ An object of class \code{fetwfe} containing the following elements:
 \item{d}{The final number of covariates that appear in the final data set (after any covariates may have been removed because they contained missing values or all contained the same value for every unit).}
 \item{p}{The final number of columns in the full set of covariates used to estimate the model.}
 \item{alpha}{The alpha level used for confidence intervals.}
+\item{cohort_probs_overall}{A vector of the estimated cohort probabilities
+on the overall sample (treated and untreated), used in computing the
+variance of the overall ATT.}
+\item{indep_counts_used}{Logical scalar; \code{TRUE} if a valid \code{indep_counts}
+argument was provided and used for asymptotically-exact ATT inference,
+\code{FALSE} otherwise.}
+\item{se_type}{Character scalar; the \code{se_type} argument the user passed
+(\code{"default"} or \code{"cluster"}).}
 \item{y_mean}{Numeric scalar; the mean of the original (pre-centering)
 response. Stored so downstream methods (\code{augment()}, \code{predict()})
 can return fitted values on the original-response scale.}
@@ -196,6 +204,7 @@ internally). Consumed by \verb{augment.<class>()}.}
 \item{y}{The vector of responses, containing \code{nrow(X_ints)} entries.}
 \item{X_final}{The design matrix after applying the change in coordinates to fit the model and also multiplying on the left by the square root inverse of the estimated covariance matrix for each unit.}
 \item{y_final}{The final response after multiplying on the left by the square root inverse of the estimated covariance matrix for each unit.}
+\item{theta_hat}{The vector of estimated coefficients in the transformed (fused) space, including the intercept as the first element.}
 \item{calc_ses}{Logical indicating whether standard errors were calculated.}
 }
 }

--- a/man/fetwfeWithSimulatedData.Rd
+++ b/man/fetwfeWithSimulatedData.Rd
@@ -106,6 +106,14 @@ An object of class \code{fetwfe} containing the following elements:
 \item{d}{The final number of covariates that appear in the final data set (after any covariates may have been removed because they contained missing values or all contained the same value for every unit).}
 \item{p}{The final number of columns in the full set of covariates used to estimate the model.}
 \item{alpha}{The alpha level used for confidence intervals.}
+\item{cohort_probs_overall}{A vector of the estimated cohort probabilities
+on the overall sample (treated and untreated), used in computing the
+variance of the overall ATT.}
+\item{indep_counts_used}{Logical scalar; \code{TRUE} if a valid \code{indep_counts}
+argument was provided and used for asymptotically-exact ATT inference,
+\code{FALSE} otherwise.}
+\item{se_type}{Character scalar; the \code{se_type} argument the user passed
+(\code{"default"} or \code{"cluster"}).}
 \item{y_mean}{Numeric scalar; the mean of the original (pre-centering)
 response. Stored so downstream methods (\code{augment()}, \code{predict()})
 can return fitted values on the original-response scale.}
@@ -126,6 +134,7 @@ internally). Consumed by \verb{augment.<class>()}.}
 \item{y}{The vector of responses, containing \code{nrow(X_ints)} entries.}
 \item{X_final}{The design matrix after applying the change in coordinates to fit the model and also multiplying on the left by the square root inverse of the estimated covariance matrix for each unit.}
 \item{y_final}{The final response after multiplying on the left by the square root inverse of the estimated covariance matrix for each unit.}
+\item{theta_hat}{The vector of estimated coefficients in the transformed (fused) space, including the intercept as the first element.}
 \item{calc_ses}{Logical indicating whether standard errors were calculated.}
 }
 }

--- a/man/twfeCovs.Rd
+++ b/man/twfeCovs.Rd
@@ -68,8 +68,8 @@ All entries of \code{indep_counts} must be strictly positive (if you are concern
 that this might not work out, maybe your data set is on the small side and
 it's best to just leave your full data set in \code{pdata}). The sum of all the
 counts in \code{indep_counts} must match the total number of units in \code{pdata}.
-Default is NA (in which case conservative standard errors will be calculated
-if \code{q < 1}.)}
+Default is NA (in which case the conservative standard error formula will
+be used).}
 
 \item{sig_eps_sq}{(Optional.) Numeric; the variance of the row-level IID
 noise assumed to apply to each observation. See Section 2 of Faletto (2025)
@@ -168,6 +168,15 @@ the original \code{pdata}. Reserved for future \code{augment()} / \code{predict(
 arguments the user passed.}
 \item{covs}{Character vector; the original \code{covs} argument (pre-factor-
 expansion).}
+\item{calc_ses}{Logical indicating whether standard errors were calculated.}
+\item{cohort_probs_overall}{A vector of the estimated cohort probabilities
+on the overall sample (treated and untreated), used in computing the
+variance of the overall ATT.}
+\item{indep_counts_used}{Logical scalar; \code{TRUE} if a valid \code{indep_counts}
+argument was provided and used for asymptotically-exact ATT inference,
+\code{FALSE} otherwise.}
+\item{se_type}{Character scalar; the \code{se_type} argument the user passed
+(\code{"default"} or \code{"cluster"}).}
 }
 \description{
 \strong{WARNING: This function should NOT be used for estimation. It
@@ -178,6 +187,31 @@ the treated units). It is implemented only for the sake of the simulation
 studies in Faletto (2025). This estimator is only unbiased under the
 assumptions that treatment effects are homogeneous across covariates and are
 identical within cohorts across all times since treatment.
+}
+\examples{
+\dontrun{
+set.seed(23451)
+
+library(bacondecomp)
+
+data(divorce)
+
+# No `covs` here: twfeCovs is pure OLS (no bridge penalty), so it cannot
+# handle the rank-deficient design that the bacondecomp::divorce panel
+# produces when small cohorts and three covariates are combined.
+res <- twfeCovs(
+    pdata = divorce[divorce$sex == 2, ],
+    time_var = "year",
+    unit_var = "st",
+    treatment = "changed",
+    response = "suiciderate_elast_jag",
+    sig_eps_sq = 0.0344,
+    sig_eps_c_sq = 0.1507,
+    verbose = TRUE)
+
+# Print results
+print(res, max_cohorts = Inf)
+}
 }
 \references{
 Faletto, G (2025). Fused Extended Two-Way Fixed Effects for

--- a/man/twfeCovsWithSimulatedData.Rd
+++ b/man/twfeCovsWithSimulatedData.Rd
@@ -46,17 +46,19 @@ Default is \code{"default"}.}
 \value{
 A named list with the following elements: \item{att_hat}{The
 estimated overall average treatment effect for a randomly selected treated
-unit.} \item{att_se}{If \code{q < 1}, a standard error for the ATT. If
-\code{indep_counts} was provided, this standard error is asymptotically exact; if
-not, it is asymptotically conservative. If \code{q >= 1}, this will be NA.}
+unit.} \item{att_se}{A standard error for the ATT. If \code{indep_counts} was
+provided, this standard error is asymptotically exact; otherwise, it is
+asymptotically conservative. If the Gram matrix is not invertible, this
+will be NA.}
 \item{att_p_value}{A two-sided p-value for the overall ATT against the
 null \code{H_0: tau = 0}, computed as \verb{2 * pnorm(-|att_hat / att_se|)}. \code{NA} if
 \code{att_se} is zero or \code{NA}. Standard post-OLS interpretation; \code{twfeCovs} does
 not perform selection.}
 \item{catt_hats}{A named vector containing the estimated average treatment
-effects for each cohort.} \item{catt_ses}{If \code{q < 1}, a named vector
-containing the (asymptotically exact, non-conservative) standard errors for
-the estimated average treatment effects within each cohort.}
+effects for each cohort.} \item{catt_ses}{A named vector containing the
+(asymptotically exact, non-conservative) standard errors for the estimated
+average treatment effects within each cohort. If the Gram matrix is not
+invertible, the entries are NA.}
 \item{cohort_probs}{A vector of the estimated probabilities of being in each
 cohort conditional on being treated, which was used in calculating \code{att_hat}.
 If \code{indep_counts} was provided, \code{cohort_probs} was calculated from that;
@@ -90,6 +92,24 @@ of covariates that appear in the final data set (after any covariates may
 have been removed because they contained missing values or all contained the
 same value for every unit).} \item{p}{The final number of columns in the full
 set of covariates used to estimate the model.}
+\item{calc_ses}{Logical indicating whether standard errors were calculated.}
+\item{cohort_probs_overall}{A vector of the estimated cohort probabilities
+on the overall sample (treated and untreated), used in computing the
+variance of the overall ATT.}
+\item{indep_counts_used}{Logical scalar; \code{TRUE} if a valid \code{indep_counts}
+argument was provided and used for asymptotically-exact ATT inference,
+\code{FALSE} otherwise.}
+\item{se_type}{Character scalar; the \code{se_type} argument the user passed
+(\code{"default"} or \code{"cluster"}).}
+\item{y_mean}{Numeric scalar; mean of the original (pre-centering) response.
+Stored so downstream methods (\code{augment()}, \code{predict()}) can return fitted
+values on the original-response scale.}
+\item{response_col_name}{Character scalar; the response column name in
+the original \code{pdata}.}
+\item{time_var, unit_var, treatment}{Character scalars; the corresponding
+arguments the user passed.}
+\item{covs}{Character vector; the original \code{covs} argument (pre-factor-
+expansion).}
 }
 \description{
 This function runs the bridge-penalized extended two-way fixed effects estimator (\code{twfeCovs()}) on

--- a/tests/testthat/test-class-helpers.R
+++ b/tests/testthat/test-class-helpers.R
@@ -34,7 +34,10 @@
 		att_hat = 0.3,
 		att_se = 0.05,
 		att_p_value = 0.01,
-		se_type = "standard",
+		# se_type must mirror the live `match.arg(c("default", "cluster"))`
+		# choice in the estimator entry points; "standard" was a stale
+		# mock value (issue #55).
+		se_type = "default",
 		catt_df = .make_catt_df_5(),
 		N = 100,
 		T = 6,


### PR DESCRIPTION
Resolves #55 . Recent feature PRs (v1.5.5 zero-effect p-values, v1.7.0 event_study, v1.9.0 broom integration) added new slots to the estimator outputs. The `@return` blocks on the public estimator entry points (etwfe, betwfe, twfeCovs, their `*WithSimulatedData` wrappers, plus the `internal` sublist of fetwfe and its wrapper) drifted from the live `names()` output. This PR refreshes them all and addresses several small related lint items. Resolves #55.

**Items shipped:**

- `@return` slot listings refreshed on **`fetwfe()` / `fetwfeWithSimulatedData()`** (added `cohort_probs_overall`, `indep_counts_used`, `se_type`; plus `theta_hat` in the `internal` sublist), **`etwfe()` / `etwfeWithSimulatedData()`** (added 11 slots), **`betwfe()` / `betwfeWithSimulatedData()`** (added 5), **`twfeCovs()` / `twfeCovsWithSimulatedData()`** (added 4). All public estimator docs now match `names()` of a live fitted object.
- `@examples` added to **`etwfe()`** and **`twfeCovs()`** (the only public estimator entry points that lacked them). Use the divorce panel **without `covs`** — both are pure OLS, so the rank-deficient cohorts path errors with covariates.
- Stripped **9 copy-paste references** to a bridge-penalty `q` parameter from `R/twfeCovs.R` (7) and `R/etwfe_core.R` (2). Neither function takes a `q` argument. Replaced with the canonical "If the Gram matrix is not invertible, this will be NA" wording.
- Removed self-referential `@inheritParams getTeResults2` from `getTeResults2`'s own documentation block (`R/fetwfe_core.R:99`).
- Cleaned up **`etwfe_core()`** and **`twfeCovs_core()`** `@return` blocks, which listed bridge-only slots (`theta_hat`, `lambda.max`, `lambda.min`, etc.) those functions never return.
- **`attgtToFetwfeDf()`** and **`etwfeToFetwfeDf()`** gain a `verbose = FALSE` argument; the previously-unconditional "Dropped N unit-period(s) treated in the first period" message is now gated on `verbose`. Default-silenced to match the project convention that non-interactive code paths should not emit console output without opt-in.
- Fixed stale mock value in `tests/testthat/test-class-helpers.R:37`: `se_type = "standard"` → `"default"` (the live `match.arg()` options are `"default"` and `"cluster"`, not `"standard"`).

Plan-review caught that the issue body's slot lists were stale from v1.5.5; the live slot inventory was empirically captured during plan drafting and used as the source of truth. Post-execution review caught that `fetwfe()` and `fetwfeWithSimulatedData()` were ALSO missing 3 slots — same bug class — fixed before merge.

**Deferred follow-up:** `etwfe_core()` and `twfeCovs_core()` `@details` and `@param` blocks still describe a bridge-regression / `lambda`-grid / `theta_hat` pipeline neither function executes (both are pure OLS). The PR's item 4 was scoped to the `@return` drift only; extending to `@details` is a meaningfully larger rewrite. Both helpers are `@noRd` internal, so the staleness is misleading-on-read but invisible to users. Worth a follow-up cleanup PR.

No public API or behavior changes outside the `verbose` default flip.