### PR TITLE
Add method-entry preconditions; fix event_study q≥1 finite SEs (#86 + #73, 1.9.10)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"7baba400-cad0-45d1-a679-c8ad2e0a4ac0","pid":36195,"procStart":"Sun May 10 17:46:23 2026","acquiredAt":1779064209321}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,10 +189,15 @@ construction time rather than at downstream-method-confusion time.
 
 When adding a new method that READS from a class object (`event_study`,
 `augment`, `tidy`, `glance`, `plot`, `coef`, future `predict`, etc.), call the
-matching `.check_<class>_for_<method>()` helper at the top of the method
-(infrastructure added by issue #86). This re-validates the object and asserts
-any method-specific contracts. The pattern is what would have prevented #73
-(`event_study()` reporting finite SEs when the fit's `calc_ses` was FALSE).
+matching `.check_for_<method>(x)` helper at the top of the method
+(infrastructure added by issue #86 — see `R/class_helpers.R`). The helper
+re-validates the object via `.assert_estimator_object(x)` and dispatches to
+the right `.validate_<class>` internally based on `inherits()`. For methods
+that need a derived contract (e.g., `.check_for_event_study(x)` returns
+`list(has_valid_ses = ...)` to gate SE computation), the helper returns a
+small named list; otherwise it returns `invisible(x)`. The pattern is what
+fixed #73 (`event_study()` reporting finite SEs when the fit's `calc_ses`
+was FALSE).
 
 When adding a new slot to a class's `@return`:
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.9
+Version: 1.9.10
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,25 @@
 # NEWS
 
+## Version 1.9.10 (2026-05-17)
+
+- Fixed a cross-method consistency bug in `event_study()` (GitHub #73):
+  the function previously reported finite SEs and p-values for `q >= 1`
+  fits even though the corresponding `fetwfe()` / `betwfe()` objects
+  correctly return `att_se = NA` in that regime (the bridge oracle
+  property is required for the model-based SEs). After this fix,
+  `event_study()` propagates the fit's `calc_ses` status: when the fit
+  has no valid SEs, `event_study()` returns NA SEs and NA p-values,
+  matching the parent object's contract. The point estimates remain
+  valid (and finite) in both regimes. Same fix applies under
+  `se_type = "cluster"`.
+- Added internal method-entry preconditions for cross-class consumers
+  (`event_study`, `augment`, `tidy`, `glance`, `plot`, `coef`). Each
+  such method now re-validates the input fitted object before computing
+  on it, catching hand-modified or programmatically-malformed inputs
+  early with a clear error message. Foundation PR beta of three (with
+  Foundation alpha #85 already shipped and Foundation gamma #87
+  drift-sentinel subagent queued). Resolves GitHub #86.
+
 ## Version 1.9.9 (2026-05-17)
 
 - Added internal constructor validators for each estimator class

--- a/R/betwfe_class.R
+++ b/R/betwfe_class.R
@@ -7,7 +7,10 @@ NULL
 # coef() method
 #—--------------------------------------------------------------------
 #' @export
-coef.betwfe <- function(object, ...) object$beta_hat
+coef.betwfe <- function(object, ...) {
+	.check_for_coef(object)
+	object$beta_hat
+}
 
 #—--------------------------------------------------------------------
 # print() method for betwfe objects

--- a/R/broom_methods.R
+++ b/R/broom_methods.R
@@ -39,6 +39,7 @@ NULL
 	conf.level = 1 - x$alpha,
 	include_selected = inherits(x, c("fetwfe", "betwfe"))
 ) {
+	.check_for_tidy(x)
 	stopifnot(conf.level > 0, conf.level < 1)
 
 	z <- stats::qnorm(1 - (1 - conf.level) / 2)
@@ -109,6 +110,7 @@ NULL
 #' @keywords internal
 #' @noRd
 .glance_fetwfe_betwfe <- function(x) {
+	.check_for_glance(x)
 	data.frame(
 		nobs = x$N * x$T,
 		n_units = x$N,
@@ -131,6 +133,7 @@ NULL
 #' @keywords internal
 #' @noRd
 .glance_etwfe <- function(x) {
+	.check_for_glance(x)
 	data.frame(
 		nobs = x$N * x$T,
 		n_units = x$N,
@@ -179,6 +182,7 @@ NULL
 #' @keywords internal
 #' @noRd
 .augment_estimator_output <- function(x, data, ...) {
+	.check_for_augment(x)
 	if (missing(data)) {
 		stop(
 			"augment(): the fitted object does not store the original panel ",

--- a/R/class_helpers.R
+++ b/R/class_helpers.R
@@ -420,3 +420,103 @@
 		)
 	}
 }
+
+#-------------------------------------------------------------------------------
+# Method-entry preconditions (issue #86).
+#
+# Each downstream method that reads from a fitted estimator object calls
+# a .check_for_<method>(x) helper at its top. The helper:
+#   (1) Re-runs the constructor validator from #85 (defense-in-depth;
+#       the object may have been hand-modified between construction and
+#       method call).
+#   (2) Returns a small named list of method-relevant invariants the
+#       method can use rather than re-deriving them.
+#
+# This is what fixes #73: .check_for_event_study(x) returns
+# `has_valid_ses` derived from `x$internal$calc_ses` (fetwfe) or
+# `x$calc_ses` (etwfe/betwfe), and the event_study dispatchers
+# AND-gate their SE-computation branch on it.
+#-------------------------------------------------------------------------------
+
+#' @title Universal dispatcher: validate any estimator-class object
+#' @description Dispatches via `inherits()` to the appropriate
+#' `.validate_<class>` helper from #85. twfeCovs is not currently
+#' classed (#76 will add `class(out) <- "twfeCovs"`); when that lands,
+#' a corresponding branch can be added here. No current method
+#' precondition routes a twfeCovs object through this dispatcher.
+#' @keywords internal
+#' @noRd
+.assert_estimator_object <- function(x) {
+	if (inherits(x, "fetwfe")) {
+		.validate_fetwfe(x)
+	} else if (inherits(x, "etwfe")) {
+		.validate_etwfe(x)
+	} else if (inherits(x, "betwfe")) {
+		.validate_betwfe(x)
+	} else {
+		stop(
+			"Expected a `fetwfe`, `etwfe`, or `betwfe` object; got class(es): ",
+			paste(class(x), collapse = ", "),
+			call. = FALSE
+		)
+	}
+	invisible(x)
+}
+
+#' @title Method precondition: event_study
+#' @description Validates the input + derives `has_valid_ses` (the
+#' contract gate that fixes #73). `calc_ses` lives in different paths
+#' across classes: nested under `$internal` for fetwfe; top-level for
+#' etwfe/betwfe.
+#' @return list(has_valid_ses = logical).
+#' @keywords internal
+#' @noRd
+.check_for_event_study <- function(x) {
+	.assert_estimator_object(x)
+	calc_ses <- if (inherits(x, "fetwfe")) {
+		x$internal$calc_ses
+	} else {
+		x$calc_ses
+	}
+	list(has_valid_ses = isTRUE(calc_ses))
+}
+
+#' @title Method precondition: augment
+#' @keywords internal
+#' @noRd
+.check_for_augment <- function(x) {
+	.assert_estimator_object(x)
+	invisible(x)
+}
+
+#' @title Method precondition: tidy
+#' @keywords internal
+#' @noRd
+.check_for_tidy <- function(x) {
+	.assert_estimator_object(x)
+	invisible(x)
+}
+
+#' @title Method precondition: glance
+#' @keywords internal
+#' @noRd
+.check_for_glance <- function(x) {
+	.assert_estimator_object(x)
+	invisible(x)
+}
+
+#' @title Method precondition: plot
+#' @keywords internal
+#' @noRd
+.check_for_plot <- function(x) {
+	.assert_estimator_object(x)
+	invisible(x)
+}
+
+#' @title Method precondition: coef
+#' @keywords internal
+#' @noRd
+.check_for_coef <- function(x) {
+	.assert_estimator_object(x)
+	invisible(x)
+}

--- a/R/etwfe_class.R
+++ b/R/etwfe_class.R
@@ -7,7 +7,10 @@ NULL
 # coef() method
 #----------------------------------------------------------------------
 #' @export
-coef.etwfe <- function(object, ...) object$beta_hat
+coef.etwfe <- function(object, ...) {
+	.check_for_coef(object)
+	object$beta_hat
+}
 
 #----------------------------------------------------------------------
 # print() method for etwfe objects

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -73,6 +73,12 @@ event_study <- function(x, alpha = NULL) {
 #' @keywords internal
 #' @noRd
 .event_study_etwfe_betwfe <- function(x, alpha = NULL) {
+	# Method-entry precondition (#86). Validates the fitted object and
+	# derives `has_valid_ses` — the contract gate that fixes #73
+	# (event_study reporting finite SEs when the fit's att_se is NA
+	# for q >= 1).
+	contract <- .check_for_event_study(x)
+
 	if (is.null(alpha)) {
 		alpha <- x$alpha
 	}
@@ -109,9 +115,9 @@ event_study <- function(x, alpha = NULL) {
 		sel_treat_inds_shifted <- which(beta_hat[treat_inds] != 0)
 	}
 
-	calc_ses <- TRUE
+	calc_ses <- contract$has_valid_ses
 	gram_inv <- NULL
-	if (length(sel_treat_inds_shifted) > 0) {
+	if (calc_ses && length(sel_treat_inds_shifted) > 0) {
 		res_gram <- getGramInv(
 			N = N,
 			T = T,
@@ -244,6 +250,12 @@ event_study <- function(x, alpha = NULL) {
 #' @keywords internal
 #' @noRd
 .event_study_fetwfe <- function(x, alpha = NULL) {
+	# Method-entry precondition (#86). Validates the fitted object and
+	# derives `has_valid_ses` — the contract gate that fixes #73
+	# (event_study reporting finite SEs when the fit's att_se is NA
+	# for q >= 1).
+	contract <- .check_for_event_study(x)
+
 	if (is.null(alpha)) {
 		alpha <- x$alpha
 	}
@@ -294,9 +306,9 @@ event_study <- function(x, alpha = NULL) {
 		d_inv_treat_sel <- NULL
 	}
 
-	calc_ses <- TRUE
+	calc_ses <- contract$has_valid_ses
 	gram_inv <- NULL
-	if (length(sel_treat_inds_shifted) > 0) {
+	if (calc_ses && length(sel_treat_inds_shifted) > 0) {
 		res_gram <- getGramInv(
 			N = N,
 			T = T,
@@ -531,6 +543,7 @@ plot.betwfe <- function(x, ...) {
 #' @keywords internal
 #' @noRd
 .plot_event_study <- function(x, alpha = NULL, ...) {
+	.check_for_plot(x)
 	if (!requireNamespace("ggplot2", quietly = TRUE)) {
 		stop(
 			"Install ggplot2 to use plot.fetwfe() / plot.etwfe() / plot.betwfe(): install.packages('ggplot2')"

--- a/R/fetwfe_class.R
+++ b/R/fetwfe_class.R
@@ -7,7 +7,10 @@ NULL
 # coef() method (unchanged)
 #—--------------------------------------------------------------------
 #' @export
-coef.fetwfe <- function(object, ...) object$beta_hat
+coef.fetwfe <- function(object, ...) {
+	.check_for_coef(object)
+	object$beta_hat
+}
 
 #—--------------------------------------------------------------------
 # print() method for fetwfe objects

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.9",
+  note    = "R package version 1.9.10",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-lex-cohort-sort.R
+++ b/tests/testthat/test-lex-cohort-sort.R
@@ -61,21 +61,61 @@ test_that(".truncate_catt full-output sort order is numeric (no truncation)", {
 test_that("tidy.<class> sorts cohorts numerically when labels include >= 10", {
 	skip_if_not_installed("broom")
 
-	# Build a minimal fetwfe-classed object with a catt_df containing
-	# cohorts >= 10. This bypasses the full estimator pipeline; we only
-	# need .tidy_estimator_output to be exercised.
+	# Build a fully-validator-compliant fetwfe-classed object with a
+	# catt_df containing cohorts >= 10. Most slots are NA/0/empty
+	# placeholders; only catt_df, R, alpha, and the SE-consistency
+	# slots need to be coherent. The constructor validator from #85
+	# (called by .check_for_tidy from #86) requires the full slot
+	# inventory; pre-#85 versions of this test got away with a
+	# minimal mock.
+	R_test <- 11L
+	T_test <- 13L
+	d_test <- 2L
+	p_test <- 50L
+	num_treats <- T_test * R_test - R_test * (R_test + 1L) / 2L # 88
 	obj <- list(
 		att_hat = 0.05,
 		att_se = 0.01,
 		att_p_value = 0.001,
 		att_selected = TRUE,
-		alpha = 0.05,
+		catt_hats = setNames(rep(0.01, R_test), as.character(2:12)),
+		catt_ses = setNames(rep(0.005, R_test), as.character(2:12)),
+		cohort_probs = rep(1 / (R_test + 5L), R_test), # < 1/(R+1) each so sum < 1
+		cohort_probs_overall = rep(1 / (R_test + 5L), R_test),
 		catt_df = .make_catt_df_11(),
-		N = 100,
-		T = 13,
-		R = 11,
-		d = 2,
-		p = 50
+		beta_hat = rep(0, p_test),
+		treat_inds = seq_len(num_treats),
+		treat_int_inds = (num_treats + 1L):p_test,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		lambda.max = 1,
+		lambda.max_model_size = 1L,
+		lambda.min = 0.01,
+		lambda.min_model_size = p_test + 1L,
+		lambda_star = 0.1,
+		lambda_star_model_size = 5L,
+		N = 100L,
+		T = T_test,
+		R = R_test,
+		d = d_test,
+		p = p_test,
+		alpha = 0.05,
+		indep_counts_used = FALSE,
+		se_type = "default",
+		y_mean = 0,
+		response_col_name = "y",
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		covs = c("cov1", "cov2"),
+		internal = list(
+			X_ints = matrix(0, 100L * T_test, p_test),
+			y = rep(0, 100L * T_test),
+			X_final = matrix(0, 100L * T_test, p_test),
+			y_final = rep(0, 100L * T_test),
+			theta_hat = rep(0, p_test + 1L),
+			calc_ses = TRUE
+		)
 	)
 	class(obj) <- "fetwfe"
 

--- a/tests/testthat/test-method-preconditions.R
+++ b/tests/testthat/test-method-preconditions.R
@@ -1,0 +1,178 @@
+# Tests for the method-entry preconditions introduced in #86.
+#
+# Two main goals:
+#   (1) #73 regression: event_study() returns all-NA SEs when the
+#       fitted object's calc_ses is FALSE (q in {1, 2} for fetwfe/betwfe).
+#   (2) Cross-class method-entry checks: each .check_for_<method>()
+#       helper accepts well-formed input, returns the expected shape,
+#       and is wired into the corresponding method's entry point.
+
+# ------------------------------------------------------------------------------
+# Shared fixture
+# ------------------------------------------------------------------------------
+
+.precond_fixture <- function(q = 0.5, seed = 1) {
+	sim <- simulateData(
+		genCoefs(R = 3, T = 6, d = 2, density = 0.5, eff_size = 2, seed = seed),
+		N = 120,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5
+	)
+	list(
+		sim = sim,
+		fetwfe = suppressWarnings(fetwfeWithSimulatedData(sim, q = q)),
+		etwfe = suppressWarnings(etwfeWithSimulatedData(sim)),
+		betwfe = suppressWarnings(betwfeWithSimulatedData(sim, q = q))
+	)
+}
+
+# ------------------------------------------------------------------------------
+# #73 regression: event_study() respects the fit's calc_ses contract
+# ------------------------------------------------------------------------------
+
+test_that("event_study(fetwfe(q=1)) returns all-NA SEs and p-values (fixes #73)", {
+	fx <- .precond_fixture(q = 1)
+	# Sanity: the fit's own contract says no SEs.
+	expect_true(is.na(fx$fetwfe$att_se))
+	expect_false(isTRUE(fx$fetwfe$internal$calc_ses))
+	# event_study must respect that.
+	es <- event_study(fx$fetwfe)
+	expect_true(all(is.na(es$se)))
+	expect_true(all(is.na(es$p_value)))
+	# Point estimates ARE valid even without SEs.
+	expect_true(any(is.finite(es$estimate)))
+})
+
+test_that("event_study(fetwfe(q=2)) returns all-NA SEs (ridge, fixes #73)", {
+	fx <- .precond_fixture(q = 2)
+	expect_true(is.na(fx$fetwfe$att_se))
+	expect_false(isTRUE(fx$fetwfe$internal$calc_ses))
+	es <- event_study(fx$fetwfe)
+	expect_true(all(is.na(es$se)))
+	expect_true(all(is.na(es$p_value)))
+})
+
+test_that("event_study(betwfe(q=1)) returns all-NA SEs (fixes #73 for BETWFE)", {
+	fx <- .precond_fixture(q = 1)
+	expect_true(is.na(fx$betwfe$att_se))
+	expect_false(isTRUE(fx$betwfe$calc_ses))
+	es <- event_study(fx$betwfe)
+	expect_true(all(is.na(es$se)))
+	expect_true(all(is.na(es$p_value)))
+})
+
+test_that("event_study(betwfe(q=2)) returns all-NA SEs (ridge, fixes #73)", {
+	fx <- .precond_fixture(q = 2)
+	expect_true(is.na(fx$betwfe$att_se))
+	es <- event_study(fx$betwfe)
+	expect_true(all(is.na(es$se)))
+})
+
+test_that("event_study still produces finite SEs on the valid paths (regression check)", {
+	fx <- .precond_fixture(q = 0.5)
+	# fetwfe q=0.5 has valid SEs.
+	expect_true(isTRUE(fx$fetwfe$internal$calc_ses))
+	es_f <- event_study(fx$fetwfe)
+	expect_true(any(is.finite(es_f$se)))
+	# etwfe always has valid SEs (pure OLS).
+	expect_true(isTRUE(fx$etwfe$calc_ses))
+	es_e <- event_study(fx$etwfe)
+	expect_true(any(is.finite(es_e$se)))
+	# betwfe q=0.5 has valid SEs.
+	expect_true(isTRUE(fx$betwfe$calc_ses))
+	es_b <- event_study(fx$betwfe)
+	expect_true(any(is.finite(es_b$se)))
+})
+
+# ------------------------------------------------------------------------------
+# Each .check_for_<method> accepts well-formed input
+# ------------------------------------------------------------------------------
+
+test_that(".check_for_event_study returns has_valid_ses derived from calc_ses path", {
+	fx05 <- .precond_fixture(q = 0.5)
+	contract_f <- fetwfe:::.check_for_event_study(fx05$fetwfe)
+	expect_true(contract_f$has_valid_ses)
+	contract_e <- fetwfe:::.check_for_event_study(fx05$etwfe)
+	expect_true(contract_e$has_valid_ses)
+	contract_b <- fetwfe:::.check_for_event_study(fx05$betwfe)
+	expect_true(contract_b$has_valid_ses)
+
+	fx1 <- .precond_fixture(q = 1)
+	expect_false(fetwfe:::.check_for_event_study(fx1$fetwfe)$has_valid_ses)
+	expect_false(fetwfe:::.check_for_event_study(fx1$betwfe)$has_valid_ses)
+})
+
+test_that(".check_for_augment / tidy / glance / plot / coef accept all 3 estimators", {
+	fx <- .precond_fixture(q = 0.5)
+	for (res in list(fx$fetwfe, fx$etwfe, fx$betwfe)) {
+		expect_silent(fetwfe:::.check_for_augment(res))
+		expect_silent(fetwfe:::.check_for_tidy(res))
+		expect_silent(fetwfe:::.check_for_glance(res))
+		expect_silent(fetwfe:::.check_for_plot(res))
+		expect_silent(fetwfe:::.check_for_coef(res))
+	}
+})
+
+# ------------------------------------------------------------------------------
+# Each helper rejects non-estimator input with a clear message
+# ------------------------------------------------------------------------------
+
+test_that("preconditions reject non-estimator objects with a clear message", {
+	not_estimator <- list(att_hat = 0.5, foo = "bar")
+	expect_error(
+		fetwfe:::.assert_estimator_object(not_estimator),
+		"Expected a `fetwfe`, `etwfe`, or `betwfe` object",
+		fixed = TRUE
+	)
+	expect_error(
+		fetwfe:::.check_for_event_study(not_estimator),
+		"Expected a `fetwfe`, `etwfe`, or `betwfe` object",
+		fixed = TRUE
+	)
+	expect_error(
+		fetwfe:::.check_for_augment(not_estimator),
+		"Expected a `fetwfe`, `etwfe`, or `betwfe` object",
+		fixed = TRUE
+	)
+})
+
+# ------------------------------------------------------------------------------
+# Mutation: hand-modify a class object to violate the C1 contract; the
+# precondition (via .validate_<class>) catches it
+# ------------------------------------------------------------------------------
+
+test_that("precondition catches hand-modified objects that violate C1 (att_se NA but calc_ses FALSE)", {
+	fx <- .precond_fixture(q = 0.5)
+	res <- fx$fetwfe
+	# Mutate: set calc_ses=FALSE (now C1 requires att_se to be NA, but
+	# the original fit had a finite att_se).
+	res$internal$calc_ses <- FALSE
+	expect_true(is.finite(res$att_se)) # mutation set up the inconsistency
+	expect_error(
+		fetwfe:::.check_for_event_study(res),
+		"C1 SE consistency",
+		fixed = TRUE
+	)
+})
+
+# ------------------------------------------------------------------------------
+# Cluster-SE × q=1: contract gate cascades through the cluster path too
+# ------------------------------------------------------------------------------
+
+test_that("event_study respects calc_ses under se_type='cluster' × q=1", {
+	# Use a panel large enough for the cluster path to be well-conditioned.
+	sim <- simulateData(
+		genCoefs(R = 3, T = 6, d = 2, density = 0.5, eff_size = 2, seed = 1),
+		N = 200,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5
+	)
+	res <- suppressWarnings(
+		fetwfeWithSimulatedData(sim, q = 1, se_type = "cluster")
+	)
+	# Sanity: q=1 still means calc_ses=FALSE regardless of se_type.
+	expect_true(is.na(res$att_se))
+	expect_false(isTRUE(res$internal$calc_ses))
+	es <- event_study(res)
+	expect_true(all(is.na(es$se)))
+})


### PR DESCRIPTION
## Summary

Resolves #86. Resolves #73. **Foundation PR β of three** (with #85 constructor validators already shipped and #87 drift-sentinel subagent queued). Ships the fix for **issue #73** (`event_study()` reporting finite SEs when `q >= 1` even though the fit's `att_se` is NA) as the first user of the new infrastructure — validating that the contract-assertion pattern works for its intended purpose.

## What's new in `R/class_helpers.R`

- **`.assert_estimator_object(x)`** — universal dispatcher that calls the right `.validate_<class>` helper (from #85) based on `inherits(x, ...)`.
- **`.check_for_event_study(x)`** — runs the universal check and derives `has_valid_ses` from the fit's `calc_ses` path (nested under `$internal` for fetwfe; top-level for etwfe/betwfe). Returns `list(has_valid_ses)`.
- **`.check_for_augment / .check_for_tidy / .check_for_glance / .check_for_plot / .check_for_coef`** — each runs the universal check and returns `invisible(x)`. Defense-in-depth against hand-modified objects between construction and method call.

## Wired at 11 sites

| Category | Site(s) | Coverage |
|---|---|---|
| event_study | `.event_study_fetwfe`, `.event_study_etwfe_betwfe` | Both AND-gate SE branch on `contract$has_valid_ses` → **#73 fix** |
| augment | `.augment_estimator_output` (shared body) | All 3 augment dispatchers |
| tidy | `.tidy_estimator_output` (shared body) | All 3 tidy dispatchers |
| glance | `.glance_fetwfe_betwfe`, `.glance_etwfe` (2 helpers) | All 3 dispatchers |
| plot | `.plot_event_study` (shared body) | All 3 plot dispatchers |
| coef | `coef.fetwfe`, `coef.etwfe`, `coef.betwfe` | 3 dispatchers |

## #73 fix in detail

`fetwfe()` and `betwfe()` correctly return `att_se = NA` for `q >= 1` (the bridge oracle property is required). But `event_study()` was unconditionally setting `calc_ses = TRUE` and producing finite SEs (and finite p-values) that the package explicitly disclaims elsewhere.

After this PR:

```r
res <- fetwfeWithSimulatedData(sim, q = 1)
res$att_se               # NA (correct, unchanged)
event_study(res)$se      # all NA (was finite pre-fix)
event_study(res)$p_value # all NA (was finite pre-fix)
# Point estimates are still finite — they're valid even without SEs.
event_study(res)$estimate # finite values
```

Same fix applies to `q = 2` (ridge) and to BETWFE. Cluster-SE path inherits the gate (since `calc_ses` cascades through the recomputed `getGramInv` branch).

## Test plan

- [x] New `tests/testthat/test-method-preconditions.R` (49 assertions):
  - #73 regression × 4 (q=1/q=2 × fetwfe/betwfe).
  - Valid-path regression: q=0.5 fetwfe and etwfe still produce finite SEs (catches accidental NA-out of working paths).
  - Each `.check_for_<method>` accepts valid input.
  - Each rejects non-estimator input with a clear message.
  - Mutation: set `internal$calc_ses <- FALSE` on a q=0.5 fit; the C1 contract from #85 fires through `.check_for_event_study`.
  - Cluster-SE × q=1: contract gate cascades through the cluster path.
- [x] `tests/testthat/test-lex-cohort-sort.R` updated: prior minimal mock was failing under the new `.check_for_tidy` precondition; replaced with a fully-validator-compliant mock (35 top-level slots + 6 internal slots). Test assertion unchanged.
- [x] `devtools::check(args = "--as-cran")`: 0 errors / 0 warnings / 0 notes.
- [x] `devtools::test()`: 1598 PASS / 0 FAIL (1549 prior + 49 new).
- [x] `devtools::spell_check()` / `urlchecker::url_check()`: clean.

## What's NOT changed

- Public API: unchanged.
- Behavior on valid paths: unchanged (the gate only fires when the fit itself disclaims SEs).
- twfeCovs methods: not touched (twfeCovs has no augment/tidy/glance/plot/coef methods; would be added when #76 ships its S3 class).