### PR TITLE
Add print-method snapshot guardrail before *_class.R consolidation (#77 step 1/2)

### DIFF
--- a/tests/testthat/_snaps/print-method-snapshot.md
+++ b/tests/testthat/_snaps/print-method-snapshot.md
@@ -1,0 +1,156 @@
+# print.fetwfe output is stable
+
+    Code
+      print(fit_fetwfe)
+    Output
+      Fused Extended Two-Way Fixed Effects Results
+      ===========================================
+      
+      Overall Average Treatment Effect (ATT):
+        Estimate:   0.0000
+        Std. Error: 0.0000
+        P-value:    NA
+        Selected:   FALSE
+        95% CI:    [0.0000, 0.0000]
+      
+      Cohort Average Treatment Effects (CATT):
+       Cohort Estimated TE SE ConfIntLow ConfIntHigh P_value selected
+            2            0  0          0           0      NA    FALSE
+            3            0  0          0           0      NA    FALSE
+      
+      Model Details:
+        Units (N)           : 30
+        Time periods (T)    : 5
+        Treated cohorts (R) : 2
+        Covariates (d)      : 2
+        Features (p)        : 41
+        Selected size       : 1
+        Lambda*             : 0.0299
+
+# print.summary.fetwfe output is stable
+
+    Code
+      print(summary(fit_fetwfe))
+    Output
+      Summary of Fused Extended Two-Way Fixed Effects
+      ================================================
+      
+      Overall ATT: 0.0000  (SE = 0.0000, p = NA, 95% CI = [0.0000, 0.0000])
+      Selected: FALSE
+      
+      CATT (preview):
+       Cohort Estimated TE SE ConfIntLow ConfIntHigh P_value selected
+            2            0  0          0           0      NA    FALSE
+            3            0  0          0           0      NA    FALSE
+      
+      Model Details:
+        Units (N)           : 30
+        Time periods (T)    : 5
+        Treated cohorts (R) : 2
+        Covariates (d)      : 2
+        Features (p)        : 41
+        Selected size       : 1
+        Lambda*             : 0.0299
+
+# print.etwfe output is stable
+
+    Code
+      print(fit_etwfe)
+    Output
+      Extended Two-Way Fixed Effects Results
+      =====================================
+      
+      Overall Average Treatment Effect (ATT):
+        Estimate:   -0.0456
+        Std. Error: 0.4012
+        P-value:    0.9094
+        95% CI:    [-0.8319, 0.7406]
+      
+      Cohort Average Treatment Effects (CATT):
+       Cohort Estimated TE        SE ConfIntLow ConfIntHigh   P_value
+            2  0.009060593 0.4879617 -0.9473267   0.9654479 0.9851855
+            3 -0.127673929 0.4655589 -1.0401525   0.7848047 0.7839017
+      
+      Model Details:
+        Units (N)           : 30
+        Time periods (T)    : 5
+        Treated cohorts (R) : 2
+        Covariates (d)      : 2
+        Features (p)        : 41
+
+# print.summary.etwfe output is stable
+
+    Code
+      print(summary(fit_etwfe))
+    Output
+      Summary of Extended Two-Way Fixed Effects
+      ========================================
+      
+      Overall ATT: -0.0456  (SE = 0.4012, p = 0.9094, 95% CI = [-0.8319, 0.7406])
+      
+      CATT (preview):
+       Cohort Estimated TE        SE ConfIntLow ConfIntHigh   P_value
+            2  0.009060593 0.4879617 -0.9473267   0.9654479 0.9851855
+            3 -0.127673929 0.4655589 -1.0401525   0.7848047 0.7839017
+      
+      Model Details:
+        Units (N)           : 30
+        Time periods (T)    : 5
+        Treated cohorts (R) : 2
+        Covariates (d)      : 2
+        Features (p)        : 41
+
+# print.betwfe output is stable
+
+    Code
+      print(fit_betwfe)
+    Output
+      Bridge-Penalized Extended Two-Way Fixed Effects Results
+      =======================================================
+      
+      Overall Average Treatment Effect (ATT):
+        Estimate:   0.0000
+        Std. Error: 0.0000
+        P-value:    NA
+        Selected:   FALSE
+        95% CI:    [0.0000, 0.0000]
+      
+      Cohort Average Treatment Effects (CATT):
+       Cohort Estimated TE SE ConfIntLow ConfIntHigh P_value selected
+            2            0  0          0           0      NA    FALSE
+            3            0  0          0           0      NA    FALSE
+      
+      Model Details:
+        Units (N)           : 30
+        Time periods (T)    : 5
+        Treated cohorts (R) : 2
+        Covariates (d)      : 2
+        Features (p)        : 41
+        Selected size       : 1
+        Lambda*             : 0.0265
+
+# print.summary.betwfe output is stable
+
+    Code
+      print(summary(fit_betwfe))
+    Output
+      Summary of Bridge-Penalized Extended Two-Way Fixed Effects
+      ==========================================================
+      
+      Overall ATT: 0.0000  (SE = 0.0000, p = NA, 95% CI = [0.0000, 0.0000])
+      Selected: FALSE
+      
+      CATT (preview):
+       Cohort Estimated TE SE ConfIntLow ConfIntHigh P_value selected
+            2            0  0          0           0      NA    FALSE
+            3            0  0          0           0      NA    FALSE
+      
+      Model Details:
+        Units (N)           : 30
+        Time periods (T)    : 5
+        Treated cohorts (R) : 2
+        Covariates (d)      : 2
+        Features (p)        : 41
+        Selected size       : 1
+        Lambda*             : 0.0265
+

--- a/tests/testthat/test-print-method-snapshot.R
+++ b/tests/testthat/test-print-method-snapshot.R
@@ -1,0 +1,120 @@
+library(testthat)
+library(fetwfe)
+
+# Snapshot-based guardrail for `print.<class>(x)` and `print.summary.<class>(x)`
+# across the three estimators (`fetwfe`, `etwfe`, `betwfe`). Locks the current
+# printed output of each method against six markdown goldens under
+# tests/testthat/_snaps/print-method-snapshot.md so any byte drift surfaces as
+# a failing test. Issue #77 step 1 of 2 (the follow-up consolidates the three
+# `R/*_class.R` print/summary bodies into a shared helper; this guardrail
+# protects that refactor).
+#
+# Fixture parameters (N=30, T=5, R=2, seed=123) are the only ones all three
+# estimators can fit without error: `etwfe()` rejects larger (T, R) due to
+# pure-OLS rank deficiency (the bridge regression in `fetwfe()`/`betwfe()`
+# absorbs it). The `generate_panel_data()` body is verbatim from
+# `tests/testthat/test-fetwfe.R`; the duplication is acceptable so the
+# guardrail file is self-contained (see .plans/feat-print-snapshot-77/PLAN.md
+# Decision Log D3 / D4).
+#
+# Snapshot tests require testthat edition 3 and skip under CRAN by default
+# (so `R CMD check --as-cran` shows SKIPs for these tests; `devtools::test()`
+# runs them).
+
+testthat::local_edition(3)
+
+generate_panel_data <- function(N = 30, T = 10, R = 9, seed = 123) {
+	set.seed(seed)
+	stopifnot(R <= T - 1)
+	unit_ids <- sprintf("unit%02d", 1:N)
+	time_vals <- 1:T
+
+	first_treat <- sapply(unit_ids, function(u) {
+		if (runif(1) < 0.5) {
+			Inf
+		} else {
+			if (R > 1) {
+				sample(2:(R + 1), 1)
+			} else {
+				2
+			}
+		}
+	})
+
+	df <- do.call(
+		rbind,
+		lapply(seq_along(unit_ids), function(i) {
+			unit <- unit_ids[i]
+			ft <- first_treat[i]
+			data.frame(
+				time = as.integer(time_vals),
+				unit = as.character(unit),
+				treatment = as.integer(ifelse(time_vals >= ft, 1, 0)),
+				cov1 = rnorm(T),
+				cov2 = runif(T),
+				y = rnorm(T)
+			)
+		})
+	)
+
+	df <- df[!(df$time == 1 & df$treatment == 1), ]
+	df <- df[order(df$unit, df$time), ]
+	rownames(df) <- NULL
+	return(df)
+}
+
+pdata <- generate_panel_data(N = 30, T = 5, R = 2, seed = 123)
+
+fit_fetwfe <- fetwfe(
+	pdata = pdata,
+	time_var = "time",
+	unit_var = "unit",
+	treatment = "treatment",
+	response = "y",
+	covs = c("cov1", "cov2"),
+	verbose = FALSE
+)
+
+fit_etwfe <- etwfe(
+	pdata = pdata,
+	time_var = "time",
+	unit_var = "unit",
+	treatment = "treatment",
+	response = "y",
+	covs = c("cov1", "cov2"),
+	verbose = FALSE
+)
+
+fit_betwfe <- betwfe(
+	pdata = pdata,
+	time_var = "time",
+	unit_var = "unit",
+	treatment = "treatment",
+	response = "y",
+	covs = c("cov1", "cov2"),
+	verbose = FALSE
+)
+
+test_that("print.fetwfe output is stable", {
+	expect_snapshot(print(fit_fetwfe))
+})
+
+test_that("print.summary.fetwfe output is stable", {
+	expect_snapshot(print(summary(fit_fetwfe)))
+})
+
+test_that("print.etwfe output is stable", {
+	expect_snapshot(print(fit_etwfe))
+})
+
+test_that("print.summary.etwfe output is stable", {
+	expect_snapshot(print(summary(fit_etwfe)))
+})
+
+test_that("print.betwfe output is stable", {
+	expect_snapshot(print(fit_betwfe))
+})
+
+test_that("print.summary.betwfe output is stable", {
+	expect_snapshot(print(summary(fit_betwfe)))
+})


### PR DESCRIPTION
Refs #77 (step 1 of 2). Adds `tests/testthat/test-print-method-snapshot.R` and its golden file `tests/testthat/_snaps/print-method-snapshot.md` to lock the current `print()` and `print(summary())` output of small `fetwfe()` / `etwfe()` / `betwfe()` fits against six byte-identical snapshots, so the follow-up PR consolidating the three `R/*_class.R` files can be reviewed as mechanically output-preserving (any drift surfaces as a failing snapshot diff).

Tests-only PR: no source-code, roxygen, `man/`, or `DESCRIPTION`/`NEWS.md`/`inst/CITATION` edits. Follows PR #70 precedent for test-infrastructure changes (no version bump); the follow-up refactor PR will bump for both. Snapshots skip under `--as-cran` per testthat's `cran = FALSE` default — `devtools::test()` runs them, CRAN doesn't. Smoke-checked by deliberately changing `print.fetwfe()`'s `Estimate: %.4f` → `%.5f` and confirming the corresponding snapshot fails with a clean diff. Local `devtools::test()`: 1604 PASS / 0 FAIL.
