### PR TITLE
Tighten idCohorts() balance check to catch duplicate time periods (#75, v1.9.13)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.12
+Version: 1.9.13
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # NEWS
 
+## Version 1.9.13 (2026-05-18)
+
+- Tightened `idCohorts()`'s panel-balance check to catch units
+  with the right row count but duplicate or missing time periods
+  (GitHub #75). A unit with rows at times `(1, 2, 2)` and `T = 3`
+  previously passed silently, causing a confusing downstream
+  failure in `processCovs()`. The new check requires both
+  `nrow == T` and exact time coverage; the violation message
+  includes both counts. The parallel balance check in
+  `processCovs()` (defense-in-depth) is tightened to match.
+
 ## Version 1.9.12 (2026-05-18)
 
 - Fixed a silent bug in `betwfe(..., add_ridge = TRUE)`

--- a/R/etwfe_core.R
+++ b/R/etwfe_core.R
@@ -1204,11 +1204,25 @@ processCovs <- function(
 	T,
 	verbose = FALSE
 ) {
-	# Always check that every unit has exactly T observations.
+	# Always check that every unit has exactly T observations covering all
+	# time periods. Defense-in-depth: `idCohorts()` (called upstream by every
+	# entry point that reaches here) already enforces this contract since
+	# #75. If a future code path reaches `processCovs()` without going
+	# through `idCohorts()` first, this check still catches the bug class.
 	for (s in units) {
 		df_s <- df[df[, unit_var] == s, ]
-		if (nrow(df_s) != T) {
-			stop(paste("Unit", s, "does not have exactly", T, "observations."))
+		if (nrow(df_s) != T || !setequal(df_s[, time_var], times)) {
+			stop(paste0(
+				"Unit ",
+				s,
+				" does not have exactly T = ",
+				T,
+				" observations covering all time periods (got ",
+				nrow(df_s),
+				" observations, ",
+				length(unique(df_s[, time_var])),
+				" distinct time periods)."
+			))
 		}
 	}
 

--- a/R/utility.R
+++ b/R/utility.R
@@ -81,11 +81,21 @@ idCohorts <- function(df, time_var, unit_var, treat_var) {
 
 		# Balance check (gates the absorbing-state check on the same unit;
 		# we can't trust the per-period treatment vector when observations
-		# are missing).
-		if (nrow(df_s) != T) {
+		# are missing or when a time period is duplicated). The
+		# setequal() clause catches the (1, 2, 2)-style duplicate-time
+		# case that nrow == T silently passed pre-#75.
+		if (nrow(df_s) != T || !setequal(df_s[, time_var], times)) {
 			balance_violations <- c(
 				balance_violations,
-				paste0("unit ", s, " has ", nrow(df_s), " observations")
+				paste0(
+					"unit ",
+					s,
+					" has ",
+					nrow(df_s),
+					" observations (",
+					length(unique(df_s[, time_var])),
+					" distinct time periods)"
+				)
 			)
 			next
 		}

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.12",
+  note    = "R package version 1.9.13",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-idcohorts-collect-violations.R
+++ b/tests/testthat/test-idcohorts-collect-violations.R
@@ -160,6 +160,44 @@ test_that("idCohorts: balance + absorbing violations both surfaced in one messag
 # Truncation: 25 balance violations → first 20 + "... and 5 more".
 # ------------------------------------------------------------------------------
 
+test_that("idCohorts: duplicate-time-period unit flagged alongside missing-period unit (issue #75)", {
+	# Build T = 3 panel with three unit shapes:
+	#   - "good01": rows at times {1, 2, 3} → balanced, passes.
+	#   - "dup01":  rows at times {1, 2, 2} → nrow == T but only 2 distinct
+	#               periods (the canonical duplicate-time bug fix target).
+	#   - "miss01": rows at times {1, 2}    → nrow != T (missing period 3).
+	df <- data.frame(
+		unit = c(
+			rep("good01", 3),
+			"dup01",
+			"dup01",
+			"dup01",
+			"miss01",
+			"miss01"
+		),
+		time = c(1L, 2L, 3L, 1L, 2L, 2L, 1L, 2L),
+		treat = 0L,
+		stringsAsFactors = FALSE
+	)
+	err <- .catch_idcohorts(df)
+	expect_match(err, "Panel does not appear to be balanced")
+	# The duplicate-time unit must be named — without the fix, this
+	# assertion fails because the bug lets dup01 pass silently.
+	expect_match(
+		err,
+		"dup01 has 3 observations (2 distinct time periods)",
+		fixed = TRUE
+	)
+	# The missing-period unit is also named with the same format.
+	expect_match(
+		err,
+		"miss01 has 2 observations (2 distinct time periods)",
+		fixed = TRUE
+	)
+	# good01 stays absent.
+	expect_false(grepl("good01", err, fixed = TRUE))
+})
+
 test_that("idCohorts: more than 20 balance violations are truncated to 20 + summary", {
 	# Build 26 units, all balanced (3 rows each), then drop the third row
 	# from 25 of them so they fail balance.


### PR DESCRIPTION
Resolves #75. `R/utility.R::idCohorts()` validated panel balance with `nrow(df_s) != T` only — a unit with rows at times `(1, 2, 2)` and `T = 3` passed silently and downstream `processCovs()` then errored with the unhelpful `"undefined columns selected"`. Adds a `!setequal(df_s[, time_var], times)` clause to the balance check and expands the violation message from `"X has N observations"` to `"X has N observations (M distinct time periods)"`. The v1.9.6 collect-all-violations machinery surfaces the new case for free; existing tests use `expect_match(..., fixed = TRUE)` and remain backward-compatible.

Drift sentinel surfaced a parallel `nrow != T` check at `R/etwfe_core.R::processCovs()` lines 1207-1213 — currently dead-code-gated (idCohorts runs upstream on every existing path) but the canonical "sibling not updated" trap per `WORKFLOW_LESSONS.md` §14. Bundled the same `setequal()` tightening there as defense-in-depth, with a code comment marking the relationship.

New `test_that` block in `tests/testthat/test-idcohorts-collect-violations.R` exercises a mixed panel (one good + one duplicate-time + one missing-period unit), asserts the malformed units are flagged with the expanded format and the good one isn't. Patch version bump `1.9.12 → 1.9.13`. `devtools::check(args = "--as-cran")`: `0 errors / 0 warnings / 0 notes`. `devtools::test()`: `1653 → 1657 PASS`.
