### PR TITLE
Consolidate 4 'no features selected' early-exit blocks into one helper (#80, v1.9.14)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.13
+Version: 1.9.14
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # NEWS
 
+## Version 1.9.14 (2026-05-18)
+
+- Refactored the four "no features selected" early-exit blocks
+  in `fetwfe()` and `betwfe()` (intercept-only and no-treatment
+  cases for each estimator) to share a single internal helper
+  `.build_selected_out_result()` in `R/core_funcs.R`. No
+  user-visible behavior change: the return-list shape, field
+  ordering, and values are byte-identical to v1.9.13. The
+  consolidation eliminates a 4-way drift surface that produced
+  9 stale `q < 1` references in v1.9.5 (#56). Resolves #80.
+
 ## Version 1.9.13 (2026-05-18)
 
 - Tightened `idCohorts()`'s panel-balance check to catch units

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -978,39 +978,16 @@ betwfe_core <- function(
 
 	# Handle edge case where no features are selected (model_size includes intercept)
 	if (lambda_star_model_size <= 1 && all(beta_hat[2:(p + 1)] == 0)) {
-		# only intercept might be non-zero
-		if (verbose) {
-			message(
-				"No features selected (or only intercept); all treatment effects estimated to be 0."
-			)
-		}
-
-		if (q < 1) {
-			ret_se <- 0
-		} else {
-			ret_se <- NA
-		}
-
-		catt_df_to_ret <- data.frame(
-			Cohort = c_names,
-			`Estimated TE` = rep(0, R),
-			SE = rep(ret_se, R),
-			ConfIntLow = rep(ret_se, R),
-			ConfIntHigh = rep(ret_se, R),
-			P_value = rep(NA_real_, R),
-			selected = rep(FALSE, R),
-			check.names = FALSE
-		)
-
-		return(list(
-			in_sample_att_hat = 0,
-			in_sample_att_se = ret_se,
-			in_sample_att_se_no_prob = ret_se,
-			indep_att_hat = 0,
-			indep_att_se = ret_se,
-			catt_hats = setNames(rep(0, R), c_names),
-			catt_ses = setNames(rep(ret_se, R), c_names),
-			catt_df = catt_df_to_ret,
+		# Only the intercept might be non-zero. Delegate to the shared
+		# helper (`.build_selected_out_result()` in `R/core_funcs.R`) that
+		# also serves the no-treatment branch below and the two FETWFE
+		# early-exits. BETWFE blocks omit `theta_hat` from the return.
+		return(.build_selected_out_result(
+			message_text = "No features selected (or only intercept); all treatment effects estimated to be 0.",
+			verbose = verbose,
+			R = R,
+			c_names = c_names,
+			q = q,
 			beta_hat = beta_hat[2:(p + 1)], # Slopes are all zero
 			treat_inds = treat_inds,
 			treat_int_inds = treat_int_inds,
@@ -1032,10 +1009,8 @@ betwfe_core <- function(
 			y_final = y_final,
 			N = N,
 			T = T,
-			R = R,
 			d = d,
-			p = p,
-			calc_ses = q < 1
+			p = p
 		))
 	}
 
@@ -1066,43 +1041,21 @@ betwfe_core <- function(
 
 	# Handle edge case where no treatment features selected
 	if (length(sel_treat_inds_shifted) == 0) {
-		if (verbose) {
-			message(
-				"No treatment features selected; all treatment effects estimated to be 0."
-			)
-		}
-
-		if (q < 1) {
-			ret_se <- 0
-		} else {
-			ret_se <- NA
-		}
-
-		catt_df_to_ret <- data.frame(
-			Cohort = c_names,
-			`Estimated TE` = rep(0, R),
-			SE = rep(ret_se, R),
-			ConfIntLow = rep(ret_se, R),
-			ConfIntHigh = rep(ret_se, R),
-			P_value = rep(NA_real_, R),
-			selected = rep(FALSE, R),
-			check.names = FALSE
-		)
-
+		# Apply ridge adjustment locally before early-exit return; doesn't
+		# affect later code paths (they re-compute `beta_hat` from
+		# `beta_hat_slopes` separately and run the non-early-exit
+		# `add_ridge` scaling at line ~1108). Plan D3.
 		if (add_ridge) {
 			lambda_ridge <- ifelse(is.na(lambda_ridge), 0, lambda_ridge)
 			beta_hat_slopes <- beta_hat_slopes * (1 + lambda_ridge)
 		}
 
-		return(list(
-			in_sample_att_hat = 0,
-			in_sample_att_se = ret_se,
-			in_sample_att_se_no_prob = ret_se,
-			indep_att_hat = 0,
-			indep_att_se = ret_se,
-			catt_hats = setNames(rep(0, R), c_names),
-			catt_ses = setNames(rep(ret_se, R), c_names),
-			catt_df = catt_df_to_ret,
+		return(.build_selected_out_result(
+			message_text = "No treatment features selected; all treatment effects estimated to be 0.",
+			verbose = verbose,
+			R = R,
+			c_names = c_names,
+			q = q,
 			beta_hat = beta_hat_slopes, # Untransformed slopes
 			treat_inds = treat_inds,
 			treat_int_inds = treat_int_inds,
@@ -1124,10 +1077,8 @@ betwfe_core <- function(
 			y_final = y_final,
 			N = N,
 			T = T,
-			R = R,
 			d = d,
-			p = p,
-			calc_ses = q < 1
+			p = p
 		))
 	}
 

--- a/R/core_funcs.R
+++ b/R/core_funcs.R
@@ -832,3 +832,203 @@ genFullInvFusionTransformMat <- function(first_inds, T, R, d, num_treats) {
 
 	return(full_D_inv)
 }
+
+#' @title Build the "no features selected" early-exit return list shared by
+#'   `fetwfe_core()` and `betwfe_core()`
+#'
+#' @description
+#' Internal helper that consolidates four near-duplicate early-exit blocks
+#' that previously lived inline in `R/betwfe_core.R` and `R/fetwfe_core.R`
+#' (BETWFE intercept-only, BETWFE no-treatment-selected, FETWFE
+#' intercept-only, FETWFE no-treatment-selected). All four blocks construct
+#' the same 33-/34-field return list with all-zero CATTs / ATTs and the same
+#' `data.frame` of CATT placeholders; they differ only in the `beta_hat`
+#' value, whether `theta_hat` is in the return, and the verbose-message
+#' text. Caller computes the final `beta_hat` (including any
+#' `add_ridge` adjustment and, for FETWFE, the
+#' `untransformCoefImproved()` transformation back from `theta`) and
+#' passes it in; helper builds the return list with the contractually-fixed
+#' field ordering. Resolves drift surface that produced 9 stale `q < 1`
+#' references in v1.9.5 (#56).
+#'
+#' @param message_text Character scalar; emitted via `message()` when
+#'   `verbose` is `TRUE`. Per-block string (see callers).
+#' @param verbose Logical; whether to emit `message_text`.
+#' @param R,N,T,d,p Integers; problem dimensions.
+#' @param c_names Character vector of length `R`; cohort labels for the
+#'   `catt_df_to_ret` rows.
+#' @param q Numeric; bridge regression exponent. Drives the
+#'   `ret_se <- if (q < 1) 0 else NA` SE-shape gate.
+#' @param beta_hat Numeric vector of length `p`; the final slope estimates
+#'   (caller-computed). For BETWFE intercept-only this is
+#'   `beta_hat[2:(p+1)]` (all zero); for BETWFE no-treatment this is
+#'   `beta_hat_slopes` after caller-applied `add_ridge` adjustment; for
+#'   FETWFE intercept-only this is `rep(0, p)`; for FETWFE no-treatment
+#'   this is `untransformCoefImproved(theta_hat_slopes)` after
+#'   caller-applied `add_ridge` adjustment.
+#' @param treat_inds,treat_int_inds Integer vectors; treatment-effect column
+#'   indices.
+#' @param cohort_probs,indep_cohort_probs Numeric vectors; cohort-probability
+#'   weights computed by `prep_for_etwfe_regression()`.
+#' @param cohort_probs_overall,indep_cohort_probs_overall Numeric scalars;
+#'   overall cohort-probability weights.
+#' @param sig_eps_sq,sig_eps_c_sq Numeric scalars; variance components.
+#' @param lambda.max,lambda.min,lambda_star Numeric scalars; bridge penalty
+#'   path endpoints and the BIC-selected lambda.
+#' @param lambda.max_model_size,lambda.min_model_size,lambda_star_model_size
+#'   Integer scalars; model sizes at each lambda.
+#' @param X_ints Numeric matrix; original-basis design.
+#' @param y Numeric vector; centered response.
+#' @param X_final,y_final Numeric matrix/vector; GLS-whitened design and
+#'   response actually fed to the bridge regression.
+#' @param theta_hat Optional numeric vector of length `p + 1` (includes
+#'   intercept). For FETWFE blocks only; BETWFE blocks omit (default
+#'   `NULL`).
+#' @param include_theta Logical; if `TRUE`, inserts `theta_hat` into the
+#'   return list between `catt_df` and `beta_hat` (FETWFE field order).
+#'   Default `FALSE` (BETWFE field order: no `theta_hat`).
+#'
+#' @return A 33-field (BETWFE) or 34-field (FETWFE) list with the same
+#'   field ordering as the pre-refactor inline blocks. The ordering is
+#'   load-bearing: downstream code in `betwfe()` / `fetwfe()` and the S3
+#'   class machinery in `R/*_class.R` indexes the result by name, but the
+#'   snapshot tests in `tests/testthat/_snaps/print-method-snapshot.md` and
+#'   the constructors in `R/class_helpers.R` are sensitive to the *names()*
+#'   ordering.
+#'
+#' @keywords internal
+#' @noRd
+.build_selected_out_result <- function(
+	message_text,
+	verbose,
+	R,
+	c_names,
+	q,
+	beta_hat,
+	treat_inds,
+	treat_int_inds,
+	cohort_probs,
+	indep_cohort_probs,
+	cohort_probs_overall,
+	indep_cohort_probs_overall,
+	sig_eps_sq,
+	sig_eps_c_sq,
+	lambda.max,
+	lambda.max_model_size,
+	lambda.min,
+	lambda.min_model_size,
+	lambda_star,
+	lambda_star_model_size,
+	X_ints,
+	y,
+	X_final,
+	y_final,
+	N,
+	T,
+	d,
+	p,
+	theta_hat = NULL,
+	include_theta = FALSE
+) {
+	if (verbose) {
+		message(message_text)
+	}
+
+	if (q < 1) {
+		ret_se <- 0
+	} else {
+		ret_se <- NA
+	}
+
+	catt_df_to_ret <- data.frame(
+		Cohort = c_names,
+		`Estimated TE` = rep(0, R),
+		SE = rep(ret_se, R),
+		ConfIntLow = rep(ret_se, R),
+		ConfIntHigh = rep(ret_se, R),
+		P_value = rep(NA_real_, R),
+		selected = rep(FALSE, R),
+		check.names = FALSE
+	)
+
+	# Build the FULL union list with every possible field, then drop
+	# the fields that don't belong to this block via name-vector
+	# selection (per PR #92's `.summary_estimator_output()` pattern).
+	# The `keep` vector encodes the contractual field ordering:
+	# `theta_hat` slots between `catt_df` and `beta_hat` for FETWFE
+	# blocks (3 + 4); BETWFE blocks (1 + 2) omit it.
+	out <- list(
+		in_sample_att_hat = 0,
+		in_sample_att_se = ret_se,
+		in_sample_att_se_no_prob = ret_se,
+		indep_att_hat = 0,
+		indep_att_se = ret_se,
+		catt_hats = setNames(rep(0, R), c_names),
+		catt_ses = setNames(rep(ret_se, R), c_names),
+		catt_df = catt_df_to_ret,
+		theta_hat = theta_hat,
+		beta_hat = beta_hat,
+		treat_inds = treat_inds,
+		treat_int_inds = treat_int_inds,
+		cohort_probs = cohort_probs,
+		indep_cohort_probs = indep_cohort_probs,
+		cohort_probs_overall = cohort_probs_overall,
+		indep_cohort_probs_overall = indep_cohort_probs_overall,
+		sig_eps_sq = sig_eps_sq,
+		sig_eps_c_sq = sig_eps_c_sq,
+		lambda.max = lambda.max,
+		lambda.max_model_size = lambda.max_model_size,
+		lambda.min = lambda.min,
+		lambda.min_model_size = lambda.min_model_size,
+		lambda_star = lambda_star,
+		lambda_star_model_size = lambda_star_model_size,
+		X_ints = X_ints,
+		y = y,
+		X_final = X_final,
+		y_final = y_final,
+		N = N,
+		T = T,
+		R = R,
+		d = d,
+		p = p,
+		calc_ses = q < 1
+	)
+
+	keep <- c(
+		"in_sample_att_hat",
+		"in_sample_att_se",
+		"in_sample_att_se_no_prob",
+		"indep_att_hat",
+		"indep_att_se",
+		"catt_hats",
+		"catt_ses",
+		"catt_df",
+		if (include_theta) "theta_hat",
+		"beta_hat",
+		"treat_inds",
+		"treat_int_inds",
+		"cohort_probs",
+		"indep_cohort_probs",
+		"cohort_probs_overall",
+		"indep_cohort_probs_overall",
+		"sig_eps_sq",
+		"sig_eps_c_sq",
+		"lambda.max",
+		"lambda.max_model_size",
+		"lambda.min",
+		"lambda.min_model_size",
+		"lambda_star",
+		"lambda_star_model_size",
+		"X_ints",
+		"y",
+		"X_final",
+		"y_final",
+		"N",
+		"T",
+		"R",
+		"d",
+		"p",
+		"calc_ses"
+	)
+	out[keep]
+}

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -900,40 +900,18 @@ fetwfe_core <- function(
 
 	# Handle edge case where no features are selected (model_size includes intercept)
 	if (lambda_star_model_size <= 1 && all(theta_hat[2:(p + 1)] == 0)) {
-		# only intercept might be non-zero
-		if (verbose) {
-			message(
-				"No features selected (or only intercept); all treatment effects estimated to be 0."
-			)
-		}
-
-		if (q < 1) {
-			ret_se <- 0
-		} else {
-			ret_se <- NA
-		}
-
-		catt_df_to_ret <- data.frame(
-			Cohort = c_names,
-			`Estimated TE` = rep(0, R),
-			SE = rep(ret_se, R),
-			ConfIntLow = rep(ret_se, R),
-			ConfIntHigh = rep(ret_se, R),
-			P_value = rep(NA_real_, R),
-			selected = rep(FALSE, R),
-			check.names = FALSE
-		)
-
-		return(list(
-			in_sample_att_hat = 0,
-			in_sample_att_se = ret_se,
-			in_sample_att_se_no_prob = ret_se,
-			indep_att_hat = 0,
-			indep_att_se = ret_se,
-			catt_hats = setNames(rep(0, R), c_names),
-			catt_ses = setNames(rep(ret_se, R), c_names),
-			catt_df = catt_df_to_ret,
-			theta_hat = theta_hat, # Includes intercept
+		# Only the intercept might be non-zero. Delegate to the shared
+		# helper (`.build_selected_out_result()` in `R/core_funcs.R`) that
+		# also serves the no-treatment branch below and the two BETWFE
+		# early-exits. FETWFE blocks pass `theta_hat` (with intercept)
+		# and set `include_theta = TRUE` to insert it between `catt_df`
+		# and `beta_hat`.
+		return(.build_selected_out_result(
+			message_text = "No features selected (or only intercept); all treatment effects estimated to be 0.",
+			verbose = verbose,
+			R = R,
+			c_names = c_names,
+			q = q,
 			beta_hat = rep(0, p), # Slopes are all zero
 			treat_inds = treat_inds,
 			treat_int_inds = treat_int_inds,
@@ -955,10 +933,10 @@ fetwfe_core <- function(
 			y_final = y_final,
 			N = N,
 			T = T,
-			R = R,
 			d = d,
 			p = p,
-			calc_ses = q < 1
+			theta_hat = theta_hat, # Includes intercept
+			include_theta = TRUE
 		))
 	}
 
@@ -989,30 +967,10 @@ fetwfe_core <- function(
 
 	# Handle edge case where no treatment features selected
 	if (length(sel_treat_inds_shifted) == 0) {
-		if (verbose) {
-			message(
-				"No treatment features selected; all treatment effects estimated to be 0."
-			)
-		}
-
-		if (q < 1) {
-			ret_se <- 0
-		} else {
-			ret_se <- NA
-		}
-
-		catt_df_to_ret <- data.frame(
-			Cohort = c_names,
-			`Estimated TE` = rep(0, R),
-			SE = rep(ret_se, R),
-			ConfIntLow = rep(ret_se, R),
-			ConfIntHigh = rep(ret_se, R),
-			P_value = rep(NA_real_, R),
-			selected = rep(FALSE, R),
-			check.names = FALSE
-		)
-
-		# Need to untransform theta_hat_slopes to get beta_hat for consistency
+		# Untransform `theta_hat_slopes` back to original (beta) basis for
+		# the helper's contract — `untransformCoefImproved()` is the
+		# FETWFE-specific reparameterization (theta -> beta) and stays at
+		# the caller (the helper is parameterization-agnostic).
 		beta_hat_early_exit <- untransformCoefImproved(
 			beta_hat_mod = theta_hat_slopes, # Pass slopes only
 			first_inds = first_inds,
@@ -1022,21 +980,21 @@ fetwfe_core <- function(
 			d = d,
 			num_treats = num_treats
 		)
+		# Apply ridge adjustment locally before early-exit return; doesn't
+		# affect later code paths (they re-compute `beta_hat` separately
+		# and run the non-early-exit `add_ridge` scaling at line ~1083).
+		# Plan D3.
 		if (add_ridge) {
 			lambda_ridge <- ifelse(is.na(lambda_ridge), 0, lambda_ridge)
 			beta_hat_early_exit <- beta_hat_early_exit * (1 + lambda_ridge)
 		}
 
-		return(list(
-			in_sample_att_hat = 0,
-			in_sample_att_se = ret_se,
-			in_sample_att_se_no_prob = ret_se,
-			indep_att_hat = 0,
-			indep_att_se = ret_se,
-			catt_hats = setNames(rep(0, R), c_names),
-			catt_ses = setNames(rep(ret_se, R), c_names),
-			catt_df = catt_df_to_ret,
-			theta_hat = theta_hat, # Full theta_hat with intercept
+		return(.build_selected_out_result(
+			message_text = "No treatment features selected; all treatment effects estimated to be 0.",
+			verbose = verbose,
+			R = R,
+			c_names = c_names,
+			q = q,
 			beta_hat = beta_hat_early_exit, # Untransformed slopes
 			treat_inds = treat_inds,
 			treat_int_inds = treat_int_inds,
@@ -1058,10 +1016,10 @@ fetwfe_core <- function(
 			y_final = y_final,
 			N = N,
 			T = T,
-			R = R,
 			d = d,
 			p = p,
-			calc_ses = q < 1
+			theta_hat = theta_hat, # Full theta_hat with intercept
+			include_theta = TRUE
 		))
 	}
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.13",
+  note    = "R package version 1.9.14",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-build-selected-out-result-80.R
+++ b/tests/testthat/test-build-selected-out-result-80.R
@@ -1,0 +1,283 @@
+# Tests for `.build_selected_out_result()` in R/core_funcs.R (issue #80).
+#
+# The helper consolidates the four pre-1.9.14 inline "no features selected"
+# early-exit blocks that lived in `R/betwfe_core.R` (lines 979-1040,
+# 1067-1132) and `R/fetwfe_core.R` (lines 901-963, 990-1066). Per the plan
+# (`.plans/refactor-selected-out-helper-80/PLAN.md`), the 4 blocks share
+# the same 33-/34-field return list and only differ in (a) the `beta_hat`
+# value, (b) whether `theta_hat` is included, and (c) the verbose-message
+# text. These tests lock the helper's contract directly with hand-crafted
+# inputs rather than constructing fixtures that trigger each early-exit
+# path from an end-to-end fit (much simpler; the existing test suite
+# already exercises the integration).
+#
+# Snapshot guardrail covers Blocks 1 + 3 (BETWFE and FETWFE intercept-only)
+# via `tests/testthat/_snaps/print-method-snapshot.md`; these tests cover
+# Blocks 2 + 4 (no-treatment) and lock the helper's contract directly.
+
+# Builder for the minimal helper-input keyword-arg list. Returns a list
+# with the union of all arguments at deterministic values. Callers spread
+# this via `do.call(fetwfe:::.build_selected_out_result, ...)` and override
+# specific fields per test.
+.make_helper_args <- function() {
+	R <- 2L
+	N <- 10L
+	T <- 3L
+	d <- 0L
+	p <- 7L # contrived but consistent; helper doesn't validate p arithmetic
+	list(
+		message_text = "test message",
+		verbose = FALSE,
+		R = R,
+		c_names = c("2", "3"),
+		q = 0.5,
+		beta_hat = rep(0, p),
+		treat_inds = 3:5,
+		treat_int_inds = integer(0),
+		cohort_probs = c(0.5, 0.5),
+		indep_cohort_probs = c(0.5, 0.5),
+		cohort_probs_overall = 0.7,
+		indep_cohort_probs_overall = 0.7,
+		sig_eps_sq = 1.0,
+		sig_eps_c_sq = 0.5,
+		lambda.max = 0.10,
+		lambda.max_model_size = 5L,
+		lambda.min = 0.001,
+		lambda.min_model_size = 20L,
+		lambda_star = 0.05,
+		lambda_star_model_size = 1L,
+		X_ints = matrix(0, N * T, p),
+		y = rep(0, N * T),
+		X_final = matrix(0, N * T, p),
+		y_final = rep(0, N * T),
+		N = N,
+		T = T,
+		d = d,
+		p = p
+	)
+}
+
+# Field ordering the helper must produce for BETWFE-shape returns (Blocks
+# 1 + 2). 33 fields. No `theta_hat`. Matches the pre-refactor inline
+# `return(list(...))` order verified by the plan reviewer.
+.expected_betwfe_field_order <- c(
+	"in_sample_att_hat",
+	"in_sample_att_se",
+	"in_sample_att_se_no_prob",
+	"indep_att_hat",
+	"indep_att_se",
+	"catt_hats",
+	"catt_ses",
+	"catt_df",
+	"beta_hat",
+	"treat_inds",
+	"treat_int_inds",
+	"cohort_probs",
+	"indep_cohort_probs",
+	"cohort_probs_overall",
+	"indep_cohort_probs_overall",
+	"sig_eps_sq",
+	"sig_eps_c_sq",
+	"lambda.max",
+	"lambda.max_model_size",
+	"lambda.min",
+	"lambda.min_model_size",
+	"lambda_star",
+	"lambda_star_model_size",
+	"X_ints",
+	"y",
+	"X_final",
+	"y_final",
+	"N",
+	"T",
+	"R",
+	"d",
+	"p",
+	"calc_ses"
+)
+
+# Field ordering the helper must produce for FETWFE-shape returns (Blocks
+# 3 + 4). 34 fields. `theta_hat` slots between `catt_df` and `beta_hat`.
+.expected_fetwfe_field_order <- c(
+	"in_sample_att_hat",
+	"in_sample_att_se",
+	"in_sample_att_se_no_prob",
+	"indep_att_hat",
+	"indep_att_se",
+	"catt_hats",
+	"catt_ses",
+	"catt_df",
+	"theta_hat",
+	"beta_hat",
+	"treat_inds",
+	"treat_int_inds",
+	"cohort_probs",
+	"indep_cohort_probs",
+	"cohort_probs_overall",
+	"indep_cohort_probs_overall",
+	"sig_eps_sq",
+	"sig_eps_c_sq",
+	"lambda.max",
+	"lambda.max_model_size",
+	"lambda.min",
+	"lambda.min_model_size",
+	"lambda_star",
+	"lambda_star_model_size",
+	"X_ints",
+	"y",
+	"X_final",
+	"y_final",
+	"N",
+	"T",
+	"R",
+	"d",
+	"p",
+	"calc_ses"
+)
+
+test_that("BETWFE intercept-only block (Block 1) shape: 33 fields, expected ordering, no theta_hat", {
+	args <- .make_helper_args()
+	# Block 1 input shape: all-zero beta_hat (slopes), no theta_hat,
+	# q < 1 -> ret_se = 0.
+	args$beta_hat <- rep(0, args$p)
+	args$message_text <- "No features selected (or only intercept); all treatment effects estimated to be 0."
+
+	res <- do.call(fetwfe:::.build_selected_out_result, args)
+
+	expect_type(res, "list")
+	expect_length(res, 33L)
+	expect_identical(names(res), .expected_betwfe_field_order)
+	expect_false("theta_hat" %in% names(res))
+
+	# Spot-check key field values.
+	expect_identical(res$in_sample_att_hat, 0)
+	expect_identical(res$indep_att_hat, 0)
+	expect_identical(res$in_sample_att_se, 0) # q < 1 -> ret_se = 0
+	expect_identical(res$indep_att_se, 0)
+	expect_true(res$calc_ses)
+
+	expect_named(res$catt_hats, c("2", "3"))
+	expect_identical(unname(res$catt_hats), c(0, 0))
+	expect_identical(unname(res$catt_ses), c(0, 0))
+
+	expect_s3_class(res$catt_df, "data.frame")
+	expect_named(
+		res$catt_df,
+		c(
+			"Cohort",
+			"Estimated TE",
+			"SE",
+			"ConfIntLow",
+			"ConfIntHigh",
+			"P_value",
+			"selected"
+		)
+	)
+	expect_equal(nrow(res$catt_df), args$R)
+	expect_identical(res$catt_df$Cohort, args$c_names)
+	expect_identical(res$catt_df$selected, rep(FALSE, args$R))
+	expect_identical(res$catt_df$P_value, rep(NA_real_, args$R))
+
+	expect_identical(res$beta_hat, rep(0, args$p))
+	expect_identical(res$N, args$N)
+	expect_identical(res$T, args$T)
+	expect_identical(res$R, args$R)
+	expect_identical(res$d, args$d)
+	expect_identical(res$p, args$p)
+})
+
+test_that("BETWFE no-treatment block (Block 2) shape: caller-applied add_ridge scaling propagates", {
+	args <- .make_helper_args()
+	args$message_text <- "No treatment features selected; all treatment effects estimated to be 0."
+	# Block 2 input shape: non-zero beta_hat (some non-treatment
+	# coefs selected), no theta_hat. Simulate caller-applied
+	# `add_ridge` scaling: beta_hat * (1 + lambda_ridge).
+	base_beta <- c(0.5, -0.3, 0, 0, 0, 0.2, 0)
+	lambda_ridge <- 0.1
+	args$beta_hat <- base_beta * (1 + lambda_ridge)
+
+	res <- do.call(fetwfe:::.build_selected_out_result, args)
+
+	expect_length(res, 33L)
+	expect_identical(names(res), .expected_betwfe_field_order)
+	expect_false("theta_hat" %in% names(res))
+
+	expect_identical(res$beta_hat, base_beta * 1.1)
+	expect_identical(res$in_sample_att_hat, 0)
+	expect_identical(unname(res$catt_hats), c(0, 0))
+})
+
+test_that("FETWFE intercept-only block (Block 3) shape: 34 fields, theta_hat between catt_df and beta_hat", {
+	args <- .make_helper_args()
+	args$message_text <- "No features selected (or only intercept); all treatment effects estimated to be 0."
+	args$beta_hat <- rep(0, args$p)
+	args$theta_hat <- c(1.5, rep(0, args$p)) # intercept + zero slopes
+	args$include_theta <- TRUE
+
+	res <- do.call(fetwfe:::.build_selected_out_result, args)
+
+	expect_length(res, 34L)
+	expect_identical(names(res), .expected_fetwfe_field_order)
+
+	# theta_hat present, immediately between catt_df (pos 8) and beta_hat (pos 10)
+	expect_true("theta_hat" %in% names(res))
+	expect_identical(which(names(res) == "theta_hat"), 9L)
+	expect_identical(which(names(res) == "beta_hat"), 10L)
+	expect_identical(which(names(res) == "catt_df"), 8L)
+
+	expect_identical(res$theta_hat, args$theta_hat)
+	expect_identical(res$beta_hat, rep(0, args$p))
+})
+
+test_that("FETWFE no-treatment block (Block 4) shape: caller passes untransformed beta_hat plus theta_hat", {
+	args <- .make_helper_args()
+	args$message_text <- "No treatment features selected; all treatment effects estimated to be 0."
+	# Block 4 caller computes beta_hat via `untransformCoefImproved()`
+	# then optionally scales by (1 + lambda_ridge). Simulate the
+	# final value the helper receives.
+	args$beta_hat <- c(0.4, -0.2, 0, 0, 0, 0.1, 0) * 1.05 # post-untransform + add_ridge
+	args$theta_hat <- c(2.0, 0.3, -0.1, 0, 0, 0, 0.15, 0) # full theta with intercept
+	args$include_theta <- TRUE
+
+	res <- do.call(fetwfe:::.build_selected_out_result, args)
+
+	expect_length(res, 34L)
+	expect_identical(names(res), .expected_fetwfe_field_order)
+	expect_identical(res$theta_hat, args$theta_hat)
+	expect_identical(res$beta_hat, args$beta_hat)
+})
+
+test_that("q gating: q >= 1 -> ret_se = NA, calc_ses = FALSE; q < 1 -> ret_se = 0, calc_ses = TRUE", {
+	args_low <- .make_helper_args()
+	args_low$q <- 0.5
+	res_low <- do.call(fetwfe:::.build_selected_out_result, args_low)
+
+	expect_identical(res_low$in_sample_att_se, 0)
+	expect_identical(res_low$indep_att_se, 0)
+	expect_identical(unname(res_low$catt_ses), c(0, 0))
+	expect_identical(res_low$catt_df$SE, c(0, 0))
+	expect_true(res_low$calc_ses)
+
+	args_high <- .make_helper_args()
+	args_high$q <- 1
+	res_high <- do.call(fetwfe:::.build_selected_out_result, args_high)
+
+	expect_identical(res_high$in_sample_att_se, NA)
+	expect_identical(res_high$indep_att_se, NA)
+	expect_true(all(is.na(res_high$catt_ses)))
+	expect_true(all(is.na(res_high$catt_df$SE)))
+	expect_false(res_high$calc_ses)
+})
+
+test_that("verbose = TRUE emits the supplied message_text; verbose = FALSE is silent", {
+	args <- .make_helper_args()
+	args$verbose <- TRUE
+	args$message_text <- "No features selected (or only intercept); all treatment effects estimated to be 0."
+	expect_message(
+		do.call(fetwfe:::.build_selected_out_result, args),
+		"No features selected"
+	)
+
+	args$verbose <- FALSE
+	expect_no_message(do.call(fetwfe:::.build_selected_out_result, args))
+})


### PR DESCRIPTION
Resolves #80. The four "no features selected" early-exit blocks in `R/betwfe_core.R` and `R/fetwfe_core.R` (each ~60 lines, all constructing the same ~30-field return list when the bridge's `lambda_star` lands on either the intercept-only model or a model with no selected treatment features) are consolidated into a single internal helper `.build_selected_out_result()` in `R/core_funcs.R`. Per-block call sites become ~25-line dispatch wrappers passing the right per-block `beta_hat` (and optionally `theta_hat` + `include_theta = TRUE` for FETWFE blocks). The `add_ridge` adjustment (Blocks 2 + 4) and `untransformCoefImproved()` (Block 4) stay at the caller per D3.

Field ordering is preserved byte-identically (PR #92's `keep`-name-vector reorder pattern slots `theta_hat` between `catt_df` and `beta_hat`). The PR #90 snapshot exercises both Block 1 AND Block 3 (intercept-only paths for betwfe and fetwfe); `git diff origin/main -- tests/testthat/_snaps/print-method-snapshot.md` is empty after the refactor, regression-locking 50% of the 4-block surface. New `tests/testthat/test-build-selected-out-result-80.R` directly tests the helper's contract with 6 `test_that` blocks / 54 expectations covering both block shapes.

The v1.9.5 / #56 PR found 9 stale `q < 1` references concentrated in exactly these blocks; consolidation reduces the drift surface from 4 sites to 1. Patch bump 1.9.13 → 1.9.14. `devtools::check(args = "--as-cran")`: `0/0/0`. `devtools::test()`: 1657 → 1711 PASS.
