### PR TITLE
Consolidate cluster-robust sandwich assembly across 4 call sites (#78, v1.9.15)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.14
+Version: 1.9.15
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # NEWS
 
+## Version 1.9.15 (2026-05-18)
+
+- Consolidated the cluster-robust sandwich assembly across 4 call
+  sites (`getCohortATTsFinalOLS`, `getCohortATTsFinal`,
+  `.event_study_etwfe_betwfe`, `.event_study_fetwfe`) into a single
+  internal helper `.assemble_cluster_robust_sandwich()` in
+  `R/ols_calcs.R`. No user-visible behavior change; the sandwich
+  matrix and `treat_block_mask` outputs are bit-identical to v1.9.14.
+  The consolidation reduces the drift surface that produced the
+  v1.9.5 `10e-6` threshold typo (#56) from 4 sites to 1.
+  Resolves #78.
+
 ## Version 1.9.14 (2026-05-18)
 
 - Refactored the four "no features selected" early-exit blocks

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -138,22 +138,17 @@ event_study <- function(x, alpha = NULL) {
 	sandwich_full <- NULL
 	treat_block_mask <- NULL
 	if (identical(se_type, "cluster") && calc_ses) {
-		if (any(!is.na(sel_feat_inds))) {
-			X_S <- X_final[, sel_feat_inds, drop = FALSE]
-			treat_block_mask <- sel_feat_inds %in% treat_inds
-		} else {
-			X_S <- X_final
-			treat_block_mask <- logical(ncol(X_S))
-			treat_block_mask[treat_inds] <- TRUE
-		}
-		y_ <- y_final[seq_len(N * T)]
-		ols_fit <- stats::lm.fit(cbind(1, X_S), y_)
-		sandwich_full <- .compute_cluster_robust_sandwich(
-			X_S = X_S,
-			residuals = ols_fit$residuals,
+		sel_arg <- if (any(!is.na(sel_feat_inds))) sel_feat_inds else NULL
+		res <- .assemble_cluster_robust_sandwich(
+			X_final = X_final,
+			y_final = y_final,
 			N = N,
-			T = T
+			T = T,
+			treat_inds = treat_inds,
+			sel_feat_inds = sel_arg
 		)
+		sandwich_full <- res$sandwich_full
+		treat_block_mask <- res$treat_block_mask
 	}
 
 	max_event <- T - 2L
@@ -329,16 +324,16 @@ event_study <- function(x, alpha = NULL) {
 	sandwich_full <- NULL
 	treat_block_mask <- NULL
 	if (identical(se_type, "cluster") && calc_ses) {
-		X_S <- X_final[, sel_feat_inds, drop = FALSE]
-		treat_block_mask <- sel_feat_inds %in% treat_inds
-		y_ <- y_final[seq_len(N * T)]
-		ols_fit <- stats::lm.fit(cbind(1, X_S), y_)
-		sandwich_full <- .compute_cluster_robust_sandwich(
-			X_S = X_S,
-			residuals = ols_fit$residuals,
+		res <- .assemble_cluster_robust_sandwich(
+			X_final = X_final,
+			y_final = y_final,
 			N = N,
-			T = T
+			T = T,
+			treat_inds = treat_inds,
+			sel_feat_inds = sel_feat_inds
 		)
+		sandwich_full <- res$sandwich_full
+		treat_block_mask <- res$treat_block_mask
 	}
 
 	max_event <- T - 2L

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -2332,19 +2332,16 @@ getCohortATTsFinal <- function(
 	if (identical(se_type, "cluster") && calc_ses) {
 		stopifnot(!is.null(y_final))
 		stopifnot(length(y_final) >= N * T)
-
-		X_S <- X_final[, sel_feat_inds, drop = FALSE]
-		y_ <- y_final[seq_len(N * T)]
-		ols_fit <- stats::lm.fit(cbind(1, X_S), y_)
-
-		sandwich_full <- .compute_cluster_robust_sandwich(
-			X_S = X_S,
-			residuals = ols_fit$residuals,
+		res <- .assemble_cluster_robust_sandwich(
+			X_final = X_final,
+			y_final = y_final,
 			N = N,
-			T = T
+			T = T,
+			treat_inds = treat_inds,
+			sel_feat_inds = sel_feat_inds
 		)
-
-		treat_block_mask <- sel_feat_inds %in% treat_inds
+		sandwich_full <- res$sandwich_full
+		treat_block_mask <- res$treat_block_mask
 		stopifnot(length(treat_block_mask) == length(sel_feat_inds))
 		stopifnot(sum(treat_block_mask) == length(sel_treat_inds_shifted))
 	}

--- a/R/ols_calcs.R
+++ b/R/ols_calcs.R
@@ -103,20 +103,16 @@ getCohortATTsFinalOLS <- function(
 	if (identical(se_type, "cluster") && calc_ses) {
 		stopifnot(!is.null(y_final))
 		stopifnot(length(y_final) >= N * T)
-
-		X_S <- X_final
-		y_ <- y_final[seq_len(N * T)]
-		ols_fit <- stats::lm.fit(cbind(1, X_S), y_)
-
-		sandwich_full <- .compute_cluster_robust_sandwich(
-			X_S = X_S,
-			residuals = ols_fit$residuals,
+		res <- .assemble_cluster_robust_sandwich(
+			X_final = X_final,
+			y_final = y_final,
 			N = N,
-			T = T
+			T = T,
+			treat_inds = treat_inds,
+			sel_feat_inds = NULL
 		)
-
-		treat_block_mask <- logical(ncol(X_S))
-		treat_block_mask[treat_inds] <- TRUE
+		sandwich_full <- res$sandwich_full
+		treat_block_mask <- res$treat_block_mask
 	}
 
 	# First, each cohort
@@ -614,4 +610,71 @@ getPsiRUnfused <- function(
 	}
 	cadjust <- N / (N - 1)
 	cadjust * gram_inv_full %*% meat %*% gram_inv_full
+}
+
+#' @title Assemble the cluster-robust sandwich for the OLS-selected support
+#' @description
+#' Wraps the 4-step assembly ritual used by `getCohortATTsFinalOLS()`,
+#' `getCohortATTsFinal()`, and the two `event_study` dispatchers
+#' (`.event_study_etwfe_betwfe`, `.event_study_fetwfe`): extract `X_S`
+#' from `X_final` (optionally filtered by `sel_feat_inds`), run
+#' `stats::lm.fit(cbind(1, X_S), y_final[seq_len(N * T)])`, compute the
+#' cluster-robust sandwich via `.compute_cluster_robust_sandwich()`, and
+#' build the corresponding `treat_block_mask`. Returns both as a list so
+#' the caller can use them downstream.
+#'
+#' Resolves GitHub #78. The drift class this addresses is the v1.9.5
+#' `10e-6` threshold typo: same logic written across 4 siblings, one
+#' site could get a fix while the others quietly didn't.
+#' @param X_final Numeric matrix. The post-GLS, post-augmentation design.
+#' @param y_final Numeric vector. The post-GLS response (length >=
+#'   `N * T`; only the first `N * T` entries are used).
+#' @param N Integer. Number of units.
+#' @param T Integer. Number of time periods.
+#' @param treat_inds Integer vector. The (1-based) indices of treatment
+#'   features in the full `X_final` columns. Used in both branches'
+#'   `treat_block_mask` construction.
+#' @param sel_feat_inds Integer vector or `NULL`. If `NULL` (the default),
+#'   the full `X_final` is used as `X_S` and `treat_block_mask` is built
+#'   via `logical(ncol(X_S)); [treat_inds] <- TRUE`. If a vector, `X_S`
+#'   is `X_final[, sel_feat_inds, drop = FALSE]` and `treat_block_mask`
+#'   is `sel_feat_inds %in% treat_inds`.
+#' @return A list with two elements:
+#'   \describe{
+#'     \item{`sandwich_full`}{Numeric matrix; the Liang-Zeger
+#'       cluster-robust sandwich from `.compute_cluster_robust_sandwich()`.}
+#'     \item{`treat_block_mask`}{Logical vector of length `ncol(X_S)`;
+#'       TRUE at positions corresponding to treatment features.}
+#'   }
+#' @keywords internal
+#' @noRd
+.assemble_cluster_robust_sandwich <- function(
+	X_final,
+	y_final,
+	N,
+	T,
+	treat_inds,
+	sel_feat_inds = NULL
+) {
+	X_S <- if (is.null(sel_feat_inds)) {
+		X_final
+	} else {
+		X_final[, sel_feat_inds, drop = FALSE]
+	}
+	y_ <- y_final[seq_len(N * T)]
+	ols_fit <- stats::lm.fit(cbind(1, X_S), y_)
+	sandwich_full <- .compute_cluster_robust_sandwich(
+		X_S = X_S,
+		residuals = ols_fit$residuals,
+		N = N,
+		T = T
+	)
+	treat_block_mask <- if (is.null(sel_feat_inds)) {
+		mask <- logical(ncol(X_S))
+		mask[treat_inds] <- TRUE
+		mask
+	} else {
+		sel_feat_inds %in% treat_inds
+	}
+	list(sandwich_full = sandwich_full, treat_block_mask = treat_block_mask)
 }

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.14",
+  note    = "R package version 1.9.15",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-assemble-cluster-sandwich-78.R
+++ b/tests/testthat/test-assemble-cluster-sandwich-78.R
@@ -1,0 +1,230 @@
+library(testthat)
+library(fetwfe)
+
+# Tests for the cluster-robust sandwich assembly helper (issue #78, v1.9.15).
+#
+# `R/ols_calcs.R::.assemble_cluster_robust_sandwich()` wraps the 4-step
+# assembly ritual (extract X_S from X_final, slice y_, lm.fit, call
+# .compute_cluster_robust_sandwich, build treat_block_mask) that was
+# previously duplicated across 4 call sites:
+#
+#   * R/ols_calcs.R::getCohortATTsFinalOLS         (unfiltered path)
+#   * R/fetwfe_core.R::getCohortATTsFinal           (filtered path)
+#   * R/event_study.R::.event_study_etwfe_betwfe   (runtime if/else)
+#   * R/event_study.R::.event_study_fetwfe          (filtered path)
+#
+# The helper dispatches between two patterns via `sel_feat_inds`:
+#   * NULL (default): X_S = X_final; treat_block_mask via boolean fill.
+#   * vector: X_S = X_final[, sel_feat_inds]; treat_block_mask via %in%.
+#
+# These tests verify the helper's output bit-identically matches the
+# manual inline computation that the 4 call sites used to do.
+
+# Small deterministic fixture: N=6 units, T=5 periods, p=10 columns
+# in X_final. treat_inds = c(3, 7) means columns 3 and 7 are treatment
+# features.
+.build_fixture <- function(seed = 123) {
+	set.seed(seed)
+	N <- 6L
+	T <- 5L
+	p <- 10L
+	X_final <- matrix(rnorm(N * T * p), nrow = N * T, ncol = p)
+	y_final <- rnorm(N * T)
+	list(
+		X_final = X_final,
+		y_final = y_final,
+		N = N,
+		T = T,
+		p = p,
+		treat_inds = c(3L, 7L)
+	)
+}
+
+test_that(".assemble_cluster_robust_sandwich(sel_feat_inds = NULL) matches manual unfiltered computation", {
+	fx <- .build_fixture()
+
+	# Reference (manual): replicate the pre-refactor inline pattern
+	# from R/ols_calcs.R::getCohortATTsFinalOLS.
+	X_S_ref <- fx$X_final
+	y_ref <- fx$y_final[seq_len(fx$N * fx$T)]
+	ols_ref <- stats::lm.fit(cbind(1, X_S_ref), y_ref)
+	sandwich_ref <- fetwfe:::.compute_cluster_robust_sandwich(
+		X_S = X_S_ref,
+		residuals = ols_ref$residuals,
+		N = fx$N,
+		T = fx$T
+	)
+	mask_ref <- logical(ncol(X_S_ref))
+	mask_ref[fx$treat_inds] <- TRUE
+
+	# Helper.
+	res <- fetwfe:::.assemble_cluster_robust_sandwich(
+		X_final = fx$X_final,
+		y_final = fx$y_final,
+		N = fx$N,
+		T = fx$T,
+		treat_inds = fx$treat_inds,
+		sel_feat_inds = NULL
+	)
+
+	expect_equal(res$sandwich_full, sandwich_ref, tolerance = 1e-12)
+	expect_equal(res$treat_block_mask, mask_ref)
+	expect_length(res$treat_block_mask, fx$p)
+	expect_true(res$treat_block_mask[3])
+	expect_true(res$treat_block_mask[7])
+	expect_equal(sum(res$treat_block_mask), 2L)
+})
+
+test_that(".assemble_cluster_robust_sandwich(sel_feat_inds = <vector>) matches manual filtered computation", {
+	fx <- .build_fixture()
+	# Pick a selected support that includes one treatment column
+	# (index 3) and one not (index 7 is NOT in sel_feat_inds here).
+	sel_feat_inds <- c(2L, 3L, 5L, 8L)
+
+	# Reference (manual): replicate the pre-refactor inline pattern
+	# from R/fetwfe_core.R::getCohortATTsFinal.
+	X_S_ref <- fx$X_final[, sel_feat_inds, drop = FALSE]
+	y_ref <- fx$y_final[seq_len(fx$N * fx$T)]
+	ols_ref <- stats::lm.fit(cbind(1, X_S_ref), y_ref)
+	sandwich_ref <- fetwfe:::.compute_cluster_robust_sandwich(
+		X_S = X_S_ref,
+		residuals = ols_ref$residuals,
+		N = fx$N,
+		T = fx$T
+	)
+	mask_ref <- sel_feat_inds %in% fx$treat_inds
+
+	# Helper.
+	res <- fetwfe:::.assemble_cluster_robust_sandwich(
+		X_final = fx$X_final,
+		y_final = fx$y_final,
+		N = fx$N,
+		T = fx$T,
+		treat_inds = fx$treat_inds,
+		sel_feat_inds = sel_feat_inds
+	)
+
+	expect_equal(res$sandwich_full, sandwich_ref, tolerance = 1e-12)
+	expect_equal(res$treat_block_mask, mask_ref)
+	expect_length(res$treat_block_mask, length(sel_feat_inds))
+	# sel_feat_inds = c(2, 3, 5, 8); treat_inds = c(3, 7). Only
+	# position 2 (column 3) is treatment. Position 4 (column 8) is
+	# NOT, because column 8 is not in treat_inds.
+	expect_equal(res$treat_block_mask, c(FALSE, TRUE, FALSE, FALSE))
+})
+
+test_that(".assemble_cluster_robust_sandwich filtered path also covers all-treatment and no-treatment selected supports", {
+	fx <- .build_fixture()
+
+	# All selected positions are in treat_inds (sel = c(3, 7)).
+	res_all_treat <- fetwfe:::.assemble_cluster_robust_sandwich(
+		X_final = fx$X_final,
+		y_final = fx$y_final,
+		N = fx$N,
+		T = fx$T,
+		treat_inds = fx$treat_inds,
+		sel_feat_inds = fx$treat_inds
+	)
+	expect_equal(res_all_treat$treat_block_mask, c(TRUE, TRUE))
+
+	# None of the selected positions are in treat_inds (sel = c(1, 4, 5)).
+	res_no_treat <- fetwfe:::.assemble_cluster_robust_sandwich(
+		X_final = fx$X_final,
+		y_final = fx$y_final,
+		N = fx$N,
+		T = fx$T,
+		treat_inds = fx$treat_inds,
+		sel_feat_inds = c(1L, 4L, 5L)
+	)
+	expect_equal(
+		res_no_treat$treat_block_mask,
+		c(FALSE, FALSE, FALSE)
+	)
+	expect_equal(sum(res_no_treat$treat_block_mask), 0L)
+})
+
+test_that(".assemble_cluster_robust_sandwich integration parity: betwfe cluster-SE fit reproduces helper output", {
+	# Integration check: fit betwfe with se_type = "cluster" on a
+	# simulated panel with strong signal (so selection actually
+	# fires and the cluster-SE path is exercised). Re-call the
+	# helper on the same fitted object's inputs and assert
+	# bit-identical output. This locks the refactor at the
+	# integration boundary: if a future PR changes betwfe_core's
+	# call to the helper (e.g., swaps which arg gets passed to
+	# `sel_feat_inds`), the assertion fails.
+	coefs <- genCoefs(
+		R = 2,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 4,
+		seed = 42
+	)
+	sim <- simulateData(
+		coefs,
+		N = 60,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5
+	)
+	fit <- betwfeWithSimulatedData(sim, se_type = "cluster")
+
+	# Sanity: structure is right and selection actually fired.
+	expect_s3_class(fit, "betwfe")
+	expect_true(any(fit$beta_hat != 0))
+
+	sel_feat_inds_fit <- which(fit$beta_hat != 0)
+
+	res_helper <- fetwfe:::.assemble_cluster_robust_sandwich(
+		X_final = fit$X_final,
+		y_final = fit$y_final,
+		N = fit$N,
+		T = fit$T,
+		treat_inds = fit$treat_inds,
+		sel_feat_inds = sel_feat_inds_fit
+	)
+
+	expect_named(res_helper, c("sandwich_full", "treat_block_mask"))
+	expect_true(is.matrix(res_helper$sandwich_full))
+	expect_equal(
+		dim(res_helper$sandwich_full),
+		c(length(sel_feat_inds_fit), length(sel_feat_inds_fit))
+	)
+	expect_length(res_helper$treat_block_mask, length(sel_feat_inds_fit))
+	expect_equal(
+		res_helper$treat_block_mask,
+		sel_feat_inds_fit %in% fit$treat_inds
+	)
+	# att_se from the cluster-SE fit must be finite (proves the
+	# end-to-end cluster-SE path ran without error post-refactor).
+	expect_true(is.finite(fit$att_se))
+})
+
+test_that(".assemble_cluster_robust_sandwich: NULL default produces the same output as explicit NULL", {
+	fx <- .build_fixture()
+
+	res_default <- fetwfe:::.assemble_cluster_robust_sandwich(
+		X_final = fx$X_final,
+		y_final = fx$y_final,
+		N = fx$N,
+		T = fx$T,
+		treat_inds = fx$treat_inds
+		# sel_feat_inds defaults to NULL
+	)
+	res_explicit_null <- fetwfe:::.assemble_cluster_robust_sandwich(
+		X_final = fx$X_final,
+		y_final = fx$y_final,
+		N = fx$N,
+		T = fx$T,
+		treat_inds = fx$treat_inds,
+		sel_feat_inds = NULL
+	)
+	expect_equal(
+		res_default$sandwich_full,
+		res_explicit_null$sandwich_full,
+		tolerance = 1e-12
+	)
+	expect_equal(
+		res_default$treat_block_mask,
+		res_explicit_null$treat_block_mask
+	)
+})


### PR DESCRIPTION
Resolves #78. Consolidates the 4-step cluster-robust sandwich assembly ritual (extract `X_S` from `X_final`, slice `y_`, run `lm.fit(cbind(1, X_S), y_)`, call `.compute_cluster_robust_sandwich()`, build `treat_block_mask`) across 4 call sites — `getCohortATTsFinalOLS()`, `getCohortATTsFinal()`, `.event_study_etwfe_betwfe()`, `.event_study_fetwfe()` — into a new internal helper `.assemble_cluster_robust_sandwich()` in `R/ols_calcs.R` (placed directly after the existing math helper `.compute_cluster_robust_sandwich()`).

Helper signature: `(X_final, y_final, N, T, treat_inds, sel_feat_inds = NULL)`. Two patterns dispatched by `sel_feat_inds`: NULL (default) = unfiltered design + boolean-mask `treat_block_mask`; vector = filtered design + `%in%`-based mask. Returns `list(sandwich_full, treat_block_mask)`. Site 2's two extra `stopifnot` invariants (length / sum checks tied to `sel_treat_inds_shifted`) stay at the caller per D3. Site 3's runtime if/else collapses to a one-line `sel_arg <- if (any(!is.na(sel_feat_inds))) sel_feat_inds else NULL` dispatch before the helper call.

New `tests/testthat/test-assemble-cluster-sandwich-78.R` with 5 `test_that` blocks / 23 expectations: helper-contract assertions for both branches (NULL and vector), edge cases (all-treatment / no-treatment selected supports), end-to-end integration parity via `betwfeWithSimulatedData(se_type = "cluster")`, and a NULL-default equivalence check.

The drift surface drops from 4 sites to 1. The v1.9.5 `10e-6` threshold typo (#56) was the same drift class — would have been a single-site edit had this helper existed. Patch version bump 1.9.14 → 1.9.15. `devtools::check(args = "--as-cran")`: `0/0/0`. `devtools::test()`: 1711 → 1734 PASS (+23). Snapshot byte-identical (`git diff origin/main -- tests/testthat/_snaps/print-method-snapshot.md` empty).
