### PR TITLE
Micro-helpers (.cohort_block_inds, .multinomial_cov) + threshold standardization (#83, v1.9.16)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.15
+Version: 1.9.16
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # NEWS
 
+## Version 1.9.16 (2026-05-18)
+
+- Extracted two micro-helpers to `R/utility.R` and standardized one
+  threshold convention (GitHub #83):
+  (1) `.cohort_block_inds(r, R, first_inds, num_treats)` replaces 6
+  inline `first_ind_r <- first_inds[r]; last_ind_r <- if (r < R) ...
+  else num_treats` constructions across `R/core_funcs.R`,
+  `R/fetwfe_core.R`, `R/gen_funcs.R`, and `R/ols_calcs.R`.
+  (2) `.multinomial_cov(probs)` replaces 3 inline `Sigma_pi_hat <-
+  -outer(probs, probs); diag(...) <- probs * (1 - probs)` blocks
+  across `R/fetwfe_core.R`, `R/ols_calcs.R`, and `R/event_study.R`.
+  (3) `R/core_funcs.R`'s 4 occurrences of `10^(-6)` replaced with
+  `1e-6` to match the rest of the package (bit-identical value;
+  pure cosmetic). No user-visible behavior change.
+
 ## Version 1.9.15 (2026-05-18)
 
 - Consolidated the cluster-robust sandwich assembly across 4 call

--- a/R/core_funcs.R
+++ b/R/core_funcs.R
@@ -183,15 +183,8 @@ prep_for_etwfe_regression <- function(
 		treat_inds_mat <- matrix(as.numeric(NA), nrow = N * T, ncol = R)
 
 		for (r in 1:R) {
-			first_ind_r <- first_inds[r]
-			if (r == R) {
-				last_ind_r <- num_treats
-			} else {
-				last_ind_r <- first_inds[r + 1] - 1
-			}
-
-			cols_r <- R + T - 1 + d + first_ind_r:last_ind_r
-
+			inds_r <- .cohort_block_inds(r, R, first_inds, num_treats)
+			cols_r <- R + T - 1 + d + inds_r
 			treat_inds_mat[, r] <- rowSums(X_final[, cols_r, drop = FALSE])
 		}
 
@@ -283,12 +276,12 @@ prep_for_etwfe_regression <- function(
 	stopifnot(all(cohort_probs >= 0))
 	stopifnot(all(cohort_probs <= 1))
 	stopifnot(length(cohort_probs) == R)
-	stopifnot(abs(sum(cohort_probs) - 1) < 10^(-6))
+	stopifnot(abs(sum(cohort_probs) - 1) < 1e-6)
 
 	cohort_probs_overall <- in_sample_counts[2:(R + 1)] / N
 
 	stopifnot(
-		abs(1 - sum(cohort_probs_overall) - in_sample_counts[1] / N) < 10^(-6)
+		abs(1 - sum(cohort_probs_overall) - in_sample_counts[1] / N) < 1e-6
 	)
 
 	if (indep_count_data_available) {
@@ -299,7 +292,7 @@ prep_for_etwfe_regression <- function(
 		stopifnot(all(indep_cohort_probs >= 0))
 		stopifnot(all(indep_cohort_probs <= 1))
 		stopifnot(length(indep_cohort_probs) == R)
-		stopifnot(abs(sum(indep_cohort_probs) - 1) < 10^(-6))
+		stopifnot(abs(sum(indep_cohort_probs) - 1) < 1e-6)
 
 		indep_cohort_probs_overall <- indep_counts[2:(R + 1)] / N
 
@@ -311,7 +304,7 @@ prep_for_etwfe_regression <- function(
 					) -
 					indep_counts[1] / N
 			) <
-				10^(-6)
+				1e-6
 		)
 	} else {
 		indep_cohort_probs <- NA

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -461,9 +461,8 @@ event_study <- function(x, alpha = NULL) {
 		return(0)
 	}
 
-	# Multinomial Sigma_pi_hat on the masked cohort probabilities
-	Sigma_pi_hat <- -outer(masked, masked)
-	diag(Sigma_pi_hat) <- masked * (1 - masked)
+	# Multinomial Sigma_pi_hat on the masked cohort probabilities.
+	Sigma_pi_hat <- .multinomial_cov(masked)
 
 	# Per-event-time Jacobian: R rows, length(sel_treat_inds_shifted) cols.
 	# Rows for r not in V_e are zero (and are zero-killed by Sigma_pi_hat).

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -1925,13 +1925,8 @@ getSecondVarTermDataApp <- function(
 	stopifnot(length(theta_hat_treat_sel) == length(sel_treat_inds_shifted))
 
 	# Get Sigma_pi_hat, the (sample-estimated) covariance matrix for the
-	# sample proportions (derived from the multinomial distribution)
-	Sigma_pi_hat <- -outer(
-		cohort_probs_overall[1:(R)],
-		cohort_probs_overall[1:(R)]
-	)
-	diag(Sigma_pi_hat) <- cohort_probs_overall[1:(R)] *
-		(1 - cohort_probs_overall[1:(R)])
+	# sample proportions (derived from the multinomial distribution).
+	Sigma_pi_hat <- .multinomial_cov(cohort_probs_overall[1:R])
 
 	stopifnot(nrow(Sigma_pi_hat) == R)
 	stopifnot(ncol(Sigma_pi_hat) == R)
@@ -1964,15 +1959,7 @@ getSecondVarTermDataApp <- function(
 		sel_inds <- list()
 
 		for (r in 1:R) {
-			first_ind_r <- first_inds[r]
-
-			if (r < R) {
-				last_ind_r <- first_inds[r + 1] - 1
-			} else {
-				last_ind_r <- num_treats
-			}
-			stopifnot(last_ind_r >= first_ind_r)
-			sel_inds[[r]] <- first_ind_r:last_ind_r
+			sel_inds[[r]] <- .cohort_block_inds(r, R, first_inds, num_treats)
 			if (r > 1) {
 				stopifnot(min(sel_inds[[r]]) > max(sel_inds[[r - 1]]))
 				stopifnot(length(sel_inds[[r]]) <= length(sel_inds[[r - 1]]))
@@ -2367,13 +2354,12 @@ getCohortATTsFinal <- function(
 
 	# loop over cohorts
 	for (r in 1:R) {
-		# Get indices corresponding to marginal treatment effects for rth cohort
-		first_ind_r <- first_inds[r]
-		if (r < R) {
-			last_ind_r <- first_inds[r + 1] - 1
-		} else {
-			last_ind_r <- num_treats
-		}
+		# Get indices corresponding to marginal treatment effects for rth cohort.
+		# Endpoint-preservation form: downstream `getPsiRFused()` takes
+		# `first_ind_r, last_ind_r` as separate positional args.
+		inds_r <- .cohort_block_inds(r, R, first_inds, num_treats)
+		first_ind_r <- inds_r[1]
+		last_ind_r <- inds_r[length(inds_r)]
 
 		stopifnot(last_ind_r >= first_ind_r)
 		stopifnot(all(first_ind_r:last_ind_r %in% 1:num_treats))

--- a/R/gen_funcs.R
+++ b/R/gen_funcs.R
@@ -1392,14 +1392,8 @@ getActualCohortTes <- function(R, first_inds, treat_inds, coefs, num_treats) {
 	actual_cohort_tes <- rep(as.numeric(NA), R)
 
 	for (r in 1:R) {
-		first_ind_r <- first_inds[r]
-		if (r < R) {
-			last_ind_r <- first_inds[r + 1] - 1
-		} else {
-			last_ind_r <- num_treats
-		}
-
-		actual_cohort_tes[r] <- mean(coefs[treat_inds][first_ind_r:last_ind_r])
+		inds_r <- .cohort_block_inds(r, R, first_inds, num_treats)
+		actual_cohort_tes[r] <- mean(coefs[treat_inds][inds_r])
 	}
 
 	return(actual_cohort_tes)

--- a/R/ols_calcs.R
+++ b/R/ols_calcs.R
@@ -122,13 +122,12 @@ getCohortATTsFinalOLS <- function(
 	psi_mat <- matrix(0, num_treats, R)
 
 	for (r in 1:R) {
-		# Get indices corresponding to rth treatment
-		first_ind_r <- first_inds[r]
-		if (r < R) {
-			last_ind_r <- first_inds[r + 1] - 1
-		} else {
-			last_ind_r <- num_treats
-		}
+		# Get indices corresponding to rth treatment.
+		# Endpoint-preservation form: downstream `getPsiRUnfused()` takes
+		# `first_ind_r, last_ind_r` as separate positional args.
+		inds_r <- .cohort_block_inds(r, R, first_inds, num_treats)
+		first_ind_r <- inds_r[1]
+		last_ind_r <- inds_r[length(inds_r)]
 
 		stopifnot(last_ind_r >= first_ind_r)
 		stopifnot(all(first_ind_r:last_ind_r %in% 1:num_treats))
@@ -414,13 +413,8 @@ getSecondVarTermOLS <- function(
 ) {
 	stopifnot(length(tes) == nrow(psi_mat))
 	# Get Sigma_pi_hat, the (sample-estimated) covariance matrix for the
-	# sample proportions (derived from the multinomial distribution)
-	Sigma_pi_hat <- -outer(
-		cohort_probs_overall[1:(R)],
-		cohort_probs_overall[1:(R)]
-	)
-	diag(Sigma_pi_hat) <- cohort_probs_overall[1:R] *
-		(1 - cohort_probs_overall[1:R])
+	# sample proportions (derived from the multinomial distribution).
+	Sigma_pi_hat <- .multinomial_cov(cohort_probs_overall[1:R])
 
 	stopifnot(nrow(Sigma_pi_hat) == R)
 	stopifnot(ncol(Sigma_pi_hat) == R)
@@ -430,15 +424,7 @@ getSecondVarTermOLS <- function(
 	sel_inds <- list()
 
 	for (r in 1:R) {
-		first_ind_r <- first_inds[r]
-
-		if (r < R) {
-			last_ind_r <- first_inds[r + 1] - 1
-		} else {
-			last_ind_r <- num_treats
-		}
-		stopifnot(last_ind_r >= first_ind_r)
-		sel_inds[[r]] <- first_ind_r:last_ind_r
+		sel_inds[[r]] <- .cohort_block_inds(r, R, first_inds, num_treats)
 		if (r > 1) {
 			stopifnot(min(sel_inds[[r]]) > max(sel_inds[[r - 1]]))
 			stopifnot(length(sel_inds[[r]]) <= length(sel_inds[[r - 1]]))

--- a/R/utility.R
+++ b/R/utility.R
@@ -670,3 +670,54 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 	)
 	truncated
 }
+
+#' @title Cohort-r treatment-coefficient index range
+#' @description
+#' For cohort `r` (one of `1:R`), returns the integer range
+#' `first_ind_r:last_ind_r` indexing into a length-`num_treats`
+#' treatment-coefficient vector. The closed-form is
+#' `first_ind_r = first_inds[r]` and
+#' `last_ind_r = if (r < R) first_inds[r + 1] - 1 else num_treats`.
+#' Used inside `for (r in 1:R)` cohort loops in `getCohortATTsFinal`,
+#' `getCohortATTsFinalOLS`, `getSecondVarTermDataApp`,
+#' `getSecondVarTermOLS`, `prep_for_etwfe_regression`, and
+#' `getActualCohortTes`. Consolidated by GitHub #83.
+#' @param r Integer; the cohort index, `1 <= r <= R`.
+#' @param R Integer; total number of treated cohorts.
+#' @param first_inds Integer vector; the per-cohort starting indices
+#'   (length `R`), as returned by `getFirstInds()`.
+#' @param num_treats Integer; the total number of treatment coefficients
+#'   (one per (cohort, time) pair), as returned by `getNumTreats()`.
+#' @return Integer vector; the range `first_ind_r:last_ind_r`.
+#' @seealso `getFirstInds()`, `getNumTreats()`.
+#' @keywords internal
+#' @noRd
+.cohort_block_inds <- function(r, R, first_inds, num_treats) {
+	first_ind_r <- first_inds[r]
+	last_ind_r <- if (r < R) first_inds[r + 1] - 1 else num_treats
+	first_ind_r:last_ind_r
+}
+
+#' @title Multinomial covariance matrix from cohort-membership probabilities
+#' @description
+#' Returns the `length(probs) x length(probs)` covariance matrix of the
+#' multinomial random variable with cell probabilities `probs` and a
+#' single trial (or, equivalently, the per-observation covariance of the
+#' indicator vector for cohort membership). The closed-form is
+#' `S = -outer(probs, probs); diag(S) <- probs * (1 - probs)`.
+#' Used inside the variance-term-2 machinery at `getSecondVarTermDataApp`
+#' (R/fetwfe_core.R), `getSecondVarTermOLS` (R/ols_calcs.R), and
+#' `.event_study_var2_fetwfe` (R/event_study.R). Consolidated by
+#' GitHub #83.
+#' @param probs Numeric vector of length `R`; cohort-membership
+#'   probabilities P(W = r) for r in 1:R. Should sum to less than 1
+#'   (the residual mass is the never-treated probability).
+#' @return Numeric matrix of dimensions `length(probs) x length(probs)`;
+#'   the symmetric covariance matrix.
+#' @keywords internal
+#' @noRd
+.multinomial_cov <- function(probs) {
+	S <- -outer(probs, probs)
+	diag(S) <- probs * (1 - probs)
+	S
+}

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.15",
+  note    = "R package version 1.9.16",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-micro-helpers-83.R
+++ b/tests/testthat/test-micro-helpers-83.R
@@ -1,0 +1,122 @@
+library(testthat)
+library(fetwfe)
+
+# Tests for the two micro-helpers added by issue #83 to R/utility.R:
+#   - .cohort_block_inds(r, R, first_inds, num_treats) replaces 6 inline
+#     `first_ind_r <- first_inds[r]; last_ind_r <- if (r < R) ... else
+#     num_treats` patterns across core_funcs / fetwfe_core / gen_funcs /
+#     ols_calcs.
+#   - .multinomial_cov(probs) replaces 3 inline `Sigma_pi_hat <-
+#     -outer(probs, probs); diag(...) <- probs * (1 - probs)` blocks
+#     across fetwfe_core / ols_calcs / event_study.
+
+# ------------------------------------------------------------------------------
+# .cohort_block_inds()
+# ------------------------------------------------------------------------------
+
+test_that(".cohort_block_inds returns the correct range for an interior cohort", {
+	# R = 4, first_inds = c(1, 4, 6, 9), num_treats = 10.
+	# r = 2 → block is first_inds[2]:first_inds[3]-1 = 4:5.
+	expect_equal(
+		fetwfe:::.cohort_block_inds(
+			r = 2L,
+			R = 4L,
+			first_inds = c(1L, 4L, 6L, 9L),
+			num_treats = 10L
+		),
+		4L:5L
+	)
+})
+
+test_that(".cohort_block_inds returns the correct range for the last cohort", {
+	# R = 4, first_inds = c(1, 4, 6, 9), num_treats = 10.
+	# r = R = 4 → block is first_inds[4]:num_treats = 9:10.
+	expect_equal(
+		fetwfe:::.cohort_block_inds(
+			r = 4L,
+			R = 4L,
+			first_inds = c(1L, 4L, 6L, 9L),
+			num_treats = 10L
+		),
+		9L:10L
+	)
+})
+
+test_that(".cohort_block_inds returns the correct range for the singleton R = 1 case", {
+	# R = 1, first_inds = c(1), num_treats = 7.
+	# r = 1 = R → block is 1:7.
+	expect_equal(
+		fetwfe:::.cohort_block_inds(
+			r = 1L,
+			R = 1L,
+			first_inds = 1L,
+			num_treats = 7L
+		),
+		1L:7L
+	)
+})
+
+test_that(".cohort_block_inds matches the prior inline construction for all cohorts in a panel", {
+	# Reference: hand-build the 6-line inline pattern that 6 call sites
+	# used pre-#83 and confirm bit-identical output across all R cohorts.
+	first_inds <- c(1L, 3L, 6L, 10L)
+	R <- 4L
+	num_treats <- 12L
+	for (r in seq_len(R)) {
+		first_ind_r <- first_inds[r]
+		last_ind_r <- if (r < R) first_inds[r + 1] - 1L else num_treats
+		expected <- first_ind_r:last_ind_r
+		expect_identical(
+			fetwfe:::.cohort_block_inds(r, R, first_inds, num_treats),
+			expected
+		)
+	}
+})
+
+# ------------------------------------------------------------------------------
+# .multinomial_cov()
+# ------------------------------------------------------------------------------
+
+test_that(".multinomial_cov returns a symmetric matrix with the documented form", {
+	probs <- c(0.3, 0.5)
+	# Off-diagonal: -outer(probs, probs)[1, 2] = -0.3 * 0.5 = -0.15.
+	# Diagonal:    probs * (1 - probs) = c(0.21, 0.25).
+	expected <- matrix(c(0.21, -0.15, -0.15, 0.25), 2L, 2L)
+	res <- fetwfe:::.multinomial_cov(probs)
+	expect_equal(res, expected, tolerance = 1e-14)
+	expect_equal(t(res), res, tolerance = 1e-14)
+})
+
+test_that(".multinomial_cov diagonal is probs * (1 - probs); off-diagonal is -outer", {
+	probs <- c(0.1, 0.2, 0.4)
+	res <- fetwfe:::.multinomial_cov(probs)
+	expect_equal(diag(res), probs * (1 - probs), tolerance = 1e-14)
+	# Off-diagonal entries.
+	expect_equal(res[1L, 2L], -0.1 * 0.2, tolerance = 1e-14)
+	expect_equal(res[1L, 3L], -0.1 * 0.4, tolerance = 1e-14)
+	expect_equal(res[2L, 3L], -0.2 * 0.4, tolerance = 1e-14)
+	# Symmetry.
+	expect_equal(t(res), res, tolerance = 1e-14)
+	# Dimensions.
+	expect_equal(dim(res), c(3L, 3L))
+})
+
+test_that(".multinomial_cov matches the prior inline -outer/diag construction", {
+	# Reference: replicate the pre-#83 inline 2-line block byte-identically.
+	probs <- c(0.2, 0.3, 0.1)
+	S_ref <- -outer(probs, probs)
+	diag(S_ref) <- probs * (1 - probs)
+	expect_equal(
+		fetwfe:::.multinomial_cov(probs),
+		S_ref,
+		tolerance = 1e-14
+	)
+})
+
+test_that(".multinomial_cov works for length-1 probs (degenerate single-cohort case)", {
+	# Single-cohort: 1x1 matrix with diag = p * (1 - p), off-diag absent.
+	probs <- 0.4
+	res <- fetwfe:::.multinomial_cov(probs)
+	expect_equal(dim(res), c(1L, 1L))
+	expect_equal(res[1L, 1L], 0.24, tolerance = 1e-14)
+})


### PR DESCRIPTION
Resolves #83. Three small consolidations bundled:

1. **`.cohort_block_inds(r, R, first_inds, num_treats)`** in `R/utility.R` replaces 6 inline `first_ind_r:last_ind_r` constructions across `R/core_funcs.R`, `R/fetwfe_core.R` (2 sites), `R/gen_funcs.R`, and `R/ols_calcs.R` (2 sites). Sites that pass endpoints downstream to `getPsiRFused()` / `getPsiRUnfused()` (2 of 6) use the endpoint-preservation form per Decision D8; the other 4 use range-only.

2. **`.multinomial_cov(probs)`** in `R/utility.R` replaces 3 inline `Sigma_pi_hat <- -outer(probs, probs); diag(...) <- probs * (1 - probs)` blocks across `R/fetwfe_core.R`, `R/ols_calcs.R`, and `R/event_study.R`.

3. **Threshold convention standardization.** `R/core_funcs.R`'s 4 occurrences of `10^(-6)` replaced with `1e-6` to match the convention used everywhere else. `identical(1e-6, 10^(-6))` is TRUE (both produce IEEE 754 double `9.99999999999999954748e-07`); pure cosmetic; no numerical drift.

New `tests/testthat/test-micro-helpers-83.R` with 8 `test_that` blocks / 18 expectations covering both helpers (parity-with-inline-pattern, edge cases like singleton `R=1` and length-1 probs vector). Drift surface 6+3+2-conventions → 1+1+1.

Patch version bump 1.9.15 → 1.9.16. `devtools::check(args = "--as-cran")`: `0/0/0`. `devtools::test()`: 1734 → 1752 PASS (+18). Snapshot byte-identical (`git diff origin/main -- tests/testthat/_snaps/print-method-snapshot.md` empty).
