### PR TITLE
Split prep_for_etwfe_regression() god function (#81, 1.9.18)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.17
+Version: 1.9.18
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # NEWS
 
+## Version 1.9.18 (2026-05-19)
+
+- Internal refactor of `R/core_funcs.R::prep_for_etwfe_regression()`
+  (GitHub #81). The 237-line god function is split into four named
+  helpers — `.estimate_variance_and_gls()`, `.collapse_design_for_twfe_covs()`,
+  `.append_ridge_rows()`, `.compute_cohort_probs()` — with the
+  orchestrator reduced to an ~100-line sequence of helper calls. No
+  public API change; all four caller sites (`fetwfe_core()`,
+  `etwfe_core()`, `betwfe_core()`, `twfeCovs_core()`) continue to
+  unpack the same 12-field result list. Four direct return-shape
+  tests added in `tests/testthat/test-prep-helpers-81.R` to lock the
+  helpers' contracts against future drift.
+
 ## Version 1.9.17 (2026-05-19)
 
 - Small consistency-and-cleanup bundle (GitHub #76). Eight items:

--- a/R/core_funcs.R
+++ b/R/core_funcs.R
@@ -110,13 +110,118 @@ prep_for_etwfe_regression <- function(
 	is_fetwfe,
 	is_twfe_covs = FALSE
 ) {
+	gls <- .estimate_variance_and_gls(
+		y = y,
+		X_ints = X_ints,
+		X_mod = X_mod,
+		sig_eps_sq = sig_eps_sq,
+		sig_eps_c_sq = sig_eps_c_sq,
+		N = N,
+		T = T,
+		p = p,
+		verbose = verbose
+	)
+	y_final <- gls$y_gls
+	X_final <- gls$X_gls
+	sig_eps_sq <- gls$sig_eps_sq
+	sig_eps_c_sq <- gls$sig_eps_c_sq
+
+	if (is_twfe_covs) {
+		coll <- .collapse_design_for_twfe_covs(
+			X_gls = X_final,
+			N = N,
+			T = T,
+			R = R,
+			d = d,
+			num_treats = num_treats,
+			first_inds = first_inds
+		)
+		X_final <- coll$X_collapsed
+		p <- coll$p_short
+	}
+
+	X_final_scaled <- my_scale(X_final)
+	stopifnot(ncol(X_final_scaled) == p)
+	scale_center <- attr(X_final_scaled, "scaled:center")
+	scale_scale <- attr(X_final_scaled, "scaled:scale")
+
+	ridge <- .append_ridge_rows(
+		X_scaled = X_final_scaled,
+		y_gls = y_final,
+		p = p,
+		add_ridge = add_ridge,
+		is_fetwfe = is_fetwfe,
+		first_inds = first_inds,
+		T = T,
+		R = R,
+		d = d,
+		num_treats = num_treats,
+		sig_eps_sq = sig_eps_sq,
+		sig_eps_c_sq = sig_eps_c_sq,
+		N = N
+	)
+	X_final_scaled <- ridge$X_scaled
+	y_final <- ridge$y_final
+	lambda_ridge <- ridge$lambda_ridge
+
+	probs <- .compute_cohort_probs(
+		in_sample_counts = in_sample_counts,
+		indep_counts = indep_counts,
+		N = N,
+		R = R,
+		indep_count_data_available = indep_count_data_available
+	)
+
+	list(
+		X_final_scaled = X_final_scaled,
+		X_final = X_final,
+		y_final = y_final,
+		scale_center = scale_center,
+		scale_scale = scale_scale,
+		cohort_probs = probs$cohort_probs,
+		cohort_probs_overall = probs$cohort_probs_overall,
+		indep_cohort_probs = probs$indep_cohort_probs,
+		indep_cohort_probs_overall = probs$indep_cohort_probs_overall,
+		sig_eps_sq = sig_eps_sq,
+		sig_eps_c_sq = sig_eps_c_sq,
+		lambda_ridge = lambda_ridge
+	)
+}
+
+#' @title Estimate variance components and apply GLS whitening
+#' @description If `sig_eps_sq` or `sig_eps_c_sq` is NA, estimate both via
+#'   `estOmegaSqrtInv()` (REML on `y ~ X + (1 | unit)`). Then build
+#'   `Omega = sig_eps_sq * I_T + sig_eps_c_sq * J_T`, take its
+#'   matrix square root inverse, and apply the kronecker-product GLS
+#'   transform to `y` and `X_mod`.
+#' @param y Numeric vector of length `N*T`; raw response.
+#' @param X_ints Numeric matrix used by REML when variance components are
+#'   NA.
+#' @param X_mod Numeric matrix to GLS-transform.
+#' @param sig_eps_sq,sig_eps_c_sq Numeric or NA; row-level / unit-level
+#'   variance components.
+#' @param N,T,p Integers; units, time periods, design columns.
+#' @param verbose Logical; if TRUE, print timing messages.
+#' @return List with `y_gls`, `X_gls`, `sig_eps_sq`, `sig_eps_c_sq`.
+#' @keywords internal
+#' @noRd
+.estimate_variance_and_gls <- function(
+	y,
+	X_ints,
+	X_mod,
+	sig_eps_sq,
+	sig_eps_c_sq,
+	N,
+	T,
+	p,
+	verbose
+) {
 	if (verbose) {
 		message("Getting omega sqrt inverse estimate...")
 		t0 <- Sys.time()
 	}
 
 	if (is.na(sig_eps_sq) | is.na(sig_eps_c_sq)) {
-		# Get omega_sqrt_inv matrix to multiply y and X_mod by on the left
 		omega_res <- estOmegaSqrtInv(
 			y,
 			X_ints,
@@ -140,7 +245,6 @@ prep_for_etwfe_regression <- function(
 	stopifnot(!is.na(sig_eps_sq) & !is.na(sig_eps_c_sq))
 
 	Omega <- diag(rep(sig_eps_sq, T)) + matrix(sig_eps_c_sq, T, T)
-
 	Omega_sqrt_inv <- expm::sqrtm(solve(Omega))
 
 	if (verbose) {
@@ -148,127 +252,180 @@ prep_for_etwfe_regression <- function(
 		message(Sys.time() - t0)
 	}
 
-	y_final <- kronecker(diag(N), sqrt(sig_eps_sq) * Omega_sqrt_inv) %*% y
-	X_final <- kronecker(diag(N), sqrt(sig_eps_sq) * Omega_sqrt_inv) %*% X_mod
+	y_gls <- kronecker(diag(N), sqrt(sig_eps_sq) * Omega_sqrt_inv) %*% y
+	X_gls <- kronecker(diag(N), sqrt(sig_eps_sq) * Omega_sqrt_inv) %*% X_mod
 
-	stopifnot(ncol(X_final) == p)
+	stopifnot(ncol(X_gls) == p)
 
-	#
-	#
-	# twfeCovs modifications
-	#
-	#
+	list(
+		y_gls = y_gls,
+		X_gls = X_gls,
+		sig_eps_sq = sig_eps_sq,
+		sig_eps_c_sq = sig_eps_c_sq
+	)
+}
 
-	if (is_twfe_covs) {
-		stopifnot(nrow(X_final) == N * T)
-		# stopifnot(nrow(X_final_scaled) == N * T)
+#' @title Collapse the twfeCovs design matrix
+#' @description Drop treatment-effect interaction columns and the
+#'   covariate-by-time / covariate-by-cohort interaction columns, then
+#'   collapse the per-cohort treatment dummies into one column per
+#'   cohort. Called from the orchestrator only when
+#'   `is_twfe_covs = TRUE`.
+#' @param X_gls Numeric matrix; GLS-transformed design.
+#' @param N,T,R,d Integers; units, time periods, treated cohorts,
+#'   covariates.
+#' @param num_treats Integer; treatment-column count in the pre-collapse
+#'   design.
+#' @param first_inds Integer vector; first-index-within-cohort offsets.
+#' @return List with `X_collapsed` (post-collapse design) and `p_short`
+#'   (column count `= R + T - 1 + d + R`).
+#' @keywords internal
+#' @noRd
+.collapse_design_for_twfe_covs <- function(
+	X_gls,
+	N,
+	T,
+	R,
+	d,
+	num_treats,
+	first_inds
+) {
+	stopifnot(nrow(X_gls) == N * T)
 
-		# Drop columns corresponding to treatment effect interactions
-		X_final <- X_final[, 1:(R + T - 1 + d * (1 + R + T - 1) + num_treats)]
-		# X_final_scaled <- X_final_scaled[, 1:(R + T - 1 + d * (1 + R + T - 1) + num_treats)]
+	X <- X_gls[, 1:(R + T - 1 + d * (1 + R + T - 1) + num_treats)]
 
-		# Drop columns corresponding to interactions between X and time, cohorts
-		first_treat_ind <- R + T - 1 + d * (1 + R + T - 1)
-		treat_inds <- first_treat_ind:(first_treat_ind + num_treats - 1)
+	first_treat_ind <- R + T - 1 + d * (1 + R + T - 1)
+	treat_inds <- first_treat_ind:(first_treat_ind + num_treats - 1)
+	stopifnot(length(treat_inds) == num_treats)
 
-		stopifnot(length(treat_inds) == num_treats)
+	X <- X[, c(1:(R + T - 1 + d), treat_inds)]
+	stopifnot(nrow(X) == N * T)
 
-		X_final <- X_final[, c(1:(R + T - 1 + d), treat_inds)]
-		# X_final_scaled <- X_final_scaled[, c(1:(R + T - 1 + d), treat_inds)]
+	treat_inds_mat <- matrix(as.numeric(NA), nrow = N * T, ncol = R)
+	for (r in 1:R) {
+		inds_r <- .cohort_block_inds(r, R, first_inds, num_treats)
+		cols_r <- R + T - 1 + d + inds_r
+		treat_inds_mat[, r] <- rowSums(X[, cols_r, drop = FALSE])
+	}
+	stopifnot(all(!is.na(treat_inds_mat)))
 
-		stopifnot(nrow(X_final) == N * T)
+	X_collapsed <- cbind(X[, 1:(R + T - 1 + d)], treat_inds_mat)
 
-		# Collapse together all columns corresponding to the same cohort
-		# stopifnot(nrow(X_final_scaled) == N * T)
-		treat_inds_mat <- matrix(as.numeric(NA), nrow = N * T, ncol = R)
+	p_short <- R + T - 1 + d + R
+	stopifnot(ncol(X_collapsed) == p_short)
 
-		for (r in 1:R) {
-			inds_r <- .cohort_block_inds(r, R, first_inds, num_treats)
-			cols_r <- R + T - 1 + d + inds_r
-			treat_inds_mat[, r] <- rowSums(X_final[, cols_r, drop = FALSE])
-		}
+	list(X_collapsed = X_collapsed, p_short = p_short)
+}
 
-		stopifnot(all(!is.na(treat_inds_mat)))
-
-		X_final <- cbind(X_final[, 1:(R + T - 1 + d)], treat_inds_mat)
-		# X_final_scaled <- cbind(X_final_scaled[, 1:(R + T - 1 + d)], treat_inds_mat)
-
-		p_short <- R + T - 1 + d + R
-
-		stopifnot(ncol(X_final) == p_short)
-		# stopifnot(ncol(X_final_scaled) == p_short)
-
-		treat_inds_short <- (R + T - 1 + d + 1):p_short
-
-		stopifnot(length(treat_inds_short) == R)
-
-		#
-		#
-		# Wrap up, store needed values
-		#
-		#
-
-		p <- p_short
-		treat_inds <- treat_inds_short
-		num_treats <- R
+#' @title Append ridge-augmentation rows to the scaled design
+#' @description When `add_ridge = TRUE`, build the augmentation matrix
+#'   (`D_inverse` from the fusion transform for FETWFE; `diag(p)` for
+#'   ETWFE / BETWFE / twfeCovs), then append
+#'   `sqrt(lambda_ridge) * mat` rows to `X_scaled` and zeros to `y_gls`.
+#'   When `add_ridge = FALSE`, returns inputs unchanged with
+#'   `lambda_ridge = NA`. The long arg list reflects two semantic
+#'   groups: `(N, T, p, sig_eps_sq, sig_eps_c_sq)` feed the
+#'   `lambda_ridge` formula; `(is_fetwfe, first_inds, T, R, d,
+#'   num_treats)` feed the `D_inverse` construction.
+#' @param X_scaled Numeric matrix; the scaled, GLS-transformed design.
+#' @param y_gls Numeric vector; the GLS-transformed response.
+#' @param p Integer; column count of `X_scaled`.
+#' @param add_ridge Logical.
+#' @param is_fetwfe Logical; selects fusion-inverse vs identity.
+#' @param first_inds,T,R,d,num_treats Args for
+#'   `genFullInvFusionTransformMat()` (only used when
+#'   `is_fetwfe = TRUE`).
+#' @param sig_eps_sq,sig_eps_c_sq,N Numeric / integer; inputs to the
+#'   `lambda_ridge = 1e-5 * (sig_eps_sq + sig_eps_c_sq) * sqrt(p/(N*T))`
+#'   formula.
+#' @return List with the (possibly-augmented) `X_scaled`, `y_final`,
+#'   and `lambda_ridge`.
+#' @keywords internal
+#' @noRd
+.append_ridge_rows <- function(
+	X_scaled,
+	y_gls,
+	p,
+	add_ridge,
+	is_fetwfe,
+	first_inds,
+	T,
+	R,
+	d,
+	num_treats,
+	sig_eps_sq,
+	sig_eps_c_sq,
+	N
+) {
+	if (!add_ridge) {
+		return(list(
+			X_scaled = X_scaled,
+			y_final = y_gls,
+			lambda_ridge = as.numeric(NA)
+		))
 	}
 
-	#
-	#
-	# Optional: if using ridge regularization on untransformed coefficients,
-	# add those rows now
-	#
-	#
+	mat_to_multiply <- diag(p)
 
-	X_final_scaled <- my_scale(X_final)
-	stopifnot(ncol(X_final_scaled) == p)
-	scale_center <- attr(X_final_scaled, "scaled:center")
-	scale_scale <- attr(X_final_scaled, "scaled:scale")
-
-	if (add_ridge) {
-		# Initialize identity matrix
-		mat_to_multiply <- diag(p)
-
-		if (is_fetwfe) {
-			# First need to get D^{-1}:
-			D_inverse <- genFullInvFusionTransformMat(
-				first_inds = first_inds,
-				T = T,
-				R = R,
-				d = d,
-				num_treats = num_treats
-			)
-
-			stopifnot(ncol(D_inverse) == p)
-			stopifnot(nrow(D_inverse) == p)
-
-			mat_to_multiply <- D_inverse
-		}
-
-		# Now add rows to X_final_scaled
-		lambda_ridge <- 0.00001 *
-			(sig_eps_sq + sig_eps_c_sq) *
-			sqrt(p / (N * T))
-
-		X_final_scaled <- rbind(
-			X_final_scaled,
-			sqrt(lambda_ridge) * mat_to_multiply
+	if (is_fetwfe) {
+		D_inverse <- genFullInvFusionTransformMat(
+			first_inds = first_inds,
+			T = T,
+			R = R,
+			d = d,
+			num_treats = num_treats
 		)
-		y_final <- c(y_final, rep(0, p))
 
-		stopifnot(length(y_final) == N * T + p)
-		stopifnot(nrow(X_final_scaled) == N * T + p)
-	} else {
-		lambda_ridge <- as.numeric(NA)
+		stopifnot(ncol(D_inverse) == p)
+		stopifnot(nrow(D_inverse) == p)
+
+		mat_to_multiply <- D_inverse
 	}
 
-	#
-	#
-	# Step 2: get cohort-specific sample proportions (estimated treatment
-	# probabilities)
-	#
-	#
+	lambda_ridge <- 0.00001 *
+		(sig_eps_sq + sig_eps_c_sq) *
+		sqrt(p / (N * T))
 
+	X_scaled <- rbind(
+		X_scaled,
+		sqrt(lambda_ridge) * mat_to_multiply
+	)
+	y_final <- c(y_gls, rep(0, p))
+
+	stopifnot(length(y_final) == N * T + p)
+	stopifnot(nrow(X_scaled) == N * T + p)
+
+	list(
+		X_scaled = X_scaled,
+		y_final = y_final,
+		lambda_ridge = lambda_ridge
+	)
+}
+
+#' @title Compute in-sample (and optionally independent) cohort probabilities
+#' @description Convert raw cohort counts into two normalizations:
+#'   within-treated (`cohort_probs`, sums to 1) and overall
+#'   (`cohort_probs_overall`, equals `count_r / N`). If
+#'   `indep_count_data_available = TRUE`, do the same for `indep_counts`;
+#'   otherwise the indep-side outputs are NA.
+#' @param in_sample_counts Integer vector of length `R + 1`; counts of
+#'   never-treated + treated cohorts in the working panel.
+#' @param indep_counts Integer vector of length `R + 1` or NA;
+#'   independent-sample counts.
+#' @param N Integer; total units.
+#' @param R Integer; treated cohorts.
+#' @param indep_count_data_available Logical.
+#' @return List with `cohort_probs`, `cohort_probs_overall`,
+#'   `indep_cohort_probs`, `indep_cohort_probs_overall`.
+#' @keywords internal
+#' @noRd
+.compute_cohort_probs <- function(
+	in_sample_counts,
+	indep_counts,
+	N,
+	R,
+	indep_count_data_available
+) {
 	cohort_probs <- in_sample_counts[2:(R + 1)] /
 		sum(in_sample_counts[2:(R + 1)])
 
@@ -299,9 +456,7 @@ prep_for_etwfe_regression <- function(
 		stopifnot(
 			abs(
 				1 -
-					sum(
-						indep_cohort_probs_overall
-					) -
+					sum(indep_cohort_probs_overall) -
 					indep_counts[1] / N
 			) <
 				1e-6
@@ -311,20 +466,12 @@ prep_for_etwfe_regression <- function(
 		indep_cohort_probs_overall <- NA
 	}
 
-	return(list(
-		X_final_scaled = X_final_scaled,
-		X_final = X_final,
-		y_final = y_final,
-		scale_center = scale_center,
-		scale_scale = scale_scale,
+	list(
 		cohort_probs = cohort_probs,
 		cohort_probs_overall = cohort_probs_overall,
 		indep_cohort_probs = indep_cohort_probs,
-		indep_cohort_probs_overall = indep_cohort_probs_overall,
-		sig_eps_sq = sig_eps_sq,
-		sig_eps_c_sq = sig_eps_c_sq,
-		lambda_ridge = lambda_ridge
-	))
+		indep_cohort_probs_overall = indep_cohort_probs_overall
+	)
 }
 
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.17",
+  note    = "R package version 1.9.18",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-prep-helpers-81.R
+++ b/tests/testthat/test-prep-helpers-81.R
@@ -1,0 +1,133 @@
+# Direct return-shape tests for the helpers extracted from
+# prep_for_etwfe_regression() in #81. Each helper is also exercised
+# end-to-end by every fit-side test; these tests lock the return-list
+# names/shapes so future return-shape drift in an individual helper is
+# caught at the helper boundary, not 20 stack frames later.
+
+# ------------------------------------------------------------------------------
+# .estimate_variance_and_gls(): when variance components are supplied,
+# the helper should pass them through unchanged and return a transformed
+# (y_gls, X_gls) of the right shape.
+# ------------------------------------------------------------------------------
+test_that(".estimate_variance_and_gls returns expected list shape (#81)", {
+	set.seed(1)
+	N <- 5
+	T <- 4
+	p <- 3
+	y <- rnorm(N * T)
+	X_mod <- matrix(rnorm(N * T * p), nrow = N * T, ncol = p)
+	X_ints <- X_mod # unused when variance components are supplied
+
+	out <- fetwfe:::.estimate_variance_and_gls(
+		y = y,
+		X_ints = X_ints,
+		X_mod = X_mod,
+		sig_eps_sq = 1.0,
+		sig_eps_c_sq = 0.5,
+		N = N,
+		T = T,
+		p = p,
+		verbose = FALSE
+	)
+
+	expect_named(out, c("y_gls", "X_gls", "sig_eps_sq", "sig_eps_c_sq"))
+	expect_equal(length(out$y_gls), N * T)
+	expect_equal(dim(out$X_gls), c(N * T, p))
+	expect_equal(out$sig_eps_sq, 1.0)
+	expect_equal(out$sig_eps_c_sq, 0.5)
+})
+
+# ------------------------------------------------------------------------------
+# .collapse_design_for_twfe_covs(): given a synthetic design matrix sized
+# to satisfy the column-slicing arithmetic, the helper should return a
+# (N*T) x p_short matrix with p_short = R + T - 1 + d + R.
+# ------------------------------------------------------------------------------
+test_that(".collapse_design_for_twfe_covs returns expected shape (#81)", {
+	R <- 2L
+	T <- 4L
+	N <- 3L
+	d <- 1L
+	first_inds <- fetwfe:::getFirstInds(R, T)
+	num_treats <- fetwfe:::getNumTreats(R, T)
+
+	n_cols <- R + T - 1 + d * (1 + R + T - 1) + num_treats
+	X_gls <- matrix(seq_len(N * T * n_cols), nrow = N * T, ncol = n_cols)
+
+	out <- fetwfe:::.collapse_design_for_twfe_covs(
+		X_gls = X_gls,
+		N = N,
+		T = T,
+		R = R,
+		d = d,
+		num_treats = num_treats,
+		first_inds = first_inds
+	)
+
+	expect_named(out, c("X_collapsed", "p_short"))
+	expect_equal(out$p_short, R + T - 1 + d + R)
+	expect_equal(ncol(out$X_collapsed), out$p_short)
+	expect_equal(nrow(out$X_collapsed), N * T)
+})
+
+# ------------------------------------------------------------------------------
+# .append_ridge_rows(): with add_ridge = FALSE, the helper should pass
+# inputs through unchanged and return lambda_ridge = NA.
+# ------------------------------------------------------------------------------
+test_that(".append_ridge_rows is a no-op when add_ridge = FALSE (#81)", {
+	N <- 4
+	T <- 3
+	p <- 5
+	X_scaled <- matrix(rnorm(N * T * p), nrow = N * T, ncol = p)
+	y_gls <- rnorm(N * T)
+
+	out <- fetwfe:::.append_ridge_rows(
+		X_scaled = X_scaled,
+		y_gls = y_gls,
+		p = p,
+		add_ridge = FALSE,
+		is_fetwfe = FALSE,
+		first_inds = 1L, # unused
+		T = T,
+		R = 1L,
+		d = 0L,
+		num_treats = 1L,
+		sig_eps_sq = 1.0,
+		sig_eps_c_sq = 0.5,
+		N = N
+	)
+
+	expect_named(out, c("X_scaled", "y_final", "lambda_ridge"))
+	expect_identical(out$X_scaled, X_scaled)
+	expect_identical(out$y_final, y_gls)
+	expect_true(is.na(out$lambda_ridge))
+})
+
+# ------------------------------------------------------------------------------
+# .compute_cohort_probs(): the two normalizations (within-treated and
+# overall) should match the documented formulae on a simple count vector.
+# ------------------------------------------------------------------------------
+test_that(".compute_cohort_probs returns expected shape and values (#81)", {
+	# 100 total: 50 never-treated, 30 cohort 1, 20 cohort 2.
+	in_sample_counts <- c(50L, 30L, 20L)
+	out <- fetwfe:::.compute_cohort_probs(
+		in_sample_counts = in_sample_counts,
+		indep_counts = NA,
+		N = 100L,
+		R = 2L,
+		indep_count_data_available = FALSE
+	)
+
+	expect_named(
+		out,
+		c(
+			"cohort_probs",
+			"cohort_probs_overall",
+			"indep_cohort_probs",
+			"indep_cohort_probs_overall"
+		)
+	)
+	expect_equal(out$cohort_probs, c(30 / 50, 20 / 50))
+	expect_equal(out$cohort_probs_overall, c(30 / 100, 20 / 100))
+	expect_true(is.na(out$indep_cohort_probs))
+	expect_true(is.na(out$indep_cohort_probs_overall))
+})


### PR DESCRIPTION
## Summary

Closes #81. Pure internal refactor — splits the 237-line god function `R/core_funcs.R::prep_for_etwfe_regression()` (6 phases, gated by 2 flags) into 4 named helpers + a ~100-line orchestrator.

**Helpers added** (each `@noRd` + `@keywords internal`, all in `R/core_funcs.R`):

| Helper | Phase | Original lines | Helper lines |
|---|---|---|---|
| `.estimate_variance_and_gls()` | Variance estimation + GLS transform | 113-154 | ~70 |
| `.collapse_design_for_twfe_covs()` | twfeCovs design surgery | 162-213 | ~58 |
| `.append_ridge_rows()` | Ridge augmentation | 228-263 | ~74 |
| `.compute_cohort_probs()` | In-sample + indep probabilities | 272-312 | ~64 |

The orchestrator's 16-arg input contract and 12-field return list are preserved exactly — all four caller sites (`fetwfe_core()`, `etwfe_core()`, `betwfe_core()`, `twfeCovs_core()`) are byte-identical to `origin/main`.

**Additional cleanups**:
- Removed 6 commented-out dead `X_final_scaled` scaffolding lines (from a prior refactor that swapped surgery/scaling order).
- Dropped 1 of 25 original `stopifnot()` invariants — `length(treat_inds_short) == R`. It was a structural tautology of R-range syntax and is no longer reachable since `.collapse_design_for_twfe_covs()` doesn't return `treat_inds_short` (the original function didn't either; downstream consumers recompute it themselves). The other 24 invariants are preserved.

**Tests**: Adds `tests/testthat/test-prep-helpers-81.R` with 4 direct return-shape tests (one per helper) to lock the contracts against future drift. End-to-end coverage is unchanged; the helpers' contracts are also exercised by every fit-side test indirectly.

**Version bump**: 1.9.17 → 1.9.18.

## Test plan

- [x] Full test suite: 1769 passing, 0 failures, 0 errors, 2 pre-existing warnings.
- [x] `devtools::check(--as-cran)`: 0 errors, 0 warnings, 1 environmental NOTE.
- [x] Drift sentinel: MINOR DRIFT (doc-side only — sub-tally inconsistencies in plan's Outcomes section, amended).
- [x] Post-execution reviewer: READY-TO-SHIP (no code changes required).
- [x] All 4 caller sites confirmed byte-identical (`git diff origin/main R/fetwfe_core.R R/etwfe_core.R R/betwfe_core.R R/twfeCovs.R` is empty).
- [x] 24 of 25 `stopifnot()` invariants preserved; 1 dropped tautology documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
