### PR TITLE
Add error-message snapshot guardrail for entry points (#79 PR A)

### DIFF
--- a/tests/testthat/_snaps/estimator-entry-snapshot.md
+++ b/tests/testthat/_snaps/estimator-entry-snapshot.md
@@ -1,0 +1,42 @@
+# entry-point error: pdata[[time_var]] not integer (#79 PR A)
+
+    Code
+      cat(msgs$fetwfe)
+    Output
+      is.integer(pdata[[time_var]]) is not TRUE
+
+# entry-point error: time_var not a column (#79 PR A)
+
+    Code
+      cat(msgs$fetwfe)
+    Output
+      time_var %in% colnames(pdata) is not TRUE
+
+# entry-point error: time_var not character (#79 PR A)
+
+    Code
+      cat(msgs$fetwfe)
+    Output
+      is.character(time_var) is not TRUE
+
+# entry-point error: verbose not logical (#79 PR A)
+
+    Code
+      cat(msgs$fetwfe)
+    Output
+      is.logical(verbose) is not TRUE
+
+# entry-point error: alpha out of range (#79 PR A)
+
+    Code
+      cat(msgs$fetwfe)
+    Output
+      alpha > 0 is not TRUE
+
+# entry-point error: fetwfe + betwfe q out of range (#79 PR A)
+
+    Code
+      cat(msgs$fetwfe)
+    Output
+      q > 0 is not TRUE
+

--- a/tests/testthat/test-estimator-entry-snapshot.R
+++ b/tests/testthat/test-estimator-entry-snapshot.R
@@ -1,0 +1,202 @@
+library(testthat)
+library(fetwfe)
+
+# Snapshot guardrail for the four estimator entry points' input-validation
+# error messages. Locks the canonical `<predicate> is not TRUE` strings
+# produced by `checkEtwfeInputs()` (and `checkFetwfeInputs()` for the
+# fetwfe-specific extension) against six markdown goldens under
+# tests/testthat/_snaps/estimator-entry-snapshot.md so any byte drift
+# surfaces as a failing test. Pre-refactor guardrail for issue #79's
+# entry-point consolidation: PR B will eliminate the verbatim 12-step
+# pipeline duplication, and any accidental error-message rewording will
+# trip this file.
+#
+# Each test mutates one field of a known-good 4-unit x 3-period panel
+# to trigger one canonical malformed-input pattern, then runs all 4
+# entry points (or 2, for the fetwfe/betwfe-specific `q` test) and
+# asserts byte-equality of the captured `conditionMessage()`. The
+# canonical message is then snapshotted so it can't drift without
+# explicit re-blessing.
+#
+# Snapshot tests require testthat edition 3 and skip under CRAN by
+# default (so `R CMD check --as-cran` shows SKIPs for these tests;
+# `devtools::test()` runs them).
+
+testthat::local_edition(3)
+
+# In-file panel fixture (NOT shared with other test files; this PR's
+# scope is intentionally narrow). 4 units x 3 time periods = 12 rows.
+# U1 never treated, U2/U3 in cohort 2, U4 in cohort 3.
+.build_valid_panel <- function() {
+	data.frame(
+		unit = rep(c("U1", "U2", "U3", "U4"), each = 3),
+		time = rep(1L:3L, 4),
+		treat = c(
+			0L, 0L, 0L, # U1: never
+			0L, 1L, 1L, # U2: cohort 2
+			0L, 1L, 1L, # U3: cohort 2
+			0L, 0L, 1L  # U4: cohort 3
+		),
+		y = as.numeric(1:12),
+		stringsAsFactors = FALSE
+	)
+}
+
+# Capture conditionMessage() from each entry point under a given
+# malformed call. Returns a list with one entry per estimator name.
+.capture_entry_point_errors <- function(args, estimators = c(
+	"fetwfe",
+	"etwfe",
+	"betwfe",
+	"twfeCovs"
+)) {
+	fns <- list(
+		fetwfe = fetwfe,
+		etwfe = etwfe,
+		betwfe = betwfe,
+		twfeCovs = twfeCovs
+	)
+	out <- list()
+	for (est in estimators) {
+		out[[est]] <- tryCatch(
+			do.call(fns[[est]], args),
+			error = function(e) conditionMessage(e)
+		)
+	}
+	out
+}
+
+# ------------------------------------------------------------------------------
+# Test 1: wrong column type. `pdata[[time_var]]` is numeric (not integer).
+# Trips `stopifnot(is.integer(pdata[[time_var]]))` in checkEtwfeInputs.
+# ------------------------------------------------------------------------------
+test_that("entry-point error: pdata[[time_var]] not integer (#79 PR A)", {
+	pdata <- .build_valid_panel()
+	pdata$time <- as.numeric(pdata$time) # cast away the integer marker
+	args <- list(
+		pdata = pdata,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treat",
+		response = "y"
+	)
+	msgs <- .capture_entry_point_errors(args)
+
+	expect_identical(msgs$fetwfe, msgs$etwfe)
+	expect_identical(msgs$etwfe, msgs$betwfe)
+	expect_identical(msgs$betwfe, msgs$twfeCovs)
+
+	expect_snapshot(cat(msgs$fetwfe))
+})
+
+# ------------------------------------------------------------------------------
+# Test 2: missing column. `time_var` references a column that's not in pdata.
+# Trips `stopifnot(time_var %in% colnames(pdata))`.
+# ------------------------------------------------------------------------------
+test_that("entry-point error: time_var not a column (#79 PR A)", {
+	pdata <- .build_valid_panel()
+	args <- list(
+		pdata = pdata,
+		time_var = "nonexistent",
+		unit_var = "unit",
+		treatment = "treat",
+		response = "y"
+	)
+	msgs <- .capture_entry_point_errors(args)
+
+	expect_identical(msgs$fetwfe, msgs$etwfe)
+	expect_identical(msgs$etwfe, msgs$betwfe)
+	expect_identical(msgs$betwfe, msgs$twfeCovs)
+
+	expect_snapshot(cat(msgs$fetwfe))
+})
+
+# ------------------------------------------------------------------------------
+# Test 3: non-character flag arg. `time_var` is an integer.
+# Trips `stopifnot(is.character(time_var))`.
+# ------------------------------------------------------------------------------
+test_that("entry-point error: time_var not character (#79 PR A)", {
+	pdata <- .build_valid_panel()
+	args <- list(
+		pdata = pdata,
+		time_var = 42L,
+		unit_var = "unit",
+		treatment = "treat",
+		response = "y"
+	)
+	msgs <- .capture_entry_point_errors(args)
+
+	expect_identical(msgs$fetwfe, msgs$etwfe)
+	expect_identical(msgs$etwfe, msgs$betwfe)
+	expect_identical(msgs$betwfe, msgs$twfeCovs)
+
+	expect_snapshot(cat(msgs$fetwfe))
+})
+
+# ------------------------------------------------------------------------------
+# Test 4: non-logical flag arg. `verbose` is a character.
+# Trips `stopifnot(is.logical(verbose))`.
+# ------------------------------------------------------------------------------
+test_that("entry-point error: verbose not logical (#79 PR A)", {
+	pdata <- .build_valid_panel()
+	args <- list(
+		pdata = pdata,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treat",
+		response = "y",
+		verbose = "yes"
+	)
+	msgs <- .capture_entry_point_errors(args)
+
+	expect_identical(msgs$fetwfe, msgs$etwfe)
+	expect_identical(msgs$etwfe, msgs$betwfe)
+	expect_identical(msgs$betwfe, msgs$twfeCovs)
+
+	expect_snapshot(cat(msgs$fetwfe))
+})
+
+# ------------------------------------------------------------------------------
+# Test 5: range violation. `alpha` is negative.
+# Trips `stopifnot(alpha > 0)`.
+# ------------------------------------------------------------------------------
+test_that("entry-point error: alpha out of range (#79 PR A)", {
+	pdata <- .build_valid_panel()
+	args <- list(
+		pdata = pdata,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treat",
+		response = "y",
+		alpha = -0.1
+	)
+	msgs <- .capture_entry_point_errors(args)
+
+	expect_identical(msgs$fetwfe, msgs$etwfe)
+	expect_identical(msgs$etwfe, msgs$betwfe)
+	expect_identical(msgs$betwfe, msgs$twfeCovs)
+
+	expect_snapshot(cat(msgs$fetwfe))
+})
+
+# ------------------------------------------------------------------------------
+# Test 6: fetwfe / betwfe `q` violation. Both call checkFetwfeInputs(), so
+# both should produce a byte-identical "q > 0 is not TRUE" message.
+# etwfe / twfeCovs don't have a `q` arg and are excluded.
+# ------------------------------------------------------------------------------
+test_that("entry-point error: fetwfe + betwfe q out of range (#79 PR A)", {
+	pdata <- .build_valid_panel()
+	args <- list(
+		pdata = pdata,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treat",
+		response = "y",
+		q = -1
+	)
+	msgs <- .capture_entry_point_errors(args, estimators = c("fetwfe", "betwfe"))
+
+	expect_identical(msgs$fetwfe, msgs$betwfe)
+
+	expect_snapshot(cat(msgs$fetwfe))
+})


### PR DESCRIPTION
## Summary

Part 1 of a 2-PR sequence on issue #79 (consolidate four estimator entry points' input/output pipeline). The issue itself prescribes this sequence:

> input validation is the FIRST thing users see when something goes wrong, so error messages need to remain consistent... add a `test-estimator-entry-snapshot.R` that captures the error messages produced by each entry point on canonical malformed-input fixtures and asserts byte-equality.

This PR is that snapshot guardrail. **Test-only** — zero source changes — so PR B (the actual entry-point consolidation) ships without accidentally renaming or restructuring any user-facing error message.

**Six snapshot tests** in `tests/testthat/test-estimator-entry-snapshot.R`, one per canonical malformed-input pattern:

| Test | Trigger | `stopifnot()` predicate |
|---|---|---|
| 1 | `pdata[[time_var]]` numeric | `is.integer(pdata[[time_var]])` |
| 2 | `time_var = "nonexistent"` | `time_var %in% colnames(pdata)` |
| 3 | `time_var = 42L` | `is.character(time_var)` |
| 4 | `verbose = "yes"` | `is.logical(verbose)` |
| 5 | `alpha = -0.1` | `alpha > 0` |
| 6 | `q = -1` | `q > 0` (fetwfe + betwfe only) |

Tests 1–5 assert byte-equality across all 4 entry points (`fetwfe`, `etwfe`, `betwfe`, `twfeCovs`); Test 6 asserts byte-equality across `fetwfe` + `betwfe` (the two that route through `checkFetwfeInputs`). The canonical message is then captured via `expect_snapshot()` so PR B's refactor can't silently reword.

**No version bump** per PR #65 precedent (tests-only).

The snapshot file at `tests/testthat/_snaps/estimator-entry-snapshot.md` captures the literal `<predicate> is not TRUE` strings. By design this is brittle to wording changes: if PR B's refactor renames a formal arg inside `checkEtwfeInputs()`, the snapshot will fail and require explicit re-blessing. That's a feature — the snapshot forces a conscious decision rather than silent drift.

## Test plan

- [x] Full test suite: 1791 passing, 0 failures, 0 errors, 2 pre-existing warnings (+22 expectations from the 6 new snapshot tests).
- [x] `devtools::check(--as-cran)`: 0 errors, 0 warnings, 1 environmental NOTE.
- [x] Drift sentinel: NO DRIFT.
- [x] Post-execution reviewer: READY-TO-SHIP.
- [x] Cross-entry-point identity traced by hand on Test 1 (all 4 estimators hit the same `stopifnot()` line via `checkEtwfeInputs`).
- [x] Test 6 mutex verified: `q = -1` passes `is.numeric(q)` and `length(q) == 1` before tripping `q > 0`.
- [x] Snapshot file format matches PR #90's `_snaps/print-method-snapshot.md` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
