### PR TITLE
Consolidate four estimator entry points' pipeline (#79 PR B, 1.9.19)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.18
+Version: 1.9.19
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # NEWS
 
+## Version 1.9.19 (2026-05-19)
+
+- Internal consolidation of the input/output pipeline shared by the
+  four public estimator entry points `fetwfe()`, `etwfe()`,
+  `betwfe()`, and `twfeCovs()` (GitHub #79). Two new internal helpers
+  in `R/utility.R` --- `.run_estimator_input_prep()` and
+  `.select_att_branch()` --- absorb the verbatim Steps 3-5 (input
+  validation + auto-truncation + design-matrix prep) and Step 8
+  ("pick from in-sample vs indep ATT/SE/cohort-probs") that were
+  previously copy-pasted across the four entry points. The four
+  caller-side rewrites trim ~250 LOC of duplication while leaving
+  the eleven other steps (match.arg, original-covs capture, core
+  call, rank-deficiency warning loop, p-value, output-list build,
+  validator, class assignment) inline. No public API change; the
+  snapshot guardrail from v1.9.18 (PR A, #103) confirms all four
+  validators' error messages remain byte-identical. The new helpers
+  carry `@noRd` / `@keywords internal` and do not appear in the
+  exported docs surface.
+
 ## Version 1.9.18 (2026-05-19)
 
 - Internal refactor of `R/core_funcs.R::prep_for_etwfe_regression()`

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -283,8 +283,8 @@ betwfe <- function(
 
 	covs_orig <- covs
 
-	# Check inputs
-	ret <- checkFetwfeInputs(
+	# Steps 3-5: input validation + auto-truncation + design-matrix prep.
+	prep <- .run_estimator_input_prep(
 		pdata = pdata,
 		time_var = time_var,
 		unit_var = unit_var,
@@ -299,49 +299,27 @@ betwfe <- function(
 		q = q,
 		verbose = verbose,
 		alpha = alpha,
-		add_ridge = add_ridge
+		add_ridge = add_ridge,
+		allow_no_never_treated = allow_no_never_treated,
+		estimator_type = "fetwfe"
 	)
 
-	pdata <- ret$pdata
-	indep_count_data_available = ret$indep_count_data_available
+	pdata <- prep$pdata
+	covs <- prep$covs
+	X_ints <- prep$X_ints
+	y <- prep$y
+	y_mean <- prep$y_mean
+	N <- prep$N
+	T <- prep$T
+	d <- prep$d
+	p <- prep$p
+	in_sample_counts <- prep$in_sample_counts
+	num_treats <- prep$num_treats
+	first_inds <- prep$first_inds
+	R <- prep$R
+	indep_count_data_available <- prep$indep_count_data_available
 
-	rm(ret)
-
-	pdata <- .truncate_if_no_never_treated(
-		pdata,
-		time_var = time_var,
-		unit_var = unit_var,
-		treat_var = treatment,
-		allow_no_never_treated = allow_no_never_treated
-	)
-
-	res1 <- prep_for_etwfe_core(
-		pdata = pdata,
-		response = response,
-		time_var = time_var,
-		unit_var = unit_var,
-		treatment = treatment,
-		covs = covs,
-		verbose = verbose,
-		indep_count_data_available = indep_count_data_available,
-		indep_counts = indep_counts
-	)
-
-	pdata <- res1$pdata
-	covs <- res1$covs
-	X_ints <- res1$X_ints
-	y <- res1$y
-	y_mean <- res1$y_mean
-	N <- res1$N
-	T <- res1$T
-	d <- res1$d
-	p <- res1$p
-	in_sample_counts <- res1$in_sample_counts
-	num_treats <- res1$num_treats
-	first_inds <- res1$first_inds
-	R <- res1$R
-
-	rm(res1)
+	rm(prep)
 
 	res <- betwfe_core(
 		X_ints = X_ints,
@@ -366,30 +344,15 @@ betwfe <- function(
 		se_type = se_type
 	)
 
-	if (indep_count_data_available) {
-		stopifnot(!is.na(res$indep_att_hat))
-
-		if ((q < 1) & res$calc_ses) {
-			stopifnot(!is.na(res$indep_att_se))
-		}
-
-		stopifnot(all(!is.na(res$indep_cohort_probs)))
-		att_hat <- res$indep_att_hat
-		att_se <- res$indep_att_se
-		cohort_probs <- res$indep_cohort_probs
-		cohort_probs_overall <- res$indep_cohort_probs_overall
-	} else {
-		stopifnot(!is.na(res$in_sample_att_hat))
-
-		if ((q < 1) & res$calc_ses) {
-			stopifnot(!is.na(res$in_sample_att_se))
-		}
-
-		att_hat <- res$in_sample_att_hat
-		att_se <- res$in_sample_att_se
-		cohort_probs <- res$cohort_probs
-		cohort_probs_overall <- res$cohort_probs_overall
-	}
+	att_branch <- .select_att_branch(
+		res,
+		indep_count_data_available = indep_count_data_available,
+		q = q
+	)
+	att_hat <- att_branch$att_hat
+	att_se <- att_branch$att_se
+	cohort_probs <- att_branch$cohort_probs
+	cohort_probs_overall <- att_branch$cohort_probs_overall
 
 	att_p_value <- .compute_p_values(att_hat, att_se)
 	att_selected <- att_hat != 0

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -242,8 +242,8 @@ fetwfe <- function(
 	# form; we want the original on the output.
 	covs_orig <- covs
 
-	# Check inputs
-	ret <- checkFetwfeInputs(
+	# Steps 3-5: input validation + auto-truncation + design-matrix prep.
+	prep <- .run_estimator_input_prep(
 		pdata = pdata,
 		time_var = time_var,
 		unit_var = unit_var,
@@ -258,49 +258,27 @@ fetwfe <- function(
 		q = q,
 		verbose = verbose,
 		alpha = alpha,
-		add_ridge = add_ridge
+		add_ridge = add_ridge,
+		allow_no_never_treated = allow_no_never_treated,
+		estimator_type = "fetwfe"
 	)
 
-	pdata <- ret$pdata
-	indep_count_data_available = ret$indep_count_data_available
+	pdata <- prep$pdata
+	covs <- prep$covs
+	X_ints <- prep$X_ints
+	y <- prep$y
+	y_mean <- prep$y_mean
+	N <- prep$N
+	T <- prep$T
+	d <- prep$d
+	p <- prep$p
+	in_sample_counts <- prep$in_sample_counts
+	num_treats <- prep$num_treats
+	first_inds <- prep$first_inds
+	R <- prep$R
+	indep_count_data_available <- prep$indep_count_data_available
 
-	rm(ret)
-
-	pdata <- .truncate_if_no_never_treated(
-		pdata,
-		time_var = time_var,
-		unit_var = unit_var,
-		treat_var = treatment,
-		allow_no_never_treated = allow_no_never_treated
-	)
-
-	res1 <- prep_for_etwfe_core(
-		pdata = pdata,
-		response = response,
-		time_var = time_var,
-		unit_var = unit_var,
-		treatment = treatment,
-		covs = covs,
-		verbose = verbose,
-		indep_count_data_available = indep_count_data_available,
-		indep_counts = indep_counts
-	)
-
-	pdata <- res1$pdata
-	covs <- res1$covs
-	X_ints <- res1$X_ints
-	y <- res1$y
-	y_mean <- res1$y_mean
-	N <- res1$N
-	T <- res1$T
-	d <- res1$d
-	p <- res1$p
-	in_sample_counts <- res1$in_sample_counts
-	num_treats <- res1$num_treats
-	first_inds <- res1$first_inds
-	R <- res1$R
-
-	rm(res1)
+	rm(prep)
 
 	res <- fetwfe_core(
 		X_ints = X_ints,
@@ -325,30 +303,15 @@ fetwfe <- function(
 		se_type = se_type
 	)
 
-	if (indep_count_data_available) {
-		stopifnot(!is.na(res$indep_att_hat))
-
-		if ((q < 1) & res$calc_ses) {
-			stopifnot(!is.na(res$indep_att_se))
-		}
-
-		stopifnot(all(!is.na(res$indep_cohort_probs)))
-		att_hat <- res$indep_att_hat
-		att_se <- res$indep_att_se
-		cohort_probs <- res$indep_cohort_probs
-		cohort_probs_overall <- res$indep_cohort_probs_overall
-	} else {
-		stopifnot(!is.na(res$in_sample_att_hat))
-
-		if ((q < 1) & res$calc_ses) {
-			stopifnot(!is.na(res$in_sample_att_se))
-		}
-
-		att_hat <- res$in_sample_att_hat
-		att_se <- res$in_sample_att_se
-		cohort_probs <- res$cohort_probs
-		cohort_probs_overall <- res$cohort_probs_overall
-	}
+	att_branch <- .select_att_branch(
+		res,
+		indep_count_data_available = indep_count_data_available,
+		q = q
+	)
+	att_hat <- att_branch$att_hat
+	att_se <- att_branch$att_se
+	cohort_probs <- att_branch$cohort_probs
+	cohort_probs_overall <- att_branch$cohort_probs_overall
 
 	att_p_value <- .compute_p_values(att_hat, att_se)
 	att_selected <- att_hat != 0
@@ -811,8 +774,8 @@ etwfe <- function(
 
 	covs_orig <- covs
 
-	# Check inputs
-	ret <- checkEtwfeInputs(
+	# Steps 3-5: input validation + auto-truncation + design-matrix prep.
+	prep <- .run_estimator_input_prep(
 		pdata = pdata,
 		time_var = time_var,
 		unit_var = unit_var,
@@ -824,49 +787,27 @@ etwfe <- function(
 		sig_eps_c_sq = sig_eps_c_sq,
 		verbose = verbose,
 		alpha = alpha,
-		add_ridge = add_ridge
+		add_ridge = add_ridge,
+		allow_no_never_treated = allow_no_never_treated,
+		estimator_type = "etwfe"
 	)
 
-	pdata <- ret$pdata
-	indep_count_data_available = ret$indep_count_data_available
+	pdata <- prep$pdata
+	covs <- prep$covs
+	X_ints <- prep$X_ints
+	y <- prep$y
+	y_mean <- prep$y_mean
+	N <- prep$N
+	T <- prep$T
+	d <- prep$d
+	p <- prep$p
+	in_sample_counts <- prep$in_sample_counts
+	num_treats <- prep$num_treats
+	first_inds <- prep$first_inds
+	R <- prep$R
+	indep_count_data_available <- prep$indep_count_data_available
 
-	rm(ret)
-
-	pdata <- .truncate_if_no_never_treated(
-		pdata,
-		time_var = time_var,
-		unit_var = unit_var,
-		treat_var = treatment,
-		allow_no_never_treated = allow_no_never_treated
-	)
-
-	res1 <- prep_for_etwfe_core(
-		pdata = pdata,
-		response = response,
-		time_var = time_var,
-		unit_var = unit_var,
-		treatment = treatment,
-		covs = covs,
-		verbose = verbose,
-		indep_count_data_available = indep_count_data_available,
-		indep_counts = indep_counts
-	)
-
-	pdata <- res1$pdata
-	covs <- res1$covs
-	X_ints <- res1$X_ints
-	y <- res1$y
-	y_mean <- res1$y_mean
-	N <- res1$N
-	T <- res1$T
-	d <- res1$d
-	p <- res1$p
-	in_sample_counts <- res1$in_sample_counts
-	num_treats <- res1$num_treats
-	first_inds <- res1$first_inds
-	R <- res1$R
-
-	rm(res1)
+	rm(prep)
 
 	warning_flag <- FALSE
 
@@ -907,20 +848,14 @@ etwfe <- function(
 		se_type = se_type
 	)
 
-	if (indep_count_data_available) {
-		stopifnot(!is.na(res$indep_att_hat))
-		stopifnot(!is.na(res$indep_att_se))
-		stopifnot(all(!is.na(res$indep_cohort_probs)))
-		att_hat <- res$indep_att_hat
-		att_se <- res$indep_att_se
-		cohort_probs <- res$indep_cohort_probs
-		cohort_probs_overall <- res$indep_cohort_probs_overall
-	} else {
-		att_hat <- res$in_sample_att_hat
-		att_se <- res$in_sample_att_se
-		cohort_probs <- res$cohort_probs
-		cohort_probs_overall <- res$cohort_probs_overall
-	}
+	att_branch <- .select_att_branch(
+		res,
+		indep_count_data_available = indep_count_data_available
+	)
+	att_hat <- att_branch$att_hat
+	att_se <- att_branch$att_se
+	cohort_probs <- att_branch$cohort_probs
+	cohort_probs_overall <- att_branch$cohort_probs_overall
 
 	att_p_value <- .compute_p_values(att_hat, att_se)
 

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -211,8 +211,8 @@ twfeCovs <- function(
 
 	covs_orig <- covs
 
-	# Check inputs
-	ret <- checkEtwfeInputs(
+	# Steps 3-5: input validation + auto-truncation + design-matrix prep.
+	prep <- .run_estimator_input_prep(
 		pdata = pdata,
 		time_var = time_var,
 		unit_var = unit_var,
@@ -224,49 +224,27 @@ twfeCovs <- function(
 		sig_eps_c_sq = sig_eps_c_sq,
 		verbose = verbose,
 		alpha = alpha,
-		add_ridge = add_ridge
+		add_ridge = add_ridge,
+		allow_no_never_treated = allow_no_never_treated,
+		estimator_type = "etwfe"
 	)
 
-	pdata <- ret$pdata
-	indep_count_data_available = ret$indep_count_data_available
+	pdata <- prep$pdata
+	covs <- prep$covs
+	X_ints <- prep$X_ints
+	y <- prep$y
+	y_mean <- prep$y_mean
+	N <- prep$N
+	T <- prep$T
+	d <- prep$d
+	p <- prep$p
+	in_sample_counts <- prep$in_sample_counts
+	num_treats <- prep$num_treats
+	first_inds <- prep$first_inds
+	R <- prep$R
+	indep_count_data_available <- prep$indep_count_data_available
 
-	rm(ret)
-
-	pdata <- .truncate_if_no_never_treated(
-		pdata,
-		time_var = time_var,
-		unit_var = unit_var,
-		treat_var = treatment,
-		allow_no_never_treated = allow_no_never_treated
-	)
-
-	res1 <- prep_for_etwfe_core(
-		pdata = pdata,
-		response = response,
-		time_var = time_var,
-		unit_var = unit_var,
-		treatment = treatment,
-		covs = covs,
-		verbose = verbose,
-		indep_count_data_available = indep_count_data_available,
-		indep_counts = indep_counts
-	)
-
-	pdata <- res1$pdata
-	covs <- res1$covs
-	X_ints <- res1$X_ints
-	y <- res1$y
-	y_mean <- res1$y_mean
-	N <- res1$N
-	T <- res1$T
-	d <- res1$d
-	p <- res1$p
-	in_sample_counts <- res1$in_sample_counts
-	num_treats <- res1$num_treats
-	first_inds <- res1$first_inds
-	R <- res1$R
-
-	rm(res1)
+	rm(prep)
 
 	warning_flag <- FALSE
 
@@ -307,20 +285,14 @@ twfeCovs <- function(
 		se_type = se_type
 	)
 
-	if (indep_count_data_available) {
-		stopifnot(!is.na(res$indep_att_hat))
-		stopifnot(!is.na(res$indep_att_se))
-		stopifnot(all(!is.na(res$indep_cohort_probs)))
-		att_hat <- res$indep_att_hat
-		att_se <- res$indep_att_se
-		cohort_probs <- res$indep_cohort_probs
-		cohort_probs_overall <- res$indep_cohort_probs_overall
-	} else {
-		att_hat <- res$in_sample_att_hat
-		att_se <- res$in_sample_att_se
-		cohort_probs <- res$cohort_probs
-		cohort_probs_overall <- res$cohort_probs_overall
-	}
+	att_branch <- .select_att_branch(
+		res,
+		indep_count_data_available = indep_count_data_available
+	)
+	att_hat <- att_branch$att_hat
+	att_se <- att_branch$att_se
+	cohort_probs <- att_branch$cohort_probs
+	cohort_probs_overall <- att_branch$cohort_probs_overall
 
 	att_p_value <- .compute_p_values(att_hat, att_se)
 

--- a/R/utility.R
+++ b/R/utility.R
@@ -721,3 +721,225 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 	diag(S) <- probs * (1 - probs)
 	S
 }
+
+#' @title Run the shared input-prep pipeline for the four estimator entry points
+#' @description
+#' Internal helper that consolidates the verbatim Steps 3-5 (input
+#' validation + auto-truncation + design-matrix prep) shared across
+#' `fetwfe()`, `etwfe()`, `betwfe()`, and `twfeCovs()`. Branches on
+#' `estimator_type` to pick the correct validator
+#' (`checkFetwfeInputs()` for fetwfe/betwfe, `checkEtwfeInputs()` for
+#' etwfe/twfeCovs), then calls `.truncate_if_no_never_treated()` and
+#' `prep_for_etwfe_core()`. The four caller-side rewrites consume the
+#' returned list with verbose per-field unpacking. Consolidated by
+#' GitHub #79.
+#' @param pdata,time_var,unit_var,treatment,response,covs,indep_counts,sig_eps_sq,sig_eps_c_sq,verbose,alpha,add_ridge
+#'   The shared arguments validated by both `checkEtwfeInputs()` and
+#'   `checkFetwfeInputs()`. See either validator's source for the
+#'   per-argument contracts.
+#' @param lambda.max,lambda.min,q The fetwfe/betwfe-specific bridge
+#'   penalty arguments. Forwarded to `checkFetwfeInputs()` when
+#'   `estimator_type == "fetwfe"`. When `estimator_type == "etwfe"`,
+#'   these must remain `NA` (their defaults); a `stopifnot()` guards
+#'   caller-side misuse.
+#' @param allow_no_never_treated Logical; forwarded to
+#'   `.truncate_if_no_never_treated()`. Defaults to `TRUE`.
+#' @param estimator_type Character scalar; one of `"fetwfe"` or
+#'   `"etwfe"`. Selects which validator to call. `"fetwfe"` covers
+#'   both `fetwfe()` and `betwfe()` (they share `checkFetwfeInputs()`);
+#'   `"etwfe"` covers both `etwfe()` and `twfeCovs()` (they share
+#'   `checkEtwfeInputs()`).
+#' @return A list with exactly 14 elements:
+#'   `pdata`, `covs`, `X_ints`, `y`, `y_mean`, `N`, `T`, `d`, `p`,
+#'   `in_sample_counts`, `num_treats`, `first_inds`, `R`,
+#'   `indep_count_data_available`. Each caller unpacks these into local
+#'   variables before invoking its `_core()` function.
+#' @keywords internal
+#' @noRd
+.run_estimator_input_prep <- function(
+	pdata,
+	time_var,
+	unit_var,
+	treatment,
+	response,
+	covs = c(),
+	indep_counts = NA,
+	sig_eps_sq = NA,
+	sig_eps_c_sq = NA,
+	lambda.max = NA,
+	lambda.min = NA,
+	q = NA,
+	verbose = FALSE,
+	alpha = 0.05,
+	add_ridge = FALSE,
+	allow_no_never_treated = TRUE,
+	estimator_type
+) {
+	stopifnot(
+		is.character(estimator_type),
+		length(estimator_type) == 1,
+		estimator_type %in% c("fetwfe", "etwfe")
+	)
+
+	# Defensive caller-error guard: etwfe/twfeCovs callers must not
+	# forward bridge-penalty arguments.
+	if (estimator_type == "etwfe") {
+		stopifnot(is.na(q) && is.na(lambda.max) && is.na(lambda.min))
+	}
+
+	# Step 3: input validation.
+	if (estimator_type == "fetwfe") {
+		ret <- checkFetwfeInputs(
+			pdata = pdata,
+			time_var = time_var,
+			unit_var = unit_var,
+			treatment = treatment,
+			response = response,
+			covs = covs,
+			indep_counts = indep_counts,
+			sig_eps_sq = sig_eps_sq,
+			sig_eps_c_sq = sig_eps_c_sq,
+			lambda.max = lambda.max,
+			lambda.min = lambda.min,
+			q = q,
+			verbose = verbose,
+			alpha = alpha,
+			add_ridge = add_ridge
+		)
+	} else {
+		ret <- checkEtwfeInputs(
+			pdata = pdata,
+			time_var = time_var,
+			unit_var = unit_var,
+			treatment = treatment,
+			response = response,
+			covs = covs,
+			indep_counts = indep_counts,
+			sig_eps_sq = sig_eps_sq,
+			sig_eps_c_sq = sig_eps_c_sq,
+			verbose = verbose,
+			alpha = alpha,
+			add_ridge = add_ridge
+		)
+	}
+
+	pdata <- ret$pdata
+	indep_count_data_available <- ret$indep_count_data_available
+
+	# Step 4: auto-truncation when no never-treated units.
+	pdata <- .truncate_if_no_never_treated(
+		pdata,
+		time_var = time_var,
+		unit_var = unit_var,
+		treat_var = treatment,
+		allow_no_never_treated = allow_no_never_treated
+	)
+
+	# Step 5: design-matrix prep.
+	res1 <- prep_for_etwfe_core(
+		pdata = pdata,
+		response = response,
+		time_var = time_var,
+		unit_var = unit_var,
+		treatment = treatment,
+		covs = covs,
+		verbose = verbose,
+		indep_count_data_available = indep_count_data_available,
+		indep_counts = indep_counts
+	)
+
+	list(
+		pdata = res1$pdata,
+		covs = res1$covs,
+		X_ints = res1$X_ints,
+		y = res1$y,
+		y_mean = res1$y_mean,
+		N = res1$N,
+		T = res1$T,
+		d = res1$d,
+		p = res1$p,
+		in_sample_counts = res1$in_sample_counts,
+		num_treats = res1$num_treats,
+		first_inds = res1$first_inds,
+		R = res1$R,
+		indep_count_data_available = indep_count_data_available
+	)
+}
+
+#' @title Select the ATT/SE/cohort-probs branch from a `_core()` result
+#' @description
+#' Internal helper that consolidates the verbatim Step 8 ("pick from
+#' in-sample vs indep") shared across the four estimator entry points.
+#' Reads `res$indep_*` vs `res$in_sample_*` based on
+#' `indep_count_data_available`. The SE-non-NA `stopifnot()` guards
+#' that the four pre-consolidation entry points carried differ in
+#' shape between the bridge and OLS estimators, so the helper takes a
+#' `q` argument to discriminate. For fetwfe/betwfe callers (non-NA
+#' `q`), the SE-non-NA guard runs only when `q < 1 && res$calc_ses` in
+#' both branches. For etwfe/twfeCovs callers (`q == NA`), the SE-non-NA
+#' guard on `res$indep_att_se` runs unconditionally in the indep
+#' branch (matching pre-#79 etwfe/twfeCovs behavior: rank-deficient
+#' fits with `indep_counts` still trip this guard); the in-sample
+#' branch carries no SE-non-NA guard for these callers. Consolidated
+#' by GitHub #79.
+#' @param res A list returned by `fetwfe_core()`, `etwfe_core()`,
+#'   `betwfe_core()`, or `twfeCovs_core()`. Required fields are
+#'   `att_hat`, `att_se`, `cohort_probs`, `cohort_probs_overall`,
+#'   `indep_att_hat`, `indep_att_se`, `indep_cohort_probs`,
+#'   `indep_cohort_probs_overall`, `in_sample_att_hat`,
+#'   `in_sample_att_se`, and `calc_ses`.
+#' @param indep_count_data_available Logical scalar; if `TRUE`, the
+#'   indep_* branch is selected.
+#' @param q Numeric scalar; the bridge penalty exponent. `NA` (default)
+#'   for etwfe/twfeCovs callers; non-NA for fetwfe/betwfe callers.
+#'   Selects which SE-non-NA guards run (see Description).
+#' @return A list with four elements: `att_hat`, `att_se`,
+#'   `cohort_probs`, `cohort_probs_overall`.
+#' @keywords internal
+#' @noRd
+.select_att_branch <- function(
+	res,
+	indep_count_data_available,
+	q = NA
+) {
+	uses_bridge <- !is.na(q)
+
+	if (indep_count_data_available) {
+		stopifnot(!is.na(res$indep_att_hat))
+
+		if (uses_bridge) {
+			if (q < 1 && res$calc_ses) {
+				stopifnot(!is.na(res$indep_att_se))
+			}
+		} else {
+			# Pre-#79 etwfe/twfeCovs unconditional guard.
+			stopifnot(!is.na(res$indep_att_se))
+		}
+
+		stopifnot(all(!is.na(res$indep_cohort_probs)))
+		att_hat <- res$indep_att_hat
+		att_se <- res$indep_att_se
+		cohort_probs <- res$indep_cohort_probs
+		cohort_probs_overall <- res$indep_cohort_probs_overall
+	} else {
+		if (uses_bridge) {
+			stopifnot(!is.na(res$in_sample_att_hat))
+
+			if (q < 1 && res$calc_ses) {
+				stopifnot(!is.na(res$in_sample_att_se))
+			}
+		}
+
+		att_hat <- res$in_sample_att_hat
+		att_se <- res$in_sample_att_se
+		cohort_probs <- res$cohort_probs
+		cohort_probs_overall <- res$cohort_probs_overall
+	}
+
+	list(
+		att_hat = att_hat,
+		att_se = att_se,
+		cohort_probs = cohort_probs,
+		cohort_probs_overall = cohort_probs_overall
+	)
+}

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.18",
+  note    = "R package version 1.9.19",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,6 +1,7 @@
 ε
 σ
 al
+arg
 Arora
 Asjad
 att
@@ -24,11 +25,15 @@ Catalogue
 catt
 CATTs
 cdot
+coef
 counterintuitive
+covs
 CR
 df
 DGP
 DiD
+docstring
+docstrings
 doi
 Duflo
 econometricians
@@ -57,6 +62,7 @@ lexicographically
 Liang
 lme
 lmer
+LOC
 Maechler
 mathcal
 mathrm
@@ -66,6 +72,7 @@ mundlak
 Mundlak
 Naqvi
 natively
+orchestrator
 OUP
 overfits
 Patterson
@@ -74,8 +81,10 @@ Pesaran
 Pinheiro
 pre
 preprint
+probs
 PRs
 REML
+roxygen
 Sant'Anna
 Schwarz
 SEs
@@ -91,6 +100,7 @@ twfeCovs
 un
 uncentered
 unselected
+validator
 validators
 varepsilon
 widehat

--- a/tests/testthat/test-estimator-entry-snapshot.R
+++ b/tests/testthat/test-estimator-entry-snapshot.R
@@ -32,10 +32,18 @@ testthat::local_edition(3)
 		unit = rep(c("U1", "U2", "U3", "U4"), each = 3),
 		time = rep(1L:3L, 4),
 		treat = c(
-			0L, 0L, 0L, # U1: never
-			0L, 1L, 1L, # U2: cohort 2
-			0L, 1L, 1L, # U3: cohort 2
-			0L, 0L, 1L  # U4: cohort 3
+			0L,
+			0L,
+			0L, # U1: never
+			0L,
+			1L,
+			1L, # U2: cohort 2
+			0L,
+			1L,
+			1L, # U3: cohort 2
+			0L,
+			0L,
+			1L # U4: cohort 3
 		),
 		y = as.numeric(1:12),
 		stringsAsFactors = FALSE
@@ -44,12 +52,15 @@ testthat::local_edition(3)
 
 # Capture conditionMessage() from each entry point under a given
 # malformed call. Returns a list with one entry per estimator name.
-.capture_entry_point_errors <- function(args, estimators = c(
-	"fetwfe",
-	"etwfe",
-	"betwfe",
-	"twfeCovs"
-)) {
+.capture_entry_point_errors <- function(
+	args,
+	estimators = c(
+		"fetwfe",
+		"etwfe",
+		"betwfe",
+		"twfeCovs"
+	)
+) {
 	fns <- list(
 		fetwfe = fetwfe,
 		etwfe = etwfe,
@@ -194,7 +205,10 @@ test_that("entry-point error: fetwfe + betwfe q out of range (#79 PR A)", {
 		response = "y",
 		q = -1
 	)
-	msgs <- .capture_entry_point_errors(args, estimators = c("fetwfe", "betwfe"))
+	msgs <- .capture_entry_point_errors(
+		args,
+		estimators = c("fetwfe", "betwfe")
+	)
 
 	expect_identical(msgs$fetwfe, msgs$betwfe)
 


### PR DESCRIPTION
## Summary

Closes #79. Part 2 of a 2-PR sequence; PR A (#103, merged) added the snapshot guardrail. This PR is the actual consolidation.

**Two helpers added to `R/utility.R`** (both `@noRd` + `@keywords internal`):

| Helper | Replaces | Callers |
|---|---|---|
| `.run_estimator_input_prep()` | Steps 3-5 of the 12-step pipeline (input validation + auto-truncation + design-matrix prep) | all 4 |
| `.select_att_branch()` | Step 8 (pick from in-sample vs indep, plus SE-non-NA guards) | all 4 |

The 4 entry points (`fetwfe`, `etwfe`, `betwfe`, `twfeCovs`) are rewritten to call them. The 1-line patterns (Step 1 `match.arg`, Step 2 `covs_orig`, Step 9 `compute_p_values`, Step 10 `att_selected`) stay inline. Output-list construction (Step 11) stays unique per estimator since the field sets diverge between bridge (fetwfe/betwfe) and OLS (etwfe/twfeCovs) variants.

**Critical guardrail intact**: PR #103's snapshot file `tests/testthat/_snaps/estimator-entry-snapshot.md` passes byte-equal — no re-blessing — confirming zero behavior change on the input-validation error-message surface.

**Asymmetric-guard surprise** (documented in [PLAN.md](.plans/consolidate-entry-points-79/PLAN.md) Surprises & Discoveries): the Step 8 SE-non-NA guards were more asymmetric than the plan-review estimate suggested. `etwfe`/`twfeCovs` have an unconditional `stopifnot(!is.na(res$indep_att_se))` in the indep branch (fires for rank-deficient OLS fits with `indep_counts` supplied) and NO in-sample guard; `fetwfe`/`betwfe` have a conditional `(q < 1 && res$calc_ses)` guard in BOTH branches. Helper 2 discriminates on `is.na(q)` (the `uses_bridge` flag) and preserves all four pre-refactor shapes byte-equal.

**Honest about LOC**: net +92 LOC (vs plan-review's -140 to -200 estimate). Entry-point reduction: -130 LOC. Helper additions: +222 LOC (~65 roxygen + ~157 R code). Larger than estimated because:
1. Helper 2 needs the documented `uses_bridge` branch with explicit comments.
2. Helper 1 uses verbose per-arg pass-through to the validators (per plan-review NTH4 — terseness via `...` was rejected for readability).

The single-source-of-truth value is the real benefit: future changes to Steps 3-5 or Step 8 touch one file (`R/utility.R`) rather than four.

**Secondary cleanup**: `inst/WORDLIST` +10 spell-check terms (pre-existing debt from NEWS entries 1.9.17 / 1.9.18 not having added their new vocabulary, plus the new 1.9.19 terms). `devtools::spell_check()` is now empty. Mechanical `air format` reflow of `test-estimator-entry-snapshot.R` (no behavior change).

**Version bump**: 1.9.18 → 1.9.19.

## Test plan

- [x] Full test suite: 1793 passing, 0 failures, 0 errors, 2 pre-existing warnings.
- [x] `devtools::check(--as-cran)`: 0 errors, 0 warnings, 1 environmental NOTE.
- [x] PR #103 snapshot tests pass byte-equal (no re-blessing).
- [x] Drift sentinel: NO DRIFT.
- [x] Post-execution reviewer: READY-TO-SHIP. Asymmetric-guard correctness verified against all 4 pre-refactor regions.
- [x] `devtools::spell_check()`: empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
