### PR TITLE
Replace hostile stopifnot errors with named messages (#84 item 11, 1.9.20)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.19
+Version: 1.9.20
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,36 @@
 # NEWS
 
+## Version 1.9.20 (2026-05-19)
+
+- User-facing input-validation error messages for the four estimator
+  entry points (`fetwfe()`, `etwfe()`, `betwfe()`, `twfeCovs()`) are
+  now actionable instead of cryptic (GitHub #84, item 11). The legacy
+  `Error: is.character(time_var) is not TRUE` family produced by
+  `stopifnot()` is replaced with a named, multi-line `stop()` message
+  of the form
+  `Invalid inputs:\n  - <arg>: <expected>; got <received>`, where
+  ALL malformed args are collected on a single call so the user sees
+  every violation at once instead of one error round-trip per arg.
+  Two new internal helpers in `R/etwfe_core.R` ---
+  `.collect_etwfe_input_violations()` and `.format_input_violations()`
+  --- absorb the collect-and-render plumbing; `checkEtwfeInputs()` and
+  `checkFetwfeInputs()` (the latter at `R/fetwfe_core.R`) became thin
+  wrappers around them. Per-arg failures cascade within an arg (the
+  first failure in an arg's check chain short-circuits — e.g.,
+  `time_var %in% colnames(pdata)` isn't run if `time_var` isn't a
+  length-1 character) but collect independently across args. NULL
+  inputs are handled cleanly (`class(NULL) = "NULL"`, `length(NULL) = 0`
+  interpolate fine). The PR #103 snapshot guardrail (which locked the
+  legacy `is.foo() is not TRUE` strings) was deliberately re-blessed
+  with the new helpful messages; the snapshot mechanism continues to
+  lock the new contract against accidental drift. Internal validators
+  (`check_etwfe_core_inputs()`, `prepXints()`) were intentionally left
+  as terse `stopifnot()`s — they check post-prep invariants, not user
+  input. Item 12 of #84 (strict-vs-lenient reconciliations:
+  `lambda.max >= 0` vs `> 0`; `sig_eps_c_sq = 0`; `R >= 1` vs `R >= 2`)
+  is deferred to a follow-up since it involves API-behavior decisions
+  rather than UX wording.
+
 ## Version 1.9.19 (2026-05-19)
 
 - Internal consolidation of the input/output pipeline shared by the

--- a/R/etwfe_core.R
+++ b/R/etwfe_core.R
@@ -153,12 +153,436 @@ etwfeWithSimulatedData <- function(
 }
 
 
+# .collect_etwfe_input_violations
+#' @title Collect input-validation violations for the etwfe-family entry points
+#' @description Internal helper that runs the per-argument checks of
+#'   `checkEtwfeInputs()` without `stop()`-ing on the first failure. Each
+#'   malformed argument contributes one human-readable line to a
+#'   character vector that the caller (`checkEtwfeInputs()` or
+#'   `checkFetwfeInputs()`) consolidates into a single multi-line
+#'   `stop()` message. This collect-all-violations pattern means a user
+#'   with K malformed args sees K violations on the first call instead
+#'   of one error round-trip per arg.
+#' @return A list with three elements:
+#'   - `violations`: character vector of human-readable per-arg violation
+#'     lines (empty when all inputs are valid).
+#'   - `pdata`: the (possibly tibble-coerced) `pdata`. Coercion runs
+#'     regardless of downstream violations so the caller does not have
+#'     to redo it.
+#'   - `indep_count_data_available`: logical scalar; `TRUE` if a valid
+#'     `indep_counts` argument was provided, `FALSE` otherwise.
+#' @details Within a single argument's check chain (e.g., `time_var`
+#'   must be character, length 1, present in `pdata`, integer column),
+#'   the first failure short-circuits — downstream checks for that arg
+#'   are unsafe to run (e.g., `time_var %in% colnames(pdata)` cannot
+#'   sensibly be evaluated if `time_var` is not a length-1 character).
+#'   Across DIFFERENT arguments, violations collect independently — if
+#'   both `time_var` and `unit_var` are malformed, BOTH violations
+#'   appear in the final list. This is "cascade within arg, collect
+#'   across args".
+#' @keywords internal
+#' @noRd
+.collect_etwfe_input_violations <- function(
+	pdata,
+	time_var,
+	unit_var,
+	treatment,
+	response,
+	covs = c(),
+	indep_counts = NA,
+	sig_eps_sq = NA,
+	sig_eps_c_sq = NA,
+	verbose = FALSE,
+	alpha = 0.05,
+	add_ridge = FALSE
+) {
+	violations <- character(0)
+
+	# `pdata` itself must be a data frame before we can probe its
+	# columns. If it is not, every downstream column-existence /
+	# column-type check is meaningless; record the violation and skip
+	# all pdata-dependent checks.
+	pdata_ok <- is.data.frame(pdata)
+	if (!pdata_ok) {
+		violations <- c(
+			violations,
+			sprintf(
+				"pdata must be a data frame; got %s",
+				paste(class(pdata), collapse = "/")
+			)
+		)
+	} else {
+		# Tibble -> data frame coercion; harmless when pdata is already
+		# a plain data.frame.
+		if ("tbl_df" %in% class(pdata)) {
+			pdata <- as.data.frame(pdata)
+		}
+		if (nrow(pdata) < 4) {
+			violations <- c(
+				violations,
+				sprintf(
+					"pdata must have at least 4 rows (2 units at 2 times); got %d",
+					nrow(pdata)
+				)
+			)
+		}
+	}
+
+	# --- time_var --------------------------------------------------------
+	if (!is.character(time_var) || length(time_var) != 1) {
+		violations <- c(
+			violations,
+			sprintf(
+				"time_var must be a single character string; got %s (length %d)",
+				paste(class(time_var), collapse = "/"),
+				length(time_var)
+			)
+		)
+	} else if (pdata_ok && !(time_var %in% colnames(pdata))) {
+		violations <- c(
+			violations,
+			sprintf(
+				"time_var = '%s' is not a column in pdata; columns are: %s",
+				time_var,
+				paste(colnames(pdata), collapse = ", ")
+			)
+		)
+	} else if (pdata_ok && !is.integer(pdata[[time_var]])) {
+		violations <- c(
+			violations,
+			sprintf(
+				"the time_var column '%s' must be integer; got %s",
+				time_var,
+				paste(class(pdata[[time_var]]), collapse = "/")
+			)
+		)
+	}
+
+	# --- unit_var --------------------------------------------------------
+	if (!is.character(unit_var) || length(unit_var) != 1) {
+		violations <- c(
+			violations,
+			sprintf(
+				"unit_var must be a single character string; got %s (length %d)",
+				paste(class(unit_var), collapse = "/"),
+				length(unit_var)
+			)
+		)
+	} else if (pdata_ok && !(unit_var %in% colnames(pdata))) {
+		violations <- c(
+			violations,
+			sprintf(
+				"unit_var = '%s' is not a column in pdata; columns are: %s",
+				unit_var,
+				paste(colnames(pdata), collapse = ", ")
+			)
+		)
+	} else if (pdata_ok && !is.character(pdata[[unit_var]])) {
+		violations <- c(
+			violations,
+			sprintf(
+				"the unit_var column '%s' must be character; got %s",
+				unit_var,
+				paste(class(pdata[[unit_var]]), collapse = "/")
+			)
+		)
+	}
+
+	# --- treatment -------------------------------------------------------
+	if (!is.character(treatment) || length(treatment) != 1) {
+		violations <- c(
+			violations,
+			sprintf(
+				"treatment must be a single character string; got %s (length %d)",
+				paste(class(treatment), collapse = "/"),
+				length(treatment)
+			)
+		)
+	} else if (pdata_ok && !(treatment %in% colnames(pdata))) {
+		violations <- c(
+			violations,
+			sprintf(
+				"treatment = '%s' is not a column in pdata; columns are: %s",
+				treatment,
+				paste(colnames(pdata), collapse = ", ")
+			)
+		)
+	} else if (pdata_ok && !is.integer(pdata[[treatment]])) {
+		violations <- c(
+			violations,
+			sprintf(
+				"the treatment column '%s' must be integer; got %s",
+				treatment,
+				paste(class(pdata[[treatment]]), collapse = "/")
+			)
+		)
+	} else if (pdata_ok && !all(pdata[, treatment] %in% c(0, 1))) {
+		bad_vals <- unique(pdata[, treatment][
+			!(pdata[, treatment] %in% c(0, 1))
+		])
+		violations <- c(
+			violations,
+			sprintf(
+				"the treatment column '%s' must contain only 0/1; saw other value(s): %s",
+				treatment,
+				paste(utils::head(bad_vals, 5), collapse = ", ")
+			)
+		)
+	}
+
+	# --- covs ------------------------------------------------------------
+	if (length(covs) > 0) {
+		if (!is.character(covs)) {
+			violations <- c(
+				violations,
+				sprintf(
+					"covs must be a character vector of column names; got %s",
+					paste(class(covs), collapse = "/")
+				)
+			)
+		} else if (pdata_ok && !all(covs %in% colnames(pdata))) {
+			missing_covs <- covs[!(covs %in% colnames(pdata))]
+			violations <- c(
+				violations,
+				sprintf(
+					"covs contains name(s) not in pdata: %s",
+					paste(missing_covs, collapse = ", ")
+				)
+			)
+		} else if (pdata_ok) {
+			bad_cov_types <- character(0)
+			for (cov in covs) {
+				if (
+					!(is.numeric(pdata[[cov]]) ||
+						is.integer(pdata[[cov]]) ||
+						is.factor(pdata[[cov]]))
+				) {
+					bad_cov_types <- c(
+						bad_cov_types,
+						sprintf(
+							"'%s' (%s)",
+							cov,
+							paste(class(pdata[[cov]]), collapse = "/")
+						)
+					)
+				}
+			}
+			if (length(bad_cov_types) > 0) {
+				violations <- c(
+					violations,
+					sprintf(
+						"each cov column must be numeric, integer, or factor; offending column(s): %s",
+						paste(bad_cov_types, collapse = ", ")
+					)
+				)
+			}
+		}
+	}
+
+	# --- response --------------------------------------------------------
+	if (!is.character(response) || length(response) != 1) {
+		violations <- c(
+			violations,
+			sprintf(
+				"response must be a single character string; got %s (length %d)",
+				paste(class(response), collapse = "/"),
+				length(response)
+			)
+		)
+	} else if (pdata_ok && !(response %in% colnames(pdata))) {
+		violations <- c(
+			violations,
+			sprintf(
+				"response = '%s' is not a column in pdata; columns are: %s",
+				response,
+				paste(colnames(pdata), collapse = ", ")
+			)
+		)
+	} else if (
+		pdata_ok &&
+			!(is.numeric(pdata[[response]]) || is.integer(pdata[[response]]))
+	) {
+		violations <- c(
+			violations,
+			sprintf(
+				"the response column '%s' must be numeric or integer; got %s",
+				response,
+				paste(class(pdata[[response]]), collapse = "/")
+			)
+		)
+	}
+
+	# --- indep_counts ----------------------------------------------------
+	# Mirrors original: only validated when not all-NA. If valid, the
+	# `indep_count_data_available` flag is TRUE.
+	indep_count_data_available <- FALSE
+	if (any(!is.na(indep_counts))) {
+		if (!is.integer(indep_counts)) {
+			violations <- c(
+				violations,
+				sprintf(
+					"indep_counts must be an integer vector; got %s",
+					paste(class(indep_counts), collapse = "/")
+				)
+			)
+		} else if (any(indep_counts <= 0)) {
+			# Original message preserved verbatim (also surfaced in
+			# `etwfeWithSimulatedData()` regression coverage).
+			violations <- c(
+				violations,
+				"At least one cohort in the independent count data has 0 members"
+			)
+		} else {
+			indep_count_data_available <- TRUE
+		}
+	}
+
+	# --- sig_eps_sq ------------------------------------------------------
+	if (any(!is.na(sig_eps_sq))) {
+		if (!(is.numeric(sig_eps_sq) || is.integer(sig_eps_sq))) {
+			violations <- c(
+				violations,
+				sprintf(
+					"sig_eps_sq must be numeric or integer; got %s",
+					paste(class(sig_eps_sq), collapse = "/")
+				)
+			)
+		} else if (length(sig_eps_sq) != 1) {
+			violations <- c(
+				violations,
+				sprintf(
+					"sig_eps_sq must be a single value; got length %d",
+					length(sig_eps_sq)
+				)
+			)
+		} else if (sig_eps_sq < 0) {
+			violations <- c(
+				violations,
+				sprintf(
+					"sig_eps_sq must be non-negative; got %s",
+					format(sig_eps_sq)
+				)
+			)
+		}
+	}
+
+	# --- sig_eps_c_sq ----------------------------------------------------
+	if (any(!is.na(sig_eps_c_sq))) {
+		if (!(is.numeric(sig_eps_c_sq) || is.integer(sig_eps_c_sq))) {
+			violations <- c(
+				violations,
+				sprintf(
+					"sig_eps_c_sq must be numeric or integer; got %s",
+					paste(class(sig_eps_c_sq), collapse = "/")
+				)
+			)
+		} else if (length(sig_eps_c_sq) != 1) {
+			violations <- c(
+				violations,
+				sprintf(
+					"sig_eps_c_sq must be a single value; got length %d",
+					length(sig_eps_c_sq)
+				)
+			)
+		} else if (sig_eps_c_sq < 0) {
+			violations <- c(
+				violations,
+				sprintf(
+					"sig_eps_c_sq must be non-negative; got %s",
+					format(sig_eps_c_sq)
+				)
+			)
+		}
+	}
+
+	# --- verbose ---------------------------------------------------------
+	if (!is.logical(verbose) || length(verbose) != 1) {
+		violations <- c(
+			violations,
+			sprintf(
+				"verbose must be a single logical (TRUE or FALSE); got %s (length %d)",
+				paste(class(verbose), collapse = "/"),
+				length(verbose)
+			)
+		)
+	}
+
+	# --- alpha -----------------------------------------------------------
+	# Match original: only emit the alpha > 0.5 warning when alpha is
+	# otherwise fully valid (numeric, length 1, in (0, 1)). The warning
+	# is a UX nudge and was unreachable when any alpha check failed.
+	alpha_valid <- FALSE
+	if (!is.numeric(alpha) || length(alpha) != 1) {
+		violations <- c(
+			violations,
+			sprintf(
+				"alpha must be a single numeric; got %s (length %d)",
+				paste(class(alpha), collapse = "/"),
+				length(alpha)
+			)
+		)
+	} else if (!(alpha > 0 && alpha < 1)) {
+		violations <- c(
+			violations,
+			sprintf(
+				"alpha must be in (0, 1); got %s",
+				format(alpha)
+			)
+		)
+	} else {
+		alpha_valid <- TRUE
+	}
+	if (alpha_valid && alpha > 0.5) {
+		warning(
+			"Provided alpha > 0.5; are you sure you didn't mean to enter a smaller alpha? The confidence level will be 1 - alpha."
+		)
+	}
+
+	# --- add_ridge -------------------------------------------------------
+	if (!is.logical(add_ridge) || length(add_ridge) != 1) {
+		violations <- c(
+			violations,
+			sprintf(
+				"add_ridge must be a single logical (TRUE or FALSE); got %s (length %d)",
+				paste(class(add_ridge), collapse = "/"),
+				length(add_ridge)
+			)
+		)
+	}
+
+	list(
+		violations = violations,
+		pdata = pdata,
+		indep_count_data_available = indep_count_data_available
+	)
+}
+
+# .format_input_violations
+#' @title Assemble a multi-line input-violations error message
+#' @description Internal helper used by `checkEtwfeInputs()` and
+#'   `checkFetwfeInputs()` to render a vector of per-arg violation
+#'   lines as a multi-line `stop()` body. Centralising the header /
+#'   prefix here means both validators speak with one voice, and the
+#'   four entry points (`fetwfe`, `etwfe`, `betwfe`, `twfeCovs`)
+#'   continue to produce byte-identical messages — a property the
+#'   PR #103 snapshot guardrail asserts.
+#' @keywords internal
+#' @noRd
+.format_input_violations <- function(violations) {
+	paste0(
+		"Invalid inputs:\n  - ",
+		paste(violations, collapse = "\n  - ")
+	)
+}
+
 # checkEtwfeInputs
 #' @title Check Inputs for the main `etwfe` / `betwfe` / `twfeCovs` functions
 #' @description Validates the inputs provided to the OLS-style entry points
 #'   (`etwfe`, `betwfe`, `twfeCovs`), ensuring they meet type, dimension,
-#'   and content requirements. Stops
-#'   execution with an error message if any check fails.
+#'   and content requirements. Stops execution with a multi-line error
+#'   message listing every malformed input on a single call (instead of
+#'   one round-trip per arg). Delegates the per-arg checks to
+#'   `.collect_etwfe_input_violations()`.
 #' @param pdata Dataframe; the panel data set.
 #' @param time_var Character; name of the time variable column.
 #' @param unit_var Character; name of the unit variable column.
@@ -173,20 +597,20 @@ etwfeWithSimulatedData <- function(
 #' @param verbose Logical; if TRUE, print progress. Default `FALSE`.
 #' @param alpha Numeric; significance level for confidence intervals. Default `0.05`.
 #' @param add_ridge Logical; if TRUE, add small ridge penalty. Default `FALSE`.
-#' @return Logical `indep_count_data_available`, which is `TRUE` if valid
-#'   `indep_counts` were provided, `FALSE` otherwise.
-#' @details This function performs a series of `stopifnot` checks on each
-#'   parameter. For example:
-#'   - `pdata` must be a dataframe with at least 4 rows.
-#'   - `time_var`, `unit_var`, `treatment`, `response` must be single characters,
-#'     present in `pdata`, and the corresponding columns must have the correct
-#'     type (e.g., integer for time, character for unit, 0/1 integer for treatment).
-#'   - `covs` if provided, must be characters, present in `pdata`, and columns
-#'     must be numeric, integer, or factor.
-#'   - `indep_counts` if provided, must be positive integers.
-#'   - `sig_eps_sq`, `sig_eps_c_sq` if provided, must be non-negative numerics.
-#'   - `alpha` must be in `(0, 1)`.
-#'   Issues a warning if `alpha > 0.5`.
+#' @return A list with two elements:
+#'   - `pdata`: the (possibly tibble-coerced) panel data frame.
+#'   - `indep_count_data_available`: logical; `TRUE` if a valid
+#'     `indep_counts` argument was provided.
+#' @details All per-argument checks live in
+#'   `.collect_etwfe_input_violations()`; this thin wrapper renders the
+#'   collected violations into a multi-line `stop()` message. The
+#'   user-facing wording was upgraded from the legacy
+#'   `is.character(time_var) is not TRUE` style to named, actionable
+#'   lines naming the arg, the expected shape, and (when feasible) the
+#'   received shape (GitHub #84). The message header is
+#'   `"Invalid inputs:"` — deliberately caller-agnostic so error text
+#'   stays byte-identical across the four entry points (locked by the
+#'   PR #103 snapshot tests).
 #' @keywords internal
 #' @noRd
 checkEtwfeInputs <- function(
@@ -203,90 +627,27 @@ checkEtwfeInputs <- function(
 	alpha = 0.05,
 	add_ridge = FALSE
 ) {
-	# Check inputs
-	stopifnot(is.data.frame(pdata))
-	# Check if pdata is a tibble; if so, convert to a dataframe
-	if ("tbl_df" %in% class(pdata)) {
-		pdata <- as.data.frame(pdata)
-	}
-	stopifnot(nrow(pdata) >= 4) # bare minimum, 2 units at 2 times
-
-	stopifnot(is.character(time_var))
-	stopifnot(length(time_var) == 1)
-	stopifnot(time_var %in% colnames(pdata))
-	stopifnot(is.integer(pdata[[time_var]]))
-
-	stopifnot(is.character(unit_var))
-	stopifnot(length(unit_var) == 1)
-	stopifnot(unit_var %in% colnames(pdata))
-	stopifnot(is.character(pdata[[unit_var]]))
-
-	stopifnot(is.character(treatment))
-	stopifnot(length(treatment) == 1)
-	stopifnot(treatment %in% colnames(pdata))
-	stopifnot(is.integer(pdata[[treatment]]))
-	stopifnot(all(pdata[, treatment] %in% c(0, 1)))
-
-	if (length(covs) > 0) {
-		stopifnot(is.character(covs))
-		stopifnot(all(covs %in% colnames(pdata)))
-		for (cov in covs) {
-			stopifnot(
-				is.numeric(pdata[[cov]]) |
-					is.integer(pdata[[cov]]) |
-					is.factor(pdata[[cov]])
-			)
-		}
-	}
-
-	stopifnot(is.character(response))
-	stopifnot(length(response) == 1)
-	stopifnot(response %in% colnames(pdata))
-	stopifnot(is.numeric(pdata[[response]]) | is.integer(pdata[[response]]))
-
-	indep_count_data_available <- FALSE
-	if (any(!is.na(indep_counts))) {
-		stopifnot(is.integer(indep_counts))
-		if (any(indep_counts <= 0)) {
-			stop(
-				"At least one cohort in the independent count data has 0 members"
-			)
-		}
-		indep_count_data_available <- TRUE
-	}
-
-	if (any(!is.na(sig_eps_sq))) {
-		stopifnot(is.numeric(sig_eps_sq) | is.integer(sig_eps_sq))
-		stopifnot(length(sig_eps_sq) == 1)
-		stopifnot(sig_eps_sq >= 0)
-	}
-
-	if (any(!is.na(sig_eps_c_sq))) {
-		stopifnot(is.numeric(sig_eps_c_sq) | is.integer(sig_eps_c_sq))
-		stopifnot(length(sig_eps_c_sq) == 1)
-		stopifnot(sig_eps_c_sq >= 0)
-	}
-
-	stopifnot(is.logical(verbose))
-	stopifnot(length(verbose) == 1)
-
-	stopifnot(is.numeric(alpha))
-	stopifnot(length(alpha) == 1)
-	stopifnot(alpha > 0)
-	stopifnot(alpha < 1)
-	if (alpha > 0.5) {
-		warning(
-			"Provided alpha > 0.5; are you sure you didn't mean to enter a smaller alpha? The confidence level will be 1 - alpha."
-		)
-	}
-
-	stopifnot(is.logical(add_ridge))
-	stopifnot(length(add_ridge) == 1)
-
-	return(list(
+	res <- .collect_etwfe_input_violations(
 		pdata = pdata,
-		indep_count_data_available = indep_count_data_available
-	))
+		time_var = time_var,
+		unit_var = unit_var,
+		treatment = treatment,
+		response = response,
+		covs = covs,
+		indep_counts = indep_counts,
+		sig_eps_sq = sig_eps_sq,
+		sig_eps_c_sq = sig_eps_c_sq,
+		verbose = verbose,
+		alpha = alpha,
+		add_ridge = add_ridge
+	)
+	if (length(res$violations) > 0) {
+		stop(.format_input_violations(res$violations), call. = FALSE)
+	}
+	list(
+		pdata = res$pdata,
+		indep_count_data_available = res$indep_count_data_available
+	)
 }
 
 #' Core Estimation Logic for Extended Two-Way Fixed Effects

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -203,9 +203,13 @@ getTeResults2 <- function(
 
 # checkFetwfeInputs
 #' @title Check Inputs for the main `fetwfe` function
-#' @description Validates the inputs provided to the main `fetwfe` function,
-#'   ensuring they meet type, dimension, and content requirements. Stops
-#'   execution with an error message if any check fails.
+#' @description Validates the inputs provided to the main `fetwfe` function
+#'   (and, via the shared validator wiring in `.run_estimator_input_prep()`,
+#'   `betwfe()`). Stops execution with a multi-line error message listing
+#'   every malformed input on a single call. Delegates the etwfe-shared
+#'   per-arg checks to `.collect_etwfe_input_violations()` and appends
+#'   the fetwfe/betwfe-specific bridge-penalty (`lambda.max`,
+#'   `lambda.min`, `q`) checks before stopping.
 #' @param pdata Dataframe; the panel data set.
 #' @param time_var Character; name of the time variable column.
 #' @param unit_var Character; name of the unit variable column.
@@ -223,23 +227,19 @@ getTeResults2 <- function(
 #' @param verbose Logical; if TRUE, print progress. Default `FALSE`.
 #' @param alpha Numeric; significance level for confidence intervals. Default `0.05`.
 #' @param add_ridge Logical; if TRUE, add small ridge penalty. Default `FALSE`.
-#' @return Logical `indep_count_data_available`, which is `TRUE` if valid
-#'   `indep_counts` were provided, `FALSE` otherwise.
-#' @details This function performs a series of `stopifnot` checks on each
-#'   parameter. For example:
-#'   - `pdata` must be a dataframe with at least 4 rows.
-#'   - `time_var`, `unit_var`, `treatment`, `response` must be single characters,
-#'     present in `pdata`, and the corresponding columns must have the correct
-#'     type (e.g., integer for time, character for unit, 0/1 integer for treatment).
-#'   - `covs` if provided, must be characters, present in `pdata`, and columns
-#'     must be numeric, integer, or factor.
-#'   - `indep_counts` if provided, must be positive integers.
-#'   - `sig_eps_sq`, `sig_eps_c_sq` if provided, must be non-negative numerics.
-#'   - `lambda.max`, `lambda.min` if provided, must be valid numerics
-#'     (`lambda.max > lambda.min >= 0`).
-#'   - `q` must be in `(0, 2]`.
-#'   - `alpha` must be in `(0, 1)`.
-#'   Issues a warning if `alpha > 0.5`.
+#' @return A list with two elements:
+#'   - `pdata`: the (possibly tibble-coerced) panel data frame.
+#'   - `indep_count_data_available`: logical; `TRUE` if a valid
+#'     `indep_counts` argument was provided.
+#' @details The error-message UX (header `"Invalid inputs:"` followed by
+#'   one bullet per malformed arg) is shared with `checkEtwfeInputs()`
+#'   so that, when the only failing arg is etwfe-shared, the four entry
+#'   points (`fetwfe`, `etwfe`, `betwfe`, `twfeCovs`) produce
+#'   byte-identical messages (a property the PR #103 snapshot tests
+#'   assert). The fetwfe-specific bridge-penalty violations append
+#'   AFTER the etwfe-shared ones, so when only `q`/`lambda.*` are
+#'   malformed, `fetwfe()` and `betwfe()` agree with each other
+#'   verbatim.
 #' @keywords internal
 #' @noRd
 checkFetwfeInputs <- function(
@@ -259,7 +259,7 @@ checkFetwfeInputs <- function(
 	alpha = 0.05,
 	add_ridge = FALSE
 ) {
-	res <- checkEtwfeInputs(
+	res <- .collect_etwfe_input_violations(
 		pdata = pdata,
 		time_var = time_var,
 		unit_var = unit_var,
@@ -273,36 +273,112 @@ checkFetwfeInputs <- function(
 		alpha = alpha,
 		add_ridge = add_ridge
 	)
-
-	indep_count_data_available <- res$indep_count_data_available
+	violations <- res$violations
 	pdata <- res$pdata
+	indep_count_data_available <- res$indep_count_data_available
 
-	rm(res)
-
+	# --- lambda.max ------------------------------------------------------
 	if (any(!is.na(lambda.max))) {
-		stopifnot(is.numeric(lambda.max) | is.integer(lambda.max))
-		stopifnot(length(lambda.max) == 1)
-		stopifnot(lambda.max > 0)
-	}
-
-	if (any(!is.na(lambda.min))) {
-		stopifnot(is.numeric(lambda.min) | is.integer(lambda.min))
-		stopifnot(length(lambda.min) == 1)
-		stopifnot(lambda.min >= 0)
-		if (any(!is.na(lambda.max))) {
-			stopifnot(lambda.max > lambda.min)
+		if (!(is.numeric(lambda.max) || is.integer(lambda.max))) {
+			violations <- c(
+				violations,
+				sprintf(
+					"lambda.max must be numeric or integer; got %s",
+					paste(class(lambda.max), collapse = "/")
+				)
+			)
+		} else if (length(lambda.max) != 1) {
+			violations <- c(
+				violations,
+				sprintf(
+					"lambda.max must be a single value; got length %d",
+					length(lambda.max)
+				)
+			)
+		} else if (!(lambda.max > 0)) {
+			violations <- c(
+				violations,
+				sprintf(
+					"lambda.max must be > 0; got %s",
+					format(lambda.max)
+				)
+			)
 		}
 	}
 
-	stopifnot(is.numeric(q) | is.integer(q))
-	stopifnot(length(q) == 1)
-	stopifnot(q > 0)
-	stopifnot(q <= 2)
+	# --- lambda.min ------------------------------------------------------
+	if (any(!is.na(lambda.min))) {
+		if (!(is.numeric(lambda.min) || is.integer(lambda.min))) {
+			violations <- c(
+				violations,
+				sprintf(
+					"lambda.min must be numeric or integer; got %s",
+					paste(class(lambda.min), collapse = "/")
+				)
+			)
+		} else if (length(lambda.min) != 1) {
+			violations <- c(
+				violations,
+				sprintf(
+					"lambda.min must be a single value; got length %d",
+					length(lambda.min)
+				)
+			)
+		} else if (lambda.min < 0) {
+			violations <- c(
+				violations,
+				sprintf(
+					"lambda.min must be >= 0; got %s",
+					format(lambda.min)
+				)
+			)
+		} else if (
+			# Both well-formed; check ordering only when lambda.max also
+			# survived its own checks (i.e., is a valid positive scalar).
+			any(!is.na(lambda.max)) &&
+				is.numeric(lambda.max) &&
+				length(lambda.max) == 1 &&
+				lambda.max > 0 &&
+				!(lambda.max > lambda.min)
+		) {
+			violations <- c(
+				violations,
+				sprintf(
+					"lambda.max must be > lambda.min; got lambda.max = %s, lambda.min = %s",
+					format(lambda.max),
+					format(lambda.min)
+				)
+			)
+		}
+	}
 
-	return(list(
+	# --- q ---------------------------------------------------------------
+	if (!(is.numeric(q) || is.integer(q)) || length(q) != 1) {
+		violations <- c(
+			violations,
+			sprintf(
+				"q must be a single numeric; got %s (length %d)",
+				paste(class(q), collapse = "/"),
+				length(q)
+			)
+		)
+	} else if (!(q > 0 && q <= 2)) {
+		violations <- c(
+			violations,
+			sprintf(
+				"q must be in (0, 2]; got %s",
+				format(q)
+			)
+		)
+	}
+
+	if (length(violations) > 0) {
+		stop(.format_input_violations(violations), call. = FALSE)
+	}
+	list(
 		pdata = pdata,
 		indep_count_data_available = indep_count_data_available
-	))
+	)
 }
 
 # getPsiRFused

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.19",
+  note    = "R package version 1.9.20",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/_snaps/estimator-entry-snapshot.md
+++ b/tests/testthat/_snaps/estimator-entry-snapshot.md
@@ -3,40 +3,46 @@
     Code
       cat(msgs$fetwfe)
     Output
-      is.integer(pdata[[time_var]]) is not TRUE
+      Invalid inputs:
+        - the time_var column 'time' must be integer; got numeric
 
 # entry-point error: time_var not a column (#79 PR A)
 
     Code
       cat(msgs$fetwfe)
     Output
-      time_var %in% colnames(pdata) is not TRUE
+      Invalid inputs:
+        - time_var = 'nonexistent' is not a column in pdata; columns are: unit, time, treat, y
 
 # entry-point error: time_var not character (#79 PR A)
 
     Code
       cat(msgs$fetwfe)
     Output
-      is.character(time_var) is not TRUE
+      Invalid inputs:
+        - time_var must be a single character string; got integer (length 1)
 
 # entry-point error: verbose not logical (#79 PR A)
 
     Code
       cat(msgs$fetwfe)
     Output
-      is.logical(verbose) is not TRUE
+      Invalid inputs:
+        - verbose must be a single logical (TRUE or FALSE); got character (length 1)
 
 # entry-point error: alpha out of range (#79 PR A)
 
     Code
       cat(msgs$fetwfe)
     Output
-      alpha > 0 is not TRUE
+      Invalid inputs:
+        - alpha must be in (0, 1); got -0.1
 
 # entry-point error: fetwfe + betwfe q out of range (#79 PR A)
 
     Code
       cat(msgs$fetwfe)
     Output
-      q > 0 is not TRUE
+      Invalid inputs:
+        - q must be in (0, 2]; got -1
 

--- a/tests/testthat/test-betwfe.R
+++ b/tests/testthat/test-betwfe.R
@@ -77,7 +77,7 @@ test_that("betwfe errors when pdata is not a data.frame", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.data.frame"
+		"pdata must be a data frame"
 	)
 })
 
@@ -97,7 +97,7 @@ test_that("betwfe errors when time_var is not integer", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.integer"
+		"time_var column 'time' must be integer"
 	)
 })
 
@@ -117,7 +117,7 @@ test_that("betwfe errors when unit_var is not character", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.character"
+		"unit_var column 'unit' must be character"
 	)
 })
 
@@ -137,7 +137,7 @@ test_that("betwfe errors when treatment is not integer", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.integer"
+		"treatment column 'treatment' must be integer"
 	)
 })
 
@@ -158,7 +158,7 @@ test_that("betwfe errors when treatment has values other than 0/1", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"all\\(pdata\\[, treatment\\] %in% c\\(0, 1\\)\\)"
+		"treatment column 'treatment' must contain only 0/1"
 	)
 })
 
@@ -179,7 +179,7 @@ test_that("betwfe errors when a covariate column is missing", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"all\\(covs %in% colnames\\(pdata\\)\\)"
+		"covs contains name\\(s\\) not in pdata"
 	)
 })
 
@@ -199,7 +199,7 @@ test_that("betwfe errors when response is not numeric", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.numeric"
+		"response column 'y' must be numeric or integer"
 	)
 })
 
@@ -298,7 +298,7 @@ test_that("betwfe errors when data has fewer than 4 rows", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"nrow\\(pdata\\) >= 4"
+		"pdata must have at least 4 rows"
 	)
 })
 

--- a/tests/testthat/test-estimator-entry-snapshot.R
+++ b/tests/testthat/test-estimator-entry-snapshot.R
@@ -214,3 +214,39 @@ test_that("entry-point error: fetwfe + betwfe q out of range (#79 PR A)", {
 
 	expect_snapshot(cat(msgs$fetwfe))
 })
+
+# ------------------------------------------------------------------------------
+# Test 7 (#84): NULL-input handling. Plan-review explicitly called out
+# `class(NULL)[1] = "NULL"`, `length(NULL) = 0` so the per-arg sprintf
+# interpolation should produce a clean, non-crashing message. We
+# exercise two NULL args at once (`time_var`, `verbose`) and assert
+# that BOTH violations appear (collect-across-args) in a single error
+# message — this is the load-bearing behavior change for #84.
+# ------------------------------------------------------------------------------
+test_that("entry-point error: NULL inputs produce clean multi-arg message (#84)", {
+	pdata <- .build_valid_panel()
+	args <- list(
+		pdata = pdata,
+		time_var = NULL,
+		unit_var = "unit",
+		treatment = "treat",
+		response = "y",
+		verbose = NULL
+	)
+	msgs <- .capture_entry_point_errors(args)
+
+	# 4-way byte-equality still holds across the entry points.
+	expect_identical(msgs$fetwfe, msgs$etwfe)
+	expect_identical(msgs$etwfe, msgs$betwfe)
+	expect_identical(msgs$betwfe, msgs$twfeCovs)
+
+	# Both NULL args contribute their own bullet (collect-across-args).
+	expect_match(msgs$fetwfe, "time_var must be a single character")
+	expect_match(msgs$fetwfe, "verbose must be a single logical")
+	# Sanity: message header is the new "Invalid inputs:" header.
+	expect_match(msgs$fetwfe, "^Invalid inputs:")
+	# Sanity: the message references NULL (the class of a NULL arg)
+	# and length 0 — confirms sprintf interpolation didn't crash.
+	expect_match(msgs$fetwfe, "NULL")
+	expect_match(msgs$fetwfe, "length 0")
+})

--- a/tests/testthat/test-etwfe.R
+++ b/tests/testthat/test-etwfe.R
@@ -70,7 +70,7 @@ test_that("etwfe errors when pdata is not a data.frame", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.data.frame"
+		"pdata must be a data frame"
 	)
 })
 
@@ -90,7 +90,7 @@ test_that("etwfe errors when time_var is not integer", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.integer"
+		"time_var column 'time' must be integer"
 	)
 })
 
@@ -110,7 +110,7 @@ test_that("etwfe errors when unit_var is not character", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.character"
+		"unit_var column 'unit' must be character"
 	)
 })
 
@@ -130,7 +130,7 @@ test_that("etwfe errors when treatment is not integer", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.integer"
+		"treatment column 'treatment' must be integer"
 	)
 })
 
@@ -151,7 +151,7 @@ test_that("etwfe errors when treatment has values other than 0/1", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"all\\(pdata\\[, treatment\\] %in% c\\(0, 1\\)\\)"
+		"treatment column 'treatment' must contain only 0/1"
 	)
 })
 
@@ -172,7 +172,7 @@ test_that("etwfe errors when a covariate column is missing", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"all\\(covs %in% colnames\\(pdata\\)\\)"
+		"covs contains name\\(s\\) not in pdata"
 	)
 })
 
@@ -192,7 +192,7 @@ test_that("etwfe errors when response is not numeric", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.numeric"
+		"response column 'y' must be numeric or integer"
 	)
 })
 
@@ -291,7 +291,7 @@ test_that("etwfe errors when data has fewer than 4 rows", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"nrow\\(pdata\\) >= 4"
+		"pdata must have at least 4 rows"
 	)
 })
 

--- a/tests/testthat/test-fetwfe.R
+++ b/tests/testthat/test-fetwfe.R
@@ -74,7 +74,7 @@ test_that("fetwfe errors when pdata is not a data.frame", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.data.frame"
+		"pdata must be a data frame"
 	)
 })
 
@@ -94,7 +94,7 @@ test_that("fetwfe errors when time_var is not integer", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.integer"
+		"time_var column 'time' must be integer"
 	)
 })
 
@@ -114,7 +114,7 @@ test_that("fetwfe errors when unit_var is not character", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.character"
+		"unit_var column 'unit' must be character"
 	)
 })
 
@@ -134,7 +134,7 @@ test_that("fetwfe errors when treatment is not integer", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.integer"
+		"treatment column 'treatment' must be integer"
 	)
 })
 
@@ -155,7 +155,7 @@ test_that("fetwfe errors when treatment has values other than 0/1", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"all\\(pdata\\[, treatment\\] %in% c\\(0, 1\\)\\)"
+		"treatment column 'treatment' must contain only 0/1"
 	)
 })
 
@@ -176,7 +176,7 @@ test_that("fetwfe errors when a covariate column is missing", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"all\\(covs %in% colnames\\(pdata\\)\\)"
+		"covs contains name\\(s\\) not in pdata"
 	)
 })
 
@@ -196,7 +196,7 @@ test_that("fetwfe errors when response is not numeric", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.numeric"
+		"response column 'y' must be numeric or integer"
 	)
 })
 
@@ -295,7 +295,7 @@ test_that("fetwfe errors when data has fewer than 4 rows", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"nrow\\(pdata\\) >= 4"
+		"pdata must have at least 4 rows"
 	)
 })
 

--- a/tests/testthat/test-twfeCovs.R
+++ b/tests/testthat/test-twfeCovs.R
@@ -70,7 +70,7 @@ test_that("twfeCovs errors when pdata is not a data.frame", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.data.frame"
+		"pdata must be a data frame"
 	)
 })
 
@@ -90,7 +90,7 @@ test_that("twfeCovs errors when time_var is not integer", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.integer"
+		"time_var column 'time' must be integer"
 	)
 })
 
@@ -110,7 +110,7 @@ test_that("twfeCovs errors when unit_var is not character", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.character"
+		"unit_var column 'unit' must be character"
 	)
 })
 
@@ -130,7 +130,7 @@ test_that("twfeCovs errors when treatment is not integer", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.integer"
+		"treatment column 'treatment' must be integer"
 	)
 })
 
@@ -151,7 +151,7 @@ test_that("twfeCovs errors when treatment has values other than 0/1", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"all\\(pdata\\[, treatment\\] %in% c\\(0, 1\\)\\)"
+		"treatment column 'treatment' must contain only 0/1"
 	)
 })
 
@@ -172,7 +172,7 @@ test_that("twfeCovs errors when a covariate column is missing", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"all\\(covs %in% colnames\\(pdata\\)\\)"
+		"covs contains name\\(s\\) not in pdata"
 	)
 })
 
@@ -192,7 +192,7 @@ test_that("twfeCovs errors when response is not numeric", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"is.numeric"
+		"response column 'y' must be numeric or integer"
 	)
 })
 
@@ -291,7 +291,7 @@ test_that("twfeCovs errors when data has fewer than 4 rows", {
 			covs = c("cov1", "cov2"),
 			response = "y"
 		),
-		"nrow\\(pdata\\) >= 4"
+		"pdata must have at least 4 rows"
 	)
 })
 


### PR DESCRIPTION
## Summary

Implements **item 11** of issue #84 (input-validator UX). Replaces ~48 hostile `stopifnot(is.character(time_var)) is not TRUE` errors with named, helpful messages.

**Before**:
```
Error: is.character(time_var) is not TRUE
```

**After**:
```
Invalid inputs:
  - time_var must be a single character string; got integer (length 1)
```

The rewrite uses a collect-all-violations pattern (modeled on `idCohorts()`'s v1.9.6 collector) so users see every malformed arg in one error message, not one error per round-trip.

**Two new internal helpers** in `R/etwfe_core.R`:
- `.collect_etwfe_input_violations()` — per-arg cascade-within-arg checks; returns violations + prepped pdata + indep flag.
- `.format_input_violations()` — assembles the multi-line message under an `"Invalid inputs:"` header.

`checkEtwfeInputs()` and `checkFetwfeInputs()` become thin wrappers around the helper. Both preserve their public return contracts.

**Semantics**: **collect across args, cascade within arg**. With 2 malformed args, both violations appear in a single error message. Within an arg, the first failure dominates (downstream checks are unsafe — e.g., can't check `time_var %in% colnames(pdata)` if `time_var` isn't a length-1 character). The header is caller-agnostic so all 4 entry points produce byte-identical messages for any shared violation.

**Snapshot re-blessing**: PR #103's snapshot tests at `tests/testthat/_snaps/estimator-entry-snapshot.md` are deliberately re-blessed with the new helpful messages. This is exactly what the snapshot mechanism was designed to support — brittleness to wording changes forces a conscious blessing decision on deliberate rewording. The cross-entry-point byte-equality contract (Tests 1-5 across all 4 estimators; Test 6 across fetwfe + betwfe) is preserved.

**New Test 7**: exercises NULL-input handling (`time_var = NULL` and `verbose = NULL` together) and confirms the collect-across-args contract.

**Scope: item 11 only.** Item 12 (strict-vs-lenient reconciliations: `lambda.max > 0` vs `>= 0`; `sig_eps_c_sq = 0` accept vs reject; `R >= 1` vs `R >= 2`) is deferred to a follow-up — those involve API behavior judgment, unlike this UX rewrite. `check_etwfe_core_inputs()` and `prepXints()` are also intentionally left as terse `stopifnot()`s (internal invariants, not user input — per Greg's "don't validate scenarios that can't happen" preference).

**Cascading test updates**: 32 `expect_error` regex patterns across `test-fetwfe.R`, `test-etwfe.R`, `test-betwfe.R`, `test-twfeCovs.R` (8 per file) were updated to match the new descriptive wording. Mechanical.

**Honest about LOC**: net +510 LOC (vs the plan-review's 130 upper bound). Driven by per-violation multi-line `sprintf()` blocks needed to stay within `air format`'s 80-col limit; ~25 distinct violation lines × ~5 LOC per multi-line block + helpers + roxygen. Verified by both sentinel and reviewer to be genuine sprintf bloat, not scope creep. The user-facing UX benefit (helpful error messages on every malformed input) justifies the size.

**Version bump**: 1.9.19 → 1.9.20.

## Test plan

- [x] Full test suite: 1801 passing, 0 failures, 0 errors, 2 pre-existing warnings (+8 expectations from Test 7).
- [x] `devtools::check(--as-cran)`: 0 errors, 0 warnings, 1 environmental NOTE.
- [x] PR #103 snapshot file re-blessed; new helpful messages locked.
- [x] Cross-entry-point byte-equality preserved (4-way for Tests 1-5 + 7; 2-way for Test 6).
- [x] Drift sentinel: NO DRIFT.
- [x] Post-execution reviewer: READY-TO-SHIP. LOC overshoot verified to be genuine sprintf bloat; semantic correctness traced; all D1-D6 decisions honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
