### PR TITLE
tidy.FETWFE_tes broom-convention args (#84 item 14, 1.9.22)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.21
+Version: 1.9.22
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # NEWS
 
+## Version 1.9.22 (2026-05-19)
+
+- `tidy.FETWFE_tes()` now accepts `conf.int` and `conf.level` arguments
+  for broom-convention parity with the sibling `tidy.fetwfe()`,
+  `tidy.etwfe()`, `tidy.betwfe()`, and `tidy.fetwfe_event_study()`
+  methods. Defaults are `conf.int = TRUE` (preserves pre-fix output —
+  NA-valued `conf.low` / `conf.high` columns included) and
+  `conf.level = 0.95`. When `conf.int = FALSE`, the CI columns are
+  omitted entirely. `conf.level` is validated but unused (there is no
+  sampling distribution for a population truth). GitHub #84 item 14.
+
 ## Version 1.9.21 (2026-05-19)
 
 - Added compact `print` methods for `FETWFE_simulated` (output of

--- a/R/broom_methods.R
+++ b/R/broom_methods.R
@@ -471,19 +471,35 @@ tidy.fetwfe_event_study <- function(
 #' convention that cohort `r` adopts at calendar time `r + 1`, so
 #' the labels match what `tidy.<estimator>` uses on a fitted panel
 #' generated from the same `FETWFE_coefs`). Standard error /
-#' statistic / p-value / CI columns are all `NA_real_` — there is
-#' no sampling distribution for a population truth.
+#' statistic / p-value columns are always `NA_real_` — there is no
+#' sampling distribution for a population truth. When
+#' `conf.int = TRUE` (default, matching the sibling tidy methods),
+#' `conf.low` / `conf.high` columns are included and also set to
+#' `NA_real_`. When `conf.int = FALSE`, those columns are omitted.
 #'
 #' @param x An object of class `"FETWFE_tes"` returned by [getTes()].
+#' @param conf.int Logical; include `conf.low` / `conf.high` columns.
+#'   Defaults to `TRUE` to match the sibling tidy methods and preserve
+#'   pre-#84 backward compatibility. Population-truth objects have no
+#'   sampling distribution, so the CI columns are always filled with
+#'   `NA_real_` when included.
+#' @param conf.level Numeric in (0, 1). Accepted for broom-convention
+#'   parity but unused (no CIs to compute for a population truth);
+#'   validated regardless. Defaults to `0.95` (`FETWFE_tes` objects do
+#'   not carry an alpha slot, so there is no fitted-object value to
+#'   default to).
 #' @param ... Unused.
-#' @return A data frame with `R + 1` rows.
+#' @return A data frame with `R + 1` rows and columns `term`,
+#'   `estimate`, `std.error`, `statistic`, `p.value`, and (when
+#'   `conf.int = TRUE`) `conf.low` / `conf.high`.
 #' @examples
 #' \dontrun{
 #'   coefs <- genCoefs(R = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
 #'   broom::tidy(getTes(coefs))
 #' }
 #' @export
-tidy.FETWFE_tes <- function(x, ...) {
+tidy.FETWFE_tes <- function(x, conf.int = TRUE, conf.level = 0.95, ...) {
+	stopifnot(conf.level > 0, conf.level < 1)
 	R <- length(x$actual_cohort_tes)
 	cohort_times <- if (!is.null(x$cohort_times)) {
 		x$cohort_times
@@ -494,16 +510,19 @@ tidy.FETWFE_tes <- function(x, ...) {
 	}
 	terms <- c("ATT_true", paste0("Cohort ", cohort_times))
 	estimates <- c(x$att_true, x$actual_cohort_tes)
-	data.frame(
+	out <- data.frame(
 		term = terms,
 		estimate = estimates,
 		std.error = rep(NA_real_, R + 1L),
 		statistic = rep(NA_real_, R + 1L),
 		p.value = rep(NA_real_, R + 1L),
-		conf.low = rep(NA_real_, R + 1L),
-		conf.high = rep(NA_real_, R + 1L),
 		stringsAsFactors = FALSE
 	)
+	if (conf.int) {
+		out$conf.low <- rep(NA_real_, R + 1L)
+		out$conf.high <- rep(NA_real_, R + 1L)
+	}
+	out
 }
 
 #-------------------------------------------------------------------------------

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.21",
+  note    = "R package version 1.9.22",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/man/tidy.FETWFE_tes.Rd
+++ b/man/tidy.FETWFE_tes.Rd
@@ -4,15 +4,29 @@
 \alias{tidy.FETWFE_tes}
 \title{Tidy a \code{FETWFE_tes} simulation truth object}
 \usage{
-\method{tidy}{FETWFE_tes}(x, ...)
+\method{tidy}{FETWFE_tes}(x, conf.int = TRUE, conf.level = 0.95, ...)
 }
 \arguments{
 \item{x}{An object of class \code{"FETWFE_tes"} returned by \code{\link[=getTes]{getTes()}}.}
 
+\item{conf.int}{Logical; include \code{conf.low} / \code{conf.high} columns.
+Defaults to \code{TRUE} to match the sibling tidy methods and preserve
+pre-#84 backward compatibility. Population-truth objects have no
+sampling distribution, so the CI columns are always filled with
+\code{NA_real_} when included.}
+
+\item{conf.level}{Numeric in (0, 1). Accepted for broom-convention
+parity but unused (no CIs to compute for a population truth);
+validated regardless. Defaults to \code{0.95} (\code{FETWFE_tes} objects do
+not carry an alpha slot, so there is no fitted-object value to
+default to).}
+
 \item{...}{Unused.}
 }
 \value{
-A data frame with \code{R + 1} rows.
+A data frame with \code{R + 1} rows and columns \code{term},
+\code{estimate}, \code{std.error}, \code{statistic}, \code{p.value}, and (when
+\code{conf.int = TRUE}) \code{conf.low} / \code{conf.high}.
 }
 \description{
 Returns a \code{broom}-style tidy data frame for the population-truth
@@ -22,8 +36,11 @@ object returned by \code{\link[=getTes]{getTes()}}. Row 1 is the overall true AT
 convention that cohort \code{r} adopts at calendar time 1, so
 the labels match what \verb{tidy.<estimator>} uses on a fitted panel
 generated from the same \code{FETWFE_coefs}). Standard error /
-statistic / p-value / CI columns are all \code{NA_real_} — there is
-no sampling distribution for a population truth.
+statistic / p-value columns are always \code{NA_real_} — there is no
+sampling distribution for a population truth. When
+\code{conf.int = TRUE} (default, matching the sibling tidy methods),
+\code{conf.low} / \code{conf.high} columns are included and also set to
+\code{NA_real_}. When \code{conf.int = FALSE}, those columns are omitted.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-broom-methods.R
+++ b/tests/testthat/test-broom-methods.R
@@ -573,3 +573,43 @@ test_that("broom S3 methods are registered AND dispatch correctly for fetwfe / e
 		is.null(getS3method("tidy", "FETWFE_tes", optional = TRUE))
 	)
 })
+
+# ------------------------------------------------------------------------------
+# tidy.FETWFE_tes broom-convention args (#84 item 14)
+# ------------------------------------------------------------------------------
+test_that("tidy.FETWFE_tes accepts conf.int and conf.level (#84 item 14)", {
+	coefs <- genCoefs(
+		R = 3,
+		T = 6,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		seed = 42
+	)
+	tes <- getTes(coefs)
+	expect_s3_class(tes, "FETWFE_tes")
+
+	# Default behavior: backward-compatible. CI columns included with NA values.
+	td <- broom::tidy(tes)
+	expect_true("conf.low" %in% names(td))
+	expect_true("conf.high" %in% names(td))
+	expect_true(all(is.na(td$conf.low)))
+	expect_true(all(is.na(td$conf.high)))
+
+	# conf.int = FALSE: CI columns dropped entirely.
+	td_no_ci <- broom::tidy(tes, conf.int = FALSE)
+	expect_false("conf.low" %in% names(td_no_ci))
+	expect_false("conf.high" %in% names(td_no_ci))
+
+	# conf.level accepted (validated but unused; output unchanged regardless).
+	td_90 <- broom::tidy(tes, conf.int = TRUE, conf.level = 0.9)
+	expect_identical(td, td_90)
+
+	# conf.level is also ignored under conf.int = FALSE.
+	td_no_ci_99 <- broom::tidy(tes, conf.int = FALSE, conf.level = 0.99)
+	expect_identical(td_no_ci, td_no_ci_99)
+
+	# Invalid conf.level errors via stopifnot.
+	expect_error(broom::tidy(tes, conf.level = 1.5))
+	expect_error(broom::tidy(tes, conf.level = 0))
+})


### PR DESCRIPTION
## Summary

Implements **item 14** of issue #84. Adds `conf.int` and `conf.level` arguments to `tidy.FETWFE_tes()` for broom-convention parity with the sibling tidy methods.

**Before**:
```r
broom::tidy(tes)                          # NA CI columns always included
broom::tidy(tes, conf.int = FALSE)        # arg silently ignored — columns still there
broom::tidy(tes, conf.level = 0.9)        # arg silently ignored
```

**After**:
```r
broom::tidy(tes)                          # default: NA CI columns included (backward-compat)
broom::tidy(tes, conf.int = FALSE)        # CI columns dropped entirely
broom::tidy(tes, conf.level = 0.9)        # accepted + validated; ignored for population truth
broom::tidy(tes, conf.level = 1.5)        # errors via stopifnot
```

**Defaults**:
| Arg | Default | Rationale |
|---|---|---|
| `conf.int` | `TRUE` | Matches sibling tidies; preserves pre-fix output (NA-valued CI columns) for backward compatibility |
| `conf.level` | `0.95` | FETWFE_tes has no `alpha` slot to default to; matches `tidy.fetwfe_event_study`'s identical case |

**Design notes**:
- The exact precedent in the codebase is `tidy.fetwfe_event_study()` (`R/broom_methods.R:435-463`), which ships the same broom-convention pattern for a class without an `alpha` slot. The new `tidy.FETWFE_tes()` mirrors that shape.
- `conf.level` is validated even though unused (matches the validation in `.tidy_estimator_output()`) — a future caller migrating between FETWFE_tes and a fitted estimator gets consistent arg-validation behavior.
- The CI columns are always NA when included; there is no sampling distribution for a population truth.

**Tests**: 1 new test in `test-broom-methods.R` covering:
- Default `conf.int = TRUE`: CI columns present and all NA.
- `conf.int = FALSE`: CI columns dropped entirely.
- `conf.level` ignored under both branches (confirmed via `expect_identical`).
- Invalid `conf.level` errors (upper + lower bounds).

**Version bump**: 1.9.21 → 1.9.22.

## Test plan

- [x] Full test suite: 1834 passing, 0 failures, 0 errors, 2 pre-existing warnings (+11 expectations from new test).
- [x] `devtools::check(--as-cran)`: 0 errors, 0 warnings, 1 environmental NOTE.
- [x] Drift sentinel: NO DRIFT.
- [x] Post-execution reviewer: READY-TO-SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
