### PR TITLE
Add event_study + tidy schema lock-in tests (#84 item 4)

### DIFF
--- a/tests/testthat/test-doc-slot-parity.R
+++ b/tests/testthat/test-doc-slot-parity.R
@@ -302,3 +302,139 @@ test_that("cross-class slot inventory matches the documented divergence table", 
 		)
 	}
 })
+
+# ------------------------------------------------------------------------------
+# Test 4 (#84 item 4): event_study() output schema lock-in.
+#
+# Parallel to Test 1 but for the event-study aggregation surface. The
+# event_study() @return uses \describe{\item{KEY}{...}} structure so we
+# reuse the existing .extract_value_items() parser. Covers all three
+# estimator classes that event_study() accepts (fetwfe, etwfe, betwfe;
+# twfeCovs is rejected with a stop() per R/event_study.R:67-69).
+# ------------------------------------------------------------------------------
+
+test_that("event_study() @return matches live names() across estimator classes (#84 item 4)", {
+	coefs <- genCoefs(
+		R = 3,
+		T = 5,
+		d = 0,
+		density = 0.5,
+		eff_size = 1,
+		seed = 20260517
+	)
+	sim <- simulateData(
+		coefs,
+		N = 120,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5
+	)
+
+	fits <- list(
+		fetwfe = suppressWarnings(fetwfeWithSimulatedData(sim, q = 0.5)),
+		etwfe = suppressWarnings(etwfeWithSimulatedData(sim)),
+		betwfe = suppressWarnings(betwfeWithSimulatedData(sim, q = 0.5))
+	)
+
+	db <- .get_rd_db()
+	expect_true(
+		"event_study.Rd" %in% names(db),
+		info = "event_study.Rd missing from Rd db"
+	)
+	doc_cols <- .extract_value_items(db[["event_study.Rd"]])
+
+	for (cls in names(fits)) {
+		es <- suppressWarnings(event_study(fits[[cls]]))
+		live <- names(es)
+		missing <- setdiff(live, doc_cols)
+		extra <- setdiff(doc_cols, live)
+		expect_true(
+			length(missing) == 0,
+			info = paste0(
+				cls,
+				": live names() not in event_study.Rd @return: ",
+				paste(missing, collapse = ", ")
+			)
+		)
+		expect_true(
+			length(extra) == 0,
+			info = paste0(
+				cls,
+				": event_study.Rd @return slots not in live names(): ",
+				paste(extra, collapse = ", ")
+			)
+		)
+	}
+})
+
+# ------------------------------------------------------------------------------
+# Test 5 (#84 item 4): tidy.fetwfe_event_study() output schema lock-in.
+#
+# The tidy method's @return is prose (not \describe{}-structured) and the
+# schema is conditional on conf.int. Hard-coded expected column sets;
+# future drift here forces a conscious update of either the test or the
+# tidy implementation.
+# ------------------------------------------------------------------------------
+
+test_that("tidy.fetwfe_event_study() schema is locked across conf.int branches (#84 item 4)", {
+	skip_if_not_installed("broom")
+	coefs <- genCoefs(
+		R = 3,
+		T = 5,
+		d = 0,
+		density = 0.5,
+		eff_size = 1,
+		seed = 20260517
+	)
+	sim <- simulateData(
+		coefs,
+		N = 120,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5
+	)
+
+	fits <- list(
+		fetwfe = suppressWarnings(fetwfeWithSimulatedData(sim, q = 0.5)),
+		etwfe = suppressWarnings(etwfeWithSimulatedData(sim)),
+		betwfe = suppressWarnings(betwfeWithSimulatedData(sim, q = 0.5))
+	)
+
+	# Documented schema (broom convention) — hard-coded because the
+	# @return prose isn't \describe{}-structured. Source: roxygen at
+	# R/broom_methods.R:423-425.
+	expected_with_ci <- c(
+		"term",
+		"event_time",
+		"n_cohorts",
+		"estimate",
+		"std.error",
+		"statistic",
+		"p.value",
+		"conf.low",
+		"conf.high"
+	)
+	expected_no_ci <- setdiff(expected_with_ci, c("conf.low", "conf.high"))
+
+	for (cls in names(fits)) {
+		es <- suppressWarnings(event_study(fits[[cls]]))
+
+		td_ci <- broom::tidy(es)
+		expect_identical(
+			names(td_ci),
+			expected_with_ci,
+			info = paste0(
+				cls,
+				": tidy(event_study()) default columns drift"
+			)
+		)
+
+		td_no_ci <- broom::tidy(es, conf.int = FALSE)
+		expect_identical(
+			names(td_no_ci),
+			expected_no_ci,
+			info = paste0(
+				cls,
+				": tidy(event_study(), conf.int = FALSE) columns drift"
+			)
+		)
+	}
+})


### PR DESCRIPTION
## Summary

Implements **item 4** of issue #84 — schema lock-in for `event_study()` and `tidy.fetwfe_event_study()`. Analogous to the doc-vs-live parity test from PR #71 (issue #70), now extended to cover the event-study aggregation surface.

**Tests-only PR.** Zero source changes. Per PR #65 precedent: no version bump (`DESCRIPTION` stays at 1.9.22).

Two new `test_that` blocks appended to `tests/testthat/test-doc-slot-parity.R`:

| Test | Target | Strategy | Coverage |
|---|---|---|---|
| Test 4 | `event_study()` output | Rd parsing (reuses `.extract_value_items()` + `.get_rd_db()` from #70) since the `@return` is `\describe{\item{...}}`-structured | fetwfe, etwfe, betwfe |
| Test 5 | `tidy.fetwfe_event_study()` output | Hard-coded expected column sets (the `@return` is prose, not parseable; schema is conditional on `conf.int`) | fetwfe, etwfe, betwfe × `conf.int = TRUE` / `FALSE` |

`twfeCovs` is correctly excluded — `event_study()` rejects it with a `stop()` at `R/event_study.R:67-69`.

**Post-exec review catch folded**: Test 5 calls `broom::tidy()`, and `broom` is in `Suggests:` (not `Imports:`). Added `skip_if_not_installed("broom")` to match the pattern in `test-broom-methods.R:523` and `test-lex-cohort-sort.R:62`. Without it, `R CMD check --no-suggests` (and CRAN's clean-install workflow) would fail.

## Test plan

- [x] Full test suite: 1847 passing, 0 failures, 0 errors, 2 pre-existing warnings (+13 expectations from 2 new test blocks).
- [x] `devtools::check(--as-cran)`: 0 errors, 0 warnings, 1 environmental NOTE.
- [x] Drift sentinel: NO DRIFT.
- [x] Post-execution reviewer: MINOR ISSUES (`broom` guard missing — fixed before commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
