### PR TITLE
Reconcile 3 strict-vs-lenient validator inconsistencies (#109, 1.9.24)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.23
+Version: 1.9.24
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,32 @@
 # NEWS
 
+## Version 1.9.24 (2026-05-19)
+
+- Reconciled three strict-vs-lenient validator inconsistencies (GitHub
+  #109, follow-up to #84 item 12):
+  - **`lambda.max` (Case 1)**: Tightened the inner `fetwfe_core` check
+    from `lambda.max >= 0` to `lambda.max > 0` to match the outer
+    `checkFetwfeInputs` invariant. No user-visible behavior change —
+    the inner check is downstream of the outer and was effectively
+    dead code (any caller already validated `> 0` via the entry
+    point).
+  - **`sig_eps_c_sq = 0` (Case 2)**: Loosened `simulateData()` (and
+    its inner helper `testGenRandomDataInputs()`) to accept
+    `sig_eps_c_sq = 0`, matching the validator surface used by
+    `fetwfe()` / `etwfe()` / `betwfe()` / `twfeCovs()`.
+    Methodologically, `sig_eps_c_sq = 0` yields a panel with no
+    unit-level random effects (`rnorm(N, sd = 0) = rep(0, N)`).
+    Backward-compatible additive change — previously-rejected inputs
+    are now accepted.
+  - **`R >= 2` (Case 3)**: Tightened the upstream `R >= 1` checks at
+    `R/core_funcs.R::check_etwfe_core_inputs` and
+    `genFullInvFusionTransformMat` to `R >= 2`, matching the
+    user-facing helpful-error check at `R/etwfe_core.R:1127`
+    ("Only one treated cohort detected..."). No user-visible behavior
+    change — `R = 1` was already rejected with a clearer message
+    downstream. Single-treated-cohort support (R = 1) is filed
+    separately as #112.
+
 ## Version 1.9.23 (2026-05-19)
 
 - Closes out the remaining items of GitHub #84 (the 2026-05-17 periodic

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -786,7 +786,7 @@ betwfe_core <- function(
 	if (any(!is.na(lambda.max))) {
 		stopifnot(is.numeric(lambda.max) | is.integer(lambda.max))
 		stopifnot(length(lambda.max) == 1)
-		stopifnot(lambda.max >= 0)
+		stopifnot(lambda.max > 0)
 	}
 
 	if (any(!is.na(lambda.min))) {

--- a/R/core_funcs.R
+++ b/R/core_funcs.R
@@ -826,7 +826,7 @@ check_etwfe_core_inputs <- function(
 		)
 	}
 
-	stopifnot(R >= 1)
+	stopifnot(R >= 2)
 	stopifnot(R <= T - 1)
 
 	indep_count_data_available <- FALSE
@@ -924,7 +924,7 @@ check_etwfe_core_inputs <- function(
 #' @noRd
 genFullInvFusionTransformMat <- function(first_inds, T, R, d, num_treats) {
 	##———— Safety checks ————————————————————————————————————————————
-	stopifnot(is.numeric(R), length(R) == 1L, R >= 1L)
+	stopifnot(is.numeric(R), length(R) == 1L, R >= 2L)
 	stopifnot(is.numeric(T), length(T) == 1L, T >= 3L, R <= T - 1)
 	stopifnot(is.numeric(d), length(d) == 1L, d >= 0L)
 	stopifnot(length(first_inds) == R)

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -806,7 +806,7 @@ fetwfe_core <- function(
 	if (any(!is.na(lambda.max))) {
 		stopifnot(is.numeric(lambda.max) | is.integer(lambda.max))
 		stopifnot(length(lambda.max) == 1)
-		stopifnot(lambda.max >= 0)
+		stopifnot(lambda.max > 0)
 	}
 
 	if (any(!is.na(lambda.min))) {

--- a/R/gen_funcs.R
+++ b/R/gen_funcs.R
@@ -18,6 +18,8 @@
 #' @param N Integer. Number of units in the panel.
 #' @param sig_eps_sq Numeric. Variance of the idiosyncratic (observation-level) noise.
 #' @param sig_eps_c_sq Numeric. Variance of the unit-level random effects.
+#'   Must be non-negative; `0` is allowed (yields a panel with no unit-level
+#'   random effects).
 #' @param distribution Character. Distribution to generate covariates.
 #'   Defaults to \code{"gaussian"}. If set to \code{"uniform"}, covariates are drawn uniformly
 #'   from \eqn{[-\sqrt{3}, \sqrt{3}]}.
@@ -103,9 +105,9 @@ simulateData <- function(
 	if (
 		!is.numeric(sig_eps_c_sq) ||
 			length(sig_eps_c_sq) != 1 ||
-			sig_eps_c_sq <= 0
+			sig_eps_c_sq < 0
 	) {
-		stop("sig_eps_c_sq must be a positive numeric value")
+		stop("sig_eps_c_sq must be a non-negative numeric value")
 	}
 
 	# Extract parameters from the coefs object
@@ -430,6 +432,8 @@ getTes <- function(coefs_obj) {
 #' @param d Integer. Number of time-invariant covariates.
 #' @param sig_eps_sq Numeric. Variance of the idiosyncratic (observation-level) noise.
 #' @param sig_eps_c_sq Numeric. Variance of the unit-level random effects.
+#'   Must be non-negative; `0` is allowed (yields a panel with no unit-level
+#'   random effects).
 #' @param beta Numeric vector. Coefficient vector for data generation. Its required length depends
 #' on the value of \code{gen_ints}:
 #'   \itemize{
@@ -1453,7 +1457,7 @@ testGenRandomDataInputs <- function(
 	stopifnot(R >= 2)
 	stopifnot(N >= R + 1)
 	stopifnot(sig_eps_sq > 0)
-	stopifnot(sig_eps_c_sq > 0)
+	stopifnot(sig_eps_c_sq >= 0)
 
 	# Compute the number of treatment effects (common to both cases)
 	num_treats <- getNumTreats(R = R, T = T)

--- a/R/utility.R
+++ b/R/utility.R
@@ -640,8 +640,10 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 	}
 
 	# After truncation, retained cohorts are those with r_i < r_max.
-	# prep_for_etwfe_core() downstream requires R >= 2 (at least two
-	# treated cohorts), so the guard here matches that constraint.
+	# FETWFE / ETWFE / BETWFE / twfeCovs each require R >= 2 (enforced
+	# at `R/etwfe_core.R:1127` with a user-facing error); the guard here
+	# matches that constraint so the user gets a clear truncation-specific
+	# message rather than the deeper R >= 2 error after auto-truncation.
 	retained_cohorts <- setdiff(unique(unit_first_treat), r_max)
 	if (length(retained_cohorts) < 2) {
 		stop(

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.23",
+  note    = "R package version 1.9.24",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/man/simulateData.Rd
+++ b/man/simulateData.Rd
@@ -21,7 +21,9 @@ and simulation parameters.}
 
 \item{sig_eps_sq}{Numeric. Variance of the idiosyncratic (observation-level) noise.}
 
-\item{sig_eps_c_sq}{Numeric. Variance of the unit-level random effects.}
+\item{sig_eps_c_sq}{Numeric. Variance of the unit-level random effects.
+Must be non-negative; \code{0} is allowed (yields a panel with no unit-level
+random effects).}
 
 \item{distribution}{Character. Distribution to generate covariates.
 Defaults to \code{"gaussian"}. If set to \code{"uniform"}, covariates are drawn uniformly

--- a/man/simulateDataCore.Rd
+++ b/man/simulateDataCore.Rd
@@ -29,7 +29,9 @@ simulateDataCore(
 
 \item{sig_eps_sq}{Numeric. Variance of the idiosyncratic (observation-level) noise.}
 
-\item{sig_eps_c_sq}{Numeric. Variance of the unit-level random effects.}
+\item{sig_eps_c_sq}{Numeric. Variance of the unit-level random effects.
+Must be non-negative; \code{0} is allowed (yields a panel with no unit-level
+random effects).}
 
 \item{beta}{Numeric vector. Coefficient vector for data generation. Its required length depends
 on the value of \code{gen_ints}:

--- a/tests/testthat/test-simulateData.R
+++ b/tests/testthat/test-simulateData.R
@@ -393,3 +393,42 @@ test_that("print.FETWFE_simulated summarizes instead of dumping (#84 item 13)", 
 	expect_false(any(grepl("\\$X", out)))
 	expect_false(any(grepl("Levels:", out)))
 })
+
+# ------------------------------------------------------------------------------
+# Case 2 from #109: simulateData() accepts sig_eps_c_sq = 0 (no unit-level
+# random effects). Pre-fix, simulateData() rejected sig_eps_c_sq <= 0 while
+# the validators downstream of fetwfe() accepted sig_eps_c_sq >= 0.
+# Loosened simulateData (and testGenRandomDataInputs) to match.
+# ------------------------------------------------------------------------------
+test_that("simulateData accepts sig_eps_c_sq = 0 (#109 Case 2)", {
+	coefs <- genCoefs(
+		R = 2,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		seed = 109
+	)
+	# Pre-fix: this call errored with "sig_eps_c_sq must be a positive numeric value".
+	sim <- simulateData(coefs, N = 40, sig_eps_sq = 1, sig_eps_c_sq = 0)
+	expect_s3_class(sim, "FETWFE_simulated")
+	expect_equal(sim$sig_eps_c_sq, 0)
+	# rnorm(N, sd = 0) returns rep(0, N) — unit residuals are exactly zero.
+	# Response is still finite (idiosyncratic noise has sig_eps_sq = 1).
+	expect_true(all(is.finite(sim$y)))
+})
+
+test_that("simulateData still rejects negative sig_eps_c_sq (#109 Case 2)", {
+	coefs <- genCoefs(
+		R = 2,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		seed = 109
+	)
+	expect_error(
+		simulateData(coefs, N = 40, sig_eps_sq = 1, sig_eps_c_sq = -0.1),
+		"non-negative"
+	)
+})


### PR DESCRIPTION
## Summary

Closes #109 (the #84 item 12 follow-up). Three small validator-consistency changes; all backward-compatible.

| Case | Before | After | Behavior change? |
|---|---|---|---|
| 1 — `lambda.max` | Outer: `> 0`; inner (`fetwfe_core` + `betwfe_core`): `>= 0` | Both inner tightened to `> 0` | No — inner was unreachable from user code |
| 2 — `sig_eps_c_sq = 0` | `simulateData` rejects `<= 0`; validator accepts `>= 0` | `simulateData` accepts `>= 0` | **Yes (additive)** — previously-rejected zero accepted |
| 3 — `R >= 2` | Upstream: `R >= 1`; deeper check: `R >= 2` with helpful error | Upstream tightened to `R >= 2` | No — `R = 1` was already rejected downstream |

### Per-case detail

**Case 1**: Tightened `R/fetwfe_core.R:809` AND `R/betwfe_core.R:789` `lambda.max >= 0` → `> 0`. The post-execution reviewer caught the betwfe parallel — `betwfe_core` shares `checkFetwfeInputs()` (which enforces `> 0`) with `fetwfe_core`, so tightening only one would have recreated the exact inconsistency Case 1 was meant to eliminate. Both updated uniformly.

**Case 2**: Loosened `R/gen_funcs.R::simulateData()` (and its inner helper `testGenRandomDataInputs()`) to accept `sig_eps_c_sq = 0`. Methodology supports it: `rnorm(N, sd = sqrt(0)) = rep(0, N)` is the unit-residual when there are no unit-level random effects. Docstrings updated in both `simulateData` and `simulateDataCore`. Two new tests in `test-simulateData.R`:
- Positive: `simulateData(..., sig_eps_c_sq = 0)` returns `FETWFE_simulated`, `sim$sig_eps_c_sq == 0`, `all(is.finite(sim$y))`.
- Negative: `simulateData(..., sig_eps_c_sq = -0.1)` errors with "non-negative" in the message.

**Case 3**: Tightened `R/core_funcs.R::check_etwfe_core_inputs` AND `genFullInvFusionTransformMat` `R >= 1` → `R >= 2`. The deeper `R/etwfe_core.R:1127` check (`if (R < 2) stop("Only one treated cohort detected...")`) already enforces this with a clear user-facing error; the upstream checks were just inconsistent. Also refreshed the `.truncate_if_no_never_treated` comment to drop the stale `prep_for_etwfe_core() downstream requires R >= 2` reference.

### R = 1 follow-up

Issue **#112** filed for proper R = 1 (single-cohort DiD) support. That's a methodology decision + several code paths to relax + paper-side note. Out of scope here.

### Version bump

1.9.23 → 1.9.24.

## Test plan

- [x] Full test suite: 1909 passing, 0 failures, 0 errors, 2 pre-existing warnings (+2 expectations from new tests).
- [x] `devtools::check(--as-cran)`: 0 errors, 0 warnings, 1 environmental NOTE.
- [x] `devtools::spell_check()`: empty.
- [x] Drift sentinel: NO DRIFT.
- [x] Post-execution reviewer: MINOR (caught the missed `betwfe_core` Case 1 parallel — folded before commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
