### PR TITLE
Fix 4 roxygen rendering typos (#115, 1.9.26)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.25
+Version: 1.9.26
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # NEWS
 
+## Version 1.9.26 (2026-05-19)
+
+- Fixed four roxygen-comment typos surfaced by the 2026-05-19 periodic
+  code review (GitHub #115): `#"` instead of `#'` on the
+  `simulateData()` and `simulateDataCore()` docstrings in
+  `R/gen_data.R`, and an unmatched backtick before `fetwfe()` in the
+  `attgtToFetwfeDf()` and `etwfeToFetwfeDf()` descriptions in
+  `R/convert_dfs.R`. The latter fix restores correct inline-code
+  rendering in `man/attgtToFetwfeDf.Rd` and `man/etwfeToFetwfeDf.Rd`;
+  the former is a latent typo that roxygen2 happened to parse around.
+
 ## Version 1.9.25 (2026-05-19)
 
 - Reorganized the `R/` source tree so each file's contents match its

--- a/R/convert_dfs.R
+++ b/R/convert_dfs.R
@@ -2,7 +2,7 @@
 #'
 #' `attgtToFetwfeDf()` reshapes and renames a panel dataset that is already
 #' formatted for `did::att_gt()` (Callaway and Sant'Anna 2021) so that it can be
-#' passed directly to fetwfe()` or `etwfe()` from the `fetwfe` package. In
+#' passed directly to `fetwfe()` or `etwfe()` from the `fetwfe` package. In
 #' particular, it
 #'   * creates an *absorbing‑state* treatment dummy that equals 1 from the
 #'     first treated period onward* and 0 otherwise,
@@ -109,7 +109,7 @@ attgtToFetwfeDf <- function(
 #'
 #' `etwfeToFetwfeDf()` reshapes and renames a panel dataset that is already
 #' formatted for `etwfe::etwfe()` (McDermott 2024) so that it can be
-#' passed directly to fetwfe()` or `etwfe()` from the `fetwfe` package. In
+#' passed directly to `fetwfe()` or `etwfe()` from the `fetwfe` package. In
 #' particular, it
 #'   * creates an *absorbing‑state* treatment dummy that equals 1 from the
 #'     first treated period onward* and 0 otherwise,

--- a/R/gen_data.R
+++ b/R/gen_data.R
@@ -71,7 +71,7 @@
 #'
 #' When \eqn{d = 0} (i.e. no covariates), the function omits any covariate-related columns
 #' and their interactions.
-#"
+#'
 #' @references
 #' Faletto, G (2025). Fused Extended Two-Way Fixed Effects for
 #' Difference-in-Differences with Staggered Adoptions.
@@ -264,7 +264,7 @@ simulateData <- function(
 #'
 #' When \eqn{d = 0} (i.e. no covariates), the function omits any covariate-related columns
 #' and their interactions.
-#"
+#'
 #' @references
 #' Faletto, G (2025). Fused Extended Two-Way Fixed Effects for
 #' Difference-in-Differences with Staggered Adoptions.

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.25",
+  note    = "R package version 1.9.26",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -8,6 +8,7 @@ Asjad
 att
 ATT
 augment
+backtick
 bacondecomp
 Bates
 betwfe

--- a/man/attgtToFetwfeDf.Rd
+++ b/man/attgtToFetwfeDf.Rd
@@ -63,7 +63,7 @@ covariates requested in \code{covars}, ready to be fed to
 \description{
 \code{attgtToFetwfeDf()} reshapes and renames a panel dataset that is already
 formatted for \code{did::att_gt()} (Callaway and Sant'Anna 2021) so that it can be
-passed directly to fetwfe()\code{or}etwfe()\verb{from the}fetwfe` package. In
+passed directly to \code{fetwfe()} or \code{etwfe()} from the \code{fetwfe} package. In
 particular, it
 \itemize{
 \item creates an \emph{absorbing‑state} treatment dummy that equals 1 from the

--- a/man/etwfeToFetwfeDf.Rd
+++ b/man/etwfeToFetwfeDf.Rd
@@ -59,7 +59,7 @@ Ready to pass straight to \code{fetwfe()} or \code{fetwfe::etwfe()}.
 \description{
 \code{etwfeToFetwfeDf()} reshapes and renames a panel dataset that is already
 formatted for \code{etwfe::etwfe()} (McDermott 2024) so that it can be
-passed directly to fetwfe()\code{or}etwfe()\verb{from the}fetwfe` package. In
+passed directly to \code{fetwfe()} or \code{etwfe()} from the \code{fetwfe} package. In
 particular, it
 \itemize{
 \item creates an \emph{absorbing‑state} treatment dummy that equals 1 from the


### PR DESCRIPTION
Resolves #115.

## Summary

Fixes 4 single-character roxygen typos surfaced by the 2026-05-19 periodic code review (Agent 3):

- `R/gen_data.R:74,267` — `#"` instead of `#'` on the `simulateData()` / `simulateDataCore()` docstring continuation lines.
- `R/convert_dfs.R:5,112` — a closing backtick after `fetwfe()` with no opening counterpart in the `attgtToFetwfeDf()` / `etwfeToFetwfeDf()` descriptions.

The `convert_dfs.R` fix is the load-bearing one. The rendered `.Rd` description previously read:

```
passed directly to fetwfe()\code{or}etwfe()\verb{from the}fetwfe` package.
```

It now renders cleanly as three inline-code spans:

```
passed directly to \code{fetwfe()} or \code{etwfe()} from the \code{fetwfe} package.
```

The `#"` fix is latent — roxygen2 happened to parse around it (the `.Rd` for `simulateData` and `simulateDataCore` is byte-identical before and after `devtools::document()`), but the typo is clearly visible in source, misleading to readers, and could trip stricter parsers in future.

Patch bump 1.9.25 → 1.9.26 with matching `NEWS.md` and `inst/CITATION` entries. Added "backtick" to `inst/WORDLIST` to keep `spell_check()` clean.

## Test plan

- [x] `devtools::document()` regenerates only `man/attgtToFetwfeDf.Rd` and `man/etwfeToFetwfeDf.Rd` (the `#"` fix produces no .Rd churn — confirmed)
- [x] `devtools::test()` — full suite green (1909 tests, only the two expected `augment` first-period-treated warnings)
- [x] `devtools::check(args = "--as-cran")` — `0 errors / 0 warnings / 0 notes` on `fetwfe 1.9.26`
- [x] `devtools::spell_check()` — clean
- [x] `urlchecker::url_check()` — all 19 URLs reachable
- [x] `git diff man/` shows only the two `convert_dfs`-derived .Rd description fixes
