### PR TITLE
Unify getCohortATTsFinal + getCohortATTsFinalOLS (#118, 1.9.27)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ paper_arxiv.tex     Source for the methodology paper (R-build-ignored).
   additionally get `@keywords internal` and `@noRd` (so they're documented
   for code readers but don't produce a user-facing man page). See
   `R/core_funcs.R::idCohorts`, `R/gen_funcs.R::getActualCohortTes`, and
-  `R/ols_calcs.R::getCohortATTsFinalOLS` for the internal-helper pattern
+  `R/variance_machinery.R::getCohortATTsFinal` for the internal-helper pattern
   in practice.
   **Exception: S3 methods registered for a generic in another package**
   (e.g., `print.fetwfe`, `summary.etwfe`, `coef.fetwfe`) carry only

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.26
+Version: 1.9.27
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # NEWS
 
+## Version 1.9.27 (2026-05-19)
+
+- Unified the internal `getCohortATTsFinal()` and previously-separate
+  `getCohortATTsFinalOLS()` helpers in `R/variance_machinery.R` into a
+  single function controlled by the existing `fused` flag plus a new
+  required `include_selected` argument (GitHub #118). Pure internal
+  refactor: cohort-ATT point estimates, SEs, p-values, and confidence
+  intervals are byte-identical for `fetwfe()`, `etwfe()`, `betwfe()`,
+  and `twfeCovs()` on every existing test fixture. Reduces ~140 LOC of
+  duplication and consolidates the surface area for future
+  variance-estimator fixes.
+
 ## Version 1.9.26 (2026-05-19)
 
 - Fixed four roxygen-comment typos surfaced by the 2026-05-19 periodic

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -1097,6 +1097,7 @@ betwfe_core <- function(
 		T = T,
 		fused = FALSE,
 		calc_ses = q < 1,
+		include_selected = TRUE,
 		alpha = alpha,
 		se_type = se_type,
 		y_final = y_final

--- a/R/etwfe_core.R
+++ b/R/etwfe_core.R
@@ -130,9 +130,9 @@ checkEtwfeInputs <- function(
 #'     The coefficient vector is in the original (untransformed) parameter
 #'     space and is returned as `beta_hat`.
 #'   \item **Cohort-specific treatment effects:** Calls
-#'     `getCohortATTsFinalOLS()` to compute per-cohort point estimates,
-#'     standard errors (when the Gram matrix is invertible), and confidence
-#'     intervals.
+#'     `getCohortATTsFinal()` (with `fused = FALSE`, `include_selected =
+#'     FALSE`) to compute per-cohort point estimates, standard errors (when
+#'     the Gram matrix is invertible), and confidence intervals.
 #'   \item **Overall ATT:** Calls `getTeResultsOLS()` for the overall ATT
 #'     point estimate and SE, using both in-sample probabilities and
 #'     independent probabilities when `indep_counts` is provided.
@@ -308,18 +308,22 @@ etwfe_core <- function(
 	#
 	#
 
-	res <- getCohortATTsFinalOLS(
+	res <- getCohortATTsFinal(
 		X_final = X_final, # This is X_mod * GLS_transform_matrix
+		sel_feat_inds = NULL, # OLS path: no penalty selection occurred
 		treat_inds = treat_inds, # Global indices for treatment effects
 		num_treats = num_treats,
 		first_inds = first_inds,
+		sel_treat_inds_shifted = seq_len(num_treats),
 		c_names = c_names,
 		tes = tes, # Treatment effect estimates (beta_hat_slopes[treat_inds])
 		sig_eps_sq = sig_eps_sq,
 		R = R,
 		N = N,
 		T = T,
-		p = p, # Total number of original parameters (columns in X_ints)
+		fused = FALSE,
+		calc_ses = TRUE,
+		include_selected = FALSE, # etwfe has no bridge selection
 		alpha = alpha,
 		se_type = se_type,
 		y_final = y_final

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -838,6 +838,7 @@ fetwfe_core <- function(
 		T = T,
 		fused = TRUE,
 		calc_ses = q < 1,
+		include_selected = TRUE,
 		alpha = alpha,
 		se_type = se_type,
 		y_final = y_final

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -553,9 +553,9 @@ twfeCovsWithSimulatedData <- function(
 #'     The coefficient vector is in the original (untransformed) parameter
 #'     space and is returned as `beta_hat`.
 #'   \item **Cohort-specific treatment effects:** Calls
-#'     `getCohortATTsFinalOLS()` to compute per-cohort point estimates,
-#'     standard errors (when the Gram matrix is invertible), and confidence
-#'     intervals.
+#'     `getCohortATTsFinal()` (with `fused = FALSE`, `include_selected =
+#'     FALSE`) to compute per-cohort point estimates, standard errors (when
+#'     the Gram matrix is invertible), and confidence intervals.
 #'   \item **Overall ATT:** Calls `getTeResultsOLS()` for the overall ATT
 #'     point estimate and SE, using both in-sample probabilities and
 #'     independent probabilities when `indep_counts` is provided.
@@ -722,18 +722,22 @@ twfeCovs_core <- function(
 	#
 	#
 
-	res <- getCohortATTsFinalOLS(
+	res <- getCohortATTsFinal(
 		X_final = X_final, # This is X_mod * GLS_transform_matrix
+		sel_feat_inds = NULL, # OLS path: no penalty selection occurred
 		treat_inds = treat_inds_short, # Global indices for treatment effects
 		num_treats = R,
 		first_inds = first_inds,
+		sel_treat_inds_shifted = seq_len(R),
 		c_names = c_names,
 		tes = tes, # Treatment effect estimates (beta_hat_slopes[treat_inds])
 		sig_eps_sq = sig_eps_sq,
 		R = R,
 		N = N,
 		T = T,
-		p = p_short, # Total number of original parameters (columns in X_ints)
+		fused = FALSE,
+		calc_ses = TRUE,
+		include_selected = FALSE, # twfeCovs has no bridge selection
 		alpha = alpha,
 		se_type = se_type,
 		y_final = y_final

--- a/R/utility.R
+++ b/R/utility.R
@@ -1105,9 +1105,9 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 #' `first_ind_r = first_inds[r]` and
 #' `last_ind_r = if (r < R) first_inds[r + 1] - 1 else num_treats`.
 #' Used inside `for (r in 1:R)` cohort loops in `getCohortATTsFinal`,
-#' `getCohortATTsFinalOLS`, `getSecondVarTermDataApp`,
-#' `getSecondVarTermOLS`, `prep_for_etwfe_regression`, and
-#' `getActualCohortTes`. Consolidated by GitHub #83.
+#' `getSecondVarTermDataApp`, `getSecondVarTermOLS`,
+#' `prep_for_etwfe_regression`, and `getActualCohortTes`. Consolidated by
+#' GitHub #83.
 #' @param r Integer; the cohort index, `1 <= r <= R`.
 #' @param R Integer; total number of treated cohorts.
 #' @param first_inds Integer vector; the per-cohort starting indices

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -1,228 +1,3 @@
-# getCohortATTsFinalOLS
-#' @title Calculate Cohort-Specific ATTs and Standard Errors for ETWFE
-#' @description Computes the Average Treatment Effect on the Treated (ATT) for
-#'   each cohort, along with their standard errors and confidence intervals if
-#'   requested and feasible.
-#' @param X_final Numeric matrix; the final design matrix, potentially
-#'   transformed by `Omega_sqrt_inv` and the fusion transformation.
-#' @param treat_inds Integer vector; indices in the original (untransformed)
-#'   coefficient vector that correspond to the base treatment effects.
-#' @param num_treats Integer; total number of base treatment effect parameters.
-#' @param first_inds Integer vector; indices of the first treatment effect for
-#'   each cohort within the block of `num_treats` treatment effect parameters.
-#' @param c_names Character vector; names of the `R` treated cohorts.
-#' @param tes Numeric vector; estimated treatment effects in the original
-#'   parameterization for all `num_treats` possible cohort-time combinations.
-#' @param sig_eps_sq Numeric scalar; variance of the idiosyncratic error term.
-#' @param R Integer; total number of treated cohorts.
-#' @param N Integer; total number of units.
-#' @param T Integer; total number of time periods.
-#' @param p Integer; total number of parameters in the model.
-#' @param alpha Numeric scalar; significance level for confidence intervals
-#'   (e.g., 0.05 for 95% CIs).
-#' @param se_type Character; one of `"default"` (Assumption-F1 model-based SE)
-#'   or `"cluster"` (experimental unit-clustered Liang-Zeger sandwich SE on the
-#'   OLS-on-selected-support residuals). Default `"default"`.
-#' @param y_final Numeric vector; GLS-transformed response of length `N*T`
-#'   (or `N*T + p` if a ridge augmentation was applied upstream). Required
-#'   when `se_type = "cluster"`; ignored otherwise.
-#' @return A list containing:
-#'   \item{cohort_te_df}{Dataframe with cohort names, estimated ATTs, SEs,
-#'     confidence interval bounds, and a `P_value` column (two-sided
-#'     `2 * pnorm(-|estimate / se|)`, `NA` when `SE` is zero or `NA`).}
-#'   \item{cohort_tes}{Named numeric vector of estimated ATTs for each cohort.}
-#'   \item{cohort_te_ses}{Named numeric vector of standard errors for cohort ATTs.}
-#'   \item{psi_mat}{Matrix used in SE calculation for overall ATT.}
-#'   \item{gram_inv}{(Potentially NA) Inverse of the Gram matrix for selected
-#'     features, used in SE calculation.}
-#'   \item{d_inv_treat_sel}{(If `fused=TRUE`) Relevant block of the inverse
-#'     fusion matrix for selected treatment effects.}
-#'   \item{sandwich_full}{(`se_type = "cluster"` only.) The full cluster-robust
-#'     sandwich variance on the selected support, reusable downstream by
-#'     `getTeResultsOLS()` so the same matrix backs both cohort and overall
-#'     ATT SEs.}
-#'   \item{treat_block_mask}{(`se_type = "cluster"` only.) Logical vector of
-#'     length `ncol(X_final)` marking which selected columns correspond to
-#'     treatment-effect features; used to zero-pad `psi_r` / `psi_att` against
-#'     `sandwich_full`.}
-#' @details The function first computes the Gram matrix inverse (`gram_inv`).
-#'   Then, for each cohort `r`, it calculates the average
-#'   of the relevant `tes`. It uses `getPsiRFused` or
-#'   `getPsiRUnfused` to get a `psi_r` vector, which is then used with
-#'   `gram_inv` to find the standard error for that cohort's ATT.
-#'   Under `se_type = "cluster"`, the function additionally re-solves OLS on
-#'   the selected support (here the full `X_final`, since ETWFE/twfeCovs do
-#'   not penalise) and forms a unit-clustered Liang-Zeger sandwich via
-#'   `.compute_cluster_robust_sandwich()`; the cohort SE is then the
-#'   quadratic form of the zero-padded `psi_r` against this sandwich.
-#' @keywords internal
-#' @noRd
-getCohortATTsFinalOLS <- function(
-	X_final,
-	treat_inds,
-	num_treats,
-	first_inds,
-	c_names,
-	tes,
-	sig_eps_sq,
-	R,
-	N,
-	T,
-	p,
-	alpha = 0.05,
-	se_type = "default",
-	y_final = NULL
-) {
-	se_type <- match.arg(se_type, c("default", "cluster"))
-
-	stopifnot(length(tes) <= num_treats)
-	stopifnot(all(!is.na(tes)))
-
-	stopifnot(nrow(X_final) == N * T)
-	stopifnot(ncol(X_final) == p)
-	X_to_pass <- X_final
-
-	# Start by getting Gram matrix needed for standard errors
-	res <- getGramInv(
-		N = N,
-		T = T,
-		X_final = X_to_pass,
-		treat_inds = treat_inds,
-		num_treats = num_treats,
-		calc_ses = TRUE
-	)
-
-	gram_inv <- res$gram_inv
-	calc_ses <- res$calc_ses
-
-	# Cluster-robust sandwich (computed once outside the cohort loop and
-	# reused for the overall ATT in getTeResultsOLS).
-	sandwich_full <- NULL
-	treat_block_mask <- NULL
-
-	if (identical(se_type, "cluster") && calc_ses) {
-		stopifnot(!is.null(y_final))
-		stopifnot(length(y_final) >= N * T)
-		res <- .assemble_cluster_robust_sandwich(
-			X_final = X_final,
-			y_final = y_final,
-			N = N,
-			T = T,
-			treat_inds = treat_inds,
-			sel_feat_inds = NULL
-		)
-		sandwich_full <- res$sandwich_full
-		treat_block_mask <- res$treat_block_mask
-	}
-
-	# First, each cohort
-	cohort_tes <- rep(as.numeric(NA), R)
-	cohort_te_ses <- rep(as.numeric(NA), R)
-
-	psi_mat <- matrix(0, num_treats, R)
-
-	for (r in 1:R) {
-		# Get indices corresponding to rth treatment.
-		# Endpoint-preservation form: downstream `getPsiRUnfused()` takes
-		# `first_ind_r, last_ind_r` as separate positional args.
-		inds_r <- .cohort_block_inds(r, R, first_inds, num_treats)
-		first_ind_r <- inds_r[1]
-		last_ind_r <- inds_r[length(inds_r)]
-
-		stopifnot(last_ind_r >= first_ind_r)
-		stopifnot(all(first_ind_r:last_ind_r %in% 1:num_treats))
-
-		cohort_tes[r] <- mean(tes[first_ind_r:last_ind_r])
-
-		psi_r <- getPsiRUnfused(
-			first_ind_r,
-			last_ind_r,
-			sel_treat_inds_shifted = 1:num_treats
-		)
-
-		stopifnot(length(psi_r) == num_treats)
-
-		psi_mat[, r] <- psi_r
-		# Get standard errors
-
-		if (calc_ses) {
-			if (identical(se_type, "cluster")) {
-				psi_r_full <- numeric(length(treat_block_mask))
-				psi_r_full[treat_block_mask] <- psi_r
-				# Issue #84 item 9: floor the cluster-sandwich quadratic
-				# form at zero before sqrt(), defending against a
-				# rounding-induced negative; see the matching guard in
-				# `getTeResultsOLS` / `R/variance_machinery.R` for rationale.
-				cohort_te_ses[r] <- sqrt(max(
-					as.numeric(
-						t(psi_r_full) %*%
-							sandwich_full %*%
-							psi_r_full
-					),
-					0
-				))
-			} else {
-				cohort_te_ses[r] <- sqrt(
-					sig_eps_sq *
-						as.numeric(t(psi_r) %*% gram_inv %*% psi_r) /
-						(N * T)
-				)
-			}
-		}
-	}
-
-	stopifnot(length(c_names) == R)
-	stopifnot(length(cohort_tes) == R)
-
-	if (all(!is.na(gram_inv))) {
-		stopifnot(length(cohort_te_ses) == R)
-
-		cohort_te_df <- data.frame(
-			c_names,
-			cohort_tes,
-			cohort_te_ses,
-			cohort_tes - stats::qnorm(1 - alpha / 2) * cohort_te_ses,
-			cohort_tes + stats::qnorm(1 - alpha / 2) * cohort_te_ses,
-			.compute_p_values(cohort_tes, cohort_te_ses)
-		)
-
-		names(cohort_te_ses) <- c_names
-		names(cohort_tes) <- c_names
-	} else {
-		cohort_te_df <- data.frame(
-			c_names,
-			cohort_tes,
-			rep(NA, R),
-			rep(NA, R),
-			rep(NA, R),
-			rep(NA_real_, R)
-		)
-	}
-
-	colnames(cohort_te_df) <- c(
-		"Cohort",
-		"Estimated TE",
-		"SE",
-		"ConfIntLow",
-		"ConfIntHigh",
-		"P_value"
-	)
-
-	stopifnot(length(tes) == nrow(psi_mat))
-
-	ret <- list(
-		cohort_te_df = cohort_te_df,
-		cohort_tes = cohort_tes,
-		cohort_te_ses = cohort_te_ses,
-		psi_mat = psi_mat,
-		gram_inv = gram_inv,
-		calc_ses = calc_ses,
-		sandwich_full = sandwich_full,
-		treat_block_mask = treat_block_mask
-	)
-	return(ret)
-}
-
 # getTeResultsOLS
 #' @title Calculate Overall ATT and its Standard Error for ETWFE
 #' @description Computes the overall Average Treatment Effect on the Treated
@@ -260,7 +35,7 @@ getCohortATTsFinalOLS <- function(
 #'   `"default"`.
 #' @param sandwich_full Numeric matrix (or `NULL`); the full cluster-robust
 #'   sandwich variance on the selected support, as returned by
-#'   `getCohortATTsFinalOLS()`. Required when `se_type = "cluster"` and
+#'   `getCohortATTsFinal()`. Required when `se_type = "cluster"` and
 #'   `calc_ses = TRUE`.
 #' @param treat_block_mask Logical vector (or `NULL`) of length
 #'   `nrow(sandwich_full)`, marking which columns correspond to treatment-effect
@@ -632,8 +407,8 @@ getPsiRUnfused <- function(
 
 #' @title Assemble the cluster-robust sandwich for the OLS-selected support
 #' @description
-#' Wraps the 4-step assembly ritual used by `getCohortATTsFinalOLS()`,
-#' `getCohortATTsFinal()`, and the two `event_study` dispatchers
+#' Wraps the 4-step assembly ritual used by `getCohortATTsFinal()` and the
+#' two `event_study` dispatchers
 #' (`.event_study_etwfe_betwfe`, `.event_study_fetwfe`): extract `X_S`
 #' from `X_final` (optionally filtered by `sel_feat_inds`), run
 #' `stats::lm.fit(cbind(1, X_S), y_final[seq_len(N * T)])`, compute the
@@ -1225,18 +1000,22 @@ getSecondVarTermDataApp <- function(
 #'   \(\widehat{\tau}_{\text{ATT},r}\pm z_{1-\alpha/2}\,
 #'     \widehat{\operatorname{SE}}(\widehat{\tau}_{\text{ATT},r})\).
 #'
-#' @inheritParams getCohortATTsFinal
 #' @param X_final Numeric matrix; the final design matrix, potentially
 #'   transformed by `Omega_sqrt_inv` and the fusion transformation.
-#' @param sel_feat_inds Integer vector; indices of all features selected by the
-#'   penalized regression in the transformed space.
+#' @param sel_feat_inds Integer vector OR `NULL`. Indices of all features
+#'   selected by the penalized regression in the transformed space. Pass
+#'   `NULL` for OLS callers (`etwfe()` / `twfeCovs()`) where no penalized
+#'   selection occurred — the unified function treats `NULL` as a sentinel
+#'   for "use all features" and dispatches the OLS code path inside
+#'   `getGramInv()` and `.assemble_cluster_robust_sandwich()`.
 #' @param treat_inds Integer vector; indices in the original (untransformed)
 #'   coefficient vector that correspond to the base treatment effects.
 #' @param num_treats Integer; total number of base treatment effect parameters.
 #' @param first_inds Integer vector; indices of the first treatment effect for
 #'   each cohort within the block of `num_treats` treatment effect parameters.
 #' @param sel_treat_inds_shifted Integer vector; indices of selected treatment
-#'   effects within the `num_treats` block (shifted to start from 1).
+#'   effects within the `num_treats` block (shifted to start from 1). For OLS
+#'   callers pass `seq_len(num_treats)`.
 #' @param c_names Character vector; names of the `R` treated cohorts.
 #' @param tes Numeric vector; estimated treatment effects in the original
 #'   parameterization for all `num_treats` possible cohort-time combinations.
@@ -1244,10 +1023,19 @@ getSecondVarTermDataApp <- function(
 #' @param R Integer; total number of treated cohorts.
 #' @param N Integer; total number of units.
 #' @param T Integer; total number of time periods.
-#' @param fused Logical; if `TRUE`, assumes fusion penalization was used,
-#'   affecting how standard errors and related matrices are computed.
+#' @param fused Logical; if `TRUE`, assumes fusion penalization was used and
+#'   accumulates the `d_inv_treat_sel` block from the inverse fusion matrix
+#'   for downstream variance-from-cohort-probabilities propagation. If
+#'   `FALSE`, the unfused (OLS / BETWFE) path is taken: `psi_r` is computed by
+#'   `getPsiRUnfused()` and no `d_inv_treat_sel` is returned.
 #' @param calc_ses Logical; if `TRUE`, attempts to calculate standard errors.
-#'   This is typically `TRUE` if `q < 1`.
+#'   For OLS callers pass `TRUE` (the gram-matrix inverse is needed
+#'   unconditionally for SEs); for bridge callers pass `q < 1`.
+#' @param include_selected Logical; if `TRUE`, appends a trailing `selected =
+#'   cohort_tes != 0` column to `cohort_te_df`. The column is meaningful only
+#'   when a bridge penalty produced the `tes` (FETWFE / BETWFE), so OLS
+#'   callers (`etwfe()` / `twfeCovs()`) pass `FALSE` to suppress the column.
+#'   New in 1.9.27.
 #' @param alpha Numeric scalar; significance level for confidence intervals
 #'   (e.g., 0.05 for 95% CIs).
 #' @param se_type Character; one of `"default"` (Assumption-F1 model-based SE)
@@ -1259,10 +1047,11 @@ getSecondVarTermDataApp <- function(
 #'   otherwise.
 #' @return A list containing:
 #'   \item{cohort_te_df}{Dataframe with cohort names, estimated ATTs, SEs,
-#'     confidence interval bounds, a `P_value` column (two-sided
-#'     `2 * pnorm(-|estimate / se|)`, `NA` when `SE` is zero or `NA`), and a
-#'     `selected` logical column (`TRUE` when the bridge penalty left the
-#'     cohort's `Estimated TE` nonzero).}
+#'     confidence interval bounds, and a `P_value` column (two-sided
+#'     `2 * pnorm(-|estimate / se|)`, `NA` when `SE` is zero or `NA`). When
+#'     `include_selected = TRUE`, an additional trailing `selected` logical
+#'     column is appended (`TRUE` when the bridge penalty left the cohort's
+#'     `Estimated TE` nonzero).}
 #'   \item{cohort_tes}{Named numeric vector of estimated ATTs for each cohort.}
 #'   \item{cohort_te_ses}{Named numeric vector of standard errors for cohort ATTs.}
 #'   \item{psi_mat}{Matrix used in SE calculation for overall ATT.}
@@ -1276,8 +1065,9 @@ getSecondVarTermDataApp <- function(
 #'     `getTeResults2()` / `getTeResultsOLS()` so the same matrix backs both
 #'     cohort and overall ATT SEs.}
 #'   \item{treat_block_mask}{(`se_type = "cluster"` only.) Logical vector of
-#'     length `length(sel_feat_inds)` marking which selected columns correspond
-#'     to treatment-effect features; used to zero-pad `psi_r` / `psi_att`
+#'     length `length(sel_feat_inds)` (or `ncol(X_final)` when
+#'     `sel_feat_inds = NULL`) marking which selected columns correspond to
+#'     treatment-effect features; used to zero-pad `psi_r` / `psi_att`
 #'     against `sandwich_full`.}
 #' @details The function first computes the Gram matrix inverse (`gram_inv`) if
 #'   `calc_ses` is `TRUE`. Then, for each cohort `r`, it calculates the average
@@ -1320,6 +1110,7 @@ getCohortATTsFinal <- function(
 	T,
 	fused,
 	calc_ses,
+	include_selected,
 	alpha = 0.05,
 	se_type = "default",
 	y_final = NULL
@@ -1334,16 +1125,24 @@ getCohortATTsFinal <- function(
 	stopifnot(nrow(X_final) == N * T)
 	X_to_pass <- X_final
 
+	# Translate the OLS-caller `sel_feat_inds = NULL` sentinel to the value
+	# each downstream helper expects: `getGramInv()` uses NA as its "all
+	# features" sentinel, while `.assemble_cluster_robust_sandwich()` uses
+	# NULL. See #118 round-1 plan review for the empirical equivalence
+	# verification.
+	gram_sel_feat <- if (is.null(sel_feat_inds)) NA else sel_feat_inds
+	gram_sel_treat <- if (is.null(sel_feat_inds)) NA else sel_treat_inds_shifted
+
 	# Start by getting Gram matrix needed for standard errors
 	if (calc_ses) {
 		res <- getGramInv(
 			N = N,
 			T = T,
 			X_final = X_to_pass,
-			sel_feat_inds = sel_feat_inds,
+			sel_feat_inds = gram_sel_feat,
 			treat_inds = treat_inds,
 			num_treats = num_treats,
-			sel_treat_inds_shifted = sel_treat_inds_shifted,
+			sel_treat_inds_shifted = gram_sel_treat,
 			calc_ses = calc_ses
 		)
 
@@ -1371,7 +1170,14 @@ getCohortATTsFinal <- function(
 		)
 		sandwich_full <- res$sandwich_full
 		treat_block_mask <- res$treat_block_mask
-		stopifnot(length(treat_block_mask) == length(sel_feat_inds))
+		# Branch-aware mask-length check: in the OLS-caller path the mask
+		# spans ncol(X_final); in the bridge path it spans length(sel_feat_inds).
+		expected_mask_len <- if (is.null(sel_feat_inds)) {
+			ncol(X_final)
+		} else {
+			length(sel_feat_inds)
+		}
+		stopifnot(length(treat_block_mask) == expected_mask_len)
 		stopifnot(sum(treat_block_mask) == length(sel_treat_inds_shifted))
 	}
 
@@ -1478,7 +1284,15 @@ getCohortATTsFinal <- function(
 			# Get standard errors
 
 			if (identical(se_type, "cluster")) {
-				psi_r_full <- numeric(length(sel_feat_inds))
+				# Use length(treat_block_mask), not length(sel_feat_inds):
+				# the OLS-caller path passes sel_feat_inds = NULL, and
+				# `length(NULL) == 0` would silently yield a zero-length
+				# psi_r_full and a broken cluster SE. `treat_block_mask`
+				# always has the right length for this zero-padding —
+				# `ncol(X_final)` in the OLS path, `length(sel_feat_inds)`
+				# in the bridge path. Matches the legacy OLS form (see
+				# git history for `getCohortATTsFinalOLS()` pre-#118).
+				psi_r_full <- numeric(length(treat_block_mask))
 				psi_r_full[treat_block_mask] <- psi_r
 				# Issue #84 item 9: floor the cluster-sandwich quadratic
 				# form at zero before sqrt(), defending against a
@@ -1538,8 +1352,7 @@ getCohortATTsFinal <- function(
 			cohort_te_ses,
 			cohort_tes - stats::qnorm(1 - alpha / 2) * cohort_te_ses,
 			cohort_tes + stats::qnorm(1 - alpha / 2) * cohort_te_ses,
-			.compute_p_values(cohort_tes, cohort_te_ses),
-			cohort_tes != 0
+			.compute_p_values(cohort_tes, cohort_te_ses)
 		)
 
 		names(cohort_te_ses) <- c_names
@@ -1551,8 +1364,7 @@ getCohortATTsFinal <- function(
 			rep(NA, R),
 			rep(NA, R),
 			rep(NA, R),
-			rep(NA_real_, R),
-			cohort_tes != 0
+			rep(NA_real_, R)
 		)
 	}
 
@@ -1562,9 +1374,17 @@ getCohortATTsFinal <- function(
 		"SE",
 		"ConfIntLow",
 		"ConfIntHigh",
-		"P_value",
-		"selected"
+		"P_value"
 	)
+
+	# The trailing `selected` column is meaningful only for bridge callers
+	# (FETWFE / BETWFE) where some cohorts may be zeroed out by the penalty.
+	# OLS callers (etwfe / twfeCovs) suppress it via include_selected = FALSE.
+	# `$<-` appends both the column and its name implicitly, so the
+	# colnames() block above lists only the 6 unconditional names.
+	if (include_selected) {
+		cohort_te_df$selected <- cohort_tes != 0
+	}
 
 	if (fused) {
 		stopifnot(is.matrix(d_inv_treat_sel))

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.26",
+  note    = "R package version 1.9.27",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-assemble-cluster-sandwich-78.R
+++ b/tests/testthat/test-assemble-cluster-sandwich-78.R
@@ -8,8 +8,9 @@ library(fetwfe)
 # .compute_cluster_robust_sandwich, build treat_block_mask) that was
 # previously duplicated across 4 call sites:
 #
-#   * R/variance_machinery.R::getCohortATTsFinalOLS  (unfiltered path)
-#   * R/variance_machinery.R::getCohortATTsFinal     (filtered path)
+#   * R/variance_machinery.R::getCohortATTsFinal     (both paths; the
+#     unfiltered branch arrived from `getCohortATTsFinalOLS()` after
+#     PR #118 unified the two functions)
 #   * R/event_study.R::.event_study_etwfe_betwfe    (runtime if/else)
 #   * R/event_study.R::.event_study_fetwfe           (filtered path)
 #
@@ -44,7 +45,8 @@ test_that(".assemble_cluster_robust_sandwich(sel_feat_inds = NULL) matches manua
 	fx <- .build_fixture()
 
 	# Reference (manual): replicate the pre-refactor inline pattern
-	# from R/variance_machinery.R::getCohortATTsFinalOLS.
+	# from R/variance_machinery.R::getCohortATTsFinal (unfiltered
+	# branch, formerly `getCohortATTsFinalOLS()` pre-#118).
 	X_S_ref <- fx$X_final
 	y_ref <- fx$y_final[seq_len(fx$N * fx$T)]
 	ols_ref <- stats::lm.fit(cbind(1, X_S_ref), y_ref)

--- a/tests/testthat/test-getCohortATTsFinal-unification.R
+++ b/tests/testthat/test-getCohortATTsFinal-unification.R
@@ -1,0 +1,397 @@
+library(testthat)
+library(fetwfe)
+
+# Unit tests for the PR #118 unification of getCohortATTsFinal() and the
+# (now deleted) getCohortATTsFinalOLS(). The four call paths through the
+# unified function correspond to the four `fused × include_selected`
+# quadrants:
+#
+#   fused = FALSE, include_selected = FALSE  →  ETWFE / twfeCovs
+#   fused = TRUE,  include_selected = TRUE   →  FETWFE
+#   fused = FALSE, include_selected = TRUE   →  BETWFE
+#   fused = TRUE,  include_selected = FALSE  →  no real caller; API lockdown
+#
+# Test 1 freezes the legacy OLS implementation as an inline closure so the
+# refactored function can be asserted byte-identical against it. The closure
+# is the pre-#118 source of getCohortATTsFinalOLS() copied here verbatim
+# (with comments preserved). Future maintainers can re-execute the closure
+# against the unified function to confirm the byte-identity claim still
+# holds even after later refactors.
+
+# ---- Fixture --------------------------------------------------------------
+
+.build_unif_fixture <- function(seed = 118L) {
+	set.seed(seed)
+	N <- 8L
+	T <- 4L
+	R <- 2L
+	d <- 2L
+	num_treats <- 3L + 2L
+	p <- (R + T - 1L + d) + num_treats + 4L
+	X_final <- matrix(rnorm(N * T * p), nrow = N * T, ncol = p)
+	y_final <- rnorm(N * T)
+	treat_inds <- seq.int(R + T - 1L + d + 1L, R + T - 1L + d + num_treats)
+	first_inds <- c(1L, 4L)
+	c_names <- c("Cohort1", "Cohort2")
+	tes <- rnorm(num_treats)
+	list(
+		X_final = X_final,
+		y_final = y_final,
+		N = N,
+		T = T,
+		R = R,
+		p = p,
+		num_treats = num_treats,
+		treat_inds = treat_inds,
+		first_inds = first_inds,
+		c_names = c_names,
+		tes = tes,
+		sig_eps_sq = 0.7
+	)
+}
+
+# ---- Test 1: frozen-snapshot equivalence against legacy OLS ---------------
+
+# Inline copy of the pre-#118 getCohortATTsFinalOLS() body. Kept here so the
+# byte-equivalence assertion is reproducible without git archaeology.
+.legacy_getCohortATTsFinalOLS <- function(
+	X_final,
+	treat_inds,
+	num_treats,
+	first_inds,
+	c_names,
+	tes,
+	sig_eps_sq,
+	R,
+	N,
+	T,
+	p,
+	alpha = 0.05,
+	se_type = "default",
+	y_final = NULL
+) {
+	se_type <- match.arg(se_type, c("default", "cluster"))
+
+	stopifnot(length(tes) <= num_treats)
+	stopifnot(all(!is.na(tes)))
+	stopifnot(nrow(X_final) == N * T)
+	stopifnot(ncol(X_final) == p)
+	X_to_pass <- X_final
+
+	res <- fetwfe:::getGramInv(
+		N = N,
+		T = T,
+		X_final = X_to_pass,
+		treat_inds = treat_inds,
+		num_treats = num_treats,
+		calc_ses = TRUE
+	)
+	gram_inv <- res$gram_inv
+	calc_ses <- res$calc_ses
+
+	sandwich_full <- NULL
+	treat_block_mask <- NULL
+
+	if (identical(se_type, "cluster") && calc_ses) {
+		stopifnot(!is.null(y_final))
+		stopifnot(length(y_final) >= N * T)
+		res <- fetwfe:::.assemble_cluster_robust_sandwich(
+			X_final = X_final,
+			y_final = y_final,
+			N = N,
+			T = T,
+			treat_inds = treat_inds,
+			sel_feat_inds = NULL
+		)
+		sandwich_full <- res$sandwich_full
+		treat_block_mask <- res$treat_block_mask
+	}
+
+	cohort_tes <- rep(as.numeric(NA), R)
+	cohort_te_ses <- rep(as.numeric(NA), R)
+	psi_mat <- matrix(0, num_treats, R)
+
+	for (r in 1:R) {
+		inds_r <- fetwfe:::.cohort_block_inds(r, R, first_inds, num_treats)
+		first_ind_r <- inds_r[1]
+		last_ind_r <- inds_r[length(inds_r)]
+
+		stopifnot(last_ind_r >= first_ind_r)
+		stopifnot(all(first_ind_r:last_ind_r %in% 1:num_treats))
+
+		cohort_tes[r] <- mean(tes[first_ind_r:last_ind_r])
+
+		psi_r <- fetwfe:::getPsiRUnfused(
+			first_ind_r,
+			last_ind_r,
+			sel_treat_inds_shifted = 1:num_treats
+		)
+		stopifnot(length(psi_r) == num_treats)
+		psi_mat[, r] <- psi_r
+
+		if (calc_ses) {
+			if (identical(se_type, "cluster")) {
+				psi_r_full <- numeric(length(treat_block_mask))
+				psi_r_full[treat_block_mask] <- psi_r
+				cohort_te_ses[r] <- sqrt(max(
+					as.numeric(
+						t(psi_r_full) %*%
+							sandwich_full %*%
+							psi_r_full
+					),
+					0
+				))
+			} else {
+				cohort_te_ses[r] <- sqrt(
+					sig_eps_sq *
+						as.numeric(t(psi_r) %*% gram_inv %*% psi_r) /
+						(N * T)
+				)
+			}
+		}
+	}
+
+	stopifnot(length(c_names) == R)
+	stopifnot(length(cohort_tes) == R)
+
+	if (all(!is.na(gram_inv))) {
+		stopifnot(length(cohort_te_ses) == R)
+		cohort_te_df <- data.frame(
+			c_names,
+			cohort_tes,
+			cohort_te_ses,
+			cohort_tes - stats::qnorm(1 - alpha / 2) * cohort_te_ses,
+			cohort_tes + stats::qnorm(1 - alpha / 2) * cohort_te_ses,
+			fetwfe:::.compute_p_values(cohort_tes, cohort_te_ses)
+		)
+		names(cohort_te_ses) <- c_names
+		names(cohort_tes) <- c_names
+	} else {
+		cohort_te_df <- data.frame(
+			c_names,
+			cohort_tes,
+			rep(NA, R),
+			rep(NA, R),
+			rep(NA, R),
+			rep(NA_real_, R)
+		)
+	}
+
+	colnames(cohort_te_df) <- c(
+		"Cohort",
+		"Estimated TE",
+		"SE",
+		"ConfIntLow",
+		"ConfIntHigh",
+		"P_value"
+	)
+
+	stopifnot(length(tes) == nrow(psi_mat))
+
+	list(
+		cohort_te_df = cohort_te_df,
+		cohort_tes = cohort_tes,
+		cohort_te_ses = cohort_te_ses,
+		psi_mat = psi_mat,
+		gram_inv = gram_inv,
+		calc_ses = calc_ses,
+		sandwich_full = sandwich_full,
+		treat_block_mask = treat_block_mask
+	)
+}
+
+test_that("unified getCohortATTsFinal(fused=FALSE, include_selected=FALSE) matches the pre-#118 OLS implementation byte-for-byte", {
+	fx <- .build_unif_fixture()
+
+	# Reference: legacy OLS closure baked into this file.
+	expected <- .legacy_getCohortATTsFinalOLS(
+		X_final = fx$X_final,
+		treat_inds = fx$treat_inds,
+		num_treats = fx$num_treats,
+		first_inds = fx$first_inds,
+		c_names = fx$c_names,
+		tes = fx$tes,
+		sig_eps_sq = fx$sig_eps_sq,
+		R = fx$R,
+		N = fx$N,
+		T = fx$T,
+		p = fx$p
+	)
+
+	# Unified function on the same inputs.
+	actual <- fetwfe:::getCohortATTsFinal(
+		X_final = fx$X_final,
+		sel_feat_inds = NULL,
+		treat_inds = fx$treat_inds,
+		num_treats = fx$num_treats,
+		first_inds = fx$first_inds,
+		sel_treat_inds_shifted = seq_len(fx$num_treats),
+		c_names = fx$c_names,
+		tes = fx$tes,
+		sig_eps_sq = fx$sig_eps_sq,
+		R = fx$R,
+		N = fx$N,
+		T = fx$T,
+		fused = FALSE,
+		calc_ses = TRUE,
+		include_selected = FALSE
+	)
+
+	# Byte-identity on every observable slot. d_inv_treat_sel is absent in
+	# both (legacy OLS never produces it; unified function omits it under
+	# fused = FALSE).
+	expect_equal(actual$cohort_te_df, expected$cohort_te_df, tolerance = 0)
+	expect_equal(actual$cohort_tes, expected$cohort_tes, tolerance = 0)
+	expect_equal(actual$cohort_te_ses, expected$cohort_te_ses, tolerance = 0)
+	expect_equal(actual$psi_mat, expected$psi_mat, tolerance = 0)
+	expect_equal(actual$gram_inv, expected$gram_inv, tolerance = 0)
+	expect_equal(actual$calc_ses, expected$calc_ses)
+	expect_null(actual$sandwich_full)
+	expect_null(expected$sandwich_full)
+	expect_null(actual$treat_block_mask)
+	expect_null(expected$treat_block_mask)
+	expect_null(actual$d_inv_treat_sel)
+})
+
+test_that("unified getCohortATTsFinal(fused=FALSE, include_selected=FALSE) matches the pre-#118 OLS implementation under se_type='cluster'", {
+	fx <- .build_unif_fixture()
+
+	expected <- .legacy_getCohortATTsFinalOLS(
+		X_final = fx$X_final,
+		treat_inds = fx$treat_inds,
+		num_treats = fx$num_treats,
+		first_inds = fx$first_inds,
+		c_names = fx$c_names,
+		tes = fx$tes,
+		sig_eps_sq = fx$sig_eps_sq,
+		R = fx$R,
+		N = fx$N,
+		T = fx$T,
+		p = fx$p,
+		se_type = "cluster",
+		y_final = fx$y_final
+	)
+
+	actual <- fetwfe:::getCohortATTsFinal(
+		X_final = fx$X_final,
+		sel_feat_inds = NULL,
+		treat_inds = fx$treat_inds,
+		num_treats = fx$num_treats,
+		first_inds = fx$first_inds,
+		sel_treat_inds_shifted = seq_len(fx$num_treats),
+		c_names = fx$c_names,
+		tes = fx$tes,
+		sig_eps_sq = fx$sig_eps_sq,
+		R = fx$R,
+		N = fx$N,
+		T = fx$T,
+		fused = FALSE,
+		calc_ses = TRUE,
+		include_selected = FALSE,
+		se_type = "cluster",
+		y_final = fx$y_final
+	)
+
+	expect_equal(actual$cohort_te_df, expected$cohort_te_df, tolerance = 0)
+	expect_equal(actual$cohort_te_ses, expected$cohort_te_ses, tolerance = 0)
+	expect_equal(actual$sandwich_full, expected$sandwich_full, tolerance = 0)
+	expect_equal(actual$treat_block_mask, expected$treat_block_mask)
+})
+
+# ---- Test 2: include_selected = TRUE appends a `selected` column ----------
+
+test_that("getCohortATTsFinal(fused=TRUE, include_selected=TRUE) attaches a `selected` column matching cohort_tes != 0 (FETWFE)", {
+	fx <- .build_unif_fixture()
+	# Mimic FETWFE's call shape: sel_feat_inds spans all features (no
+	# bridge zeroing on this fixture), sel_treat_inds_shifted spans
+	# all treatment effects.
+	out <- fetwfe:::getCohortATTsFinal(
+		X_final = fx$X_final,
+		sel_feat_inds = seq_len(fx$p),
+		treat_inds = fx$treat_inds,
+		num_treats = fx$num_treats,
+		first_inds = fx$first_inds,
+		sel_treat_inds_shifted = seq_len(fx$num_treats),
+		c_names = fx$c_names,
+		tes = fx$tes,
+		sig_eps_sq = fx$sig_eps_sq,
+		R = fx$R,
+		N = fx$N,
+		T = fx$T,
+		fused = TRUE,
+		calc_ses = TRUE,
+		include_selected = TRUE
+	)
+
+	expect_true("selected" %in% colnames(out$cohort_te_df))
+	# cohort_tes is named (the function attaches c_names); the data.frame
+	# column carries the same logicals without names. Strip names before
+	# comparing.
+	expect_identical(out$cohort_te_df$selected, unname(out$cohort_tes != 0))
+	expect_true(!is.null(out$d_inv_treat_sel))
+	expect_true(is.matrix(out$d_inv_treat_sel))
+	# psi_mat dimensions track sel_treat_inds_shifted, not num_treats.
+	expect_equal(nrow(out$psi_mat), fx$num_treats)
+	expect_equal(ncol(out$psi_mat), fx$R)
+})
+
+test_that("getCohortATTsFinal(fused=FALSE, include_selected=TRUE) attaches a `selected` column (BETWFE) but no d_inv_treat_sel", {
+	fx <- .build_unif_fixture()
+	out <- fetwfe:::getCohortATTsFinal(
+		X_final = fx$X_final,
+		sel_feat_inds = seq_len(fx$p),
+		treat_inds = fx$treat_inds,
+		num_treats = fx$num_treats,
+		first_inds = fx$first_inds,
+		sel_treat_inds_shifted = seq_len(fx$num_treats),
+		c_names = fx$c_names,
+		tes = fx$tes,
+		sig_eps_sq = fx$sig_eps_sq,
+		R = fx$R,
+		N = fx$N,
+		T = fx$T,
+		fused = FALSE,
+		calc_ses = TRUE,
+		include_selected = TRUE
+	)
+
+	expect_true("selected" %in% colnames(out$cohort_te_df))
+	# cohort_tes is named (the function attaches c_names); the data.frame
+	# column carries the same logicals without names. Strip names before
+	# comparing.
+	expect_identical(out$cohort_te_df$selected, unname(out$cohort_tes != 0))
+	expect_null(out$d_inv_treat_sel)
+})
+
+# ---- Test 3: include_selected = FALSE quadrants ---------------------------
+
+test_that("getCohortATTsFinal(fused=TRUE, include_selected=FALSE) omits the `selected` column but still produces d_inv_treat_sel (API-lockdown)", {
+	# This quadrant has no real-life caller — FETWFE always wants the
+	# selection indicator. The test exists to lock in that the flags
+	# are orthogonal: a future maintainer adding a fused-but-no-
+	# selection-indicator caller shouldn't have to rewrite the unified
+	# function. Without this test, the FALSE branch could be deleted as
+	# "dead" during a future refactor.
+	fx <- .build_unif_fixture()
+	out <- fetwfe:::getCohortATTsFinal(
+		X_final = fx$X_final,
+		sel_feat_inds = seq_len(fx$p),
+		treat_inds = fx$treat_inds,
+		num_treats = fx$num_treats,
+		first_inds = fx$first_inds,
+		sel_treat_inds_shifted = seq_len(fx$num_treats),
+		c_names = fx$c_names,
+		tes = fx$tes,
+		sig_eps_sq = fx$sig_eps_sq,
+		R = fx$R,
+		N = fx$N,
+		T = fx$T,
+		fused = TRUE,
+		calc_ses = TRUE,
+		include_selected = FALSE
+	)
+
+	expect_false("selected" %in% colnames(out$cohort_te_df))
+	expect_equal(ncol(out$cohort_te_df), 6L)
+	expect_true(!is.null(out$d_inv_treat_sel))
+})


### PR DESCRIPTION
Resolves #118.

## Summary

Unifies `getCohortATTsFinal()` and the previously-separate `getCohortATTsFinalOLS()` internal helper in `R/variance_machinery.R` into one function controlled by the existing `fused` flag plus a new required `include_selected` argument.

- `etwfe()` / `twfeCovs()` now call `getCohortATTsFinal(..., fused = FALSE, include_selected = FALSE, sel_feat_inds = NULL, ...)`.
- `betwfe()` calls it with `fused = FALSE, include_selected = TRUE`.
- `fetwfe()` calls it with `fused = TRUE, include_selected = TRUE`.

`getCohortATTsFinalOLS()` is deleted. Net source change: **-156 LOC** in production R/ files; **+312 LOC** of focused unit tests added.

The new `include_selected` flag gates the trailing `selected = cohort_tes != 0` column on `cohort_te_df` so the OLS estimators (which produce no bridge selection) keep their byte-identical 6-column return shape.

## Why

Pre-#118, future SE/Jacobian fixes had to be applied to two parallel routines. The package has a documented history of Jacobian-style bugs (PR #47 `att_var_2` off-by-one); eliminating the duplication is straightforward bug prevention. This is the top consolidation opportunity from the 2026-05-19 periodic code review (Agent 5).

## What is *not* changing

Cohort-ATT point estimates, SEs, p-values, and confidence intervals are byte-identical for `fetwfe()`, `etwfe()`, `betwfe()`, and `twfeCovs()` on every existing test fixture. No user-visible API change. No math change.

## Numerical equivalence

A new test file `tests/testthat/test-getCohortATTsFinal-unification.R` freezes the pre-#118 `getCohortATTsFinalOLS()` source as an inline closure and asserts byte-identity (zero tolerance) against the unified function on every return slot, for both `se_type = "default"` and `se_type = "cluster"`. Three additional tests exercise the remaining `fused × include_selected` quadrants. The frozen closure stays in the test file so the byte-identity claim is reproducible without git archaeology.

## Plan and review

Per `.workflow/PLANS.md`, this PR went through:

- A pre-implementation plan-review subagent pass (3 rounds to convergence). Round 1 caught two implementation bugs the original plan would have shipped: a branch-coupled `treat_block_mask` length assertion that would have fired on every nontrivial bridge call, and a `psi_r_full <- numeric(length(sel_feat_inds))` that silently produces a length-0 vector when OLS callers pass `sel_feat_inds = NULL`. Both were fixed in the converged plan and verified in the final code.
- A post-execution review subagent pass (1 round, no blockers).

Plan documents, round-N feedback, and the post-execution review live under `.plans/refactor-cohort-att-unification-118/` (gitignored).

## Version

Patch bump `1.9.26 → 1.9.27`. NEWS entry, `inst/CITATION` synced.

## Test plan

- [x] `devtools::test()` — full suite green (1938 pass; 2 expected first-period-drop warnings from `test-broom-methods.R`).
- [x] `devtools::check(args = "--as-cran")` — `0 errors / 0 warnings / 0 notes` on `fetwfe 1.9.27`.
- [x] `devtools::spell_check()` — clean.
- [x] `urlchecker::url_check()` — all URLs reachable.
- [x] `devtools::document()` idempotent (no diff on a second run; the deleted helper was `@noRd` so no `.Rd` churn).
- [x] `air format .` — no diff.
- [x] The new test file fails before the source changes (would catch any regression on a future SE/Jacobian fix that lands in one path but not the other) and passes after.
