### PR TITLE
Extract 3 shared helpers across estimator entry points (#119, 1.9.28)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.27
+Version: 1.9.28
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # NEWS
 
+## Version 1.9.28 (2026-05-19)
+
+- Consolidated three small shared helpers across the estimator cores into
+  `R/utility.R` (GitHub #119, follow-up to #118): the 4-way
+  `grpreg::gBridge` dispatch + lambda-path diagnostic block (formerly
+  duplicated across `R/fetwfe_core.R` and `R/betwfe_core.R`), the
+  treat-index / treat-interaction-index computation block (formerly
+  across all three `*_core.R` files), and the cohort-count rank-condition
+  check (formerly across `R/fetwfe.R` and `R/twfeCovs.R`). Pure internal
+  refactor with one minor user-visible change: `twfeCovs()`'s warning /
+  stop message under the cohort-count rank condition now uses the
+  stronger "the design matrix is rank-deficient" wording that `etwfe()`
+  always used, converging on the mathematically accurate form.
+
 ## Version 1.9.27 (2026-05-19)
 
 - Unified the internal `getCohortATTsFinal()` and previously-separate

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -886,23 +886,15 @@ betwfe_core <- function(
 	stopifnot(length(c_names) == R)
 
 	# Indices corresponding to base treatment effects
-	treat_inds <- getTreatInds(R = R, T = T, d = d, num_treats = num_treats)
-
-	if (d > 0) {
-		stopifnot(max(treat_inds) + 1 <= p)
-		stopifnot(
-			max(treat_inds) == R + T - 1 + d + R * d + (T - 1) * d + num_treats
-		)
-
-		treat_int_inds <- (max(treat_inds) + 1):p
-
-		stopifnot(length(treat_int_inds) == num_treats * d)
-	} else {
-		stopifnot(max(treat_inds) <= p)
-		stopifnot(max(treat_inds) == R + T - 1 + num_treats)
-
-		treat_int_inds <- c()
-	}
+	ti <- .compute_treat_inds(
+		R = R,
+		T = T,
+		d = d,
+		num_treats = num_treats,
+		p = p
+	)
+	treat_inds <- ti$treat_inds
+	treat_int_inds <- ti$treat_int_inds
 
 	# Handle edge case where no features are selected (model_size includes intercept)
 	if (lambda_star_model_size <= 1 && all(beta_hat[2:(p + 1)] == 0)) {

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -845,58 +845,23 @@ betwfe_core <- function(
 	#
 	#
 
-	# Estimate bridge regression
-	if (verbose) {
-		message("Estimating bridge regression...")
-		t0 <- Sys.time()
-	}
-
-	if (!is.na(lambda.max) & !is.na(lambda.min)) {
-		fit <- grpreg::gBridge(
-			X = X_final_scaled,
-			y = y_final,
-			gamma = q,
-			lambda.max = lambda.max,
-			lambda.min = lambda.min,
-			nlambda = nlambda
-		)
-	} else if (!is.na(lambda.max)) {
-		fit <- grpreg::gBridge(
-			X = X_final_scaled,
-			y = y_final,
-			gamma = q,
-			lambda.max = lambda.max,
-			nlambda = nlambda
-		)
-	} else if (!is.na(lambda.min)) {
-		fit <- grpreg::gBridge(
-			X = X_final_scaled,
-			y = y_final,
-			gamma = q,
-			lambda.min = lambda.min,
-			nlambda = nlambda
-		)
-	} else {
-		fit <- grpreg::gBridge(
-			X = X_final_scaled,
-			y = y_final,
-			gamma = q,
-			nlambda = nlambda
-		)
-	}
-
-	if (verbose) {
-		message("Done! Time for estimation:")
-		message(Sys.time() - t0)
-	}
-
-	# For diagnostics later, store largest and smallest lambda, as well as
-	# corresponding smallest and largest model sizes, to return.
-	lambda.max <- max(fit$lambda)
-	lambda.max_model_size <- sum(fit$beta[, ncol(fit$beta)] != 0)
-
-	lambda.min <- min(fit$lambda)
-	lambda.min_model_size <- sum(fit$beta[, 1] != 0)
+	# Estimate bridge regression. The 4-way gBridge dispatch + lambda-path
+	# diagnostics are shared with fetwfe_core() via .fit_bridge_with_lambda_path()
+	# in R/utility.R (issue #119).
+	bridge_fit <- .fit_bridge_with_lambda_path(
+		X_final_scaled = X_final_scaled,
+		y_final = y_final,
+		q = q,
+		lambda.max = lambda.max,
+		lambda.min = lambda.min,
+		nlambda = nlambda,
+		verbose = verbose
+	)
+	fit <- bridge_fit$fit
+	lambda.max <- bridge_fit$lambda.max
+	lambda.min <- bridge_fit$lambda.min
+	lambda.max_model_size <- bridge_fit$lambda.max_model_size
+	lambda.min_model_size <- bridge_fit$lambda.min_model_size
 
 	# Select a single set of fitted coefficients by using BIC to choose among
 	# the penalties that were fitted

--- a/R/etwfe_core.R
+++ b/R/etwfe_core.R
@@ -263,23 +263,15 @@ etwfe_core <- function(
 	stopifnot(all(!is.na(beta_hat_slopes)))
 
 	# Indices corresponding to base treatment effects
-	treat_inds <- getTreatInds(R = R, T = T, d = d, num_treats = num_treats)
-
-	if (d > 0) {
-		stopifnot(max(treat_inds) + 1 <= p)
-		stopifnot(
-			max(treat_inds) == R + T - 1 + d + R * d + (T - 1) * d + num_treats
-		)
-
-		treat_int_inds <- (max(treat_inds) + 1):p
-
-		stopifnot(length(treat_int_inds) == num_treats * d)
-	} else {
-		stopifnot(max(treat_inds) <= p)
-		stopifnot(max(treat_inds) == R + T - 1 + num_treats)
-
-		treat_int_inds <- c()
-	}
+	ti <- .compute_treat_inds(
+		R = R,
+		T = T,
+		d = d,
+		num_treats = num_treats,
+		p = p
+	)
+	treat_inds <- ti$treat_inds
+	treat_int_inds <- ti$treat_int_inds
 
 	stopifnot(length(treat_inds) == num_treats)
 

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -809,25 +809,12 @@ etwfe <- function(
 
 	rm(prep)
 
-	warning_flag <- FALSE
-
-	for (r in 1:(R + 1)) {
-		if (in_sample_counts[r] < d + 1) {
-			if (add_ridge) {
-				warning_flag <- TRUE
-			} else {
-				stop(
-					"At least one cohort contains fewer than d + 1 units. The design matrix is rank-deficient. Calculating standard errors will not be possible, and estimating treatment effects is only possible using add_ridge = TRUE."
-				)
-			}
-		}
-	}
-
-	if (warning_flag) {
-		warning(
-			"At least one cohort contains fewer than d + 1 units. The design matrix is rank-deficient. Calculating standard errors will not be possible, and estimating treatment effects is only possible using add_ridge = TRUE."
-		)
-	}
+	.check_cohort_rank_for_ols(
+		in_sample_counts = in_sample_counts,
+		R = R,
+		d = d,
+		add_ridge = add_ridge
+	)
 
 	res <- etwfe_core(
 		X_ints = X_ints,

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -594,23 +594,15 @@ fetwfe_core <- function(
 	stopifnot(length(c_names) == R)
 
 	# Indices corresponding to base treatment effects
-	treat_inds <- getTreatInds(R = R, T = T, d = d, num_treats = num_treats)
-
-	if (d > 0) {
-		stopifnot(max(treat_inds) + 1 <= p)
-		stopifnot(
-			max(treat_inds) == R + T - 1 + d + R * d + (T - 1) * d + num_treats
-		)
-
-		treat_int_inds <- (max(treat_inds) + 1):p
-
-		stopifnot(length(treat_int_inds) == num_treats * d)
-	} else {
-		stopifnot(max(treat_inds) <= p)
-		stopifnot(max(treat_inds) == R + T - 1 + num_treats)
-
-		treat_int_inds <- c()
-	}
+	ti <- .compute_treat_inds(
+		R = R,
+		T = T,
+		d = d,
+		num_treats = num_treats,
+		p = p
+	)
+	treat_inds <- ti$treat_inds
+	treat_int_inds <- ti$treat_int_inds
 
 	# Handle edge case where no features are selected (model_size includes intercept)
 	if (lambda_star_model_size <= 1 && all(theta_hat[2:(p + 1)] == 0)) {

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -553,58 +553,23 @@ fetwfe_core <- function(
 	#
 	#
 
-	# Estimate bridge regression
-	if (verbose) {
-		message("Estimating bridge regression...")
-		t0 <- Sys.time()
-	}
-
-	if (!is.na(lambda.max) & !is.na(lambda.min)) {
-		fit <- grpreg::gBridge(
-			X = X_final_scaled,
-			y = y_final,
-			gamma = q,
-			lambda.max = lambda.max,
-			lambda.min = lambda.min,
-			nlambda = nlambda
-		)
-	} else if (!is.na(lambda.max)) {
-		fit <- grpreg::gBridge(
-			X = X_final_scaled,
-			y = y_final,
-			gamma = q,
-			lambda.max = lambda.max,
-			nlambda = nlambda
-		)
-	} else if (!is.na(lambda.min)) {
-		fit <- grpreg::gBridge(
-			X = X_final_scaled,
-			y = y_final,
-			gamma = q,
-			lambda.min = lambda.min,
-			nlambda = nlambda
-		)
-	} else {
-		fit <- grpreg::gBridge(
-			X = X_final_scaled,
-			y = y_final,
-			gamma = q,
-			nlambda = nlambda
-		)
-	}
-
-	if (verbose) {
-		message("Done! Time for estimation:")
-		message(Sys.time() - t0)
-	}
-
-	# For diagnostics later, store largest and smallest lambda, as well as
-	# corresponding smallest and largest model sizes, to return.
-	lambda.max <- max(fit$lambda)
-	lambda.max_model_size <- sum(fit$beta[, ncol(fit$beta)] != 0)
-
-	lambda.min <- min(fit$lambda)
-	lambda.min_model_size <- sum(fit$beta[, 1] != 0)
+	# Estimate bridge regression. The 4-way gBridge dispatch + lambda-path
+	# diagnostics are shared with betwfe_core() via .fit_bridge_with_lambda_path()
+	# in R/utility.R (issue #119).
+	bridge_fit <- .fit_bridge_with_lambda_path(
+		X_final_scaled = X_final_scaled,
+		y_final = y_final,
+		q = q,
+		lambda.max = lambda.max,
+		lambda.min = lambda.min,
+		nlambda = nlambda,
+		verbose = verbose
+	)
+	fit <- bridge_fit$fit
+	lambda.max <- bridge_fit$lambda.max
+	lambda.min <- bridge_fit$lambda.min
+	lambda.max_model_size <- bridge_fit$lambda.max_model_size
+	lambda.min_model_size <- bridge_fit$lambda.min_model_size
 
 	# Select a single set of fitted coefficients by using BIC to choose among
 	# the penalties that were fitted

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -246,25 +246,12 @@ twfeCovs <- function(
 
 	rm(prep)
 
-	warning_flag <- FALSE
-
-	for (r in 1:(R + 1)) {
-		if (in_sample_counts[r] < d + 1) {
-			if (add_ridge) {
-				warning_flag <- TRUE
-			} else {
-				stop(
-					"At least one cohort contains fewer than d + 1 units. The design matrix may be rank-deficient. Calculating standard errors may not be possible, and estimating treatment effects may only be possible using add_ridge = TRUE."
-				)
-			}
-		}
-	}
-
-	if (warning_flag) {
-		warning(
-			"At least one cohort contains fewer than d + 1 units. The design matrix may be rank-deficient. Calculating standard errors may not be possible, and estimating treatment effects may only be possible using add_ridge = TRUE."
-		)
-	}
+	.check_cohort_rank_for_ols(
+		in_sample_counts = in_sample_counts,
+		R = R,
+		d = d,
+		add_ridge = add_ridge
+	)
 
 	res <- twfeCovs_core(
 		X_ints = X_ints,

--- a/R/utility.R
+++ b/R/utility.R
@@ -1478,3 +1478,50 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 		lambda.min_model_size = sum(fit$beta[, 1] != 0)
 	)
 }
+
+#' @title Compute treatment-effect and treatment-interaction indices
+#' @description Returns the integer index vectors `treat_inds` (base
+#'   treatment-effect columns) and `treat_int_inds` (covariate x
+#'   treatment interaction columns) for the ETWFE / FETWFE / BETWFE
+#'   design matrix.
+#'
+#'   The math is `treat_inds = getTreatInds(R, T, d, num_treats)` plus
+#'   the contract `max(treat_inds) == R + T - 1 + d + R*d + (T-1)*d +
+#'   num_treats` when `d > 0` (and `max(treat_inds) == R + T - 1 +
+#'   num_treats` when `d == 0`). The treatment-interaction block lives
+#'   immediately above `treat_inds` and runs `(max(treat_inds) + 1):p`
+#'   when `d > 0`; empty otherwise.
+#'
+#'   Extracted from a byte-identical 17-line block previously duplicated
+#'   across `R/etwfe_core.R`, `R/fetwfe_core.R`, and `R/betwfe_core.R`
+#'   (issue #119).
+#' @param R Integer; number of treated cohorts.
+#' @param T Integer; number of time periods.
+#' @param d Integer; number of (time-invariant) covariates.
+#' @param num_treats Integer; total number of base treatment-effect
+#'   parameters in the design.
+#' @param p Integer; total number of columns in the design matrix.
+#' @return A list with:
+#'   \item{treat_inds}{Integer vector of base treatment-effect column
+#'     indices, of length `num_treats`.}
+#'   \item{treat_int_inds}{Integer vector of treatment x covariate
+#'     interaction column indices, of length `num_treats * d` when
+#'     `d > 0` and empty when `d == 0`.}
+#' @keywords internal
+#' @noRd
+.compute_treat_inds <- function(R, T, d, num_treats, p) {
+	treat_inds <- getTreatInds(R = R, T = T, d = d, num_treats = num_treats)
+	if (d > 0) {
+		stopifnot(max(treat_inds) + 1 <= p)
+		stopifnot(
+			max(treat_inds) == R + T - 1 + d + R * d + (T - 1) * d + num_treats
+		)
+		treat_int_inds <- (max(treat_inds) + 1):p
+		stopifnot(length(treat_int_inds) == num_treats * d)
+	} else {
+		stopifnot(max(treat_inds) <= p)
+		stopifnot(max(treat_inds) == R + T - 1 + num_treats)
+		treat_int_inds <- c()
+	}
+	list(treat_inds = treat_inds, treat_int_inds = treat_int_inds)
+}

--- a/R/utility.R
+++ b/R/utility.R
@@ -1525,3 +1525,49 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 	}
 	list(treat_inds = treat_inds, treat_int_inds = treat_int_inds)
 }
+
+#' @title Check cohort-count rank condition for OLS estimators
+#' @description Iterates over `in_sample_counts` (length `R + 1`, indexed
+#'   from the never-treated cohort through the `R` treated cohorts) and
+#'   `stop()`s -- or `warning()`s when `add_ridge = TRUE` -- if any cohort
+#'   contains fewer than `d + 1` units. The condition forces rank
+#'   deficiency in the OLS-style estimators (etwfe / twfeCovs) because
+#'   each cohort's within-cohort regression needs at least `d + 1` units
+#'   to identify `d` covariates plus an intercept.
+#'
+#'   Extracted from `R/fetwfe.R` (the `etwfe()` wrapper) and
+#'   `R/twfeCovs.R` (the `twfeCovs()` wrapper). Pre-#119, these two sites
+#'   carried drifted wording ("is rank-deficient" vs "may be rank-
+#'   deficient"); this helper converges on the stronger etwfe wording --
+#'   the mathematically-accurate one.
+#' @param in_sample_counts Integer vector of length `R + 1`; the per-cohort
+#'   unit counts including the never-treated reference cohort.
+#' @param R Integer; number of treated cohorts.
+#' @param d Integer; number of (time-invariant) covariates.
+#' @param add_ridge Logical; if `TRUE`, the function `warning()`s rather
+#'   than `stop()`s when the condition fires, on the grounds that the
+#'   ridge fallback may still yield usable point estimates. If `FALSE`,
+#'   the function `stop()`s.
+#' @return `invisible(NULL)`. Called for side effects (warning / stop).
+#' @keywords internal
+#' @noRd
+.check_cohort_rank_for_ols <- function(in_sample_counts, R, d, add_ridge) {
+	warning_flag <- FALSE
+	for (r in 1:(R + 1)) {
+		if (in_sample_counts[r] < d + 1) {
+			if (add_ridge) {
+				warning_flag <- TRUE
+			} else {
+				stop(
+					"At least one cohort contains fewer than d + 1 units. The design matrix is rank-deficient. Calculating standard errors will not be possible, and estimating treatment effects is only possible using add_ridge = TRUE."
+				)
+			}
+		}
+	}
+	if (warning_flag) {
+		warning(
+			"At least one cohort contains fewer than d + 1 units. The design matrix is rank-deficient. Calculating standard errors will not be possible, and estimating treatment effects is only possible using add_ridge = TRUE."
+		)
+	}
+	invisible(NULL)
+}

--- a/R/utility.R
+++ b/R/utility.R
@@ -1381,3 +1381,100 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 		cohort_probs_overall = cohort_probs_overall
 	)
 }
+
+#' @title 4-way grpreg::gBridge dispatch with lambda-path diagnostics
+#' @description Dispatches `grpreg::gBridge()` based on which of `lambda.max`
+#'   and `lambda.min` were user-supplied (NA -> leave as default; non-NA ->
+#'   pass through). Returns the `fit` object plus the four lambda-path
+#'   diagnostic locals (`lambda.max`, `lambda.min`, `lambda.max_model_size`,
+#'   `lambda.min_model_size`) used by `fetwfe_core()` and `betwfe_core()`
+#'   downstream.
+#'
+#'   Extracted from a byte-identical 46-line block previously duplicated
+#'   across `R/fetwfe_core.R` and `R/betwfe_core.R`. The duplication was
+#'   a documented drift risk (issue #119); future fixes to the lambda
+#'   path now have a single landing site.
+#' @param X_final_scaled Numeric matrix; the design matrix (typically
+#'   GLS-then-fusion transformed and scaled).
+#' @param y_final Numeric vector; the GLS-transformed response.
+#' @param q Numeric scalar; the bridge-penalty exponent passed as `gamma` to
+#'   `gBridge()`.
+#' @param lambda.max Numeric scalar or `NA`; if non-NA, pass through to
+#'   `gBridge()` as the maximum lambda. If NA, `gBridge()` picks one.
+#' @param lambda.min Numeric scalar or `NA`; if non-NA, pass through to
+#'   `gBridge()`. If NA, `gBridge()` picks one.
+#' @param nlambda Integer; the lambda-grid length passed to `gBridge()`.
+#' @param verbose Logical; if `TRUE`, emit progress messages around the
+#'   `gBridge()` fit.
+#' @return A list containing:
+#'   \item{fit}{The `gBridge` fit object.}
+#'   \item{lambda.max}{`max(fit$lambda)` -- the realised maximum of the
+#'     lambda grid.}
+#'   \item{lambda.min}{`min(fit$lambda)` -- the realised minimum.}
+#'   \item{lambda.max_model_size}{Number of nonzero `fit$beta` columns at
+#'     `lambda.max` (largest lambda, smallest model).}
+#'   \item{lambda.min_model_size}{Number of nonzero `fit$beta` columns at
+#'     `lambda.min` (smallest lambda, largest model).}
+#' @keywords internal
+#' @noRd
+.fit_bridge_with_lambda_path <- function(
+	X_final_scaled,
+	y_final,
+	q,
+	lambda.max,
+	lambda.min,
+	nlambda,
+	verbose
+) {
+	if (verbose) {
+		message("Estimating bridge regression...")
+		t0 <- Sys.time()
+	}
+
+	if (!is.na(lambda.max) & !is.na(lambda.min)) {
+		fit <- grpreg::gBridge(
+			X = X_final_scaled,
+			y = y_final,
+			gamma = q,
+			lambda.max = lambda.max,
+			lambda.min = lambda.min,
+			nlambda = nlambda
+		)
+	} else if (!is.na(lambda.max)) {
+		fit <- grpreg::gBridge(
+			X = X_final_scaled,
+			y = y_final,
+			gamma = q,
+			lambda.max = lambda.max,
+			nlambda = nlambda
+		)
+	} else if (!is.na(lambda.min)) {
+		fit <- grpreg::gBridge(
+			X = X_final_scaled,
+			y = y_final,
+			gamma = q,
+			lambda.min = lambda.min,
+			nlambda = nlambda
+		)
+	} else {
+		fit <- grpreg::gBridge(
+			X = X_final_scaled,
+			y = y_final,
+			gamma = q,
+			nlambda = nlambda
+		)
+	}
+
+	if (verbose) {
+		message("Done! Time for estimation:")
+		message(Sys.time() - t0)
+	}
+
+	list(
+		fit = fit,
+		lambda.max = max(fit$lambda),
+		lambda.min = min(fit$lambda),
+		lambda.max_model_size = sum(fit$beta[, ncol(fit$beta)] != 0),
+		lambda.min_model_size = sum(fit$beta[, 1] != 0)
+	)
+}

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.27",
+  note    = "R package version 1.9.28",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-twfeCovs.R
+++ b/tests/testthat/test-twfeCovs.R
@@ -833,7 +833,7 @@ test_that("twfeCovs throws error when a cohort contains fewer than d + 1 units",
 			response = "y",
 			verbose = FALSE
 		),
-		"At least one cohort contains fewer than d \\+ 1 units\\. The design matrix may be rank-deficient\\. Calculating standard errors may not be possible, and estimating treatment effects may only be possible using add_ridge = TRUE\\."
+		"At least one cohort contains fewer than d \\+ 1 units\\. The design matrix is rank-deficient\\. Calculating standard errors will not be possible, and estimating treatment effects is only possible using add_ridge = TRUE\\."
 	)
 
 	expect_warning(
@@ -847,7 +847,7 @@ test_that("twfeCovs throws error when a cohort contains fewer than d + 1 units",
 			verbose = FALSE,
 			add_ridge = TRUE
 		),
-		"At least one cohort contains fewer than d \\+ 1 units\\. The design matrix may be rank-deficient\\. Calculating standard errors may not be possible, and estimating treatment effects may only be possible using add_ridge = TRUE\\."
+		"At least one cohort contains fewer than d \\+ 1 units\\. The design matrix is rank-deficient\\. Calculating standard errors will not be possible, and estimating treatment effects is only possible using add_ridge = TRUE\\."
 	)
 
 	res <- suppressWarnings(twfeCovs(


### PR DESCRIPTION
Resolves #119. Extracts three duplicated code blocks from the estimator entry points into internal helpers in `R/utility.R` — `.fit_bridge_with_lambda_path()` (the `grpreg::gBridge` dispatch + lambda-path diagnostics, was byte-identical across `fetwfe_core.R` / `betwfe_core.R`), `.compute_treat_inds()` (treat-index / treat-interaction-index computation, was across all three `*_core.R`), and `.check_cohort_rank_for_ols()` (the cohort-count rank-condition check, was across `fetwfe.R` / `twfeCovs.R`). This closes three copy-paste drift classes — future lambda-path / treat-index / cohort-rank fixes now land in one place.

Behavior-preserving except for one deliberate change: `twfeCovs()`'s cohort-rank warning/stop message converges onto the stronger "the design matrix is rank-deficient" wording that `etwfe()` already used (the two messages were `is` / `may be` drift; the `< d + 1` condition forces rank deficiency for both OLS estimators). The two matching `test-twfeCovs.R` assertions are updated, and `NEWS.md` flags the message change. The original issue's 4th extraction (`.build_catt_df()`) was already absorbed by #118's `getCohortATTsFinal()` unification, so it is dropped here.

3 extraction commits + a version-bump commit (1.9.27 → 1.9.28). `devtools::check(args = "--as-cran")` is clean — the lone NOTE is the environmental `future file timestamps` one, identical on `main`; full suite `FAIL 0`, test count unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
