### PR TITLE
Add test coverage for 4 paths from the 2026-05-19 review (#116, 1.9.29)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.28
+Version: 1.9.29
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # NEWS
 
+## Version 1.9.29 (2026-05-20)
+
+- Added regression-test coverage for four code paths flagged by the
+  2026-05-19 internal review: `processCovs` first-period covariate
+  broadcasting when unit IDs are not already in sorted order,
+  cluster-robust standard errors on auto-truncated (all-treated) panels
+  for `etwfe()` and `twfeCovs()`, `augment()` row-order invariance after
+  first-period-treated units are auto-dropped, and the
+  `getCohortATTsFinal()` `psi_mat` row-count contract across the OLS and
+  bridge calling conventions. Test-only; no user-facing behavior change.
+
 ## Version 1.9.28 (2026-05-19)
 
 - Consolidated three small shared helpers across the estimator cores into

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.28",
+  note    = "R package version 1.9.29",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-broom-methods.R
+++ b/tests/testthat/test-broom-methods.R
@@ -395,6 +395,78 @@ test_that("augment auto-trims first-period-treated units when present in data", 
 	expect_equal(aug$.fitted + aug$.resid, aug$y, tolerance = 1e-8)
 })
 
+# ------------------------------------------------------------------------------
+# Issue #116 Gap 3: the auto-trim test above asserts only the round-trip
+# identity .fitted + .resid == y, which holds by construction (.resid is
+# defined as y - .fitted) regardless of whether the rows are correctly
+# aligned. The row-order-invariance test at line ~286 is the genuine
+# alignment lock, but it runs on an UNTRIMMED panel. This test is the
+# intersection: it runs the permutation-invariance check on an auto-trimmed
+# fit, so a regression in augment's (unit, time) re-sort along the trim path
+# is caught. It deliberately does NOT assert the .fitted + .resid == y
+# tautology.
+# ------------------------------------------------------------------------------
+test_that("augment row order is invariant after auto-trim of first-period-treated units", {
+	setup <- .simulated_setup()
+	pdata <- setup$sim$pdata
+	# Mark one never-treated unit as treated at time 1, so the estimator and
+	# augment both auto-drop it (same pattern as the auto-trim test above).
+	never_treated_units <- unique(
+		pdata$unit[
+			vapply(
+				unique(pdata$unit),
+				function(u) {
+					all(pdata$treatment[pdata$unit == u] == 0)
+				},
+				logical(1)
+			)
+		]
+	)
+	skip_if(
+		length(never_treated_units) == 0,
+		"no never-treated units in fixture"
+	)
+	u <- never_treated_units[1]
+	# Treatment is absorbing: set it to 1 for all of this unit's periods so
+	# the estimator detects first-period treatment and drops the unit.
+	pdata$treatment[pdata$unit == u] <- 1L
+
+	# Fit on the modified panel; the trim warns, so suppress.
+	res <- suppressWarnings(fetwfe(
+		pdata = pdata,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		response = "y",
+		covs = c("cov1", "cov2"),
+		q = 0.5,
+		verbose = FALSE
+	))
+
+	# augment the original panel and a row-shuffled copy of the SAME panel;
+	# augment re-warns via its internal idCohorts(), so suppress both.
+	aug_orig <- suppressWarnings(broom::augment(res, data = pdata))
+	set.seed(116)
+	shuf_idx <- sample(nrow(pdata))
+	aug_shuf <- suppressWarnings(
+		broom::augment(res, data = pdata[shuf_idx, ])
+	)
+
+	# Match the shuffled output back to the original by (unit, time) and
+	# require .fitted values to be identical -- the genuine row-order lock.
+	key_o <- paste(aug_orig$unit, aug_orig$time, sep = "_")
+	key_s <- paste(aug_shuf$unit, aug_shuf$time, sep = "_")
+	m <- match(key_o, key_s)
+	expect_false(anyNA(m))
+	expect_equal(aug_orig$.fitted, aug_shuf$.fitted[m])
+	# The auto-dropped unit must be absent from both outputs, and the row
+	# count must equal the trimmed-fit dimensions.
+	expect_false(u %in% aug_orig$unit)
+	expect_false(u %in% aug_shuf$unit)
+	expect_equal(nrow(aug_orig), res$N * res$T)
+	expect_equal(nrow(aug_shuf), res$N * res$T)
+})
+
 test_that("augment.etwfe and augment.betwfe work with flat X_ints slot", {
 	setup <- .simulated_setup()
 	res_etwfe <- etwfeWithSimulatedData(setup$sim)

--- a/tests/testthat/test-etwfe.R
+++ b/tests/testthat/test-etwfe.R
@@ -6,6 +6,138 @@ library(fetwfe)
 # and sourced by testthat before this file runs (issue #91).
 
 # ------------------------------------------------------------------------------
+# Reference (pre-rewrite) processCovs implementation: the canonical
+# per-unit-loop version from git history, captured verbatim before issue #84
+# item 15. Kept here as a static frozen baseline shared by every processCovs
+# equivalence test in this file (#116); any future processCovs rewrite must
+# produce identical output on the fixtures those tests build.
+# ------------------------------------------------------------------------------
+processCovs_reference <- function(
+	df,
+	units,
+	unit_var,
+	times,
+	time_var,
+	covs,
+	resp_var,
+	T,
+	verbose = FALSE
+) {
+	for (s in units) {
+		df_s <- df[df[, unit_var] == s, ]
+		if (nrow(df_s) != T || !setequal(df_s[, time_var], times)) {
+			stop("balance violation")
+		}
+	}
+	if (length(covs) == 0) {
+		df <- df[, c(resp_var, time_var, unit_var)]
+		df <- df[
+			order(df[, unit_var], df[, time_var], decreasing = FALSE),
+		]
+		return(list(df = df, covs = covs))
+	}
+	d_orig <- length(covs)
+	covs_to_keep <- character()
+	first_time_val <- times[1]
+	for (cov_name in covs) {
+		is_valid_cov <- TRUE
+		for (s in units) {
+			val_first_period <- df[
+				(df[, unit_var] == s) & (df[, time_var] == first_time_val),
+				cov_name
+			]
+			if (length(val_first_period) != 1 || is.na(val_first_period)) {
+				is_valid_cov <- FALSE
+				break
+			}
+		}
+		if (is_valid_cov) {
+			covs_to_keep <- c(covs_to_keep, cov_name)
+		}
+	}
+	# Suppress reference warnings; equivalence with the live function
+	# requires matching warnings, which the live test below verifies
+	# separately.
+	suppressWarnings({
+		if (length(covs_to_keep) < d_orig && length(covs_to_keep) > 0) {
+			warning("ref na warning")
+		} else if (length(covs_to_keep) == 0 && d_orig > 0) {
+			warning("ref na warning")
+		}
+	})
+	covs <- covs_to_keep
+	d <- length(covs)
+	if (d > 0) {
+		covs_to_remove_const <- character()
+		df_temp_const_check <- df
+		for (s in units) {
+			first_period_rows_s_idx <- which(
+				(df_temp_const_check[, unit_var] == s) &
+					(df_temp_const_check[, time_var] == first_time_val)
+			)
+			stopifnot(length(first_period_rows_s_idx) == 1)
+			cov_values_s_first_period <- df_temp_const_check[
+				first_period_rows_s_idx,
+				covs,
+				drop = FALSE
+			]
+			for (t_idx in seq_along(times)) {
+				current_rows_s_t_idx <- which(
+					(df_temp_const_check[, unit_var] == s) &
+						(df_temp_const_check[, time_var] == times[t_idx])
+				)
+				stopifnot(length(current_rows_s_t_idx) == 1)
+				df_temp_const_check[
+					current_rows_s_t_idx,
+					covs
+				] <- cov_values_s_first_period
+			}
+		}
+		for (cov_name in covs) {
+			first_period_vals_for_cov <- sapply(units, function(u) {
+				df_temp_const_check[
+					(df_temp_const_check[, unit_var] == u) &
+						(df_temp_const_check[, time_var] == first_time_val),
+					cov_name
+				]
+			})
+			if (length(unique(first_period_vals_for_cov)) == 1) {
+				covs_to_remove_const <- c(covs_to_remove_const, cov_name)
+			}
+		}
+		covs <- covs[!(covs %in% covs_to_remove_const)]
+		suppressWarnings({
+			if (length(covs_to_remove_const) > 0 && length(covs) == 0) {
+				warning("ref const warning")
+			} else if (length(covs_to_remove_const) > 0) {
+				warning("ref const warning")
+			}
+		})
+		d <- length(covs)
+	}
+	df <- df[, c(resp_var, time_var, unit_var, covs), drop = FALSE]
+	if (d > 0) {
+		for (s in units) {
+			first_period_rows_s_idx <- which(
+				(df[, unit_var] == s) & (df[, time_var] == first_time_val)
+			)
+			covs_s_first_period_vals <- df[
+				first_period_rows_s_idx,
+				covs,
+				drop = FALSE
+			]
+			for (t_val in times) {
+				ind_s_t <- (df[, unit_var] == s) & (df[, time_var] == t_val)
+				stopifnot(sum(ind_s_t) == 1)
+				df[ind_s_t, covs] <- covs_s_first_period_vals
+			}
+		}
+	}
+	df <- df[order(df[, unit_var], df[, time_var], decreasing = FALSE), ]
+	list(df = df, covs = covs)
+}
+
+# ------------------------------------------------------------------------------
 # Test 1: Check that valid input produces a list with the expected output elements.
 # ------------------------------------------------------------------------------
 test_that("etwfe returns expected output structure with valid input", {
@@ -555,134 +687,9 @@ test_that("processCovs handles empty covariate vector correctly", {
 # & Discoveries`).
 # ------------------------------------------------------------------------------
 test_that("processCovs vectorized output matches reference implementation", {
-	# Reference (pre-rewrite) implementation: the canonical per-unit-loop
-	# version from git history, captured verbatim before issue #84 item 15.
-	# Kept here as a static frozen baseline; any future processCovs rewrite
-	# must produce identical output on this fixture.
-	processCovs_reference <- function(
-		df,
-		units,
-		unit_var,
-		times,
-		time_var,
-		covs,
-		resp_var,
-		T,
-		verbose = FALSE
-	) {
-		for (s in units) {
-			df_s <- df[df[, unit_var] == s, ]
-			if (nrow(df_s) != T || !setequal(df_s[, time_var], times)) {
-				stop("balance violation")
-			}
-		}
-		if (length(covs) == 0) {
-			df <- df[, c(resp_var, time_var, unit_var)]
-			df <- df[
-				order(df[, unit_var], df[, time_var], decreasing = FALSE),
-			]
-			return(list(df = df, covs = covs))
-		}
-		d_orig <- length(covs)
-		covs_to_keep <- character()
-		first_time_val <- times[1]
-		for (cov_name in covs) {
-			is_valid_cov <- TRUE
-			for (s in units) {
-				val_first_period <- df[
-					(df[, unit_var] == s) & (df[, time_var] == first_time_val),
-					cov_name
-				]
-				if (length(val_first_period) != 1 || is.na(val_first_period)) {
-					is_valid_cov <- FALSE
-					break
-				}
-			}
-			if (is_valid_cov) {
-				covs_to_keep <- c(covs_to_keep, cov_name)
-			}
-		}
-		# Suppress reference warnings; equivalence with the live function
-		# requires matching warnings, which the live test below verifies
-		# separately.
-		suppressWarnings({
-			if (length(covs_to_keep) < d_orig && length(covs_to_keep) > 0) {
-				warning("ref na warning")
-			} else if (length(covs_to_keep) == 0 && d_orig > 0) {
-				warning("ref na warning")
-			}
-		})
-		covs <- covs_to_keep
-		d <- length(covs)
-		if (d > 0) {
-			covs_to_remove_const <- character()
-			df_temp_const_check <- df
-			for (s in units) {
-				first_period_rows_s_idx <- which(
-					(df_temp_const_check[, unit_var] == s) &
-						(df_temp_const_check[, time_var] == first_time_val)
-				)
-				stopifnot(length(first_period_rows_s_idx) == 1)
-				cov_values_s_first_period <- df_temp_const_check[
-					first_period_rows_s_idx,
-					covs,
-					drop = FALSE
-				]
-				for (t_idx in seq_along(times)) {
-					current_rows_s_t_idx <- which(
-						(df_temp_const_check[, unit_var] == s) &
-							(df_temp_const_check[, time_var] == times[t_idx])
-					)
-					stopifnot(length(current_rows_s_t_idx) == 1)
-					df_temp_const_check[
-						current_rows_s_t_idx,
-						covs
-					] <- cov_values_s_first_period
-				}
-			}
-			for (cov_name in covs) {
-				first_period_vals_for_cov <- sapply(units, function(u) {
-					df_temp_const_check[
-						(df_temp_const_check[, unit_var] == u) &
-							(df_temp_const_check[, time_var] == first_time_val),
-						cov_name
-					]
-				})
-				if (length(unique(first_period_vals_for_cov)) == 1) {
-					covs_to_remove_const <- c(covs_to_remove_const, cov_name)
-				}
-			}
-			covs <- covs[!(covs %in% covs_to_remove_const)]
-			suppressWarnings({
-				if (length(covs_to_remove_const) > 0 && length(covs) == 0) {
-					warning("ref const warning")
-				} else if (length(covs_to_remove_const) > 0) {
-					warning("ref const warning")
-				}
-			})
-			d <- length(covs)
-		}
-		df <- df[, c(resp_var, time_var, unit_var, covs), drop = FALSE]
-		if (d > 0) {
-			for (s in units) {
-				first_period_rows_s_idx <- which(
-					(df[, unit_var] == s) & (df[, time_var] == first_time_val)
-				)
-				covs_s_first_period_vals <- df[
-					first_period_rows_s_idx,
-					covs,
-					drop = FALSE
-				]
-				for (t_val in times) {
-					ind_s_t <- (df[, unit_var] == s) & (df[, time_var] == t_val)
-					stopifnot(sum(ind_s_t) == 1)
-					df[ind_s_t, covs] <- covs_s_first_period_vals
-				}
-			}
-		}
-		df <- df[order(df[, unit_var], df[, time_var], decreasing = FALSE), ]
-		list(df = df, covs = covs)
-	}
+	# Reference implementation processCovs_reference is defined at file scope
+	# (top of this file) and shared with the non-lex-sortable-ID equivalence
+	# test below (#116).
 
 	# Fixture: small panel where the time-invariant collapse + the final
 	# row sort both matter for downstream alignment.
@@ -719,6 +726,80 @@ test_that("processCovs vectorized output matches reference implementation", {
 	rownames(ref$df) <- NULL
 	expect_equal(live$df, ref$df, tolerance = 1e-10)
 	expect_equal(live$covs, ref$covs)
+})
+
+# ------------------------------------------------------------------------------
+# Issue #116 Gap 1: the equivalence test above uses generate_panel_data(),
+# whose unit IDs are sprintf("unit%02d", ...) -- strictly lexically sortable,
+# so caller insertion order coincides with (unit, time) sort order. A
+# regression that re-sorted processCovs()'s internal first-period frame back
+# to the caller's insertion order would corrupt the first-period covariate
+# broadcast, yet stay invisible on a lex-sortable fixture. This test rebuilds
+# the equivalence check on a hand-crafted panel whose unit IDs are NOT in
+# sorted order on insertion, so a re-sort regression changes cell values.
+# ------------------------------------------------------------------------------
+test_that("processCovs vectorized output matches reference with non-lex-sortable unit IDs", {
+	# Insertion order: Alpha, delta, Bravo, charlie.
+	# Lexical order:   Alpha, Bravo, charlie, delta  (differs -> a re-sort
+	# regression is observable). processCovs() takes no treatment argument and
+	# never references cohorts, so a balanced unit/time/covariate/y panel is
+	# sufficient.
+	unit_order <- c("Alpha", "delta", "Bravo", "charlie")
+	T_n <- 4L
+	times_vals <- seq_len(T_n)
+	# cov1: first-period value differs across units (10/20/30/40) so a
+	# misaligned broadcast changes cell values; the within-unit value also
+	# varies over time so processCovs()'s first-period collapse is exercised.
+	# The per-unit-distinct first-period values also keep cov1 from being
+	# dropped by the constant-across-units column check.
+	first_vals <- c(Alpha = 10, delta = 20, Bravo = 30, charlie = 40)
+	df_nonlex <- do.call(
+		rbind,
+		lapply(unit_order, function(u) {
+			data.frame(
+				time = as.integer(times_vals),
+				unit = as.character(u),
+				cov1 = first_vals[[u]] + times_vals,
+				y = as.numeric(first_vals[[u]] * 100 + times_vals),
+				stringsAsFactors = FALSE
+			)
+		})
+	)
+	# Caller order: the units vector reflects insertion order, not sort order.
+	units <- unit_order
+	times <- sort(unique(df_nonlex$time))
+
+	live <- processCovs(
+		df = df_nonlex,
+		units = units,
+		unit_var = "unit",
+		times = times,
+		time_var = "time",
+		covs = "cov1",
+		resp_var = "y",
+		T = T_n,
+		verbose = FALSE
+	)
+	ref <- processCovs_reference(
+		df = df_nonlex,
+		units = units,
+		unit_var = "unit",
+		times = times,
+		time_var = "time",
+		covs = "cov1",
+		resp_var = "y",
+		T = T_n,
+		verbose = FALSE
+	)
+
+	# Row order, column order, and every cell value must agree.
+	rownames(live$df) <- NULL
+	rownames(ref$df) <- NULL
+	expect_equal(live$df, ref$df, tolerance = 1e-10)
+	expect_equal(live$covs, ref$covs)
+	# cov1 must survive the constant-across-units drop (first-period values
+	# 10/20/30/40 are distinct), otherwise the broadcast path is not exercised.
+	expect_equal(live$covs, "cov1")
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-etwfe.R
+++ b/tests/testthat/test-etwfe.R
@@ -1212,6 +1212,38 @@ test_that("etwfe auto-truncates a panel with no never-treated units (default)", 
 })
 
 # ------------------------------------------------------------------------------
+# Issue #116 Gap 2: se_type = "cluster" and the auto-truncation of an
+# all-treated panel (allow_no_never_treated) are each tested in isolation, but
+# never together. This exercises the interaction end-to-end: a cluster SE
+# computed on an auto-truncated panel must still be finite and strictly
+# positive. The > 0 assertion is load-bearing -- on an all-treated panel the
+# bridge estimators select every coefficient out and return att_se = 0
+# exactly, which a finiteness-only check would pass vacuously.
+# ------------------------------------------------------------------------------
+test_that("etwfe cluster SE is finite and positive on an auto-truncated panel", {
+	df_bad <- generate_bad_panel_data(N = 200, T = 10, seed = 123)
+
+	expect_warning(
+		res <- etwfe(
+			pdata = df_bad,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			se_type = "cluster",
+			allow_no_never_treated = TRUE,
+			verbose = FALSE
+		),
+		"auto-truncated"
+	)
+	expect_s3_class(res, "etwfe")
+	expect_true(is.finite(res$att_se))
+	expect_false(is.na(res$att_se))
+	expect_gt(res$att_se, 0)
+})
+
+# ------------------------------------------------------------------------------
 # Test: etwfe errors cleanly when truncation would yield < 2 retained cohorts
 # ------------------------------------------------------------------------------
 test_that("etwfe errors cleanly when no-never-treated truncation would yield < 2 cohorts", {

--- a/tests/testthat/test-getCohortATTsFinal-unification.R
+++ b/tests/testthat/test-getCohortATTsFinal-unification.R
@@ -395,3 +395,75 @@ test_that("getCohortATTsFinal(fused=TRUE, include_selected=FALSE) omits the `sel
 	expect_equal(ncol(out$cohort_te_df), 6L)
 	expect_true(!is.null(out$d_inv_treat_sel))
 })
+
+# ---- Test 4: psi_mat row-count contract across calling conventions --------
+
+# Issue #116 Gap 4: getCohortATTsFinal() builds psi_mat with one row per
+# entry of sel_treat_inds_shifted. Under the OLS (ETWFE / twfeCovs)
+# convention the caller passes seq_len(num_treats), so nrow(psi_mat) ==
+# num_treats; under the bridge (FETWFE / BETWFE) convention with PARTIAL
+# selection it passes a strict subset, so nrow(psi_mat) < num_treats. The
+# internal stopifnot()s only bound nrow(psi_mat) <= num_treats -- the
+# partial-selection row count is otherwise unguarded, so a silent swap of
+# the two conventions would go uncaught. This test pins both shapes.
+test_that("getCohortATTsFinal psi_mat row count tracks the calling convention (OLS vs bridge)", {
+	fx <- .build_unif_fixture()
+
+	# --- OLS convention: full sel_treat_inds_shifted, sel_feat_inds = NULL.
+	# nrow(psi_mat) must equal num_treats. (Cheap insurance: the fused = TRUE
+	# block above already covers the full-set case; the bridge-convention
+	# assertion below is the genuinely new coverage.)
+	out_ols <- fetwfe:::getCohortATTsFinal(
+		X_final = fx$X_final,
+		sel_feat_inds = NULL,
+		treat_inds = fx$treat_inds,
+		num_treats = fx$num_treats,
+		first_inds = fx$first_inds,
+		sel_treat_inds_shifted = seq_len(fx$num_treats),
+		c_names = fx$c_names,
+		tes = fx$tes,
+		sig_eps_sq = fx$sig_eps_sq,
+		R = fx$R,
+		N = fx$N,
+		T = fx$T,
+		fused = FALSE,
+		calc_ses = TRUE,
+		include_selected = FALSE
+	)
+	expect_equal(nrow(out_ols$psi_mat), fx$num_treats)
+	expect_equal(ncol(out_ols$psi_mat), fx$R)
+
+	# --- Bridge convention: strict-subset sel_treat_inds_shifted.
+	# getGramInv() enforces sum(sel_feat_inds %in% treat_inds) ==
+	# length(sel_treat_inds_shifted), so sel_feat_inds and
+	# sel_treat_inds_shifted must be co-derived from the SAME selection (as
+	# the real FETWFE caller in R/fetwfe_core.R is). Build sel_feat by
+	# keeping every non-treatment feature plus only the treatment columns
+	# named by the subset.
+	sel_subset <- c(1L, 3L, 5L) # strict subset, length 3 < num_treats (5)
+	non_treat_inds <- setdiff(seq_len(fx$p), fx$treat_inds)
+	sel_feat <- sort(c(non_treat_inds, fx$treat_inds[sel_subset]))
+
+	out_bridge <- fetwfe:::getCohortATTsFinal(
+		X_final = fx$X_final,
+		sel_feat_inds = sel_feat,
+		treat_inds = fx$treat_inds,
+		num_treats = fx$num_treats,
+		first_inds = fx$first_inds,
+		sel_treat_inds_shifted = sel_subset,
+		c_names = fx$c_names,
+		tes = fx$tes,
+		sig_eps_sq = fx$sig_eps_sq,
+		R = fx$R,
+		N = fx$N,
+		T = fx$T,
+		fused = TRUE,
+		calc_ses = TRUE,
+		include_selected = TRUE
+	)
+	# Under partial bridge selection nrow(psi_mat) tracks the subset length,
+	# strictly below num_treats -- the contract a convention swap would break.
+	expect_equal(nrow(out_bridge$psi_mat), length(sel_subset))
+	expect_lt(nrow(out_bridge$psi_mat), fx$num_treats)
+	expect_equal(ncol(out_bridge$psi_mat), fx$R)
+})

--- a/tests/testthat/test-twfeCovs.R
+++ b/tests/testthat/test-twfeCovs.R
@@ -915,6 +915,39 @@ test_that("twfeCovs auto-truncates a panel with no never-treated units (default)
 })
 
 # ------------------------------------------------------------------------------
+# Issue #116 Gap 2: se_type = "cluster" and the auto-truncation of an
+# all-treated panel (allow_no_never_treated) are each tested in isolation, but
+# never together. This exercises the interaction end-to-end: a cluster SE
+# computed on an auto-truncated panel must still be finite and strictly
+# positive. The > 0 assertion is load-bearing -- on an all-treated panel the
+# bridge estimators select every coefficient out and return att_se = 0
+# exactly, which a finiteness-only check would pass vacuously. Parallel to the
+# etwfe Gap 2 test in test-etwfe.R.
+# ------------------------------------------------------------------------------
+test_that("twfeCovs cluster SE is finite and positive on an auto-truncated panel", {
+	df_bad <- generate_bad_panel_data(N = 200, T = 10, seed = 123)
+
+	expect_warning(
+		res <- twfeCovs(
+			pdata = df_bad,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			se_type = "cluster",
+			allow_no_never_treated = TRUE,
+			verbose = FALSE
+		),
+		"auto-truncated"
+	)
+	expect_s3_class(res, "twfeCovs")
+	expect_true(is.finite(res$att_se))
+	expect_false(is.na(res$att_se))
+	expect_gt(res$att_se, 0)
+})
+
+# ------------------------------------------------------------------------------
 # Test: twfeCovs errors cleanly when truncation would yield < 2 retained cohorts
 # ------------------------------------------------------------------------------
 test_that("twfeCovs errors cleanly when no-never-treated truncation would yield < 2 cohorts", {


### PR DESCRIPTION
Resolves #116. Adds four `test_that` blocks closing untested-path gaps flagged by the 2026-05-19 internal review — test-only, no `R/` change:

- **`processCovs` broadcast alignment** — a second equivalence test with non-lexically-sortable unit IDs, catching a first-period-frame re-sort regression the existing lex-sortable-ID fixture cannot see.
- **Cluster SE on auto-truncated panels** — an end-to-end `se_type = "cluster"` × `allow_no_never_treated` test for `etwfe()` and `twfeCovs()`, asserting `att_se` is finite and `> 0`.
- **`augment()` row alignment after auto-trim** — a row-order-invariance test on an auto-trimmed fit (a permutation check — not the `.fitted + .resid == y` round-trip, which holds by construction).
- **`psi_mat` shape contract** — a direct `getCohortATTsFinal()` test pinning the `num_treats`-row (OLS) vs `length(selected)`-row (bridge) shape difference.

Each test was verified non-vacuous — it fails if the regression it guards against is introduced. Two of the issue's originally-described tests were corrected during scoping: the proposed `fetwfe` cluster test is degenerate (an all-treated panel selects out to `att_se = 0`), and the proposed `etwfe`/`betwfe` `att_se`-agreement test is unsound (BETWFE computes no SE at `q = 1`, and the bridge penalty always shrinks for `q < 1`) — hence the `etwfe`/`twfeCovs` retarget and the shape-test rescope.

5 commits, one per gap plus the version bump (1.9.28 → 1.9.29). `devtools::test()` goes 1938 → 1962 (`FAIL 0`); `devtools::check(args = "--as-cran")` is clean (the lone NOTE is the environmental `future file timestamps` one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
