### PR TITLE
Doc-and-cleanup sweep from the 2026-05-19 review (#117, 1.9.30)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.29
+Version: 1.9.30
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # NEWS
 
+## Version 1.9.30 (2026-05-20)
+
+- Documentation and cleanup sweep from the 2026-05-19 internal review:
+  documented the `cohort_times` slot in the `getTes()` return value;
+  documented the `se_type` argument in the four internal `*_core`
+  functions; extended the documentation-slot-parity test to cover
+  `getTes()`, `genCoefs()`, and `simulateData()`; corrected a misleading
+  factor-encoding comment in `processFactors()`; removed a redundant
+  cohort-count assertion in `prep_for_etwfe_core()`; and fixed two stale function
+  names in `cran-comments.md`. Documentation and cleanup only; no
+  user-facing behavior change.
+
 ## Version 1.9.29 (2026-05-20)
 
 - Added regression-test coverage for four code paths flagged by the

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -663,6 +663,11 @@ betwfeWithSimulatedData <- function(
 #'   95% CIs). Default is 0.05.
 #' @param add_ridge (Optional) Logical; if `TRUE`, adds a small L2 penalty to
 #'   the coefficients to stabilize estimation. Default is `FALSE`.
+#' @param se_type Character; the standard-error type, one of `"default"` (the
+#'   package's Assumption-F1-based standard error from the paper) or `"cluster"`
+#'   (an experimental unit-clustered Liang-Zeger sandwich SE on the
+#'   bridge-selected support). See the exported wrapper `betwfe()` for details.
+#'   Default is `"default"`.
 #'
 #' @details
 #' The function executes the following main steps:

--- a/R/core_funcs.R
+++ b/R/core_funcs.R
@@ -302,7 +302,6 @@ prep_for_etwfe_core <- function(
 	rm(res)
 
 	R <- length(in_sample_counts) - 1
-	stopifnot(R >= 1)
 	stopifnot(R <= T - 1)
 	if (R < 2) {
 		stop(

--- a/R/design_matrix.R
+++ b/R/design_matrix.R
@@ -46,7 +46,9 @@ processFactors <- function(pdata, covs) {
 	for (v in covs) {
 		if (is.factor(pdata[[v]])) {
 			# Create dummy variables from the factor.
-			# The model.matrix() call produces an intercept and dummies; we drop the intercept
+			# The `~ x - 1` formula suppresses the intercept, so model.matrix()
+			# produces one dummy column per factor level and no intercept; we
+			# drop the first dummy below to serve as the baseline category.
 			dummies <- stats::model.matrix(~ pdata[[v]] - 1)
 			# If there is more than one level, drop the first column to use it as baseline.
 			if (ncol(dummies) > 1) {

--- a/R/etwfe_core.R
+++ b/R/etwfe_core.R
@@ -106,6 +106,11 @@ checkEtwfeInputs <- function(
 #'   95% CIs). Default is 0.05.
 #' @param add_ridge (Optional) Logical; if `TRUE`, adds a small L2 penalty to
 #'   the untransformed coefficients to stabilize estimation. Default is `FALSE`.
+#' @param se_type Character; the standard-error type, one of `"default"` (the
+#'   package's Assumption-F1-based standard error from the paper) or `"cluster"`
+#'   (an experimental unit-clustered Liang-Zeger sandwich SE on the
+#'   OLS-selected support). See the exported wrapper `etwfe()` for details.
+#'   Default is `"default"`.
 #'
 #' @details
 #' The function executes the following main steps:

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -340,6 +340,11 @@ getBetaBIC <- function(fit, N, T, p, X_mod, y, scale_center, scale_scale) {
 #'   95% CIs). Default is 0.05.
 #' @param add_ridge (Optional) Logical; if `TRUE`, adds a small L2 penalty to
 #'   the untransformed coefficients to stabilize estimation. Default is `FALSE`.
+#' @param se_type Character; the standard-error type, one of `"default"` (the
+#'   package's Assumption-F1-based standard error from the paper) or `"cluster"`
+#'   (an experimental unit-clustered Liang-Zeger sandwich SE on the
+#'   bridge-selected support). See the exported wrapper `fetwfe()` for details.
+#'   Default is `"default"`.
 #'
 #' @details
 #' The function executes the following main steps:

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -158,6 +158,10 @@ genCoefs <- function(R, T, d, density, eff_size, seed = NULL) {
 #'   \item{actual_cohort_tes}{A numeric vector of length \code{R} containing the
 #'         true cohort-specific treatment effects, calculated by averaging the
 #'         coefficients corresponding to the treatment dummies for each cohort.}
+#'   \item{cohort_times}{An integer vector of length \code{R} giving the calendar
+#'         time period at which each treated cohort first adopts treatment. In
+#'         the simulator's convention cohort \code{r} adopts at calendar time
+#'         \code{r + 1} (cohort 0 is never-treated).}
 #'   \item{R, T, d, seed}{The generating parameters carried over from
 #'         \code{coefs_obj} so that \code{print()} and \code{summary()} on the
 #'         returned object are self-describing.}

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -514,6 +514,11 @@ twfeCovsWithSimulatedData <- function(
 #' @param add_ridge (Optional.) Logical; if TRUE, adds a small amount of ridge
 #'   regularization to the (untransformed) coefficients to stabilize estimation.
 #'   Default is FALSE.
+#' @param se_type Character; the standard-error type, one of "default" (the
+#'   package's Assumption-F1-based standard error from the paper) or "cluster"
+#'   (an experimental unit-clustered Liang-Zeger sandwich SE on the
+#'   OLS-selected support). See the exported wrapper twfeCovs() for details.
+#'   Default is "default".
 #'
 #' @details
 #' The function executes the following main steps:

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -14,8 +14,8 @@
   - `etwfe()` for extended two-way fixed effects estimation  
   - `etwfeWithSimulatedData()`, a convenience wrapper for running `etwfe()` on simulated data
 - **Bridge-penalized TWFE**  
-  - `btwfe()` implementing a bridge-penalized extended two-way fixed effects estimator  
-  - `btwfeWithSimulatedData()`, a wrapper for `btwfe()`
+  - `betwfe()` implementing a bridge-penalized extended two-way fixed effects estimator  
+  - `betwfeWithSimulatedData()`, a wrapper for `betwfe()`
 - **Two-way FE with covariates**  
   - `twfeCovs()` for standard two-way FE models including covariates  
   - `twfeCovsWithSimulatedData()`, a wrapper for `twfeCovs()`
@@ -29,7 +29,7 @@
 
 ### Data-format conversion helpers
 - `attgtToFetwfeDf()` converts `did::att_gt()` outputs into a format suitable for `fetwfe()`
-- `ewtfeToFetwfeDf()` converts `etwfe::etwfe()` outputs into a `fetwfe()`‐compatible data frame
+- `etwfeToFetwfeDf()` converts `etwfe::etwfe()` outputs into a `fetwfe()`‐compatible data frame
 
 ### Regularization & numerical stability
 - Added `add_ridge` argument to `fetwfe()` to include a small ridge penalty on coefficients

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.29",
+  note    = "R package version 1.9.30",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/man/getTes.Rd
+++ b/man/getTes.Rd
@@ -20,6 +20,10 @@ the cohort-specific treatment effects.}
 \item{actual_cohort_tes}{A numeric vector of length \code{R} containing the
 true cohort-specific treatment effects, calculated by averaging the
 coefficients corresponding to the treatment dummies for each cohort.}
+\item{cohort_times}{An integer vector of length \code{R} giving the calendar
+time period at which each treated cohort first adopts treatment. In
+the simulator's convention cohort \code{r} adopts at calendar time
+\code{r + 1} (cohort 0 is never-treated).}
 \item{R, T, d, seed}{The generating parameters carried over from
 \code{coefs_obj} so that \code{print()} and \code{summary()} on the
 returned object are self-describing.}

--- a/tests/testthat/test-doc-slot-parity.R
+++ b/tests/testthat/test-doc-slot-parity.R
@@ -110,7 +110,10 @@ test_that("public estimator @return blocks match live names()", {
 		list(
 			"twfeCovsWithSimulatedData",
 			function() twfeCovsWithSimulatedData(sim)
-		)
+		),
+		list("genCoefs", function() coefs),
+		list("getTes", function() getTes(coefs)),
+		list("simulateData", function() sim)
 	)
 
 	db <- .get_rd_db()


### PR DESCRIPTION
Resolves #117. A focused documentation/cleanup sweep of six small items the 2026-05-19 internal review flagged:

- `getTes()`'s `@return` now documents the `cohort_times` slot (added in #84, never documented).
- `test-doc-slot-parity.R` now covers `getTes()`, `genCoefs()`, and `simulateData()` — the extension that would have caught the `getTes()` drift, and now guards it.
- The four internal `*_core` functions document their `se_type` argument.
- A misleading factor-encoding comment in `processFactors()` is corrected (`model.matrix(~ x - 1)` produces *no* intercept; the code drops the first-level dummy as the baseline).
- A provably-redundant `stopifnot(R >= 1)` is removed from `prep_for_etwfe_core()` (the `if (R < 2) stop()` just below subsumes it — verified a no-op).
- Two stale function names in `cran-comments.md` are fixed (`btwfe`→`betwfe`, `ewtfeToFetwfeDf`→`etwfeToFetwfeDf`).

Test-and-docs only — the sole behavior-touching change (the redundant-assertion removal) is verified behavior-preserving. The `cran-comments.md` version/changelog header is intentionally left for the next CRAN submission; only the wrong function names are fixed. 5 commits, one per item-group plus the version bump (1.9.29 → 1.9.30). `devtools::check(args = "--as-cran")` clean; `devtools::test()` `FAIL 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
