### PR TITLE
Fix wrong output column names in attgtToFetwfeDf() / etwfeToFetwfeDf() docs (#128, 1.9.31)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.30
+Version: 1.9.31
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # NEWS
 
+## Version 1.9.31 (2026-05-20)
+
+- Corrected the documented output column names for `attgtToFetwfeDf()`
+  and `etwfeToFetwfeDf()`: their `@return` and `@param` blocks listed
+  `time` / `unit` / `y`, but the converters produce `time_var` /
+  `unit_var` / `response` (the `out_names` defaults). Documentation fix
+  only; no change to either function's behavior.
+
 ## Version 1.9.30 (2026-05-20)
 
 - Documentation and cleanup sweep from the 2026-05-19 internal review:

--- a/R/convert_dfs.R
+++ b/R/convert_dfs.R
@@ -17,7 +17,7 @@
 #'   never‑treated group).
 #' @param yname  Character scalar. Name of the outcome column.
 #' @param tname  Character scalar. Name of the time variable (numeric or
-#'   integer). This becomes `time` in the returned dataframe.
+#'   integer). This becomes `time_var` in the returned dataframe.
 #' @param idname Character scalar. Name of the unit identifier. Converted to
 #'   character and returned as `unit_var`.
 #' @param gname  Character scalar. Name of the *group* variable holding the
@@ -31,19 +31,20 @@
 #'   creating the treatment dummy. `fetwfe()` would do this internally, but
 #'   dropping them here keeps the returned dataframe cleaner.
 #' @param out_names  A named list giving the column names to use in the
-#'   resulting dataframe. Defaults are `list(time = "time", unit = "unit",
-#'   treatment = "treatment", response = "y")`. Override if you prefer
-#'   different names (for instance, to keep the original `yname`). The vector
+#'   resulting dataframe. Defaults are `list(time = "time_var", unit =
+#'   "unit_var", treatment = "treatment", response = "response")`. Override
+#'   if you prefer different names (for instance, to keep the original
+#'   `yname`). The vector
 #'   *must* contain exactly these four names.
 #' @param verbose Logical. If `TRUE`, a `message()` reports the count of
 #'   first-period-treated unit-period rows dropped when
 #'   `drop_first_period_treated = TRUE`. Default `FALSE` (silent).
 #'
-#' @return A `data.frame` with columns `time`, `unit`, `treatment`, `y`, and any
-#'   covariates requested in `covars`, ready to be fed to
+#' @return A `data.frame` with columns `time_var`, `unit_var`, `treatment`,
+#'   `response`, and any covariates requested in `covars`, ready to be fed to
 #'   `fetwfe()`/`etwfe()`. All required columns are of the correct type:
-#'   `time` is integer, `unit` is character, `treatment` is integer 0/1, and
-#'   `y` is numeric.
+#'   `time_var` is integer, `unit_var` is character, `treatment` is integer
+#'   0/1, and `response` is numeric.
 #' @references Callaway, Brantly and Pedro H.C. Sant'Anna. "Difference-in-
 #' Differences with Multiple Time Periods." Journal of Econometrics, Vol. 225,
 #' No. 2, pp. 200-230, 2021.
@@ -130,15 +131,15 @@ attgtToFetwfeDf <- function(
 #'   sample period be removed?  (`fetwfe()` will drop them internally anyway, but doing it
 #'   here keeps the returned dataframe clean.)  Default `TRUE`.
 #' @param out_names Named list giving the column names that the returned dataframe should have.
-#'   The default (`time`, `unit`, `treatment`, `y`) matches the arguments usually supplied to
+#'   The default (`time_var`, `unit_var`, `treatment`, `response`) matches the arguments usually supplied to
 #'   `fetwfe()`. **Do not change the *names* of this list** – only the *values* – and keep all four.
 #' @param verbose Logical. If `TRUE`, a `message()` reports the count of
 #'   first-period-treated unit-period rows dropped when
 #'   `drop_first_period_treated = TRUE`. Default `FALSE` (silent).
 #'
 #' @return A tidy `data.frame` with (in this order)
-#'   * `time`       integer,
-#'   * `unit`       character,
+#'   * `time_var`   integer,
+#'   * `unit_var`   character,
 #'   * `treatment`  integer 0/1 absorbing-state dummy,
 #'   * `response`   numeric outcome,
 #'   * any covariates requested in `covars`.

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.30",
+  note    = "R package version 1.9.31",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/man/attgtToFetwfeDf.Rd
+++ b/man/attgtToFetwfeDf.Rd
@@ -26,7 +26,7 @@ never‑treated group).}
 \item{yname}{Character scalar. Name of the outcome column.}
 
 \item{tname}{Character scalar. Name of the time variable (numeric or
-integer). This becomes \code{time} in the returned dataframe.}
+integer). This becomes \code{time_var} in the returned dataframe.}
 
 \item{idname}{Character scalar. Name of the unit identifier. Converted to
 character and returned as \code{unit_var}.}
@@ -45,8 +45,9 @@ creating the treatment dummy. \code{fetwfe()} would do this internally, but
 dropping them here keeps the returned dataframe cleaner.}
 
 \item{out_names}{A named list giving the column names to use in the
-resulting dataframe. Defaults are \code{list(time = "time", unit = "unit", treatment = "treatment", response = "y")}. Override if you prefer
-different names (for instance, to keep the original \code{yname}). The vector
+resulting dataframe. Defaults are \code{list(time = "time_var", unit = "unit_var", treatment = "treatment", response = "response")}. Override
+if you prefer different names (for instance, to keep the original
+\code{yname}). The vector
 \emph{must} contain exactly these four names.}
 
 \item{verbose}{Logical. If \code{TRUE}, a \code{message()} reports the count of
@@ -54,11 +55,11 @@ first-period-treated unit-period rows dropped when
 \code{drop_first_period_treated = TRUE}. Default \code{FALSE} (silent).}
 }
 \value{
-A \code{data.frame} with columns \code{time}, \code{unit}, \code{treatment}, \code{y}, and any
-covariates requested in \code{covars}, ready to be fed to
+A \code{data.frame} with columns \code{time_var}, \code{unit_var}, \code{treatment},
+\code{response}, and any covariates requested in \code{covars}, ready to be fed to
 \code{fetwfe()}/\code{etwfe()}. All required columns are of the correct type:
-\code{time} is integer, \code{unit} is character, \code{treatment} is integer 0/1, and
-\code{y} is numeric.
+\code{time_var} is integer, \code{unit_var} is character, \code{treatment} is integer
+0/1, and \code{response} is numeric.
 }
 \description{
 \code{attgtToFetwfeDf()} reshapes and renames a panel dataset that is already

--- a/man/etwfeToFetwfeDf.Rd
+++ b/man/etwfeToFetwfeDf.Rd
@@ -38,7 +38,7 @@ sample period be removed?  (\code{fetwfe()} will drop them internally anyway, bu
 here keeps the returned dataframe clean.)  Default \code{TRUE}.}
 
 \item{out_names}{Named list giving the column names that the returned dataframe should have.
-The default (\code{time}, \code{unit}, \code{treatment}, \code{y}) matches the arguments usually supplied to
+The default (\code{time_var}, \code{unit_var}, \code{treatment}, \code{response}) matches the arguments usually supplied to
 \code{fetwfe()}. \strong{Do not change the \emph{names} of this list} – only the \emph{values} – and keep all four.}
 
 \item{verbose}{Logical. If \code{TRUE}, a \code{message()} reports the count of
@@ -48,8 +48,8 @@ first-period-treated unit-period rows dropped when
 \value{
 A tidy \code{data.frame} with (in this order)
 \itemize{
-\item \code{time}       integer,
-\item \code{unit}       character,
+\item \code{time_var}   integer,
+\item \code{unit_var}   character,
 \item \code{treatment}  integer 0/1 absorbing-state dummy,
 \item \code{response}   numeric outcome,
 \item any covariates requested in \code{covars}.


### PR DESCRIPTION
Resolves #128. `attgtToFetwfeDf()` and `etwfeToFetwfeDf()` (`R/convert_dfs.R`) documented their output columns as `time` / `unit` / `treatment` / `y`, but the converters actually produce `time_var` / `unit_var` / `treatment` / `response` (the `out_names` defaults) — a user following `?attgtToFetwfeDf` would pass `time_var = "time"` to `fetwfe()` and hit a "time is not a column in pdata" error.

Corrects five roxygen locations (the two `@param out_names`, the two `@return`, and `attgtToFetwfeDf()`'s `@param tname` — one more than the 2026-05-20 review enumerated) and regenerates the two man pages. Documentation-only — no behavior change; `.fetwfe_df_core()` was already correct and is untouched, and no vignette mentions these converters (checked).

`devtools::check(args = "--as-cran")` is 0 errors / 0 warnings / 0 notes; the post-execution review verified the corrected names against the code three ways, including a toy-panel `names()` check. 2 commits — the roxygen fix + a version bump (1.9.30 → 1.9.31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
