### PR TITLE
Replace the remaining divorce examples with castle (1.9.33)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.9.32
+Version: 1.9.33
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # NEWS
 
+## Version 1.9.33 (2026-05-20)
+
+- Replaced the remaining `bacondecomp::divorce` examples (the four
+  estimators' help-page examples and the package's quick-start example)
+  with `bacondecomp::castle` examples, matching the main vignette; fixed
+  a stale citation year in the package documentation.
+
 ## Version 1.9.32 (2026-05-20)
 
 - Replaced the main vignette's flagship empirical example: the

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -218,23 +218,26 @@
 #' Pinheiro, J. C., & Bates, D. M. (2000). \emph{Mixed-Effects Models in
 #' S and S-PLUS}. Springer.
 #' @examples
-#' set.seed(23451)
-#'
 #' library(bacondecomp)
 #'
-#' data(divorce)
+#' data(castle)
 #'
-#' # sig_eps_sq and sig_eps_c_sq, calculated in a separate run of `fetwfe(),
-#' # are provided to speed up the computation of the example
+#' # Response: the log homicide rate. Treatment: `cdl` records the share of
+#' # the year the castle-doctrine law was in effect, so `cdl > 0` gives the
+#' # absorbing 0/1 treatment indicator. No `covs`: castle's smallest
+#' # adoption cohorts contain a single state, so the design is
+#' # rank-deficient once any covariate is added.
+#' castle$l_homicide <- log(castle$homicide)
+#' castle$treated <- as.integer(castle$cdl > 0)
+#'
+#' # On this panel betwfe's bridge penalty selects every cohort out, so the
+#' # estimated ATT and cohort effects below are all zero.
 #' res <- betwfe(
-#'     pdata = divorce[divorce$sex == 2, ],
+#'     pdata = castle,
 #'     time_var = "year",
-#'     unit_var = "st",
-#'     treatment = "changed",
-#'     covs = c("murderrate", "lnpersinc", "afdcrolls"),
-#'     response = "suiciderate_elast_jag",
-#'     sig_eps_sq = 0.0344,
-#'     sig_eps_c_sq = 0.1507,
+#'     unit_var = "state",
+#'     treatment = "treated",
+#'     response = "l_homicide",
 #'     verbose = TRUE)
 #'
 #' # Average treatment effect on the treated units (in percentage point

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -191,23 +191,24 @@
 #' Pinheiro, J. C., & Bates, D. M. (2000). \emph{Mixed-Effects Models in
 #' S and S-PLUS}. Springer.
 #' @examples
-#' set.seed(23451)
-#'
 #' library(bacondecomp)
 #'
-#' data(divorce)
+#' data(castle)
 #'
-#' # sig_eps_sq and sig_eps_c_sq, calculated in a separate run of `fetwfe(),
-#' # are provided to speed up the computation of the example
+#' # Response: the log homicide rate. Treatment: `cdl` records the share of
+#' # the year the castle-doctrine law was in effect, so `cdl > 0` gives the
+#' # absorbing 0/1 treatment indicator `fetwfe()` requires.
+#' castle$l_homicide <- log(castle$homicide)
+#' castle$treated <- as.integer(castle$cdl > 0)
+#'
+#' # No `covs` here: castle's smallest adoption cohorts contain a single
+#' # state, so the design is rank-deficient once any covariate is added.
 #' res <- fetwfe(
-#'     pdata = divorce[divorce$sex == 2, ],
+#'     pdata = castle,
 #'     time_var = "year",
-#'     unit_var = "st",
-#'     treatment = "changed",
-#'     covs = c("murderrate", "lnpersinc", "afdcrolls"),
-#'     response = "suiciderate_elast_jag",
-#'     sig_eps_sq = 0.0344,
-#'     sig_eps_c_sq = 0.1507,
+#'     unit_var = "state",
+#'     treatment = "treated",
+#'     response = "l_homicide",
 #'     verbose = TRUE)
 #'
 #' # Print results with internal details
@@ -731,23 +732,25 @@ fetwfeWithSimulatedData <- function(
 #' S and S-PLUS}. Springer.
 #' @examples
 #' \dontrun{
-#' set.seed(23451)
-#'
 #' library(bacondecomp)
 #'
-#' data(divorce)
+#' data(castle)
 #'
-#' # No `covs` here: etwfe is pure OLS (no bridge penalty), so it cannot
-#' # handle the rank-deficient design that the bacondecomp::divorce panel
-#' # produces when small cohorts and three covariates are combined.
+#' # Response: the log homicide rate. Treatment: `cdl` records the share of
+#' # the year the castle-doctrine law was in effect, so `cdl > 0` gives the
+#' # absorbing 0/1 treatment indicator.
+#' castle$l_homicide <- log(castle$homicide)
+#' castle$treated <- as.integer(castle$cdl > 0)
+#'
+#' # No `covs` here: etwfe is pure OLS (no bridge penalty), and castle's
+#' # smallest adoption cohorts contain a single state, so the design is
+#' # rank-deficient once any covariate is added.
 #' res <- etwfe(
-#'     pdata = divorce[divorce$sex == 2, ],
+#'     pdata = castle,
 #'     time_var = "year",
-#'     unit_var = "st",
-#'     treatment = "changed",
-#'     response = "suiciderate_elast_jag",
-#'     sig_eps_sq = 0.0344,
-#'     sig_eps_c_sq = 0.1507,
+#'     unit_var = "state",
+#'     treatment = "treated",
+#'     response = "l_homicide",
 #'     verbose = TRUE)
 #'
 #' # Print results

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -168,23 +168,25 @@
 #' S and S-PLUS}. Springer.
 #' @examples
 #' \dontrun{
-#' set.seed(23451)
-#'
 #' library(bacondecomp)
 #'
-#' data(divorce)
+#' data(castle)
 #'
-#' # No `covs` here: twfeCovs is pure OLS (no bridge penalty), so it cannot
-#' # handle the rank-deficient design that the bacondecomp::divorce panel
-#' # produces when small cohorts and three covariates are combined.
+#' # Response: the log homicide rate. Treatment: `cdl` records the share of
+#' # the year the castle-doctrine law was in effect, so `cdl > 0` gives the
+#' # absorbing 0/1 treatment indicator.
+#' castle$l_homicide <- log(castle$homicide)
+#' castle$treated <- as.integer(castle$cdl > 0)
+#'
+#' # No `covs` here: twfeCovs is pure OLS (no bridge penalty), and castle's
+#' # smallest adoption cohorts contain a single state, so the design is
+#' # rank-deficient once any covariate is added.
 #' res <- twfeCovs(
-#'     pdata = divorce[divorce$sex == 2, ],
+#'     pdata = castle,
 #'     time_var = "year",
-#'     unit_var = "st",
-#'     treatment = "changed",
-#'     response = "suiciderate_elast_jag",
-#'     sig_eps_sq = 0.0344,
-#'     sig_eps_c_sq = 0.1507,
+#'     unit_var = "state",
+#'     treatment = "treated",
+#'     response = "l_homicide",
 #'     verbose = TRUE)
 #'
 #' # Print results

--- a/README.md
+++ b/README.md
@@ -21,25 +21,27 @@ You can also install the latest development version by using
 remotes::install_github("gregfaletto/fetwfePackage")
 ```
 
-The primary function in the `{fetwfe}` is `fetwfe()`, which implements fused extended two-way fixed effects. Here's some example code that implements the data application from the paper:
+The primary function in the `{fetwfe}` is `fetwfe()`, which implements fused extended two-way fixed effects. Here's some example code applying `fetwfe()` to the `castle` data set from the `bacondecomp` package (the same example used in the package vignette):
 
 ```R
 library(fetwfe)
 library(bacondecomp)
 
-set.seed(23451)
+data(castle)
 
-data(divorce)
+# Response: the log homicide rate. Treatment: `cdl` records the share of
+# the year the castle-doctrine law was in effect, so `cdl > 0` gives the
+# absorbing 0/1 treatment indicator `fetwfe()` requires.
+castle$l_homicide <- log(castle$homicide)
+castle$treated <- as.integer(castle$cdl > 0)
 
 res <- fetwfe(
-    pdata=divorce[divorce$sex == 2, ],
-    time_var="year",
-    unit_var="st",
-    treatment="changed",
-    covs=c("murderrate", "lnpersinc", "afdcrolls"),
-    response="suiciderate_elast_jag",
-    q=0.5,
-    verbose=TRUE)
+    pdata = castle,
+    time_var = "year",
+    unit_var = "state",
+    treatment = "treated",
+    response = "l_homicide",
+    verbose = TRUE)
 
 summary(res)
 ```
@@ -47,5 +49,5 @@ summary(res)
 For vignettes and full documentation, check out the [page for the `{fetwfe}` package on CRAN](https://CRAN.R-project.org/package=fetwfe).
 
 ## References
-- Faletto, G (2024). *Fused Extended Two-Way Fixed Effects for Difference-in-Differences with Staggered Adoptions*. [arXiv preprint arXiv:2312.05985](https://arxiv.org/abs/2312.05985).
+- Faletto, G (2025). *Fused Extended Two-Way Fixed Effects for Difference-in-Differences with Staggered Adoptions*. [arXiv preprint arXiv:2312.05985](https://arxiv.org/abs/2312.05985).
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.9.32",
+  note    = "R package version 1.9.33",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/man/betwfe.Rd
+++ b/man/betwfe.Rd
@@ -248,23 +248,26 @@ penalty. Estimates overall ATT as well as CATT (cohort average treatment
 effects on the treated units).
 }
 \examples{
-set.seed(23451)
-
 library(bacondecomp)
 
-data(divorce)
+data(castle)
 
-# sig_eps_sq and sig_eps_c_sq, calculated in a separate run of `fetwfe(),
-# are provided to speed up the computation of the example
+# Response: the log homicide rate. Treatment: `cdl` records the share of
+# the year the castle-doctrine law was in effect, so `cdl > 0` gives the
+# absorbing 0/1 treatment indicator. No `covs`: castle's smallest
+# adoption cohorts contain a single state, so the design is
+# rank-deficient once any covariate is added.
+castle$l_homicide <- log(castle$homicide)
+castle$treated <- as.integer(castle$cdl > 0)
+
+# On this panel betwfe's bridge penalty selects every cohort out, so the
+# estimated ATT and cohort effects below are all zero.
 res <- betwfe(
-    pdata = divorce[divorce$sex == 2, ],
+    pdata = castle,
     time_var = "year",
-    unit_var = "st",
-    treatment = "changed",
-    covs = c("murderrate", "lnpersinc", "afdcrolls"),
-    response = "suiciderate_elast_jag",
-    sig_eps_sq = 0.0344,
-    sig_eps_c_sq = 0.1507,
+    unit_var = "state",
+    treatment = "treated",
+    response = "l_homicide",
     verbose = TRUE)
 
 # Average treatment effect on the treated units (in percentage point

--- a/man/etwfe.Rd
+++ b/man/etwfe.Rd
@@ -189,23 +189,25 @@ the treated units).
 }
 \examples{
 \dontrun{
-set.seed(23451)
-
 library(bacondecomp)
 
-data(divorce)
+data(castle)
 
-# No `covs` here: etwfe is pure OLS (no bridge penalty), so it cannot
-# handle the rank-deficient design that the bacondecomp::divorce panel
-# produces when small cohorts and three covariates are combined.
+# Response: the log homicide rate. Treatment: `cdl` records the share of
+# the year the castle-doctrine law was in effect, so `cdl > 0` gives the
+# absorbing 0/1 treatment indicator.
+castle$l_homicide <- log(castle$homicide)
+castle$treated <- as.integer(castle$cdl > 0)
+
+# No `covs` here: etwfe is pure OLS (no bridge penalty), and castle's
+# smallest adoption cohorts contain a single state, so the design is
+# rank-deficient once any covariate is added.
 res <- etwfe(
-    pdata = divorce[divorce$sex == 2, ],
+    pdata = castle,
     time_var = "year",
-    unit_var = "st",
-    treatment = "changed",
-    response = "suiciderate_elast_jag",
-    sig_eps_sq = 0.0344,
-    sig_eps_c_sq = 0.1507,
+    unit_var = "state",
+    treatment = "treated",
+    response = "l_homicide",
     verbose = TRUE)
 
 # Print results

--- a/man/fetwfe.Rd
+++ b/man/fetwfe.Rd
@@ -217,23 +217,24 @@ Estimates overall ATT as well as CATT (cohort average treatment effects on
 the treated units).
 }
 \examples{
-set.seed(23451)
-
 library(bacondecomp)
 
-data(divorce)
+data(castle)
 
-# sig_eps_sq and sig_eps_c_sq, calculated in a separate run of `fetwfe(),
-# are provided to speed up the computation of the example
+# Response: the log homicide rate. Treatment: `cdl` records the share of
+# the year the castle-doctrine law was in effect, so `cdl > 0` gives the
+# absorbing 0/1 treatment indicator `fetwfe()` requires.
+castle$l_homicide <- log(castle$homicide)
+castle$treated <- as.integer(castle$cdl > 0)
+
+# No `covs` here: castle's smallest adoption cohorts contain a single
+# state, so the design is rank-deficient once any covariate is added.
 res <- fetwfe(
-    pdata = divorce[divorce$sex == 2, ],
+    pdata = castle,
     time_var = "year",
-    unit_var = "st",
-    treatment = "changed",
-    covs = c("murderrate", "lnpersinc", "afdcrolls"),
-    response = "suiciderate_elast_jag",
-    sig_eps_sq = 0.0344,
-    sig_eps_c_sq = 0.1507,
+    unit_var = "state",
+    treatment = "treated",
+    response = "l_homicide",
     verbose = TRUE)
 
 # Print results with internal details

--- a/man/twfeCovs.Rd
+++ b/man/twfeCovs.Rd
@@ -190,23 +190,25 @@ identical within cohorts across all times since treatment.
 }
 \examples{
 \dontrun{
-set.seed(23451)
-
 library(bacondecomp)
 
-data(divorce)
+data(castle)
 
-# No `covs` here: twfeCovs is pure OLS (no bridge penalty), so it cannot
-# handle the rank-deficient design that the bacondecomp::divorce panel
-# produces when small cohorts and three covariates are combined.
+# Response: the log homicide rate. Treatment: `cdl` records the share of
+# the year the castle-doctrine law was in effect, so `cdl > 0` gives the
+# absorbing 0/1 treatment indicator.
+castle$l_homicide <- log(castle$homicide)
+castle$treated <- as.integer(castle$cdl > 0)
+
+# No `covs` here: twfeCovs is pure OLS (no bridge penalty), and castle's
+# smallest adoption cohorts contain a single state, so the design is
+# rank-deficient once any covariate is added.
 res <- twfeCovs(
-    pdata = divorce[divorce$sex == 2, ],
+    pdata = castle,
     time_var = "year",
-    unit_var = "st",
-    treatment = "changed",
-    response = "suiciderate_elast_jag",
-    sig_eps_sq = 0.0344,
-    sig_eps_c_sq = 0.1507,
+    unit_var = "state",
+    treatment = "treated",
+    response = "l_homicide",
     verbose = TRUE)
 
 # Print results


### PR DESCRIPTION
After PR #131 moved the main vignette to a `bacondecomp::castle` example, `bacondecomp::divorce` still appeared in the package's other user-facing example code. This replaces all of it:

- The roxygen `@examples` of all four exported estimators — `fetwfe()`, `etwfe()`, `betwfe()`, `twfeCovs()` — now use `castle` (regenerating the four man pages).
- The `README.md` quick-start example is updated from divorce to castle.
- A stale README citation year is fixed (`Faletto, G (2024)` → `2025`).

The `fetwfe()` / `betwfe()` examples lose their `covs` argument — castle's small adoption cohorts (some a single state) make the design rank-deficient with any covariate; covariate handling stays demonstrated in the vignette's simulated example. The divorce-specific precomputed `sig_eps_*` values are dropped (castle is small enough to compute live). `betwfe()` selects a null on castle — as it also did on divorce, so no regression.

Examples and documentation only — no `R/` logic change. `devtools::check(args = "--as-cran")` is 0 errors / 0 warnings / 0 notes; the `fetwfe()` and `betwfe()` examples (which run during `R CMD check`) execute cleanly. Version 1.9.33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
