### PR TITLE
Cleanup sweep: dead locals, redundant validation, att_var_2 floor, doc fixes (#126, #127, #129)

### DIFF
--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -791,26 +791,6 @@ betwfe_core <- function(
 
 	rm(ret)
 
-	if (any(!is.na(lambda.max))) {
-		stopifnot(is.numeric(lambda.max) | is.integer(lambda.max))
-		stopifnot(length(lambda.max) == 1)
-		stopifnot(lambda.max > 0)
-	}
-
-	if (any(!is.na(lambda.min))) {
-		stopifnot(is.numeric(lambda.min) | is.integer(lambda.min))
-		stopifnot(length(lambda.min) == 1)
-		stopifnot(lambda.min >= 0)
-		if (any(!is.na(lambda.max))) {
-			stopifnot(lambda.max >= lambda.min)
-		}
-	}
-
-	stopifnot(is.numeric(q) | is.integer(q))
-	stopifnot(length(q) == 1)
-	stopifnot(q > 0)
-	stopifnot(q <= 2)
-
 	res <- prep_for_etwfe_regression(
 		verbose = verbose,
 		sig_eps_sq = sig_eps_sq,

--- a/R/design_matrix.R
+++ b/R/design_matrix.R
@@ -657,8 +657,6 @@ genTreatVarsRealData <- function(
 
 	# Add treatment period dummies
 	if (n_treated_times > 0) {
-		# build a logical index of length N*T for all cohort-time pairs at once
-		treat_combo <- interaction(unit_vars, time_vars, drop = TRUE)
 		for (j in seq_len(n_treated_times)) {
 			treat_vars[
 				(unit_vars %in% cohort) & (time_vars == treated_times[j]),

--- a/R/etwfe_core.R
+++ b/R/etwfe_core.R
@@ -257,8 +257,6 @@ etwfe_core <- function(
 	stopifnot(all(!is.na(df)))
 	stopifnot("y" %in% colnames(df))
 
-	t0 <- Sys.time()
-
 	# Response already centered; no intercept needed
 	fit <- lm(y ~ . + 0, df)
 

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -472,26 +472,6 @@ fetwfe_core <- function(
 
 	rm(ret)
 
-	if (any(!is.na(lambda.max))) {
-		stopifnot(is.numeric(lambda.max) | is.integer(lambda.max))
-		stopifnot(length(lambda.max) == 1)
-		stopifnot(lambda.max > 0)
-	}
-
-	if (any(!is.na(lambda.min))) {
-		stopifnot(is.numeric(lambda.min) | is.integer(lambda.min))
-		stopifnot(length(lambda.min) == 1)
-		stopifnot(lambda.min >= 0)
-		if (any(!is.na(lambda.max))) {
-			stopifnot(lambda.max >= lambda.min)
-		}
-	}
-
-	stopifnot(is.numeric(q) | is.integer(q))
-	stopifnot(length(q) == 1)
-	stopifnot(q > 0)
-	stopifnot(q <= 2)
-
 	#
 	#
 	# Step 1: change coordinates of data so that regular bridge regression

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -245,7 +245,7 @@ getTes <- function(coefs_obj) {
 }
 
 
-#' Generate Coefficient Vector for Data Generation
+#' Generate Coefficient Vector for Data Generation (core)
 #'
 #' This function generates a coefficient vector \code{beta} along with a sparse auxiliary vector
 #' \code{theta} for simulation studies of the fused extended two-way fixed effects estimator. The

--- a/R/gen_data.R
+++ b/R/gen_data.R
@@ -172,7 +172,7 @@ simulateData <- function(
 }
 
 
-#' Generate Random Panel Data for FETWFE Simulations
+#' Generate Random Panel Data for FETWFE Simulations (core)
 #'
 #' @description
 #' Generates a random panel data set for simulation studies of the fused extended two-way fixed

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -87,7 +87,8 @@
 #' OLS-selected support; see the companion vignette `inference_vignette`
 #' for the formula, the assumptions, and the theory-pending caveat).
 #' Default is `"default"`.
-#' @return A named list with the following elements: \item{att_hat}{The
+#' @return An object of class \code{twfeCovs} containing the following elements:
+#' \item{att_hat}{The
 #' estimated overall average treatment effect for a randomly selected treated
 #' unit.} \item{att_se}{A standard error for the ATT. If the Gram matrix is not
 #' invertible, this will be NA.}
@@ -358,7 +359,8 @@ twfeCovs <- function(
 #' OLS-selected support; see the companion vignette `inference_vignette`
 #' for the formula, the assumptions, and the theory-pending caveat).
 #' Default is `"default"`.
-#' @return A named list with the following elements: \item{att_hat}{The
+#' @return An object of class \code{twfeCovs} containing the following elements:
+#' \item{att_hat}{The
 #' estimated overall average treatment effect for a randomly selected treated
 #' unit.} \item{att_se}{A standard error for the ATT. If `indep_counts` was
 #' provided, this standard error is asymptotically exact; otherwise, it is
@@ -674,8 +676,6 @@ twfeCovs_core <- function(
 	stopifnot(all(!is.na(df)))
 	stopifnot("y" %in% colnames(df))
 	stopifnot(ncol(df) == p_short + 1)
-
-	t0 <- Sys.time()
 
 	# Response already centered; no intercept needed
 	fit <- lm(y ~ . + 0, df)

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -257,17 +257,26 @@ getSecondVarTermOLS <- function(
 	# Finally, calculate variance term for ATT from Sigma_pi_hat, Jacobian
 	# matrix, psi_mat, and beta_hat. See proof of Theorem D.2 for details.
 
-	att_var_2 <- T *
-		as.numeric(
-			t(tes) %*%
-				psi_mat %*%
-				t(jacobian_mat) %*%
-				Sigma_pi_hat %*%
-				jacobian_mat %*%
-				t(psi_mat) %*%
-				tes
-		) /
-		(N * T)
+	# Issue #127: floor `att_var_2` at zero, mirroring the `att_var_1`
+	# floor PR #111 added at the analogous sibling sites in this file. The
+	# `Sigma_pi_hat` quadratic form is PSD in exact arithmetic, so
+	# `att_var_2 >= 0` always — but floating-point cancellation can leave
+	# a near-zero value marginally negative, NaN-ing the conservative
+	# overall-ATT-SE branch `2 * sqrt(att_var_1 * att_var_2)` downstream.
+	att_var_2 <- max(
+		T *
+			as.numeric(
+				t(tes) %*%
+					psi_mat %*%
+					t(jacobian_mat) %*%
+					Sigma_pi_hat %*%
+					jacobian_mat %*%
+					t(psi_mat) %*%
+					tes
+			) /
+			(N * T),
+		0
+	)
 
 	return(att_var_2)
 }
@@ -964,15 +973,24 @@ getSecondVarTermDataApp <- function(
 	stopifnot(all(!is.na(jacobian_mat)))
 
 	## variance term: theta_sel' J' sum_pi J theta_sel / N
-	att_var_2 <- T *
-		as.numeric(
-			t(theta_hat_treat_sel) %*%
-				t(jacobian_mat) %*%
-				Sigma_pi_hat %*%
-				jacobian_mat %*%
-				theta_hat_treat_sel
-		) /
-		(N * T)
+	# Issue #127: floor `att_var_2` at zero, mirroring the `att_var_1`
+	# floor PR #111 added at the analogous sibling sites in this file. The
+	# `Sigma_pi_hat` quadratic form is PSD in exact arithmetic, so
+	# `att_var_2 >= 0` always — but floating-point cancellation can leave
+	# a near-zero value marginally negative, NaN-ing the conservative
+	# overall-ATT-SE branch `2 * sqrt(att_var_1 * att_var_2)` downstream.
+	att_var_2 <- max(
+		T *
+			as.numeric(
+				t(theta_hat_treat_sel) %*%
+					t(jacobian_mat) %*%
+					Sigma_pi_hat %*%
+					jacobian_mat %*%
+					theta_hat_treat_sel
+			) /
+			(N * T),
+		0
+	)
 
 	return(att_var_2)
 }

--- a/man/genCoefsCore.Rd
+++ b/man/genCoefsCore.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/gen_coefs.R
 \name{genCoefsCore}
 \alias{genCoefsCore}
-\title{Generate Coefficient Vector for Data Generation}
+\title{Generate Coefficient Vector for Data Generation (core)}
 \usage{
 genCoefsCore(R, T, d, density, eff_size, seed = NULL)
 }

--- a/man/simulateDataCore.Rd
+++ b/man/simulateDataCore.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/gen_data.R
 \name{simulateDataCore}
 \alias{simulateDataCore}
-\title{Generate Random Panel Data for FETWFE Simulations}
+\title{Generate Random Panel Data for FETWFE Simulations (core)}
 \usage{
 simulateDataCore(
   N,

--- a/man/twfeCovs.Rd
+++ b/man/twfeCovs.Rd
@@ -115,7 +115,8 @@ for the formula, the assumptions, and the theory-pending caveat).
 Default is \code{"default"}.}
 }
 \value{
-A named list with the following elements: \item{att_hat}{The
+An object of class \code{twfeCovs} containing the following elements:
+\item{att_hat}{The
 estimated overall average treatment effect for a randomly selected treated
 unit.} \item{att_se}{A standard error for the ATT. If the Gram matrix is not
 invertible, this will be NA.}

--- a/man/twfeCovsWithSimulatedData.Rd
+++ b/man/twfeCovsWithSimulatedData.Rd
@@ -44,7 +44,8 @@ for the formula, the assumptions, and the theory-pending caveat).
 Default is \code{"default"}.}
 }
 \value{
-A named list with the following elements: \item{att_hat}{The
+An object of class \code{twfeCovs} containing the following elements:
+\item{att_hat}{The
 estimated overall average treatment effect for a randomly selected treated
 unit.} \item{att_se}{A standard error for the ATT. If \code{indep_counts} was
 provided, this standard error is asymptotically exact; otherwise, it is


### PR DESCRIPTION
Bundles three small items from the 2026-05-20 periodic code review into one cleanup-sweep PR per the maintainer's directive. Eight work items shipped; one optional sub-item (#129's DG3) deferred to a follow-up as out-of-scope.

## #126 — Cleanup sweep (3 items)

- **DC1:** removed dead `treat_combo` local in `genTreatVarsRealData()` (`R/design_matrix.R`). Surrounding loop already uses direct boolean indexing on `(unit_vars, time_vars)`.
- **DC2:** removed dead `t0 <- Sys.time()` at two unused sites (`R/etwfe_core.R`, `R/twfeCovs.R`). The verbose-gated `t0` in `R/utility.R` and `R/core_funcs.R` is left alone.
- **DC3:** removed two byte-identical 19-line `lambda.max` / `lambda.min` / `q` validation blocks from `R/fetwfe_core.R` and `R/betwfe_core.R`. Duplicated checks already enforced (and strictly stronger) by upstream `checkFetwfeInputs()`. The `_core()` functions are `@noRd` internal.

## #127 — `att_var_2` defensive floor (2 sites)

- Floored `att_var_2` at 0 at both `R/variance_machinery.R` sites (`getSecondVarTermOLS`, `getSecondVarTermDataApp`). Mirrors the `att_var_1` floor PR #111 added: wraps the inner-quadratic-form assignment with `max(., 0)`, not the bare return.
- Quadratic form is PSD in exact arithmetic; the floor only activates on floating-point cancellation, preventing a near-zero negative from NaN-ing the conservative overall-ATT-SE branch `2 * sqrt(att_var_1 * att_var_2)` downstream.

## #129 — Cosmetic docs (2 items addressed, 1 deferred)

- **DG2:** replaced `"A named list"` with `"An object of class \code{twfeCovs} containing..."` in the `@return` blocks at `R/twfeCovs.R:90` and `:361`, matching the sibling convention in `R/fetwfe.R`, `R/betwfe_core.R`, `R/etwfe_core.R`.
- **DG4:** added `"(core)"` suffix to the titles of `genCoefsCore()` and `simulateDataCore()`, disambiguating them from the non-core pair in `man/`.
- **DG3** (marked *Optional* in the issue body): **deferred**. Would require either misrepresenting the returned-object structure or restructuring the OLS-family estimators' return-object layout across three classes, which is out of scope for a docs-cleanup PR. Follow-up sketch documented in the plan's `Surprises & Discoveries`.

## Validation

- `devtools::check(args = "--as-cran")`: **`Status: OK`** — 0 errors / 0 warnings / 0 notes.
- `devtools::test()`: **`FAIL 0 | WARN 0 | PASS 1973`** (vs baseline expectation `PASS ≥ 1971`).
- `air format .`, `devtools::document()`: clean / idempotent.
- `devtools::spell_check()`, `urlchecker::url_check()`: clean.
- Post-execution review: LGTM with 0 blockers and 1 cosmetic finding (brittle line-number references in the new `att_var_2` floor comments); cosmetic addressed in-PR.

## Diff scope

12 files: 8 `R/` files (`betwfe_core.R`, `design_matrix.R`, `etwfe_core.R`, `fetwfe_core.R`, `gen_coefs.R`, `gen_data.R`, `twfeCovs.R`, `variance_machinery.R`) + 4 regenerated `man/*.Rd` (`genCoefsCore.Rd`, `simulateDataCore.Rd`, `twfeCovs.Rd`, `twfeCovsWithSimulatedData.Rd`). No `R/` exports change, no `NAMESPACE` change, no `DESCRIPTION` change, no `NEWS.md` change, no version bump.

Closes #126, #127, #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
