### PR TITLE
Add two-tier diagnostic to cluster-sandwich floor sites (#139, 1.11.2)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.11.1
+Version: 1.11.2
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # NEWS
 
+## Version 1.11.2 (2026-05-26)
+
+### Defensive improvements
+
+- The five cluster-sandwich quadratic-form floor sites in the variance
+  machinery (PR #111, item 9; the count was six before PR #118
+  consolidated `getCohortATTsFinalOLS()` into `getCohortATTsFinal()`)
+  now layer a two-tier diagnostic on top of the existing `max(., 0)`
+  floor: a `warning()` fires when the quadratic form is more negative
+  than `-1e-10` (clearly outside floating-point noise) and a `stop()`
+  fires when it is more negative than `-1` (catastrophic; outside any
+  plausible SE-squared magnitude in difference-in-differences
+  applications). On well-conditioned data the behavior is unchanged.
+  The diagnostic surfaces latent bugs that would previously have
+  silently produced `SE = 0`. Issue #139.
+
 ## Version 1.11.1 (2026-05-25)
 
 ### New features

--- a/R/cluster_floor.R
+++ b/R/cluster_floor.R
@@ -1,0 +1,77 @@
+# Two-tier diagnostic floor for cluster-sandwich quadratic forms.
+#
+# Mathematically the cluster-sandwich quadratic forms wrapped by this helper
+# (`t(psi) %*% sandwich %*% psi`, sums of outer products) are PSD by
+# construction, so any negative value in well-conditioned data is a
+# floating-point artifact at machine epsilon (~`1e-15`). Large negatives
+# would indicate a bug — a broken PSD invariant, a sign error, or a
+# numerical breakdown — and the pre-existing `max(q, 0)` floor would
+# silently absorb them, producing `SE = 0` with no signal to the user.
+#
+# This helper layers a two-tier diagnostic on top of the floor (#139):
+#
+#   q <  -1     : stop()    -- catastrophic; outside any plausible FP-noise
+#                              range or realistic SE^2 magnitude in DiD
+#                              applications.
+#   q <  -1e-10 : warning() -- clearly outside FP noise; surfaces the
+#                              anomaly without breaking the fit.
+#   q in [-1e-10, 0] : floor silently to 0 (FP cancellation in well-
+#                              conditioned data).
+#
+# On well-conditioned data the behavior is unchanged from the prior bare
+# `max(q, 0)`; the warning/error only surfaces when the quadratic form
+# is in a range that genuinely indicates trouble.
+#
+# Inputs that don't match the contract of a single non-NA numeric scalar
+# (length != 1, NA, non-numeric) are passed through unchanged so the
+# downstream code can handle them as it would have today.
+#
+# @param q numeric scalar -- the quadratic form value to floor.
+# @param site character scalar -- short site identifier (function name,
+#   optionally with `/sub_context` suffix) that gets surfaced in the
+#   diagnostic message so a developer can locate the firing site.
+# @param err_threshold numeric scalar (default -1); `q < err_threshold`
+#   fires `stop()`.
+# @param warn_threshold numeric scalar (default -1e-10); `q < warn_threshold`
+#   (but `>= err_threshold`) fires `warning()`.
+# @return The floored quadratic form: `max(q, 0)` on numeric scalars; `q`
+#   unchanged on pass-through inputs.
+#
+# @keywords internal
+#' @noRd
+.floor_cluster_quad <- function(
+	q,
+	site,
+	err_threshold = -1,
+	warn_threshold = -1e-10
+) {
+	# Pass-through if the value isn't a single non-NA numeric -- let
+	# downstream code handle those cases as it would today.
+	if (length(q) != 1L || !is.numeric(q) || is.na(q)) {
+		return(q)
+	}
+	if (q < err_threshold) {
+		stop(
+			"Cluster-sandwich quadratic form is catastrophically negative (",
+			signif(q, 3),
+			") at site '",
+			site,
+			"'; this indicates a bug or severe numerical breakdown. ",
+			"Please file an issue at ",
+			"https://github.com/gregfaletto/fetwfePackage/issues.",
+			call. = FALSE
+		)
+	}
+	if (q < warn_threshold) {
+		warning(
+			"Negative cluster-sandwich quadratic form (",
+			signif(q, 3),
+			") clipped to 0 at site '",
+			site,
+			"'; if the magnitude is non-trivial this may indicate ",
+			"numerical instability or a regression.",
+			call. = FALSE
+		)
+	}
+	max(q, 0)
+}

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -206,10 +206,13 @@ eventStudy <- function(x, alpha = NULL) {
 			# downstream sqrt() and surface as a baffling "NA SE" report.
 			# Floor at zero so any near-zero quadratic form rounds to
 			# exactly zero (the mathematically correct answer for a
-			# psi orthogonal to the sandwich's image).
-			var_1_e <- max(
+			# psi orthogonal to the sandwich's image). Issue #139 layers
+			# a two-tier (warning / error) diagnostic on top of the floor
+			# via `.floor_cluster_quad()`; on well-conditioned data the
+			# behavior is unchanged.
+			var_1_e <- .floor_cluster_quad(
 				as.numeric(t(psi_full) %*% sandwich_full %*% psi_full),
-				0
+				"event_study_etwfe_betwfe/var_1_e"
 			)
 		} else {
 			psi_e_sel <- psi_e_tes[sel_treat_inds_shifted]
@@ -401,10 +404,13 @@ eventStudy <- function(x, alpha = NULL) {
 			psi_full[treat_block_mask] <- psi_e_theta
 			# Issue #84 item 9: floor the cluster-sandwich quadratic form
 			# at zero. See the matching guard in `.event_study_etwfe_betwfe`
-			# (just above) for rationale.
-			var_1_e <- max(
+			# (just above) for rationale. Issue #139 layers a two-tier
+			# (warning / error) diagnostic on top of the floor via
+			# `.floor_cluster_quad()`; on well-conditioned data the
+			# behavior is unchanged.
+			var_1_e <- .floor_cluster_quad(
 				as.numeric(t(psi_full) %*% sandwich_full %*% psi_full),
-				0
+				"event_study_fetwfe/var_1_e"
 			)
 		} else {
 			var_1_e <- sig_eps_sq *

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -106,12 +106,15 @@ getTeResultsOLS <- function(
 
 			# Issue #84 item 9: floor the cluster-sandwich quadratic form
 			# at zero. See the matching guard in `getTeResults2`
-			# (same file, R/variance_machinery.R) for rationale.
-			att_var_1 <- max(
+			# (same file, R/variance_machinery.R) for rationale. Issue
+			# #139 layers a two-tier (warning / error) diagnostic on top
+			# of the floor via `.floor_cluster_quad()`; on well-conditioned
+			# data the behavior is unchanged.
+			att_var_1 <- .floor_cluster_quad(
 				as.numeric(
 					t(psi_att_full) %*% sandwich_full %*% psi_att_full
 				),
-				0
+				"getTeResultsOLS/att_var_1"
 			)
 		} else {
 			att_var_1 <- sig_eps_sq *
@@ -641,12 +644,15 @@ getTeResults2 <- function(
 			# could come out negative by a few ulps, NaN-ing downstream
 			# sqrt() into a baffling "NA SE" surface. Floor at zero so
 			# any rounding-induced negative collapses to the
-			# mathematically correct value.
-			att_var_1 <- max(
+			# mathematically correct value. Issue #139 layers a two-tier
+			# (warning / error) diagnostic on top of the floor via
+			# `.floor_cluster_quad()`; on well-conditioned data the
+			# behavior is unchanged.
+			att_var_1 <- .floor_cluster_quad(
 				as.numeric(
 					t(psi_att_full) %*% sandwich_full %*% psi_att_full
 				),
-				0
+				"getTeResults2/att_var_1"
 			)
 		} else {
 			att_var_1 <- sig_eps_sq *
@@ -1318,14 +1324,17 @@ getCohortATTsFinal <- function(
 				# Issue #84 item 9: floor the cluster-sandwich quadratic
 				# form at zero before sqrt(), defending against a
 				# rounding-induced negative; see the matching guard in
-				# `getTeResults2` (same file) for rationale.
-				cohort_te_ses[r] <- sqrt(max(
+				# `getTeResults2` (same file) for rationale. Issue #139
+				# layers a two-tier (warning / error) diagnostic on top of
+				# the floor via `.floor_cluster_quad()`; on well-conditioned
+				# data the behavior is unchanged.
+				cohort_te_ses[r] <- sqrt(.floor_cluster_quad(
 					as.numeric(
 						t(psi_r_full) %*%
 							sandwich_full %*%
 							psi_r_full
 					),
-					0
+					"getCohortATTsFinal/cohort_te_se"
 				))
 			} else {
 				## Variance of the treatment effect for cohort r is

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.11.1",
+  note    = "R package version 1.11.2",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-cluster_floor.R
+++ b/tests/testthat/test-cluster_floor.R
@@ -183,7 +183,14 @@ test_that("all 5 cluster-sandwich floor sites use .floor_cluster_quad", {
 	}
 
 	# Negative-direction guard: no bare `max(..., 0)` floor remains around a
-	# `sandwich_full` quadratic form.
+	# `sandwich_full` quadratic form. The historical bare-max idiom from PR
+	# #111 was `<lhs> <- max(... sandwich_full %*% ..., 0)` (single-line);
+	# the wired-up helper at every cluster-sandwich site uses
+	# `.floor_cluster_quad(...)` instead, so any `max(...sandwich_full...,0)`
+	# match indicates a partial revert / regression. We scan a space-joined
+	# concatenation (with comments stripped) so the check is robust to a
+	# future multi-line reformat and to the explanatory comments in
+	# `R/cluster_floor.R` that name the legacy pattern.
 	bare_max_on_sandwich <- 0L
 	for (f in files) {
 		path <- file.path(root, f)
@@ -191,21 +198,19 @@ test_that("all 5 cluster-sandwich floor sites use .floor_cluster_quad", {
 			next
 		}
 		src <- readLines(path, warn = FALSE)
-		# Look for the historical pattern: a `max(` line followed shortly by
-		# `sandwich_full %*%` and a closing `, 0)`. The wired-up helper does
-		# not use `max(`, so this catches a partial revert.
-		for (i in seq_along(src)) {
-			if (grepl("^\\s*max\\(", src[i])) {
-				# Inspect the next 6 lines for the sandwich pattern.
-				window <- src[i:min(length(src), i + 6L)]
-				if (
-					any(grepl("sandwich_full %*%", window, fixed = TRUE)) &&
-						any(grepl(", 0\\)", window))
-				) {
-					bare_max_on_sandwich <- bare_max_on_sandwich + 1L
-				}
-			}
-		}
+		# Strip comments so a comment that names the legacy `max(..., 0)`
+		# idiom does not false-positive.
+		src_no_comment <- sub("#.*$", "", src)
+		combined <- paste(src_no_comment, collapse = " ")
+		# Bounded non-greedy: `max(<up to 300 chars with sandwich_full><up
+		# to 200 chars>, 0)`. The bounded counts avoid catastrophic
+		# regex backtracking on a large concatenated source.
+		re <- "max\\(.{0,300}sandwich_full.{0,200}?,\\s*0\\)"
+		matches <- regmatches(
+			combined,
+			gregexpr(re, combined, perl = TRUE)
+		)[[1]]
+		bare_max_on_sandwich <- bare_max_on_sandwich + length(matches)
 	}
 	expect_equal(bare_max_on_sandwich, 0L)
 })

--- a/tests/testthat/test-cluster_floor.R
+++ b/tests/testthat/test-cluster_floor.R
@@ -1,0 +1,252 @@
+library(testthat)
+library(fetwfe)
+
+# ------------------------------------------------------------------------------
+# Tests for `.floor_cluster_quad()` and its integration at the five
+# cluster-sandwich quadratic-form floor sites (issue #139, version 1.11.2).
+#
+# `.floor_cluster_quad()` layers a two-tier diagnostic on top of the
+# pre-existing `max(q, 0)` floor at each cluster-sandwich quadratic-form
+# site. The forms are PSD in exact arithmetic, so any negative value is
+# either FP-noise (silently clipped to 0) or a bug signal (warn / stop).
+#
+# The five sites:
+#   1. R/variance_machinery.R    getTeResultsOLS         (att_var_1)
+#   2. R/variance_machinery.R    getTeResults2           (att_var_1)
+#   3. R/variance_machinery.R    getCohortATTsFinal      (cohort_te_ses)
+#   4. R/event_study.R           .event_study_etwfe_betwfe (var_1_e)
+#   5. R/event_study.R           .event_study_fetwfe       (var_1_e)
+#
+# (PR #111 added 6 sites in 3 files; PR #118 consolidated
+#  getCohortATTsFinalOLS into getCohortATTsFinal, dropping the count to 5.
+#  Surprises & Discoveries in .plans/cluster-sandwich-floor-diagnostics-139
+#  documents the 6 -> 5 reduction.)
+# ------------------------------------------------------------------------------
+
+# --- Unit tests on the helper -------------------------------------------------
+
+test_that(".floor_cluster_quad returns positive values unchanged", {
+	expect_equal(fetwfe:::.floor_cluster_quad(0.5, "test"), 0.5)
+	expect_equal(fetwfe:::.floor_cluster_quad(1e-12, "test"), 1e-12)
+	expect_equal(fetwfe:::.floor_cluster_quad(100, "test"), 100)
+})
+
+test_that(".floor_cluster_quad returns 0 unchanged", {
+	expect_equal(fetwfe:::.floor_cluster_quad(0, "test"), 0)
+})
+
+test_that(".floor_cluster_quad silently floors FP-noise negatives to 0", {
+	# Magnitudes inside the FP-noise band ([-1e-10, 0]) clip without warning.
+	expect_silent(out1 <- fetwfe:::.floor_cluster_quad(-1e-15, "test"))
+	expect_equal(out1, 0)
+	expect_silent(out2 <- fetwfe:::.floor_cluster_quad(-1e-11, "test"))
+	expect_equal(out2, 0)
+	# Exactly at the warning threshold is still silent (strict `<`).
+	expect_silent(out3 <- fetwfe:::.floor_cluster_quad(-1e-10, "test"))
+	expect_equal(out3, 0)
+})
+
+test_that(".floor_cluster_quad warns on warning-range negatives", {
+	expect_warning(
+		out <- fetwfe:::.floor_cluster_quad(-1e-8, "test_site"),
+		"Negative cluster-sandwich quadratic form"
+	)
+	expect_equal(out, 0)
+	# Site name in the message.
+	expect_warning(
+		fetwfe:::.floor_cluster_quad(-1e-8, "test_site"),
+		"test_site"
+	)
+	# Boundary: just-inside the error threshold still warns, doesn't stop.
+	expect_warning(
+		out_boundary <- fetwfe:::.floor_cluster_quad(-0.999, "test"),
+		"Negative cluster-sandwich quadratic form"
+	)
+	expect_equal(out_boundary, 0)
+})
+
+test_that(".floor_cluster_quad errors on catastrophic negatives", {
+	expect_error(
+		fetwfe:::.floor_cluster_quad(-2, "test_site"),
+		"catastrophically negative"
+	)
+	expect_error(
+		fetwfe:::.floor_cluster_quad(-1.5, "another_site"),
+		"another_site"
+	)
+	expect_error(
+		fetwfe:::.floor_cluster_quad(-1000, "test"),
+		"file an issue"
+	)
+})
+
+test_that(".floor_cluster_quad pass-through on NA / multi-element / non-numeric", {
+	# NA passes through.
+	expect_silent(out_na <- fetwfe:::.floor_cluster_quad(NA_real_, "test"))
+	expect_true(is.na(out_na))
+	# Multi-element vector passes through unchanged.
+	expect_silent(out_vec <- fetwfe:::.floor_cluster_quad(c(-2, 1), "test"))
+	expect_equal(out_vec, c(-2, 1))
+	# Non-numeric (character) passes through.
+	expect_silent(
+		out_chr <- fetwfe:::.floor_cluster_quad("not_numeric", "test")
+	)
+	expect_equal(out_chr, "not_numeric")
+	# Length-0 numeric passes through.
+	expect_silent(out_e <- fetwfe:::.floor_cluster_quad(numeric(0), "test"))
+	expect_equal(out_e, numeric(0))
+})
+
+test_that(".floor_cluster_quad respects custom thresholds", {
+	# Tighter warn threshold -> a value that would normally pass silently warns.
+	expect_warning(
+		out <- fetwfe:::.floor_cluster_quad(
+			-1e-12,
+			"test",
+			warn_threshold = -1e-13
+		),
+		"Negative cluster-sandwich quadratic form"
+	)
+	expect_equal(out, 0)
+	# Looser error threshold -> a value that would normally warn errors.
+	expect_error(
+		fetwfe:::.floor_cluster_quad(
+			-0.5,
+			"test",
+			err_threshold = -0.1
+		),
+		"catastrophically negative"
+	)
+})
+
+# --- Coverage / regression test ----------------------------------------------
+# Assert every cluster-sandwich quadratic-form site in the package code
+# routes through `.floor_cluster_quad`, catching a future revert to the bare
+# `max(., 0)` floor.
+
+test_that("all 5 cluster-sandwich floor sites use .floor_cluster_quad", {
+	pkg_root <- system.file(package = "fetwfe")
+	# When the package is loaded via devtools::load_all(), the installed
+	# `system.file()` may return the install dir (no R/ source). Prefer the
+	# source tree if it is present (the test repo root).
+	src_root <- normalizePath(file.path(testthat::test_path(), "..", ".."))
+	if (
+		dir.exists(file.path(src_root, "R")) &&
+			file.exists(file.path(src_root, "R", "variance_machinery.R"))
+	) {
+		root <- src_root
+	} else {
+		root <- pkg_root
+	}
+
+	files <- c("R/variance_machinery.R", "R/event_study.R")
+	# Count `.floor_cluster_quad(` call sites across both files. The helper
+	# is invoked once per site, so the call count is exactly 5. We skip
+	# comment lines (so the matching helper-name mention in each site's
+	# explanatory comment does not double-count).
+	call_count <- 0L
+	for (f in files) {
+		path <- file.path(root, f)
+		skip_if_not(
+			file.exists(path),
+			paste("source file not in test bundle:", f)
+		)
+		src <- readLines(path, warn = FALSE)
+		non_comment <- src[!grepl("^\\s*#", src)]
+		call_count <- call_count +
+			sum(grepl(".floor_cluster_quad(", non_comment, fixed = TRUE))
+	}
+	expect_equal(call_count, 5L)
+
+	# Per-site label coverage: each site uses its expected per-site label.
+	# This catches a future copy-paste regression where two sites end up
+	# with the same label.
+	expected_labels <- c(
+		"getTeResultsOLS/att_var_1",
+		"getTeResults2/att_var_1",
+		"getCohortATTsFinal/cohort_te_se",
+		"event_study_etwfe_betwfe/var_1_e",
+		"event_study_fetwfe/var_1_e"
+	)
+	src_all <- character(0)
+	for (f in files) {
+		path <- file.path(root, f)
+		if (file.exists(path)) {
+			src_all <- c(src_all, readLines(path, warn = FALSE))
+		}
+	}
+	for (lbl in expected_labels) {
+		expect_true(
+			any(grepl(lbl, src_all, fixed = TRUE)),
+			info = paste("missing site label:", lbl)
+		)
+	}
+
+	# Negative-direction guard: no bare `max(..., 0)` floor remains around a
+	# `sandwich_full` quadratic form.
+	bare_max_on_sandwich <- 0L
+	for (f in files) {
+		path <- file.path(root, f)
+		if (!file.exists(path)) {
+			next
+		}
+		src <- readLines(path, warn = FALSE)
+		# Look for the historical pattern: a `max(` line followed shortly by
+		# `sandwich_full %*%` and a closing `, 0)`. The wired-up helper does
+		# not use `max(`, so this catches a partial revert.
+		for (i in seq_along(src)) {
+			if (grepl("^\\s*max\\(", src[i])) {
+				# Inspect the next 6 lines for the sandwich pattern.
+				window <- src[i:min(length(src), i + 6L)]
+				if (
+					any(grepl("sandwich_full %*%", window, fixed = TRUE)) &&
+						any(grepl(", 0\\)", window))
+				) {
+					bare_max_on_sandwich <- bare_max_on_sandwich + 1L
+				}
+			}
+		}
+	}
+	expect_equal(bare_max_on_sandwich, 0L)
+})
+
+# --- Integration smoke test --------------------------------------------------
+# Fit a small cluster-SE model on well-conditioned simulated data and
+# verify no warning/error from `.floor_cluster_quad` fires.
+
+test_that("cluster-SE fit on well-conditioned data does not trigger the diagnostic", {
+	# Small but well-conditioned: same recipe as several existing tests.
+	set.seed(2026)
+	coefs <- genCoefs(
+		R = 3,
+		T = 5,
+		density = 0.5,
+		eff_size = 1,
+		d = 1,
+		seed = 2026
+	)
+	sim <- simulateData(
+		coefs,
+		N = 80,
+		sig_eps_sq = 0.5,
+		sig_eps_c_sq = 0.5
+	)
+	# Run the fit; assert no warning at all surfaces with the message
+	# pattern from `.floor_cluster_quad()`. (Other unrelated warnings are
+	# not the concern of this test; we filter by substring.)
+	withCallingHandlers(
+		res <- fetwfeWithSimulatedData(sim, q = 0.5, se_type = "cluster"),
+		warning = function(w) {
+			msg <- conditionMessage(w)
+			if (grepl("cluster-sandwich quadratic form", msg, fixed = TRUE)) {
+				stop(
+					"Unexpected .floor_cluster_quad warning on well-conditioned data: ",
+					msg
+				)
+			}
+			invokeRestart("muffleWarning")
+		}
+	)
+	expect_true(!is.null(res$att_se))
+	expect_true(is.finite(res$att_se))
+})


### PR DESCRIPTION
Layers a two-tier diagnostic on top of the existing `max(·, 0)` floors at the cluster-sandwich quadratic-form computation sites in the variance machinery. Closes #139. Version bump 1.11.1 → 1.11.2.

## Why

PR #111 (item 9) added `max(·, 0)` floors at the cluster-sandwich quadratic-form sites. The floors are mathematically correct in spirit — these forms are PSD by construction (sums of outer products), so any negative value the floor sees is a floating-point artifact, and in well-conditioned data the magnitude sits at machine epsilon (~1e-15).

The concern motivating #139 is the **inversion of intent**: item 9's stated purpose was defense against future regressions, but the current `max(·, 0)` form silently absorbs any negative value — including large ones that would actually indicate a bug. A future refactor breaking the PSD invariant or introducing a sign error would silently produce `SE = 0`, with no signal to the user that anything went wrong. That's precisely the failure mode item 9 meant to prevent.

## What

Two-tier diagnostic layered on top of the existing floor, in a new internal helper `.floor_cluster_quad()`:

| Range of `q`              | Behavior                                                                  |
| ------------------------- | ------------------------------------------------------------------------- |
| `q ≥ 0`                   | Return `q` unchanged.                                                     |
| `-1e-10 ≤ q < 0`          | Silently floor to 0 (FP cancellation — same as today).                    |
| `-1 < q < -1e-10`          | **`warning()`** with site name and value; floor to 0. Fit proceeds.       |
| `q < -1`                  | **`stop()`** with site name and value. Fit aborts — catastrophic numerical failure surfaces rather than silently producing `SE = 0`. |

On well-conditioned data the behavior is identical to before — the FP-noise range covers anything that realistic fits will encounter. The warning/error only fires when the quadratic form is in a range that genuinely indicates trouble.

## Sites

Five cluster-sandwich quadratic-form sites are routed through the helper:

| # | Site                                     | Label                                  |
| - | ---------------------------------------- | -------------------------------------- |
| 1 | `R/variance_machinery.R:113`             | `getTeResultsOLS/att_var_1`            |
| 2 | `R/variance_machinery.R:651`             | `getTeResults2/att_var_1`              |
| 3 | `R/variance_machinery.R:1331`            | `getCohortATTsFinal/cohort_te_se`      |
| 4 | `R/event_study.R:213`                    | `event_study_etwfe_betwfe/var_1_e`     |
| 5 | `R/event_study.R:411`                    | `event_study_fetwfe/var_1_e`           |

Note: #139's body references "six" sites — the pre-PR-#118 count. PR #118's `getCohortATTsFinal()` unification collapsed two of #111's original 6 sites into a single shared site, leaving 5 in the current tree. Independently verified during the post-execution review against `git show 2b31514^:R/variance_machinery.R`.

Per-site labels are surfaced in the diagnostic messages so a developer hitting the warning or error can locate the firing site without grepping.

## Implementation

- **`R/cluster_floor.R`** (new) — `.floor_cluster_quad(q, site, err_threshold = -1, warn_threshold = -1e-10)` helper. Pass-through on NA / multi-element / non-numeric / length-0 inputs. `@noRd` (internal). Thresholds match the issue's recommendations (absolute, not relative).
- **5 sites wired** through the helper across `R/variance_machinery.R` and `R/event_study.R`.
- **`tests/testthat/test-cluster_floor.R`** (new) — 38 assertions across 9 `test_that` blocks: unit tests on the helper (positive / zero / FP-noise negative / warning-range / error-range / NA / multi-element / non-numeric / site name in messages), coverage / regression test asserting each of the 5 sites uses the helper with the expected label, and an integration smoke test verifying a small cluster-SE fit doesn't trigger the diagnostic on well-conditioned data.
- **NEWS + version + CITATION** — `DESCRIPTION` 1.11.1 → 1.11.2; `inst/CITATION` same; `NEWS.md` 1.11.2 entry under "Defensive improvements".

## Validation

- `devtools::check(args = "--as-cran")`: 0 errors / 0 warnings / 1 env-only future-timestamp NOTE.
- `devtools::test()`: `FAIL 0 | WARN 0 | SKIP 0 | PASS 2183` (was 2145 pre-PR; +38 from the new test file).
- `devtools::document()`: idempotent on second run.
- `devtools::spell_check()`, `urlchecker::url_check()`: both clean.
- Two-pass review: independent post-execution review surfaced 0 blockers / 1 robustness / 1 streamlining / 1 cosmetic. Round-1 fix commit addressed the robustness finding (the bare-max scanner regex bug — the assertion looked like coverage but matched none of the real patterns, so it gave false confidence; replaced with a bounded non-greedy pattern over a comment-stripped concatenated source). Deferred: 1 streamlining (strict `== 5L` count kept as a change-detection canary), 1 cosmetic (redundant library calls match repo convention per reviewer).

## Commits

- `709491f` — Main implementation: helper + 5 site wirings + tests + NEWS + version bumps.
- `b4b882b` — Post-execution-review fix: corrected the broken bare-max scanner regex in the coverage test (was anchored at line-start, which none of the historical patterns match — so it returned 0 detections both pre- and post-PR, giving false confidence; companion call-count + label assertions in the same block carried the actual regression detection).

## Out of scope

The 2 `att_var_1` and 2 `att_var_2` non-cluster floors (in `getSecondVarTermOLS` / `getSecondVarTermDataApp`, the overall-ATT-SE second-term computation) are not in this PR — #139's body explicitly scopes to "six cluster-sandwich quadratic-form computation sites". The symmetric treatment for those 4 sites is a potential follow-up if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
