### PR TITLE
Add required-columns guard to tidy.eventStudy() (#151, 1.11.3)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.11.2
+Version: 1.11.3
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # NEWS
 
+## Version 1.11.3 (2026-05-26)
+
+### Defensive improvements
+
+- `tidy.eventStudy()` (`R/broom_methods.R`) now reports the missing
+  column name when its input is missing a required column, parallel to
+  the guard added to `tidy.cohortStudy()` in 1.11.1. Previously a
+  user-mutated `eventStudy` frame produced a cryptic "arguments imply
+  differing number of rows" error from `data.frame()`; now the failure
+  localizes to "tidy.eventStudy(): input is missing required columns:
+  ...". Required columns: `event_time`, `n_cohorts`, `estimate`, `se`,
+  `p_value`. CI columns (`ci_low`, `ci_high`) are NOT required — this
+  method computes its own CIs from `estimate +/- z * se`. Issue #151.
+
 ## Version 1.11.2 (2026-05-26)
 
 ### Defensive improvements

--- a/R/broom_methods.R
+++ b/R/broom_methods.R
@@ -439,6 +439,24 @@ tidy.eventStudy <- function(
 	...
 ) {
 	stopifnot(conf.level > 0, conf.level < 1)
+	# Guard against a user-mutated `eventStudy` frame that's missing a
+	# required column: localizes the error message rather than the cryptic
+	# "arguments imply differing number of rows" from `data.frame()` when
+	# `x$<col>` returns NULL on an absent column. Parallels the guard added
+	# to `tidy.cohortStudy()` in PR #150. The CI columns `ci_low` / `ci_high`
+	# are NOT in the required list — this method recomputes CIs from
+	# `estimate +/- z * se` rather than reading them from the input.
+	required <- c("event_time", "n_cohorts", "estimate", "se", "p_value")
+	missing_cols <- setdiff(required, names(x))
+	if (length(missing_cols) > 0L) {
+		stop(
+			"tidy.eventStudy(): input is missing required columns: ",
+			paste(missing_cols, collapse = ", "),
+			". If you have mutated the `eventStudy` object, restore the ",
+			"original data frame; otherwise please file an issue.",
+			call. = FALSE
+		)
+	}
 	statistic <- ifelse(
 		!is.na(x$se) & x$se > 0,
 		x$estimate / x$se,

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.11.2",
+  note    = "R package version 1.11.3",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -46,6 +46,7 @@ estimand
 et
 etwfe
 ETWFE
+eventStudy
 FEs
 fetwfePackage
 FETWFE’s

--- a/tests/testthat/test-broom-methods.R
+++ b/tests/testthat/test-broom-methods.R
@@ -540,6 +540,36 @@ test_that("tidy.eventStudy recomputes CIs at a custom conf.level", {
 	))
 })
 
+test_that("tidy.eventStudy localizes error when required columns are missing", {
+	# Parallels the guard PR #150 added to tidy.cohortStudy(). If a user
+	# mutated the `eventStudy` frame to drop a required column, the call
+	# should report which column is missing rather than producing a
+	# cryptic "differing number of rows" error from `data.frame()`.
+	res <- .fetwfe_fixture()
+	es <- eventStudy(res)
+	# Drop a single required column.
+	es_broken <- es
+	es_broken$se <- NULL
+	expect_error(
+		broom::tidy(es_broken),
+		"missing required columns: se"
+	)
+	# Drop two required columns; both are listed in the error message.
+	es_broken2 <- es
+	es_broken2$se <- NULL
+	es_broken2$p_value <- NULL
+	expect_error(
+		broom::tidy(es_broken2),
+		"missing required columns: se, p_value"
+	)
+	# CI columns are NOT required (this method computes its own CIs from
+	# estimate +/- z * se). Dropping them should NOT fire the guard.
+	es_no_ci <- es
+	es_no_ci$ci_low <- NULL
+	es_no_ci$ci_high <- NULL
+	expect_silent(broom::tidy(es_no_ci))
+})
+
 test_that("FETWFE_tes carries cohort_times slot (simulator convention)", {
 	setup <- .simulated_setup()
 	tes <- getTes(setup$coefs)


### PR DESCRIPTION
Adds a required-columns guard at the top of `tidy.eventStudy()`, parallel to the guard PR #150 added to `tidy.cohortStudy()`. Closes #151. Version bump 1.11.2 → 1.11.3.

## Why

The post-execution review of PR #150 (closing #137) noted that `tidy.cohortStudy()` produced a cryptic `"arguments imply differing number of rows: N, 0"` error from `data.frame()` if a user mutated the `catt_df` slot to drop a required column. PR #150 added a guard at the top of `tidy.cohortStudy()` that localizes the failure with the missing column name.

The same shape existed in `tidy.eventStudy()` (`R/broom_methods.R`). It pre-dated #150 so wasn't a regression — opened as #151 for the symmetric fix.

## What

```r
> es <- eventStudy(res)
> es$se <- NULL
> broom::tidy(es)
Error: tidy.eventStudy(): input is missing required columns: se.
       If you have mutated the `eventStudy` object, restore the
       original data frame; otherwise please file an issue.
```

## Implementation note: 5 required columns, not 7

The issue body suggested mirroring `tidy.cohortStudy()`'s required-columns list (7 columns including `ci_low`/`ci_high`). The actual code reads only 5 — `event_time`, `n_cohorts`, `estimate`, `se`, `p_value` — because unlike `tidy.cohortStudy()` (which reads precomputed CIs from `catt_df`), `tidy.eventStudy()` *computes* CIs from `estimate ± z * se` via the `conf.int`/`conf.level` parameters. So dropping `ci_low`/`ci_high` from the input is valid usage and shouldn't fire the guard.

The guard follows "guard only what you read" — listing 7 would falsely reject perfectly-fine `eventStudy` objects. Verified with an `expect_silent()` test case that drops both CI columns.

## Tests

3 new assertions in `tests/testthat/test-broom-methods.R`:

- Drop one required column (`se`) → guard fires with the column name.
- Drop two required columns (`se`, `p_value`) → guard fires listing both.
- Drop `ci_low` and `ci_high` (NOT required) → `expect_silent()` — guard does NOT fire.

## Validation

- `devtools::check(args = "--as-cran")`: 0 errors / 0 warnings / 1 env-only future-timestamp NOTE.
- `devtools::test()`: `FAIL 0 | WARN 0 | PASS 2186` (was 2183 pre-PR; +3 from the new guard tests).
- `devtools::document()`: idempotent on second run.
- `devtools::spell_check()`, `urlchecker::url_check()`: both clean.

## Commits

- `62ad6a7` — Guard + tests + version bump + NEWS.md entry + WORDLIST (`eventStudy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
