### PR TITLE
Add $internal slot parity to etwfe / betwfe / twfeCovs (#144, 1.11.4)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.11.3
+Version: 1.11.4
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # NEWS
 
+## Version 1.11.4 (2026-05-26)
+
+### New features
+
+- `etwfe()`, `betwfe()`, and `twfeCovs()` results now expose an
+  `$internal` list containing the design-machinery slots (`X_ints`,
+  `y`, `X_final`, `y_final`, `calc_ses`), matching the structure
+  `fetwfe()` already provided. Downstream consumers can now use a
+  single canonical access path (`result$internal$<slot>`) across all
+  four estimator classes. The same slots remain available at top level
+  (e.g., `result$X_ints`) for backward compat with existing user
+  scripts; no scripts are broken by this change. Issue #144.
+
 ## Version 1.11.3 (2026-05-26)
 
 ### Defensive improvements

--- a/R/betwfe_class.R
+++ b/R/betwfe_class.R
@@ -113,7 +113,22 @@ print.summary.betwfe <- function(x, ...) {
 	"time_var",
 	"unit_var",
 	"treatment",
-	"covs"
+	"covs",
+	"internal"
+)
+
+# Inner slots under `$internal` (#144). Parallel to
+# `.EXPECTED_INTERNAL_SLOTS_FETWFE` in `R/fetwfe_class.R`. The OLS-family
+# `$internal` omits `theta_hat` (bridge-selection-only, no analog here).
+# Same values are also duplicated at top level for backward compat per
+# the pure-additive strategy adopted in PR #154; the canonical path is
+# `$internal` going forward.
+.EXPECTED_INTERNAL_SLOTS_BETWFE <- c(
+	"X_ints",
+	"y",
+	"X_final",
+	"y_final",
+	"calc_ses"
 )
 
 #' @title Validate a `betwfe`-classed object's contracts
@@ -122,6 +137,12 @@ print.summary.betwfe <- function(x, ...) {
 .validate_betwfe <- function(x) {
 	cls <- "betwfe"
 	.stop_if_missing_slots(x, .EXPECTED_SLOTS_BETWFE, cls)
+	.stop_if_missing_slots(
+		x$internal,
+		.EXPECTED_INTERNAL_SLOTS_BETWFE,
+		cls,
+		where = "internal"
+	)
 	.check_type_sanity(x, cls, has_alpha = TRUE, has_att_selected = TRUE)
 	.check_se_consistency(x, calc_ses_path = "calc_ses", cls)
 	.check_selection_consistency(x, cls)

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -205,6 +205,23 @@
 #' `FALSE` otherwise.}
 #' \item{se_type}{Character scalar; the `se_type` argument the user passed
 #' (`"default"` or `"cluster"`).}
+#' \item{internal}{A list containing internal outputs that are typically
+#'   not needed for interpretation, packaged here for parity with
+#'   `fetwfe()` so downstream consumers can use a single canonical
+#'   access path across all four estimator classes (#144). The five
+#'   sub-slots are also duplicated at top level for backward compat:
+#'   \describe{
+#'     \item{X_ints}{The design matrix containing all interactions,
+#'       time and cohort dummies, etc. Same value as top-level `X_ints`.}
+#'     \item{y}{The vector of responses. Same as top-level `y`.}
+#'     \item{X_final}{The design matrix after the change-of-coordinates
+#'       step. Same as top-level `X_final`.}
+#'     \item{y_final}{The transformed response vector. Same as top-level
+#'       `y_final`.}
+#'     \item{calc_ses}{Logical indicating whether standard errors were
+#'       calculated. Same as top-level `calc_ses`.}
+#'   }
+#' }
 #' @author Gregory Faletto
 #' @references
 #' Faletto, G (2025). Fused Extended Two-Way Fixed Effects for
@@ -406,6 +423,16 @@ betwfe <- function(
 		treatment = treatment,
 		covs = covs_orig
 	)
+	# Add internal outputs in a separate list for parity with `fetwfe()` (#144).
+	# The five slots are also duplicated at top level for backward compat;
+	# `$internal` is the canonical access path going forward.
+	out$internal <- list(
+		X_ints = res$X_ints,
+		y = res$y,
+		X_final = res$X_final,
+		y_final = res$y_final,
+		calc_ses = res$calc_ses
+	)
 	# Validate constructed object's contracts (#85).
 	.validate_betwfe(out)
 	class(out) <- "betwfe"
@@ -567,6 +594,23 @@ betwfe <- function(
 #' arguments the user passed.}
 #' \item{covs}{Character vector; the original `covs` argument (pre-factor-
 #' expansion).}
+#' \item{internal}{A list containing internal outputs that are typically
+#'   not needed for interpretation, packaged here for parity with
+#'   `fetwfe()` so downstream consumers can use a single canonical
+#'   access path across all four estimator classes (#144). The five
+#'   sub-slots are also duplicated at top level for backward compat:
+#'   \describe{
+#'     \item{X_ints}{The design matrix containing all interactions,
+#'       time and cohort dummies, etc. Same value as top-level `X_ints`.}
+#'     \item{y}{The vector of responses. Same as top-level `y`.}
+#'     \item{X_final}{The design matrix after the change-of-coordinates
+#'       step. Same as top-level `X_final`.}
+#'     \item{y_final}{The transformed response vector. Same as top-level
+#'       `y_final`.}
+#'     \item{calc_ses}{Logical indicating whether standard errors were
+#'       calculated. Same as top-level `calc_ses`.}
+#'   }
+#' }
 #'
 #' @examples
 #' \dontrun{

--- a/R/etwfe_class.R
+++ b/R/etwfe_class.R
@@ -100,7 +100,22 @@ print.summary.etwfe <- function(x, ...) {
 	"time_var",
 	"unit_var",
 	"treatment",
-	"covs"
+	"covs",
+	"internal"
+)
+
+# Inner slots under `$internal` (#144). Parallel to
+# `.EXPECTED_INTERNAL_SLOTS_FETWFE` in `R/fetwfe_class.R`. The OLS-family
+# `$internal` omits `theta_hat` (bridge-selection-only, no analog here).
+# Same values are also duplicated at top level for backward compat per
+# the pure-additive strategy adopted in PR #154; the canonical path is
+# `$internal` going forward.
+.EXPECTED_INTERNAL_SLOTS_ETWFE <- c(
+	"X_ints",
+	"y",
+	"X_final",
+	"y_final",
+	"calc_ses"
 )
 
 #' @title Validate an `etwfe`-classed object's contracts
@@ -109,6 +124,12 @@ print.summary.etwfe <- function(x, ...) {
 .validate_etwfe <- function(x) {
 	cls <- "etwfe"
 	.stop_if_missing_slots(x, .EXPECTED_SLOTS_ETWFE, cls)
+	.stop_if_missing_slots(
+		x$internal,
+		.EXPECTED_INTERNAL_SLOTS_ETWFE,
+		cls,
+		where = "internal"
+	)
 	.check_type_sanity(x, cls, has_alpha = TRUE, has_att_selected = FALSE)
 	.check_se_consistency(x, calc_ses_path = "calc_ses", cls)
 	.check_p_value_na(x, cls)

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -717,6 +717,23 @@ fetwfeWithSimulatedData <- function(
 #' \item{covs}{Character vector; the original `covs` argument the user
 #'   passed (before any factor expansion the estimator performed
 #'   internally). Consumed by `augment.<class>()`.}
+#' \item{internal}{A list containing internal outputs that are typically
+#'   not needed for interpretation, packaged here for parity with
+#'   `fetwfe()` so downstream consumers can use a single canonical
+#'   access path across all four estimator classes (#144). The five
+#'   sub-slots are also duplicated at top level for backward compat:
+#'   \describe{
+#'     \item{X_ints}{The design matrix containing all interactions,
+#'       time and cohort dummies, etc. Same value as top-level `X_ints`.}
+#'     \item{y}{The vector of responses. Same as top-level `y`.}
+#'     \item{X_final}{The design matrix after the change-of-coordinates
+#'       step. Same as top-level `X_final`.}
+#'     \item{y_final}{The transformed response vector. Same as top-level
+#'       `y_final`.}
+#'     \item{calc_ses}{Logical indicating whether standard errors were
+#'       calculated. Same as top-level `calc_ses`.}
+#'   }
+#' }
 #' @author Gregory Faletto
 #' @references
 #' Wooldridge, J. M. (2021). Two-way fixed effects, the two-way mundlak
@@ -889,6 +906,17 @@ etwfe <- function(
 		covs = covs_orig
 	)
 
+	# Add internal outputs in a separate list for parity with `fetwfe()` (#144).
+	# The five slots are also duplicated at top level for backward compat;
+	# `$internal` is the canonical access path going forward.
+	out$internal <- list(
+		X_ints = res$X_ints,
+		y = res$y,
+		X_final = res$X_final,
+		y_final = res$y_final,
+		calc_ses = res$calc_ses
+	)
+
 	# Validate constructed object's contracts (#85).
 	.validate_etwfe(out)
 
@@ -1000,6 +1028,23 @@ etwfe <- function(
 #' \item{covs}{Character vector; the original `covs` argument the user
 #'   passed (before any factor expansion the estimator performed
 #'   internally).}
+#' \item{internal}{A list containing internal outputs that are typically
+#'   not needed for interpretation, packaged here for parity with
+#'   `fetwfe()` so downstream consumers can use a single canonical
+#'   access path across all four estimator classes (#144). The five
+#'   sub-slots are also duplicated at top level for backward compat:
+#'   \describe{
+#'     \item{X_ints}{The design matrix containing all interactions,
+#'       time and cohort dummies, etc. Same value as top-level `X_ints`.}
+#'     \item{y}{The vector of responses. Same as top-level `y`.}
+#'     \item{X_final}{The design matrix after the change-of-coordinates
+#'       step. Same as top-level `X_final`.}
+#'     \item{y_final}{The transformed response vector. Same as top-level
+#'       `y_final`.}
+#'     \item{calc_ses}{Logical indicating whether standard errors were
+#'       calculated. Same as top-level `calc_ses`.}
+#'   }
+#' }
 #'
 #' @examples
 #' \dontrun{

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -155,6 +155,23 @@
 #' `FALSE` otherwise.}
 #' \item{se_type}{Character scalar; the `se_type` argument the user passed
 #' (`"default"` or `"cluster"`).}
+#' \item{internal}{A list containing internal outputs that are typically
+#'   not needed for interpretation, packaged here for parity with
+#'   `fetwfe()` so downstream consumers can use a single canonical
+#'   access path across all four estimator classes (#144). The five
+#'   sub-slots are also duplicated at top level for backward compat:
+#'   \describe{
+#'     \item{X_ints}{The design matrix containing all interactions,
+#'       time and cohort dummies, etc. Same value as top-level `X_ints`.}
+#'     \item{y}{The vector of responses. Same as top-level `y`.}
+#'     \item{X_final}{The design matrix after the change-of-coordinates
+#'       step. Same as top-level `X_final`.}
+#'     \item{y_final}{The transformed response vector. Same as top-level
+#'       `y_final`.}
+#'     \item{calc_ses}{Logical indicating whether standard errors were
+#'       calculated. Same as top-level `calc_ses`.}
+#'   }
+#' }
 #' @author Gregory Faletto
 #' @references
 #' Faletto, G (2025). Fused Extended Two-Way Fixed Effects for
@@ -324,6 +341,16 @@ twfeCovs <- function(
 		treatment = treatment,
 		covs = covs_orig
 	)
+	# Add internal outputs in a separate list for parity with `fetwfe()` (#144).
+	# The five slots are also duplicated at top level for backward compat;
+	# `$internal` is the canonical access path going forward.
+	out$internal <- list(
+		X_ints = res$X_ints,
+		y = res$y,
+		X_final = res$X_final,
+		y_final = res$y_final,
+		calc_ses = res$calc_ses
+	)
 	# Validate constructed object's contracts (#85). Validator operates
 	# on the list shape regardless of class, then class is assigned.
 	.validate_twfeCovs(out)
@@ -436,6 +463,23 @@ twfeCovs <- function(
 #' arguments the user passed.}
 #' \item{covs}{Character vector; the original `covs` argument (pre-factor-
 #' expansion).}
+#' \item{internal}{A list containing internal outputs that are typically
+#'   not needed for interpretation, packaged here for parity with
+#'   `fetwfe()` so downstream consumers can use a single canonical
+#'   access path across all four estimator classes (#144). The five
+#'   sub-slots are also duplicated at top level for backward compat:
+#'   \describe{
+#'     \item{X_ints}{The design matrix containing all interactions,
+#'       time and cohort dummies, etc. Same value as top-level `X_ints`.}
+#'     \item{y}{The vector of responses. Same as top-level `y`.}
+#'     \item{X_final}{The design matrix after the change-of-coordinates
+#'       step. Same as top-level `X_final`.}
+#'     \item{y_final}{The transformed response vector. Same as top-level
+#'       `y_final`.}
+#'     \item{calc_ses}{Logical indicating whether standard errors were
+#'       calculated. Same as top-level `calc_ses`.}
+#'   }
+#' }
 #'
 #' @examples
 #' \dontrun{

--- a/R/twfeCovs_class.R
+++ b/R/twfeCovs_class.R
@@ -66,7 +66,22 @@ print.twfeCovs <- function(x, ...) {
 	"time_var",
 	"unit_var",
 	"treatment",
-	"covs"
+	"covs",
+	"internal"
+)
+
+# Inner slots under `$internal` (#144). Parallel to
+# `.EXPECTED_INTERNAL_SLOTS_FETWFE` in `R/fetwfe_class.R`. The OLS-family
+# `$internal` omits `theta_hat` (bridge-selection-only, no analog here).
+# Same values are also duplicated at top level for backward compat per
+# the pure-additive strategy adopted in PR #154; the canonical path is
+# `$internal` going forward.
+.EXPECTED_INTERNAL_SLOTS_TWFECOVS <- c(
+	"X_ints",
+	"y",
+	"X_final",
+	"y_final",
+	"calc_ses"
 )
 
 #' @title Validate a `twfeCovs`-shaped object's contracts
@@ -75,6 +90,12 @@ print.twfeCovs <- function(x, ...) {
 .validate_twfeCovs <- function(x) {
 	cls <- "twfeCovs"
 	.stop_if_missing_slots(x, .EXPECTED_SLOTS_TWFECOVS, cls)
+	.stop_if_missing_slots(
+		x$internal,
+		.EXPECTED_INTERNAL_SLOTS_TWFECOVS,
+		cls,
+		where = "internal"
+	)
 	.check_type_sanity(x, cls, has_alpha = FALSE, has_att_selected = FALSE)
 	.check_se_consistency(x, calc_ses_path = "calc_ses", cls)
 	.check_p_value_na(x, cls)

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.11.3",
+  note    = "R package version 1.11.4",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/man/betwfe.Rd
+++ b/man/betwfe.Rd
@@ -246,6 +246,23 @@ argument was provided and used for asymptotically-exact ATT inference,
 \code{FALSE} otherwise.}
 \item{se_type}{Character scalar; the \code{se_type} argument the user passed
 (\code{"default"} or \code{"cluster"}).}
+\item{internal}{A list containing internal outputs that are typically
+not needed for interpretation, packaged here for parity with
+\code{fetwfe()} so downstream consumers can use a single canonical
+access path across all four estimator classes (#144). The five
+sub-slots are also duplicated at top level for backward compat:
+\describe{
+\item{X_ints}{The design matrix containing all interactions,
+time and cohort dummies, etc. Same value as top-level \code{X_ints}.}
+\item{y}{The vector of responses. Same as top-level \code{y}.}
+\item{X_final}{The design matrix after the change-of-coordinates
+step. Same as top-level \code{X_final}.}
+\item{y_final}{The transformed response vector. Same as top-level
+\code{y_final}.}
+\item{calc_ses}{Logical indicating whether standard errors were
+calculated. Same as top-level \code{calc_ses}.}
+}
+}
 }
 \description{
 Implementation of extended two-way fixed effects with a bridge

--- a/man/betwfeWithSimulatedData.Rd
+++ b/man/betwfeWithSimulatedData.Rd
@@ -175,6 +175,23 @@ the original \code{pdata}. Consumed by \code{augment.betwfe()}.}
 arguments the user passed.}
 \item{covs}{Character vector; the original \code{covs} argument (pre-factor-
 expansion).}
+\item{internal}{A list containing internal outputs that are typically
+not needed for interpretation, packaged here for parity with
+\code{fetwfe()} so downstream consumers can use a single canonical
+access path across all four estimator classes (#144). The five
+sub-slots are also duplicated at top level for backward compat:
+\describe{
+\item{X_ints}{The design matrix containing all interactions,
+time and cohort dummies, etc. Same value as top-level \code{X_ints}.}
+\item{y}{The vector of responses. Same as top-level \code{y}.}
+\item{X_final}{The design matrix after the change-of-coordinates
+step. Same as top-level \code{X_final}.}
+\item{y_final}{The transformed response vector. Same as top-level
+\code{y_final}.}
+\item{calc_ses}{Logical indicating whether standard errors were
+calculated. Same as top-level \code{calc_ses}.}
+}
+}
 }
 \description{
 This function runs the bridge-penalized extended two-way fixed effects estimator (\code{betwfe()}) on

--- a/man/etwfe.Rd
+++ b/man/etwfe.Rd
@@ -185,6 +185,23 @@ panel to the fitted design.}
 \item{covs}{Character vector; the original \code{covs} argument the user
 passed (before any factor expansion the estimator performed
 internally). Consumed by \verb{augment.<class>()}.}
+\item{internal}{A list containing internal outputs that are typically
+not needed for interpretation, packaged here for parity with
+\code{fetwfe()} so downstream consumers can use a single canonical
+access path across all four estimator classes (#144). The five
+sub-slots are also duplicated at top level for backward compat:
+\describe{
+\item{X_ints}{The design matrix containing all interactions,
+time and cohort dummies, etc. Same value as top-level \code{X_ints}.}
+\item{y}{The vector of responses. Same as top-level \code{y}.}
+\item{X_final}{The design matrix after the change-of-coordinates
+step. Same as top-level \code{X_final}.}
+\item{y_final}{The transformed response vector. Same as top-level
+\code{y_final}.}
+\item{calc_ses}{Logical indicating whether standard errors were
+calculated. Same as top-level \code{calc_ses}.}
+}
+}
 }
 \description{
 Implementation of extended two-way fixed effects.

--- a/man/etwfeWithSimulatedData.Rd
+++ b/man/etwfeWithSimulatedData.Rd
@@ -113,6 +113,23 @@ column in the original \code{pdata}. Consumed by \verb{augment.<class>()}.}
 \item{covs}{Character vector; the original \code{covs} argument the user
 passed (before any factor expansion the estimator performed
 internally).}
+\item{internal}{A list containing internal outputs that are typically
+not needed for interpretation, packaged here for parity with
+\code{fetwfe()} so downstream consumers can use a single canonical
+access path across all four estimator classes (#144). The five
+sub-slots are also duplicated at top level for backward compat:
+\describe{
+\item{X_ints}{The design matrix containing all interactions,
+time and cohort dummies, etc. Same value as top-level \code{X_ints}.}
+\item{y}{The vector of responses. Same as top-level \code{y}.}
+\item{X_final}{The design matrix after the change-of-coordinates
+step. Same as top-level \code{X_final}.}
+\item{y_final}{The transformed response vector. Same as top-level
+\code{y_final}.}
+\item{calc_ses}{Logical indicating whether standard errors were
+calculated. Same as top-level \code{calc_ses}.}
+}
+}
 }
 \description{
 This function runs the extended two-way fixed effects estimator (\code{etwfe()}) on

--- a/man/twfeCovs.Rd
+++ b/man/twfeCovs.Rd
@@ -182,6 +182,23 @@ argument was provided and used for asymptotically-exact ATT inference,
 \code{FALSE} otherwise.}
 \item{se_type}{Character scalar; the \code{se_type} argument the user passed
 (\code{"default"} or \code{"cluster"}).}
+\item{internal}{A list containing internal outputs that are typically
+not needed for interpretation, packaged here for parity with
+\code{fetwfe()} so downstream consumers can use a single canonical
+access path across all four estimator classes (#144). The five
+sub-slots are also duplicated at top level for backward compat:
+\describe{
+\item{X_ints}{The design matrix containing all interactions,
+time and cohort dummies, etc. Same value as top-level \code{X_ints}.}
+\item{y}{The vector of responses. Same as top-level \code{y}.}
+\item{X_final}{The design matrix after the change-of-coordinates
+step. Same as top-level \code{X_final}.}
+\item{y_final}{The transformed response vector. Same as top-level
+\code{y_final}.}
+\item{calc_ses}{Logical indicating whether standard errors were
+calculated. Same as top-level \code{calc_ses}.}
+}
+}
 }
 \description{
 \strong{WARNING: This function should NOT be used for estimation. It

--- a/man/twfeCovsWithSimulatedData.Rd
+++ b/man/twfeCovsWithSimulatedData.Rd
@@ -115,6 +115,23 @@ the original \code{pdata}.}
 arguments the user passed.}
 \item{covs}{Character vector; the original \code{covs} argument (pre-factor-
 expansion).}
+\item{internal}{A list containing internal outputs that are typically
+not needed for interpretation, packaged here for parity with
+\code{fetwfe()} so downstream consumers can use a single canonical
+access path across all four estimator classes (#144). The five
+sub-slots are also duplicated at top level for backward compat:
+\describe{
+\item{X_ints}{The design matrix containing all interactions,
+time and cohort dummies, etc. Same value as top-level \code{X_ints}.}
+\item{y}{The vector of responses. Same as top-level \code{y}.}
+\item{X_final}{The design matrix after the change-of-coordinates
+step. Same as top-level \code{X_final}.}
+\item{y_final}{The transformed response vector. Same as top-level
+\code{y_final}.}
+\item{calc_ses}{Logical indicating whether standard errors were
+calculated. Same as top-level \code{calc_ses}.}
+}
+}
 }
 \description{
 This function runs the bridge-penalized extended two-way fixed effects estimator (\code{twfeCovs()}) on

--- a/tests/testthat/test-doc-slot-parity.R
+++ b/tests/testthat/test-doc-slot-parity.R
@@ -254,18 +254,31 @@ test_that("cross-class slot inventory matches the documented divergence table", 
 		)
 	)
 
-	# Effective slot set per class: fetwfe's $internal sublist is flattened
-	# so its child slots count as top-level for cross-class comparison.
-	# (User-access paths are different — fit$X_ints vs fit$internal$X_ints —
-	# but the value, semantic, and presence are equivalent across classes.)
+	# Effective slot set per class: the `$internal` sublist is flattened
+	# for ALL four classes so its child slots count as top-level for
+	# cross-class comparison. (User-access paths are different —
+	# `fit$X_ints` vs `fit$internal$X_ints` — but the value, semantic,
+	# and presence are equivalent across classes.) Post-#144 the
+	# OLS-family also carries `$internal` (in addition to duplicating
+	# the same slots at top level for backward compat); flattening
+	# all four classes here keeps the comparison symmetric.
 	effective_slots <- list(
 		fetwfe = c(
 			setdiff(fetwfe:::.EXPECTED_SLOTS_FETWFE, "internal"),
 			fetwfe:::.EXPECTED_INTERNAL_SLOTS_FETWFE
 		),
-		etwfe = fetwfe:::.EXPECTED_SLOTS_ETWFE,
-		betwfe = fetwfe:::.EXPECTED_SLOTS_BETWFE,
-		twfeCovs = fetwfe:::.EXPECTED_SLOTS_TWFECOVS
+		etwfe = c(
+			setdiff(fetwfe:::.EXPECTED_SLOTS_ETWFE, "internal"),
+			fetwfe:::.EXPECTED_INTERNAL_SLOTS_ETWFE
+		),
+		betwfe = c(
+			setdiff(fetwfe:::.EXPECTED_SLOTS_BETWFE, "internal"),
+			fetwfe:::.EXPECTED_INTERNAL_SLOTS_BETWFE
+		),
+		twfeCovs = c(
+			setdiff(fetwfe:::.EXPECTED_SLOTS_TWFECOVS, "internal"),
+			fetwfe:::.EXPECTED_INTERNAL_SLOTS_TWFECOVS
+		)
 	)
 	all_classes <- names(effective_slots)
 	universe <- unique(unlist(effective_slots))

--- a/tests/testthat/test-internal-slot-parity.R
+++ b/tests/testthat/test-internal-slot-parity.R
@@ -1,0 +1,140 @@
+library(testthat)
+library(fetwfe)
+
+# Internal-slot parity (#144): all four estimators expose `$internal` with
+# the canonical inner slots. For the three OLS-family estimators
+# (etwfe / betwfe / twfeCovs), the same five inner slots are also
+# duplicated at top level for backward compat ("pure additive" strategy);
+# `$internal` is the canonical access path going forward and the only
+# location for these slots on `fetwfe` results.
+
+.parity_setup <- function() {
+	set.seed(2026)
+	coefs <- genCoefs(R = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
+	dat <- simulateData(
+		coefs,
+		N = 60,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5
+	)
+	dat
+}
+
+# ----------------------------------------------------------------------
+# 1) All four estimators expose `$internal` with the canonical inner
+#    slots. fetwfe additionally carries `theta_hat` (bridge-selection
+#    parameter); the OLS-family does not.
+# ----------------------------------------------------------------------
+
+test_that("all four estimators expose `$internal` with the canonical inner slots", {
+	sim <- .parity_setup()
+	res_fe <- fetwfeWithSimulatedData(sim)
+	res_et <- etwfeWithSimulatedData(sim)
+	res_be <- betwfeWithSimulatedData(sim)
+	res_tc <- twfeCovsWithSimulatedData(sim)
+
+	expected_ols <- c("X_ints", "y", "X_final", "y_final", "calc_ses")
+	expected_fe <- c(expected_ols, "theta_hat")
+
+	expect_true(!is.null(res_fe$internal))
+	expect_true(all(expected_fe %in% names(res_fe$internal)))
+
+	for (res in list(res_et, res_be, res_tc)) {
+		expect_true(!is.null(res$internal))
+		expect_true(all(expected_ols %in% names(res$internal)))
+	}
+})
+
+# ----------------------------------------------------------------------
+# 2) Pure additive: for the OLS-family, `$internal` slots equal the
+#    top-level slots (same value, different access path). Regression
+#    guard against silent drift between the two paths.
+# ----------------------------------------------------------------------
+
+test_that("OLS-family: $internal slots equal top-level slots (parity)", {
+	sim <- .parity_setup()
+	for (res in list(
+		etwfeWithSimulatedData(sim),
+		betwfeWithSimulatedData(sim),
+		twfeCovsWithSimulatedData(sim)
+	)) {
+		expect_identical(res$internal$X_ints, res$X_ints)
+		expect_identical(res$internal$y, res$y)
+		expect_identical(res$internal$X_final, res$X_final)
+		expect_identical(res$internal$y_final, res$y_final)
+		expect_identical(res$internal$calc_ses, res$calc_ses)
+	}
+})
+
+# ----------------------------------------------------------------------
+# 3) fetwfe: the inner slots are EXCLUSIVELY under `$internal` (existing
+#    behavior, regression guard). Documents the asymmetry that #144
+#    consciously preserves: fetwfe gates these slots through
+#    `$internal` as the only access path; the OLS-family duplicates for
+#    backward compat.
+# ----------------------------------------------------------------------
+
+test_that("fetwfe: $internal slots are NOT duplicated at top level", {
+	sim <- .parity_setup()
+	res <- fetwfeWithSimulatedData(sim)
+	expect_true(!is.null(res$internal$X_ints))
+	# Use `[[` (exact match) -- `$` does partial matching, so `res$y`
+	# would match `res$y_mean` (a real top-level slot) and produce a
+	# false positive here.
+	expect_null(res[["X_ints"]])
+	expect_null(res[["y"]])
+	expect_null(res[["X_final"]])
+	expect_null(res[["y_final"]])
+	expect_null(res[["theta_hat"]])
+	expect_null(res[["calc_ses"]])
+})
+
+# ----------------------------------------------------------------------
+# 4) Validators enforce the new contract: if `$internal` is dropped from
+#    the constructed object, the validator stops with a structured
+#    error.
+# ----------------------------------------------------------------------
+
+test_that("validators enforce `$internal` presence for OLS-family", {
+	sim <- .parity_setup()
+	for (entry in list(
+		list(res = etwfeWithSimulatedData(sim), fn = fetwfe:::.validate_etwfe),
+		list(
+			res = betwfeWithSimulatedData(sim),
+			fn = fetwfe:::.validate_betwfe
+		),
+		list(
+			res = twfeCovsWithSimulatedData(sim),
+			fn = fetwfe:::.validate_twfeCovs
+		)
+	)) {
+		bad <- entry$res
+		bad$internal <- NULL
+		expect_error(
+			entry$fn(bad),
+			"Missing slot.*internal"
+		)
+	}
+})
+
+test_that("validators enforce inner-slot presence for OLS-family", {
+	sim <- .parity_setup()
+	for (entry in list(
+		list(res = etwfeWithSimulatedData(sim), fn = fetwfe:::.validate_etwfe),
+		list(
+			res = betwfeWithSimulatedData(sim),
+			fn = fetwfe:::.validate_betwfe
+		),
+		list(
+			res = twfeCovsWithSimulatedData(sim),
+			fn = fetwfe:::.validate_twfeCovs
+		)
+	)) {
+		bad <- entry$res
+		bad$internal$X_ints <- NULL
+		expect_error(
+			entry$fn(bad),
+			"Missing slot.*X_ints"
+		)
+	}
+})


### PR DESCRIPTION
Pure-additive harmonization of the `etwfe()` / `betwfe()` / `twfeCovs()` return-object structure to match `fetwfe()`'s `$internal` packaging. Closes #144. Version bump 1.11.3 → 1.11.4.

## Why

`fetwfe()` packages design-machinery slots (`X_ints`, `y`, `X_final`, `y_final`, `calc_ses`, plus `theta_hat`) under `result$internal`. The three OLS-family estimators returned the same conceptual slots at top level. The asymmetry forced downstream consumers (`augment.*`, broom methods, future `predict.*` per #33) to use class-specific dispatch to read internals.

## What

```r
# Before:
res_etwfe <- etwfeWithSimulatedData(sim)
res_etwfe$X_ints                # ok
res_etwfe$internal$X_ints       # NULL (slot didn't exist)

# After:
res_etwfe$X_ints                # still works (backward compat)
res_etwfe$internal$X_ints       # also works (canonical)
identical(res_etwfe$internal$X_ints, res_etwfe$X_ints)  # TRUE

# fetwfe unchanged - inner slots exclusively under $internal:
res_fe <- fetwfeWithSimulatedData(sim)
res_fe[["X_ints"]]              # NULL
res_fe$internal$X_ints          # the actual value
```

Pure-additive strategy chosen ([per design discussion in the PR thread](https://github.com/gregfaletto/fetwfePackage/issues/144)): the three OLS-family estimators now populate `$internal` AND keep the same slots at top level. No user scripts break; downstream consumers can migrate to `$internal` for cross-class consistency on their own schedule. The follow-up issue tracking eventual deprecation/removal of the duplicated top-level slots is opened separately and parked on the back burner indefinitely.

## Implementation

- **Return-object updates** in three places: the `etwfe()` wrapper in `R/fetwfe.R` and the `betwfe()` / `twfeCovs()` functions in `R/betwfe_core.R` / `R/twfeCovs.R`. Each gains an `out$internal <- list(X_ints = ..., y = ..., X_final = ..., y_final = ..., calc_ses = ...)` block before the validator call.

- **Validator updates** in `R/etwfe_class.R`, `R/betwfe_class.R`, `R/twfeCovs_class.R`:
  - Added `"internal"` to `.EXPECTED_SLOTS_<CLASS>`.
  - Added new `.EXPECTED_INTERNAL_SLOTS_<CLASS>` constants (5 slots each; OLS-family omits `theta_hat`, which is fetwfe-only).
  - Added `.stop_if_missing_slots(x$internal, ...)` call to each `.validate_<class>()`. Mirrors fetwfe's pattern at `R/fetwfe_class.R:137-143`.

- **Roxygen `@return` blocks**: added `\item{internal}{...}` with a nested `\describe` to all six relevant docstrings — the three public estimator functions (`etwfe()`, `betwfe()`, `twfeCovs()`) plus the three `*WithSimulatedData()` wrappers, each of which carries its own duplicated `@return` block.

- **Tests** (`tests/testthat/test-internal-slot-parity.R`, new — 36 assertions across 5 `test_that` blocks):
  - All four estimators expose `$internal` with canonical inner slots; fetwfe additionally carries `theta_hat`.
  - OLS-family: `$internal` slots equal top-level slots (parity; regression guard against silent drift between the two paths).
  - fetwfe: inner slots are EXCLUSIVELY under `$internal`, NOT duplicated at top level (regression guard documenting the asymmetry that #144 consciously preserves).
  - Validators enforce `$internal` presence and inner-slot presence (drop `$internal` from a fitted object → validator stops with "Missing slot.*internal"; drop a single inner slot → stops with "Missing slot.*X_ints").

- **`tests/testthat/test-doc-slot-parity.R`** updated: the cross-class effective-slot computation now flattens all four classes symmetrically (was: only fetwfe was flattened). The OLS-family classes contribute their `.EXPECTED_INTERNAL_SLOTS_<CLASS>` to the flattened view, which keeps `X_ints` / `y` / `X_final` / `y_final` / `calc_ses` passing the "all-four-classes" check (they're now in `$internal` AND at top level for the OLS-family).

## Validation

- `devtools::check(args = "--as-cran")`: 0 errors / 0 warnings / 1 env-only future-timestamp NOTE.
- `devtools::test()`: `FAIL 0 | WARN 0 | PASS 2222` (was 2186 pre-PR; +36 from the new parity test file).
- `devtools::document()`: idempotent on second run.
- `devtools::spell_check()`, `urlchecker::url_check()`: both clean.

## Follow-up

Opening a separate issue to track the eventual deprecation/removal of the duplicated top-level slots (`X_ints`, `y`, `X_final`, `y_final`, `calc_ses` on the OLS-family). Per the design decision in this PR, that issue is parked on the back burner indefinitely; it captures the idea so it isn't lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
