### PR TITLE
Add formula interface for the `covs` argument (#28, 1.11.7)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.11.6
+Version: 1.11.7
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # NEWS
 
+## Version 1.11.7 (2026-05-26)
+
+### New features
+
+- The `covs` argument on `fetwfe()`, `etwfe()`, `betwfe()`, and
+  `twfeCovs()` now accepts a one-sided formula in addition to the
+  long-standing character vector. Both forms produce identical fits:
+
+  ```r
+  fetwfe(..., covs = c("x1", "x2"))   # existing
+  fetwfe(..., covs = ~ x1 + x2)       # new
+  ```
+
+  Mirrors the convention used by `did::att_gt(xformla = ...)`. Only
+  additive bare variable names are supported in the formula form
+  (e.g., `~ x1 + x2 + x3`); interactions (`x1:x2`, `x1 * x2`) and
+  `I()` transformations are rejected with a clear pointer to compute
+  derived variables in the data frame first. Issue #28.
+
 ## Version 1.11.6 (2026-05-26)
 
 ### New features

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -24,12 +24,18 @@
 #' @param response Character; the name of a single column containing the
 #' response for each unit at each time. The response must be an integer or
 #' numeric value.
-#' @param covs (Optional.) Character; a vector containing the names of the
-#' columns for covariates. All of these columns are expected to contain integer,
-#' numeric, or factor values, and any categorical values will be automatically
-#' encoded as binary indicators. If no covariates are provided, the treatment
-#' effect estimation will proceed, but it will only be valid under unconditional
-#' versions of the parallel trends and no anticipation assumptions. Default is c().
+#' @param covs (Optional.) Either a character vector containing the names of
+#' the columns for covariates (e.g., `covs = c("x1", "x2")`), or a one-sided
+#' formula (e.g., `covs = ~ x1 + x2`) -- the formula form mirrors the
+#' convention used by `did::att_gt(xformla = ...)`. Only additive bare
+#' variable names are supported in the formula form; for derived variables,
+#' compute them in the data frame first and pass via the character-vector
+#' form. All of these columns are expected to contain integer, numeric, or
+#' factor values, and any categorical values will be automatically encoded
+#' as binary indicators. If no covariates are provided, the treatment effect
+#' estimation will proceed, but it will only be valid under unconditional
+#' versions of the parallel trends and no anticipation assumptions. Default
+#' is c().
 #' @param indep_counts (Optional.) Integer; a vector. If you have a sufficiently
 #' large number of units, you can optionally randomly split your data set in
 #' half (with `N` units in each data set). The data for half of the units should
@@ -305,6 +311,10 @@ betwfe <- function(
 	se_type = "default"
 ) {
 	se_type <- match.arg(se_type, c("default", "cluster"))
+
+	# Normalize `covs` to a character vector if a one-sided formula was
+	# supplied (#28).
+	covs <- .process_covs_input(covs)
 
 	covs_orig <- covs
 

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -27,12 +27,18 @@
 #' @param response Character; the name of a single column containing the
 #' response for each unit at each time. The response must be an integer or
 #' numeric value.
-#' @param covs (Optional.) Character; a vector containing the names of the
-#' columns for covariates. All of these columns are expected to contain integer,
-#' numeric, or factor values, and any categorical values will be automatically
-#' encoded as binary indicators. If no covariates are provided, the treatment
-#' effect estimation will proceed, but it will only be valid under unconditional
-#' versions of the parallel trends and no anticipation assumptions. Default is c().
+#' @param covs (Optional.) Either a character vector containing the names of
+#' the columns for covariates (e.g., `covs = c("x1", "x2")`), or a one-sided
+#' formula (e.g., `covs = ~ x1 + x2`) -- the formula form mirrors the
+#' convention used by `did::att_gt(xformla = ...)`. Only additive bare
+#' variable names are supported in the formula form; for derived variables,
+#' compute them in the data frame first and pass via the character-vector
+#' form. All of these columns are expected to contain integer, numeric, or
+#' factor values, and any categorical values will be automatically encoded
+#' as binary indicators. If no covariates are provided, the treatment effect
+#' estimation will proceed, but it will only be valid under unconditional
+#' versions of the parallel trends and no anticipation assumptions. Default
+#' is c().
 #' @param indep_counts (Optional.) Integer; a vector. If you have a sufficiently
 #' large number of units, you can optionally randomly split your data set in
 #' half (with `N` units in each data set). The data for half of the units should
@@ -236,6 +242,11 @@ fetwfe <- function(
 	se_type = "default"
 ) {
 	se_type <- match.arg(se_type, c("default", "cluster"))
+
+	# Normalize `covs` to a character vector if a one-sided formula was
+	# supplied (#28). All downstream code assumes the character-vector
+	# form; this is the only place that needs to know about formulas.
+	covs <- .process_covs_input(covs)
 
 	# Capture original user-supplied args so they can be stored on the output
 	# for downstream methods (augment / predict) that need to re-prep `data`.
@@ -589,12 +600,18 @@ fetwfeWithSimulatedData <- function(
 #' @param response Character; the name of a single column containing the
 #' response for each unit at each time. The response must be an integer or
 #' numeric value.
-#' @param covs (Optional.) Character; a vector containing the names of the
-#' columns for covariates. All of these columns are expected to contain integer,
-#' numeric, or factor values, and any categorical values will be automatically
-#' encoded as binary indicators. If no covariates are provided, the treatment
-#' effect estimation will proceed, but it will only be valid under unconditional
-#' versions of the parallel trends and no anticipation assumptions. Default is c().
+#' @param covs (Optional.) Either a character vector containing the names of
+#' the columns for covariates (e.g., `covs = c("x1", "x2")`), or a one-sided
+#' formula (e.g., `covs = ~ x1 + x2`) -- the formula form mirrors the
+#' convention used by `did::att_gt(xformla = ...)`. Only additive bare
+#' variable names are supported in the formula form; for derived variables,
+#' compute them in the data frame first and pass via the character-vector
+#' form. All of these columns are expected to contain integer, numeric, or
+#' factor values, and any categorical values will be automatically encoded
+#' as binary indicators. If no covariates are provided, the treatment effect
+#' estimation will proceed, but it will only be valid under unconditional
+#' versions of the parallel trends and no anticipation assumptions. Default
+#' is c().
 #' @param indep_counts (Optional.) Integer; a vector. If you have a sufficiently
 #' large number of units, you can optionally randomly split your data set in
 #' half (with `N` units in each data set). The data for half of the units should
@@ -795,6 +812,10 @@ etwfe <- function(
 	se_type = "default"
 ) {
 	se_type <- match.arg(se_type, c("default", "cluster"))
+
+	# Normalize `covs` to a character vector if a one-sided formula was
+	# supplied (#28).
+	covs <- .process_covs_input(covs)
 
 	covs_orig <- covs
 

--- a/R/process_covs.R
+++ b/R/process_covs.R
@@ -1,0 +1,78 @@
+# Formula-interface support for the `covs` argument (#28).
+#
+# Normalizes `covs` input to a character vector of column names. Accepts
+# either the long-standing character-vector form (`covs = c("x1", "x2")`)
+# or a one-sided formula (`covs = ~ x1 + x2`), mirroring
+# `did::att_gt(xformla = ~ x1 + x2)`. Called at the top of each
+# estimator's body (`fetwfe()` / `etwfe()` / `betwfe()` / `twfeCovs()`)
+# so the rest of the package can assume a character vector.
+
+#' @title Normalize the `covs` argument to a character vector
+#'
+#' @description
+#' Internal helper used by the four estimator entry points. Accepts a
+#' character vector (returned unchanged) or a one-sided formula
+#' (e.g., `~ x1 + x2`), extracting the term labels. Anything else
+#' triggers a structured stop. Only additive bare names are supported;
+#' interactions, transformations, and `I()` wrappers are rejected so
+#' the user gets a clear pointer to compute the derived variable in
+#' the data frame first.
+#'
+#' @param covs Either a character vector of column names (the current
+#'   form, including the empty `c()` default), or a one-sided formula.
+#'   `NULL` is treated as no covariates (returns `character(0)`).
+#' @return A character vector of column names. Length zero when `covs`
+#'   is `NULL`, `c()`, or `~ 1`.
+#' @keywords internal
+#' @noRd
+.process_covs_input <- function(covs) {
+	if (is.null(covs)) {
+		return(character(0))
+	}
+	if (is.character(covs)) {
+		return(covs)
+	}
+	if (inherits(covs, "formula")) {
+		# One-sided formula required: `~ x1 + x2` -- `length(f) == 2`,
+		# with `f[[1]]` the `~` operator and `f[[2]]` the RHS.
+		if (length(covs) != 2L) {
+			stop(
+				"`covs` formula must be one-sided (RHS only), e.g. `~ x1 + x2`. ",
+				"Got: ",
+				deparse(covs),
+				".",
+				call. = FALSE
+			)
+		}
+		tt <- stats::terms(covs)
+		term_labels <- attr(tt, "term.labels")
+		# Length-zero (e.g., `~ 1` or `~ 0`) is a valid "no covariates"
+		# spelling -- treat like the empty character vector.
+		if (length(term_labels) == 0L) {
+			return(character(0))
+		}
+		# Only bare variable names are supported (no interactions,
+		# I()-transforms, etc.). The user can compute derived variables
+		# in the data frame and pass them by name instead.
+		invalid <- grepl("[^A-Za-z0-9._]", term_labels)
+		if (any(invalid)) {
+			stop(
+				"`covs` formula only supports additive bare variable names ",
+				"(e.g. `~ x1 + x2`). Got non-bare term(s): ",
+				paste(term_labels[invalid], collapse = ", "),
+				". For derived variables, compute them in the data frame ",
+				"first and pass via the character-vector form ",
+				"(`covs = c(\"x1\", \"derived_x2\")`).",
+				call. = FALSE
+			)
+		}
+		return(term_labels)
+	}
+	stop(
+		"`covs` must be a character vector of column names or a one-sided ",
+		"formula (e.g. `~ x1 + x2`). Got object of class: ",
+		paste(class(covs), collapse = ", "),
+		".",
+		call. = FALSE
+	)
+}

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -30,12 +30,18 @@
 #' @param response Character; the name of a single column containing the
 #' response for each unit at each time. The response must be an integer or
 #' numeric value.
-#' @param covs (Optional.) Character; a vector containing the names of the
-#' columns for covariates. All of these columns are expected to contain integer,
-#' numeric, or factor values, and any categorical values will be automatically
-#' encoded as binary indicators. If no covariates are provided, the treatment
-#' effect estimation will proceed, but it will only be valid under unconditional
-#' versions of the parallel trends and no anticipation assumptions. Default is c().
+#' @param covs (Optional.) Either a character vector containing the names of
+#' the columns for covariates (e.g., `covs = c("x1", "x2")`), or a one-sided
+#' formula (e.g., `covs = ~ x1 + x2`) -- the formula form mirrors the
+#' convention used by `did::att_gt(xformla = ...)`. Only additive bare
+#' variable names are supported in the formula form; for derived variables,
+#' compute them in the data frame first and pass via the character-vector
+#' form. All of these columns are expected to contain integer, numeric, or
+#' factor values, and any categorical values will be automatically encoded
+#' as binary indicators. If no covariates are provided, the treatment effect
+#' estimation will proceed, but it will only be valid under unconditional
+#' versions of the parallel trends and no anticipation assumptions. Default
+#' is c().
 #' @param indep_counts (Optional.) Integer; a vector. If you have a sufficiently
 #' large number of units, you can optionally randomly split your data set in
 #' half (with `N` units in each data set). The data for half of the units should
@@ -233,6 +239,10 @@ twfeCovs <- function(
 	se_type = "default"
 ) {
 	se_type <- match.arg(se_type, c("default", "cluster"))
+
+	# Normalize `covs` to a character vector if a one-sided formula was
+	# supplied (#28).
+	covs <- .process_covs_input(covs)
 
 	covs_orig <- covs
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.11.6",
+  note    = "R package version 1.11.7",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/man/betwfe.Rd
+++ b/man/betwfe.Rd
@@ -51,12 +51,18 @@ untreated at the final time period ("never-treated units").}
 response for each unit at each time. The response must be an integer or
 numeric value.}
 
-\item{covs}{(Optional.) Character; a vector containing the names of the
-columns for covariates. All of these columns are expected to contain integer,
-numeric, or factor values, and any categorical values will be automatically
-encoded as binary indicators. If no covariates are provided, the treatment
-effect estimation will proceed, but it will only be valid under unconditional
-versions of the parallel trends and no anticipation assumptions. Default is c().}
+\item{covs}{(Optional.) Either a character vector containing the names of
+the columns for covariates (e.g., \code{covs = c("x1", "x2")}), or a one-sided
+formula (e.g., \code{covs = ~ x1 + x2}) -- the formula form mirrors the
+convention used by \code{did::att_gt(xformla = ...)}. Only additive bare
+variable names are supported in the formula form; for derived variables,
+compute them in the data frame first and pass via the character-vector
+form. All of these columns are expected to contain integer, numeric, or
+factor values, and any categorical values will be automatically encoded
+as binary indicators. If no covariates are provided, the treatment effect
+estimation will proceed, but it will only be valid under unconditional
+versions of the parallel trends and no anticipation assumptions. Default
+is c().}
 
 \item{indep_counts}{(Optional.) Integer; a vector. If you have a sufficiently
 large number of units, you can optionally randomly split your data set in

--- a/man/etwfe.Rd
+++ b/man/etwfe.Rd
@@ -47,12 +47,18 @@ untreated at the final time period ("never-treated units").}
 response for each unit at each time. The response must be an integer or
 numeric value.}
 
-\item{covs}{(Optional.) Character; a vector containing the names of the
-columns for covariates. All of these columns are expected to contain integer,
-numeric, or factor values, and any categorical values will be automatically
-encoded as binary indicators. If no covariates are provided, the treatment
-effect estimation will proceed, but it will only be valid under unconditional
-versions of the parallel trends and no anticipation assumptions. Default is c().}
+\item{covs}{(Optional.) Either a character vector containing the names of
+the columns for covariates (e.g., \code{covs = c("x1", "x2")}), or a one-sided
+formula (e.g., \code{covs = ~ x1 + x2}) -- the formula form mirrors the
+convention used by \code{did::att_gt(xformla = ...)}. Only additive bare
+variable names are supported in the formula form; for derived variables,
+compute them in the data frame first and pass via the character-vector
+form. All of these columns are expected to contain integer, numeric, or
+factor values, and any categorical values will be automatically encoded
+as binary indicators. If no covariates are provided, the treatment effect
+estimation will proceed, but it will only be valid under unconditional
+versions of the parallel trends and no anticipation assumptions. Default
+is c().}
 
 \item{indep_counts}{(Optional.) Integer; a vector. If you have a sufficiently
 large number of units, you can optionally randomly split your data set in

--- a/man/fetwfe.Rd
+++ b/man/fetwfe.Rd
@@ -51,12 +51,18 @@ untreated at the final time period ("never-treated units").}
 response for each unit at each time. The response must be an integer or
 numeric value.}
 
-\item{covs}{(Optional.) Character; a vector containing the names of the
-columns for covariates. All of these columns are expected to contain integer,
-numeric, or factor values, and any categorical values will be automatically
-encoded as binary indicators. If no covariates are provided, the treatment
-effect estimation will proceed, but it will only be valid under unconditional
-versions of the parallel trends and no anticipation assumptions. Default is c().}
+\item{covs}{(Optional.) Either a character vector containing the names of
+the columns for covariates (e.g., \code{covs = c("x1", "x2")}), or a one-sided
+formula (e.g., \code{covs = ~ x1 + x2}) -- the formula form mirrors the
+convention used by \code{did::att_gt(xformla = ...)}. Only additive bare
+variable names are supported in the formula form; for derived variables,
+compute them in the data frame first and pass via the character-vector
+form. All of these columns are expected to contain integer, numeric, or
+factor values, and any categorical values will be automatically encoded
+as binary indicators. If no covariates are provided, the treatment effect
+estimation will proceed, but it will only be valid under unconditional
+versions of the parallel trends and no anticipation assumptions. Default
+is c().}
 
 \item{indep_counts}{(Optional.) Integer; a vector. If you have a sufficiently
 large number of units, you can optionally randomly split your data set in

--- a/man/twfeCovs.Rd
+++ b/man/twfeCovs.Rd
@@ -48,12 +48,18 @@ untreated at the final time period ("never-treated units").}
 response for each unit at each time. The response must be an integer or
 numeric value.}
 
-\item{covs}{(Optional.) Character; a vector containing the names of the
-columns for covariates. All of these columns are expected to contain integer,
-numeric, or factor values, and any categorical values will be automatically
-encoded as binary indicators. If no covariates are provided, the treatment
-effect estimation will proceed, but it will only be valid under unconditional
-versions of the parallel trends and no anticipation assumptions. Default is c().}
+\item{covs}{(Optional.) Either a character vector containing the names of
+the columns for covariates (e.g., \code{covs = c("x1", "x2")}), or a one-sided
+formula (e.g., \code{covs = ~ x1 + x2}) -- the formula form mirrors the
+convention used by \code{did::att_gt(xformla = ...)}. Only additive bare
+variable names are supported in the formula form; for derived variables,
+compute them in the data frame first and pass via the character-vector
+form. All of these columns are expected to contain integer, numeric, or
+factor values, and any categorical values will be automatically encoded
+as binary indicators. If no covariates are provided, the treatment effect
+estimation will proceed, but it will only be valid under unconditional
+versions of the parallel trends and no anticipation assumptions. Default
+is c().}
 
 \item{indep_counts}{(Optional.) Integer; a vector. If you have a sufficiently
 large number of units, you can optionally randomly split your data set in

--- a/tests/testthat/test-formula-interface-covs-28.R
+++ b/tests/testthat/test-formula-interface-covs-28.R
@@ -1,0 +1,244 @@
+library(testthat)
+library(fetwfe)
+
+# Issue #28: formula interface for `covs`. The four estimators now accept
+# `covs = ~ x1 + x2` (one-sided formula) in addition to the long-standing
+# `covs = c("x1", "x2")` (character vector). Internal helper
+# `.process_covs_input()` normalizes formula -> character vector; the
+# rest of the package assumes the character form.
+
+# ----------------------------------------------------------------------
+# 1) Helper-level: character vectors are returned unchanged.
+# ----------------------------------------------------------------------
+
+test_that(".process_covs_input() returns character vectors unchanged", {
+	expect_identical(
+		fetwfe:::.process_covs_input(c("x1", "x2")),
+		c("x1", "x2")
+	)
+	expect_identical(fetwfe:::.process_covs_input(c()), character(0))
+	expect_identical(
+		fetwfe:::.process_covs_input(character(0)),
+		character(0)
+	)
+})
+
+# ----------------------------------------------------------------------
+# 2) Helper-level: NULL maps to character(0).
+# ----------------------------------------------------------------------
+
+test_that(".process_covs_input(NULL) returns character(0)", {
+	expect_identical(fetwfe:::.process_covs_input(NULL), character(0))
+})
+
+# ----------------------------------------------------------------------
+# 3) Helper-level: one-sided formulas are normalized to their term labels.
+# ----------------------------------------------------------------------
+
+test_that("one-sided formulas normalize to term labels", {
+	expect_identical(
+		fetwfe:::.process_covs_input(~x1),
+		"x1"
+	)
+	expect_identical(
+		fetwfe:::.process_covs_input(~ x1 + x2),
+		c("x1", "x2")
+	)
+	expect_identical(
+		fetwfe:::.process_covs_input(~ x1 + x2 + x3),
+		c("x1", "x2", "x3")
+	)
+	# `~ 1` and `~ 0` are "no covariates" spellings -> character(0).
+	expect_identical(fetwfe:::.process_covs_input(~1), character(0))
+	expect_identical(fetwfe:::.process_covs_input(~0), character(0))
+})
+
+# ----------------------------------------------------------------------
+# 4) Helper-level: rejections with structured messages.
+# ----------------------------------------------------------------------
+
+test_that("two-sided formulas are rejected", {
+	expect_error(
+		fetwfe:::.process_covs_input(y ~ x1 + x2),
+		"one-sided"
+	)
+})
+
+test_that("interactions and transformations are rejected with a clear pointer", {
+	# Interactions: `x1:x2` produces term label `x1:x2` (with `:`)
+	expect_error(
+		fetwfe:::.process_covs_input(~ x1:x2),
+		"additive bare variable names"
+	)
+	# `x1 * x2` expands to `x1 + x2 + x1:x2`; the `:` term triggers.
+	expect_error(
+		fetwfe:::.process_covs_input(~ x1 * x2),
+		"additive bare variable names"
+	)
+	# I() transformations
+	expect_error(
+		fetwfe:::.process_covs_input(~ I(x1^2)),
+		"additive bare variable names"
+	)
+})
+
+test_that("non-character, non-formula input is rejected with class info", {
+	expect_error(
+		fetwfe:::.process_covs_input(123),
+		"character vector.*one-sided formula"
+	)
+	expect_error(
+		fetwfe:::.process_covs_input(list("x1")),
+		"character vector.*one-sided formula"
+	)
+})
+
+# ----------------------------------------------------------------------
+# 5) End-to-end: formula and character forms produce identical fits on
+#    the same simulated panel. Each of the four estimators tested.
+# ----------------------------------------------------------------------
+
+# Build a small simulated panel WITH d > 0 so covs actually matters.
+.covs_setup <- function() {
+	set.seed(2026)
+	coefs <- genCoefs(R = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
+	dat <- simulateData(coefs, N = 60, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	# simulateData() produces pdata with covariate columns named "X1", "X2".
+	# Extract for direct fits.
+	dat
+}
+
+test_that("fetwfe(): formula and character forms produce identical results", {
+	sim <- .covs_setup()
+	df <- sim$pdata
+	# fetwfeWithSimulatedData() goes through fetwfe() with the sim's
+	# preset covs. Run direct fetwfe() for the comparison.
+	covs_char <- c("cov1", "cov2")
+	covs_form <- ~ cov1 + cov2
+	res_char <- fetwfe(
+		df,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		response = "y",
+		covs = covs_char,
+		q = 0.5
+	)
+	res_form <- fetwfe(
+		df,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		response = "y",
+		covs = covs_form,
+		q = 0.5
+	)
+	expect_equal(res_char$att_hat, res_form$att_hat)
+	expect_equal(res_char$att_se, res_form$att_se)
+	expect_equal(res_char$catt_df$estimate, res_form$catt_df$estimate)
+	expect_equal(res_char$catt_df$se, res_form$catt_df$se)
+})
+
+test_that("etwfe(): formula and character forms produce identical results", {
+	sim <- .covs_setup()
+	df <- sim$pdata
+	res_char <- etwfe(
+		df,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		response = "y",
+		covs = c("cov1", "cov2")
+	)
+	res_form <- etwfe(
+		df,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		response = "y",
+		covs = ~ cov1 + cov2
+	)
+	expect_equal(res_char$att_hat, res_form$att_hat)
+	expect_equal(res_char$att_se, res_form$att_se)
+	expect_equal(res_char$catt_df$estimate, res_form$catt_df$estimate)
+})
+
+test_that("betwfe(): formula and character forms produce identical results", {
+	sim <- .covs_setup()
+	df <- sim$pdata
+	res_char <- betwfe(
+		df,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		response = "y",
+		covs = c("cov1", "cov2"),
+		q = 0.5
+	)
+	res_form <- betwfe(
+		df,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		response = "y",
+		covs = ~ cov1 + cov2,
+		q = 0.5
+	)
+	expect_equal(res_char$att_hat, res_form$att_hat)
+	expect_equal(res_char$att_se, res_form$att_se)
+})
+
+test_that("twfeCovs(): formula and character forms produce identical results", {
+	sim <- .covs_setup()
+	df <- sim$pdata
+	res_char <- twfeCovs(
+		df,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		response = "y",
+		covs = c("cov1", "cov2")
+	)
+	res_form <- twfeCovs(
+		df,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		response = "y",
+		covs = ~ cov1 + cov2
+	)
+	expect_equal(res_char$att_hat, res_form$att_hat)
+	expect_equal(res_char$att_se, res_form$att_se)
+})
+
+# ----------------------------------------------------------------------
+# 6) End-to-end: bad formula at the estimator boundary is rejected before
+#    any expensive computation.
+# ----------------------------------------------------------------------
+
+test_that("invalid covs formula is rejected at the estimator entry", {
+	sim <- .covs_setup()
+	df <- sim$pdata
+	expect_error(
+		fetwfe(
+			df,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			response = "y",
+			covs = ~ cov1 * cov2
+		),
+		"additive bare variable names"
+	)
+	expect_error(
+		fetwfe(
+			df,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			response = "y",
+			covs = y ~ cov1 + cov2
+		),
+		"one-sided"
+	)
+})


### PR DESCRIPTION
Adds a formula interface for the `covs` argument on `fetwfe()` / `etwfe()` / `betwfe()` / `twfeCovs()`. Closes #28. Version bump 1.11.6 → 1.11.7.

Closes a comparator-feature gap identified in the May 2026 docket triage — `did::att_gt(xformla = ~ x1 + x2)` is the standard convention in the DiD ecosystem, and fetwfe was the odd one out requiring a character vector.

## What

```r
# Long-standing form (unchanged):
fetwfe(..., covs = c("x1", "x2"))

# New: one-sided formula
fetwfe(..., covs = ~ x1 + x2)
fetwfe(..., covs = ~ x1 + x2 + x3)
fetwfe(..., covs = ~ 1)     # equivalent to c() -- no covariates
```

Both forms produce identical fits. Restrictions on the formula form (each surfaces a clear error message):

| Pattern | Status |
|---------|--------|
| `~ x1 + x2` (additive bare names) | ✅ supported |
| `y ~ x1 + x2` (two-sided) | ❌ rejected (`one-sided`) |
| `~ x1:x2` (interaction) | ❌ rejected (`additive bare variable names`) |
| `~ x1 * x2` (interaction expansion) | ❌ rejected |
| `~ I(x1^2)` (transformation) | ❌ rejected |

The error messages point users to "compute derived variables in the data frame first and pass via the character-vector form" — keeping the package's existing "covs is column names" mental model intact.

## Implementation

- **`R/process_covs.R`** (new) — internal helper `.process_covs_input(covs)` that normalizes formula → character vector. Pass-through on character vectors and NULL.
- **`fetwfe()` / `etwfe()` / `betwfe()` / `twfeCovs()`** — each gets a single line near the top of the function body (`covs <- .process_covs_input(covs)`) so the rest of the package can continue to assume the character-vector form. All four edits are minimal and structurally identical.
- **`@param covs` blocks** updated in all four estimators to describe both input forms and the formula-form restrictions (additive bare names only).
- **Tests** (`tests/testthat/test-formula-interface-covs-28.R`, new — 28 assertions across 11 `test_that` blocks): helper-level pass-through + normalization + rejections; end-to-end identity (character vs formula produce identical `att_hat` / `att_se` / `catt_df$estimate` / `catt_df$se` for all 4 estimators); estimator-boundary rejection of invalid formulas.

## Validation

- `devtools::check(args = "--as-cran")`: **0 errors / 0 warnings / 0 notes**.
- `devtools::test()`: full suite passes; +28 assertions from the new test file.
- `devtools::document()`: idempotent on second run.
- `devtools::spell_check()`, `urlchecker::url_check()`: both clean.

## Commits

- `80e84af` — formula interface + helper + tests + NEWS + version bump. Rebased onto post-#157 main during review (metadata-triple conflict resolution: DESCRIPTION / NEWS.md / inst/CITATION).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
