### PR TITLE
Vectorise idCohorts() per-unit row-filter loop; ~15× on the function, 7.6× combined vs pre-#165 (#166, 1.13.2)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.13.1
+Version: 1.13.2
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,23 @@
 # NEWS
 
+## Version 1.13.2 (2026-05-28)
+
+### Performance
+
+- Vectorised `idCohorts()`'s per-unit row-filter loop in `R/utility.R`
+  (previously `O(N^2 * T)` due to a `df[df[, unit_var] == s, ]` filter
+  inside a `for (s in units)` loop). The post-fix path sorts the data
+  frame once by `(unit_var, time_var)`, tabulates per-unit row counts,
+  and runs the balance check, absorbing-state check, and cohort
+  assignment via column-wise operations on a reshaped `T x N`
+  treatment matrix. Same observable behaviour: identical balance and
+  absorbing-state violation messages (single grouped `stop()`, same
+  lex-sorted truncated listing), identical first-period-treated
+  `warning()`, identical return shape. `idCohorts()` itself is ~15x
+  faster at N = 2000, T = 5; end-to-end `fetwfe()` at the Phase B
+  fixture speeds up an additional 1.3x on top of #165, for a combined
+  **7.6x vs. pre-#165**. Issue #166.
+
 ## Version 1.13.1 (2026-05-28)
 
 ### Performance

--- a/R/utility.R
+++ b/R/utility.R
@@ -75,60 +75,149 @@ idCohorts <- function(df, time_var, unit_var, treat_var) {
 	balance_violations <- character(0)
 	absorbing_violations <- character(0)
 
-	for (s in units) {
-		df_s <- df[df[, unit_var] == s, ]
+	# Vectorised replacement for the per-unit `for (s in units) df[df[,
+	# unit_var] == s, ]` filter loop that was O(N^2 * T) (#166). Strategy:
+	# sort `df` once by `(unit_var, time_var)` so each unit's T rows are
+	# contiguous at positions `(k-1)*T + 1 .. k*T` of the k-th lex-sorted
+	# unit; then reshape the treatment vector for balanced units into a
+	# `T x N_bal` matrix and run the absorbing-state check + cohort
+	# assignment column-wise. This is structurally the same rewrite that
+	# `processCovs()` got in #84 item 15 — see
+	# `R/design_matrix.R:393-401` for the analogous pattern.
+	df_sorted <- df[order(df[, unit_var], df[, time_var]), , drop = FALSE]
+	units_v <- df_sorted[, unit_var]
+	times_v <- df_sorted[, time_var]
+	treat_v <- df_sorted[, treat_var]
+	units_sorted <- sort(units) # lex order matches df_sorted's unit blocks
 
-		# Balance check (gates the absorbing-state check on the same unit;
-		# we can't trust the per-period treatment vector when observations
-		# are missing or when a time period is duplicated). The
-		# setequal() clause catches the (1, 2, 2)-style duplicate-time
-		# case that nrow == T silently passed pre-#75.
-		if (nrow(df_s) != T || !setequal(df_s[, time_var], times)) {
+	# Per-unit row counts via tabulate.
+	counts <- as.integer(tabulate(factor(units_v, levels = units_sorted)))
+
+	# 1. Units with count != T are unbalanced by row count.
+	bad_count_idx <- which(counts != T)
+	if (length(bad_count_idx) > 0) {
+		# For each unbalanced-by-count unit, build the existing canonical
+		# violation message. n_distinct is per-unit; cheap on the (small)
+		# bad-unit subset.
+		for (j in bad_count_idx) {
+			s <- units_sorted[j]
+			n_distinct <- length(unique(times_v[units_v == s]))
 			balance_violations <- c(
 				balance_violations,
 				paste0(
-					"unit ",
-					s,
-					" has ",
-					nrow(df_s),
-					" observations (",
-					length(unique(df_s[, time_var])),
-					" distinct time periods)"
+					"unit ", s, " has ", counts[j], " observations (",
+					n_distinct, " distinct time periods)"
 				)
 			)
-			next
+		}
+	}
+
+	# 2. Units with count == T may still have duplicate-time-within-unit
+	# (the (1, 2, 2)-style case from #75). For the balanced-by-count
+	# subset, their T-row blocks in df_sorted are contiguous, so we can
+	# reshape to a T x N_bal time matrix and compare each column to
+	# `times`.
+	balanced_mask <- (counts == T)
+	balanced_units <- units_sorted[balanced_mask]
+	balanced_rows <- units_v %in% balanced_units
+	N_bal <- length(balanced_units)
+
+	dup_time_in_block <- logical(N_bal) # default FALSE
+	if (N_bal > 0) {
+		times_mat <- matrix(times_v[balanced_rows], nrow = T, ncol = N_bal)
+		# vapply column-wise check; `times` is already sorted.
+		dup_time_in_block <- vapply(
+			seq_len(N_bal),
+			function(k) !isTRUE(all.equal(sort(times_mat[, k]), times)),
+			logical(1)
+		)
+		if (any(dup_time_in_block)) {
+			for (k in which(dup_time_in_block)) {
+				s <- balanced_units[k]
+				n_distinct <- length(unique(times_mat[, k]))
+				balance_violations <- c(
+					balance_violations,
+					paste0(
+						"unit ", s, " has ", T, " observations (",
+						n_distinct, " distinct time periods)"
+					)
+				)
+			}
+		}
+	}
+
+	# After both balance checks: re-narrow to units that passed BOTH.
+	if (N_bal > 0 && any(dup_time_in_block)) {
+		passed_balance_mask_in_balanced <- !dup_time_in_block
+		balanced_units <- balanced_units[passed_balance_mask_in_balanced]
+		balanced_rows <- units_v %in% balanced_units
+		N_bal <- length(balanced_units)
+	}
+
+	# 3. Absorbing-state check + cohort assignment on the balanced subset.
+	# At this point, balanced_rows selects exactly the rows belonging to
+	# units that passed BOTH balance checks (count and time-set).
+	if (N_bal > 0) {
+		treat_mat <- matrix(treat_v[balanced_rows], nrow = T, ncol = N_bal)
+		is_treat_mat <- (treat_mat == 1)
+		any_treat <- colSums(is_treat_mat) > 0
+
+		first_treat_idx <- rep(NA_integer_, N_bal)
+		if (any(any_treat)) {
+			# For each treated column, find the first row where treat == 1.
+			# max.col on the column-transpose returns the column index per
+			# row of the transpose, which is the row index of the first
+			# `1` per column of the original.
+			first_treat_idx[any_treat] <- max.col(
+				t(is_treat_mat[, any_treat, drop = FALSE]),
+				ties.method = "first"
+			)
 		}
 
-		if (any(df_s[, treat_var] == 1)) {
-			# Identify first year of treatment (and cohort)
-			# Ensure df_s is sorted by time before finding min
-			df_s_sorted <- df_s[order(df_s[, time_var]), ]
-			treat_year_s_ind_in_sorted_times <- min(which(
-				df_s_sorted[, treat_var] == 1
-			))
-			actual_treat_time <- df_s_sorted[
-				treat_year_s_ind_in_sorted_times,
-				time_var
-			]
-
-			# Absorbing-state check.
-			# Check from the actual_treat_time onwards in the original df for unit s
-			original_unit_times_from_treatment <- df[
-				(df[, unit_var] == s) & (df[, time_var] >= actual_treat_time),
-				treat_var
-			]
-			if (any(original_unit_times_from_treatment != 1)) {
-				absorbing_violations <- c(absorbing_violations, as.character(s))
-				# Do NOT append to cohorts: only units that pass BOTH the
-				# balance and absorbing-state checks contribute to cohort
-				# membership. (load-bearing: without `next`, this unit would
-				# leak into the cohorts list before stop() fires below.)
-				next
+		# Absorbing-state check: for each treated unit, check the tail
+		# from `first_treat_idx[k]` onwards is all 1s.
+		abs_bad_mask <- logical(N_bal)
+		treated_cols <- which(any_treat)
+		for (k in treated_cols) {
+			tail_vals <- treat_mat[first_treat_idx[k]:T, k]
+			if (any(tail_vals != 1L)) {
+				abs_bad_mask[k] <- TRUE
+				absorbing_violations <- c(
+					absorbing_violations,
+					as.character(balanced_units[k])
+				)
 			}
-			cohorts[[as.character(actual_treat_time)]] <- c(
-				cohorts[[as.character(actual_treat_time)]],
-				s
+		}
+
+		# Cohort assignment: only treated units that pass the absorbing
+		# check (and trivially balance). Use `split()` for O(N) grouping
+		# instead of per-unit `c()` (O(N^2) on the appends). Preserve
+		# declaration order within each cohort by sorting the to-assign
+		# unit list by its position in the original `units` vector.
+		cohort_assign_mask <- any_treat & !abs_bad_mask
+		if (any(cohort_assign_mask)) {
+			to_assign_units <- balanced_units[cohort_assign_mask]
+			to_assign_keys <- as.character(
+				times[first_treat_idx[cohort_assign_mask]]
 			)
+			# Stable declaration-order: each to_assign_unit's index in
+			# the original `units` vector.
+			decl_order <- match(to_assign_units, units)
+			ord <- order(decl_order)
+			to_assign_units <- to_assign_units[ord]
+			to_assign_keys <- to_assign_keys[ord]
+			split_groups <- split(
+				to_assign_units,
+				factor(to_assign_keys, levels = names(cohorts))
+			)
+			for (key in names(split_groups)) {
+				if (length(split_groups[[key]]) > 0) {
+					cohorts[[key]] <- c(
+						cohorts[[key]],
+						as.character(split_groups[[key]])
+					)
+				}
+			}
 		}
 	}
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.13.1",
+  note    = "R package version 1.13.2",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-idcohorts-vectorize-166.R
+++ b/tests/testthat/test-idcohorts-vectorize-166.R
@@ -1,0 +1,136 @@
+# Regression test for #166: idCohorts() now uses a vectorised
+# (sort-once + reshape-to-T-by-N) strategy instead of the per-unit
+# O(N^2 * T) row-filter loop. The existing test-idcohorts-collect-
+# violations.R covers error-message wording and lex-ordering; this
+# file adds tests focused on the cohort-assignment result shape and
+# treated-unit accounting, plus a performance sanity check that runs
+# only locally (skip_on_cran) to avoid flakiness on CI machines.
+
+library(testthat)
+
+# ------------------------------------------------------------------------------
+# Cohort-assignment correctness on a small fixture with known truth.
+# ------------------------------------------------------------------------------
+
+test_that("idCohorts assigns treated units to the correct cohort under varied first-treatment times", {
+	df <- data.frame(
+		unit = rep(c("u01", "u02", "u03", "u04", "u05"), each = 4L),
+		time = rep(c(1L, 2L, 3L, 4L), times = 5L),
+		# u01 treated at t=2, u02 treated at t=3, u03 never-treated,
+		# u04 treated at t=4 (last period), u05 never-treated.
+		treat = c(
+			0L, 1L, 1L, 1L,
+			0L, 0L, 1L, 1L,
+			0L, 0L, 0L, 0L,
+			0L, 0L, 0L, 1L,
+			0L, 0L, 0L, 0L
+		),
+		stringsAsFactors = FALSE
+	)
+	out <- fetwfe:::idCohorts(df, "time", "unit", "treat")
+	# Cohort 1 was the first-period cohort; it gets removed up front
+	# in the existing post-loop logic, so `out$cohorts` should start
+	# from t=2 onward and contain only the non-empty treated cohorts.
+	expect_true("2" %in% names(out$cohorts))
+	expect_true("3" %in% names(out$cohorts))
+	expect_true("4" %in% names(out$cohorts))
+	expect_setequal(out$cohorts[["2"]], "u01")
+	expect_setequal(out$cohorts[["3"]], "u02")
+	expect_setequal(out$cohorts[["4"]], "u04")
+	# Never-treated units remain in df but not in any cohort.
+	expect_true(all(c("u03", "u05") %in% out$units))
+	expect_false("u03" %in% unlist(out$cohorts))
+	expect_false("u05" %in% unlist(out$cohorts))
+})
+
+test_that("idCohorts groups multiple units into the same cohort", {
+	df <- data.frame(
+		unit = rep(c("a", "b", "c", "d"), each = 3L),
+		time = rep(c(1L, 2L, 3L), times = 4L),
+		treat = c(
+			0L, 1L, 1L, # a treated t=2
+			0L, 1L, 1L, # b treated t=2
+			0L, 0L, 1L, # c treated t=3
+			0L, 0L, 0L  # d never-treated
+		),
+		stringsAsFactors = FALSE
+	)
+	out <- fetwfe:::idCohorts(df, "time", "unit", "treat")
+	expect_setequal(out$cohorts[["2"]], c("a", "b"))
+	expect_setequal(out$cohorts[["3"]], "c")
+})
+
+# ------------------------------------------------------------------------------
+# Multiple violations of mixed types in a single panel: all surface.
+# ------------------------------------------------------------------------------
+
+test_that("idCohorts reports unbalanced + duplicate-time + absorbing violations together", {
+	df <- data.frame(
+		unit = c(
+			rep("balA", 3),               # balanced, fine
+			rep("dupT", 3),               # T=3 rows but times {1, 2, 2}
+			rep("miss", 2),               # only 2 rows
+			rep("absV", 3)                # treat 0/1/0 (non-absorbing)
+		),
+		time = c(
+			1L, 2L, 3L,
+			1L, 2L, 2L,
+			1L, 2L,
+			1L, 2L, 3L
+		),
+		treat = c(
+			0L, 0L, 0L,
+			0L, 0L, 0L,
+			0L, 0L,
+			0L, 1L, 0L
+		),
+		stringsAsFactors = FALSE
+	)
+	err <- tryCatch(
+		fetwfe:::idCohorts(df, "time", "unit", "treat"),
+		error = function(e) conditionMessage(e)
+	)
+	# Both error sections present.
+	expect_match(err, "Panel does not appear to be balanced")
+	expect_match(err, "Treatment does not appear to be an absorbing state")
+	# All three balance violations named.
+	expect_match(err, "dupT has 3 observations (2 distinct time periods)", fixed = TRUE)
+	expect_match(err, "miss has 2 observations (2 distinct time periods)", fixed = TRUE)
+	# Absorbing violation named.
+	expect_match(err, "absV")
+})
+
+# ------------------------------------------------------------------------------
+# Performance smoke test: vectorised idCohorts on a large balanced panel
+# completes under a generous wall-clock budget. Skip on CRAN.
+# ------------------------------------------------------------------------------
+
+test_that("idCohorts vectorised path scales to N=2000 in under 1 second", {
+	skip_on_cran()
+	N <- 2000L
+	T <- 5L
+	df <- data.frame(
+		unit = rep(sprintf("u%04d", seq_len(N)), each = T),
+		time = rep(seq_len(T), times = N),
+		treat = 0L,
+		stringsAsFactors = FALSE
+	)
+	# Treat a random subset of units starting at varied first-treatment times.
+	set.seed(42L)
+	treated_units <- sample(N, 600)
+	for (i in treated_units) {
+		start_t <- sample(seq(2L, T), 1L)
+		df$treat[(i - 1L) * T + start_t:T] <- 1L
+	}
+	t0 <- Sys.time()
+	out <- fetwfe:::idCohorts(df, "time", "unit", "treat")
+	elapsed <- as.numeric(Sys.time() - t0, units = "secs")
+	# Generous ceiling — pre-#166 took ~0.4s; budget 1.0s tolerates a
+	# wide range of hardware while still catching any regression that
+	# brings back the O(N^2 * T) per-unit row-filter loop.
+	expect_lt(elapsed, 1.0)
+	# Result shape contract.
+	expect_named(out, c("df", "cohorts", "units", "times"))
+	expect_equal(length(out$cohorts), T - 1L) # first-period cohort removed
+	expect_true(all(lengths(out$cohorts) >= 1L))
+})


### PR DESCRIPTION
Vectorises `idCohorts()`'s per-unit row-filter loop. Closes #166. Version 1.13.1 → 1.13.2 (patch — pure performance, no behavior change).

## What changes

`R/utility.R::idCohorts()` previously did:

```r
for (s in units) {
  df_s <- df[df[, unit_var] == s, ]   # O(N*T) per iter -> O(N^2*T) total
  ...
}
```

It now sorts the data frame once by `(unit_var, time_var)` and runs the balance check, time-set check, absorbing-state check, and cohort assignment via column-wise operations on a reshaped `T × N_bal` treatment matrix.

This is the same rewrite `processCovs()` got in #84 item 15 (see `R/design_matrix.R:393-401` for the analogous pattern) — `idCohorts()` was missed by that pass.

## Algorithm

1. Sort `df` by `(unit_var, time_var)` — each unit's `T` rows become a contiguous block.
2. Per-unit row counts via `tabulate(factor(...))`. Units with count `≠ T` → balance violations.
3. For count-balanced units, reshape times to a `T × N_bal` matrix; column-wise compare sorted columns to `times` to catch the `(1, 2, 2)`-style duplicate-time-within-unit case (#75).
4. For the balanced subset, reshape treatment to a `T × N_bal` matrix. Use `max.col(t(is_treat_mat), ties.method = "first")` to find each column's first treated period in a single vectorised call.
5. Absorbing-state check via column-wise tail comparisons against `1`.
6. Cohort assignment via `split()` into the pre-allocated cohorts list, preserving declaration order within each cohort.

## Same observable behavior

- Identical balance violation messages: `"unit {s} has {n} observations ({n_distinct} distinct time periods)"`.
- Identical absorbing-state messages.
- Same single grouped `stop()` at the end (per #64).
- Same lex-sorted truncated listing via `.truncate_violations()`.
- Same single `warning()` for first-period-treated units.
- Same return shape `list(df, cohorts, units, times)`.
- The existing `test-idcohorts-collect-violations.R` suite (covering `#64` multi-violation collection, `#75` duplicate-time detection, and the `#53` lex-sort caveat) passes without modification.

## Measured speedups

**Standalone `idCohorts()`** (N=2000, T=5, 5-iteration mean):

| Implementation | Per-call |
|---|---:|
| Pre-#166 (per-unit row filter) | ~0.403s (issue's quoted baseline) |
| **Post-#166 (vectorised)** | **~0.026s** |

→ **~15× speedup on the function itself.**

**End-to-end `fetwfe()`** on Phase B's main DGP at N=2000, `lambda_selection = "bic"`:

| State | Per-call |
|---|---:|
| Pre-#165 baseline | 3.219s |
| Post-#165 only | 0.531s |
| **Post-#165 + #166** | **0.424s** (additional **1.3×** on top of #165) |

→ **7.6× combined speedup vs pre-#165.** The fraction of `fetwfe()` time spent in `idCohorts()` post-#165 was ~20%, so the marginal end-to-end win is consistent with the issue's prediction.

Carries verbatim to `etwfe()`, `betwfe()`, and `twfeCovs()` because all four estimators reach `idCohorts()` via `prepXints()`.

## Validation

- **All existing tests pass without modification**, including `test-idcohorts-collect-violations.R` (covers the canonical violation-message contract end-to-end), `test-soft-bugs-56.R`, `test-lex-cohort-sort.R`, `test-augment-treatment-parity.R`, `test-fetwfe.R`, `test-betwfe.R`, `test-lambda-selection-164.R` (byte-identical BIC reference values still match), `test-gls-kronecker-block-apply-165.R`.
- **New dedicated regression test** at `tests/testthat/test-idcohorts-vectorize-166.R`:
  - Cohort-assignment correctness on a fixture with known truth across varied first-treatment times (including last-period treatment).
  - Multiple-units-into-same-cohort grouping.
  - Multi-type violations (unbalanced + duplicate-time + absorbing) all surface together in the same error message.
  - Performance smoke (`skip_on_cran`): asserts N=2000 completes under 1 second.
- **CRAN gate**: `_R_CHECK_SYSTEM_CLOCK_=false Rscript -e 'devtools::check(args="--as-cran")'` returns **Status: OK, 0 errors / 0 warnings / 0 notes** (1:27). The naked `devtools::check()` shows a transient `unable to verify current time` NOTE due to a network call to a time server that's currently failing locally; that NOTE is environment-dependent and unrelated to this change.

## References

- Issue: #166 (closes on merge).
- Predecessor: #165 (GLS-Kronecker block-apply; the speedup baseline pre-#166 is the post-#165 baseline).
- Profiling investigation: `.plans/profile-fetwfe-pipeline/PROFILE_REPORT.md`.
- Remaining perf follow-ups from the same investigation: #167 (`my_scale`), #168 (`sse_bridge`), #169 (`getBetaBIC` loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
