### PR TITLE
Vectorise my_scale(); ~2.4× faster (#167, 1.13.3)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.13.2
+Version: 1.13.3
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,27 +12,10 @@
   with broadcasted `rep(..., each = nrow(x))` subtract / divide.
   ~2.4x speedup on the function itself (10000 x 50 fixture). Output
   is numerically identical to the prior implementation up to
-  floating-point reorder noise (~1e-15) on full-rank inputs; on
-  inputs with zero-variance columns the post-fix path is *more*
-  correct (the prior path's `(sds == 0)` guard did not fire when
-  `apply(x, 2, sd)` returned FP noise like 5e-15 instead of exact 0,
-  causing the column to be divided by 5e-15; the post-fix path
-  centers a constant column to exact 0 and divides by 1 as
-  intended). The byte-identical-BIC regression test pinned in
+  floating-point reorder noise (~1e-15) on realistic full-rank
+  inputs. The byte-identical-BIC regression test pinned in
   v1.13.0 (#164) passes byte-identically post-this-change,
   confirming the production code paths are unaffected. Issue #167.
-
-### Bug fix
-
-- (Internal, surfaced by the perf rewrite of `my_scale()`.) On the
-  unlikely-in-practice case that `my_scale()` is called with an
-  input matrix containing zero-variance columns, the prior
-  implementation could store a near-zero (5e-15) value in
-  `attr(scaled, "scaled:scale")` for that column rather than 1,
-  because `apply(x, 2, sd)` produces FP noise rather than exact 0 on
-  constant columns. The post-#167 implementation computes the
-  zero-variance check via the algebraic-exact centered sum of
-  squares and so flags constant columns correctly.
 
 ## Version 1.13.2 (2026-05-28)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,39 @@
 # NEWS
 
+## Version 1.13.3 (2026-05-28)
+
+### Performance
+
+- Vectorised `my_scale()` in `R/utility.R` (called once per `fetwfe()`
+  / `etwfe()` / `betwfe()` / `twfeCovs()` call from
+  `prep_for_etwfe_regression()`). Replaced the per-column
+  `apply(x, 2, sd)` R-level loop with a single-pass `colSums(x_c^2)`-
+  based variance, and the two `sweep(..., FUN = "-" | "/")` calls
+  with broadcasted `rep(..., each = nrow(x))` subtract / divide.
+  ~2.4x speedup on the function itself (10000 x 50 fixture). Output
+  is numerically identical to the prior implementation up to
+  floating-point reorder noise (~1e-15) on full-rank inputs; on
+  inputs with zero-variance columns the post-fix path is *more*
+  correct (the prior path's `(sds == 0)` guard did not fire when
+  `apply(x, 2, sd)` returned FP noise like 5e-15 instead of exact 0,
+  causing the column to be divided by 5e-15; the post-fix path
+  centers a constant column to exact 0 and divides by 1 as
+  intended). The byte-identical-BIC regression test pinned in
+  v1.13.0 (#164) passes byte-identically post-this-change,
+  confirming the production code paths are unaffected. Issue #167.
+
+### Bug fix
+
+- (Internal, surfaced by the perf rewrite of `my_scale()`.) On the
+  unlikely-in-practice case that `my_scale()` is called with an
+  input matrix containing zero-variance columns, the prior
+  implementation could store a near-zero (5e-15) value in
+  `attr(scaled, "scaled:scale")` for that column rather than 1,
+  because `apply(x, 2, sd)` produces FP noise rather than exact 0 on
+  constant columns. The post-#167 implementation computes the
+  zero-variance check via the algebraic-exact centered sum of
+  squares and so flags constant columns correctly.
+
 ## Version 1.13.2 (2026-05-28)
 
 ### Performance

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -480,7 +480,11 @@ betwfe <- function(
 		# fetwfe()'s shape. `res$cv_seed_used` is already NA_integer_
 		# under the BIC path (the core's dispatch sets it on that branch).
 		lambda_selection = lambda_selection,
-		cv_folds = if (lambda_selection == "cv") as.integer(cv_folds) else NA_integer_,
+		cv_folds = if (lambda_selection == "cv") {
+			as.integer(cv_folds)
+		} else {
+			NA_integer_
+		},
 		cv_seed = res$cv_seed_used,
 		X_ints = res$X_ints,
 		y = res$y,

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -433,7 +433,11 @@ fetwfe <- function(
 		# under the BIC path (the core's dispatch initializes
 		# `res$cv_seed_used` to NA_integer_ on the BIC branch).
 		lambda_selection = lambda_selection,
-		cv_folds = if (lambda_selection == "cv") as.integer(cv_folds) else NA_integer_,
+		cv_folds = if (lambda_selection == "cv") {
+			as.integer(cv_folds)
+		} else {
+			NA_integer_
+		},
 		cv_seed = res$cv_seed_used,
 		N = res$N,
 		T = res$T,

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -200,7 +200,9 @@ checkFetwfeInputs <- function(
 				length(cv_folds)
 			)
 		)
-	} else if (!is.finite(cv_folds) || cv_folds < 2 || cv_folds != round(cv_folds)) {
+	} else if (
+		!is.finite(cv_folds) || cv_folds < 2 || cv_folds != round(cv_folds)
+	) {
 		violations <- c(
 			violations,
 			sprintf(

--- a/R/utility.R
+++ b/R/utility.R
@@ -105,8 +105,13 @@ idCohorts <- function(df, time_var, unit_var, treat_var) {
 			balance_violations <- c(
 				balance_violations,
 				paste0(
-					"unit ", s, " has ", counts[j], " observations (",
-					n_distinct, " distinct time periods)"
+					"unit ",
+					s,
+					" has ",
+					counts[j],
+					" observations (",
+					n_distinct,
+					" distinct time periods)"
 				)
 			)
 		}
@@ -138,8 +143,13 @@ idCohorts <- function(df, time_var, unit_var, treat_var) {
 				balance_violations <- c(
 					balance_violations,
 					paste0(
-						"unit ", s, " has ", T, " observations (",
-						n_distinct, " distinct time periods)"
+						"unit ",
+						s,
+						" has ",
+						T,
+						" observations (",
+						n_distinct,
+						" distinct time periods)"
 					)
 				)
 			}
@@ -819,8 +829,8 @@ my_scale <- function(x) {
 	# unnecessary intermediates and runs at ~3x the cost of the inlined
 	# colSums-based variance + rep(..., each = nrow(x)) broadcasting
 	# below. Numerical result is identical up to floating-point reorder
-	# (the variance formula is the same Welford-style centered-sum-of-
-	# squares / (n - 1) base::var() uses internally). Issue #167.
+	# (the variance formula is the same two-pass centered-sum-of-
+	# squares / (n - 1) `base::var()` uses internally). Issue #167.
 	n <- nrow(x)
 	ctr <- colMeans(x)
 	# Centered in-place; equivalent to sweep(x, 2, ctr, "-").

--- a/R/utility.R
+++ b/R/utility.R
@@ -811,27 +811,35 @@ idCohorts <- function(df, time_var, unit_var, treat_var) {
 #' @keywords internal
 #' @noRd
 my_scale <- function(x) {
-	# Compute column means and standard deviations
+	# Vectorised column-wise centering and scaling. The previous
+	# implementation used `apply(x, 2, sd)` (a per-column R-level loop
+	# through a generic apply() shim) and `sweep(x, 2, ..., FUN = "-")`
+	# / `sweep(..., FUN = "/")` (each dispatches through match.fun and
+	# a vapply-style inner loop). For a (NT) x p matrix this allocates
+	# unnecessary intermediates and runs at ~3x the cost of the inlined
+	# colSums-based variance + rep(..., each = nrow(x)) broadcasting
+	# below. Numerical result is identical up to floating-point reorder
+	# (the variance formula is the same Welford-style centered-sum-of-
+	# squares / (n - 1) base::var() uses internally). Issue #167.
+	n <- nrow(x)
 	ctr <- colMeans(x)
-	sds <- apply(x, 2, sd)
-
-	# Identify zero-variance columns
+	# Centered in-place; equivalent to sweep(x, 2, ctr, "-").
+	scaled <- x - rep(ctr, each = n)
+	# Column-wise sd via vectorised colSums on the squared, centered
+	# columns. Equivalent to apply(x, 2, sd) but executed in compiled
+	# C with a single pass instead of a 50-iteration R loop.
+	sds <- sqrt(colSums(scaled * scaled) / (n - 1))
+	# Guard zero-variance columns: divide by 1 instead of 0.
 	zero_sd <- (sds == 0)
-
-	# For zero-variance columns, set scale=1 to avoid dividing by 0
-	ctr2 <- ctr
 	sds2 <- sds
 	sds2[zero_sd] <- 1
-
-	# Center and scale
-	scaled <- sweep(x, 2, ctr2, FUN = "-")
-	scaled <- sweep(scaled, 2, sds2, FUN = "/")
-
-	# Attach attributes so behavior mimics base::scale()
-	attr(scaled, "scaled:center") <- ctr2
+	scaled <- scaled / rep(sds2, each = n)
+	# Match base::scale()'s attribute contract so downstream code
+	# (R/fetwfe_core.R::getBetaBIC / .untransform_scaled_theta) can
+	# read scale_center / scale_scale unchanged.
+	attr(scaled, "scaled:center") <- ctr
 	attr(scaled, "scaled:scale") <- sds2
-
-	return(scaled)
+	scaled
 }
 
 # getNumTreats

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.13.2",
+  note    = "R package version 1.13.3",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -24,10 +24,11 @@ boldsymbol
 Bolker
 bookdown
 Brantly
+broadcasted
 broom
 Callaway
-Catalogue
 catalogue
+Catalogue
 catalogued
 catalogues
 catt
@@ -58,6 +59,7 @@ eventStudy
 FEs
 fetwfePackage
 FETWFE’s
+FP
 frac
 Gaussianity
 ggplot
@@ -99,6 +101,7 @@ OUP
 overfits
 Patterson
 pdata
+perf
 Pesaran
 Pinheiro
 pre

--- a/tests/testthat/test-betwfe-add-ridge-basis.R
+++ b/tests/testthat/test-betwfe-add-ridge-basis.R
@@ -239,7 +239,11 @@ test_that("betwfe(add_ridge = TRUE) numerical regression: att_hat matches post-f
 	# default is CV, which produces a slightly different att_hat on this
 	# fixture; that's expected, and is tested separately in
 	# test-lambda-selection-164.R.
-	fit <- betwfeWithSimulatedData(sim, add_ridge = TRUE, lambda_selection = "bic")
+	fit <- betwfeWithSimulatedData(
+		sim,
+		add_ridge = TRUE,
+		lambda_selection = "bic"
+	)
 
 	# Sanity: the fit selected something. The pre-fix code on this
 	# fixture also produces a non-degenerate fit, so this is not a

--- a/tests/testthat/test-gls-kronecker-block-apply-165.R
+++ b/tests/testthat/test-gls-kronecker-block-apply-165.R
@@ -22,7 +22,8 @@ test_that("block-apply form equals explicit Kronecker on (unit, time)-ordered da
 	sig_eps_sq <- 2.3
 	sig_eps_c_sq <- 1.1
 	J_over_T <- matrix(1 / T, nrow = T, ncol = T)
-	Omega_sqrt_inv <- (1 / sqrt(sig_eps_sq)) * (diag(T) - J_over_T) +
+	Omega_sqrt_inv <- (1 / sqrt(sig_eps_sq)) *
+		(diag(T) - J_over_T) +
 		(1 / sqrt(sig_eps_sq + T * sig_eps_c_sq)) * J_over_T
 	A <- sqrt(sig_eps_sq) * Omega_sqrt_inv
 
@@ -60,7 +61,8 @@ test_that("block-apply form is invariant to the trivial sig_eps_c_sq=0 case", {
 
 	sig_eps_sq <- 1.5
 	J_over_T <- matrix(1 / T, nrow = T, ncol = T)
-	Omega_sqrt_inv <- (1 / sqrt(sig_eps_sq)) * (diag(T) - J_over_T) +
+	Omega_sqrt_inv <- (1 / sqrt(sig_eps_sq)) *
+		(diag(T) - J_over_T) +
 		(1 / sqrt(sig_eps_sq + T * 0)) * J_over_T # sig_eps_c_sq = 0
 	A <- sqrt(sig_eps_sq) * Omega_sqrt_inv
 

--- a/tests/testthat/test-idcohorts-vectorize-166.R
+++ b/tests/testthat/test-idcohorts-vectorize-166.R
@@ -19,11 +19,26 @@ test_that("idCohorts assigns treated units to the correct cohort under varied fi
 		# u01 treated at t=2, u02 treated at t=3, u03 never-treated,
 		# u04 treated at t=4 (last period), u05 never-treated.
 		treat = c(
-			0L, 1L, 1L, 1L,
-			0L, 0L, 1L, 1L,
-			0L, 0L, 0L, 0L,
-			0L, 0L, 0L, 1L,
-			0L, 0L, 0L, 0L
+			0L,
+			1L,
+			1L,
+			1L,
+			0L,
+			0L,
+			1L,
+			1L,
+			0L,
+			0L,
+			0L,
+			0L,
+			0L,
+			0L,
+			0L,
+			1L,
+			0L,
+			0L,
+			0L,
+			0L
 		),
 		stringsAsFactors = FALSE
 	)
@@ -48,10 +63,18 @@ test_that("idCohorts groups multiple units into the same cohort", {
 		unit = rep(c("a", "b", "c", "d"), each = 3L),
 		time = rep(c(1L, 2L, 3L), times = 4L),
 		treat = c(
-			0L, 1L, 1L, # a treated t=2
-			0L, 1L, 1L, # b treated t=2
-			0L, 0L, 1L, # c treated t=3
-			0L, 0L, 0L  # d never-treated
+			0L,
+			1L,
+			1L, # a treated t=2
+			0L,
+			1L,
+			1L, # b treated t=2
+			0L,
+			0L,
+			1L, # c treated t=3
+			0L,
+			0L,
+			0L # d never-treated
 		),
 		stringsAsFactors = FALSE
 	)
@@ -67,22 +90,36 @@ test_that("idCohorts groups multiple units into the same cohort", {
 test_that("idCohorts reports unbalanced + duplicate-time + absorbing violations together", {
 	df <- data.frame(
 		unit = c(
-			rep("balA", 3),               # balanced, fine
-			rep("dupT", 3),               # T=3 rows but times {1, 2, 2}
-			rep("miss", 2),               # only 2 rows
-			rep("absV", 3)                # treat 0/1/0 (non-absorbing)
+			rep("balA", 3), # balanced, fine
+			rep("dupT", 3), # T=3 rows but times {1, 2, 2}
+			rep("miss", 2), # only 2 rows
+			rep("absV", 3) # treat 0/1/0 (non-absorbing)
 		),
 		time = c(
-			1L, 2L, 3L,
-			1L, 2L, 2L,
-			1L, 2L,
-			1L, 2L, 3L
+			1L,
+			2L,
+			3L,
+			1L,
+			2L,
+			2L,
+			1L,
+			2L,
+			1L,
+			2L,
+			3L
 		),
 		treat = c(
-			0L, 0L, 0L,
-			0L, 0L, 0L,
-			0L, 0L,
-			0L, 1L, 0L
+			0L,
+			0L,
+			0L,
+			0L,
+			0L,
+			0L,
+			0L,
+			0L,
+			0L,
+			1L,
+			0L
 		),
 		stringsAsFactors = FALSE
 	)
@@ -94,8 +131,16 @@ test_that("idCohorts reports unbalanced + duplicate-time + absorbing violations 
 	expect_match(err, "Panel does not appear to be balanced")
 	expect_match(err, "Treatment does not appear to be an absorbing state")
 	# All three balance violations named.
-	expect_match(err, "dupT has 3 observations (2 distinct time periods)", fixed = TRUE)
-	expect_match(err, "miss has 2 observations (2 distinct time periods)", fixed = TRUE)
+	expect_match(
+		err,
+		"dupT has 3 observations (2 distinct time periods)",
+		fixed = TRUE
+	)
+	expect_match(
+		err,
+		"miss has 2 observations (2 distinct time periods)",
+		fixed = TRUE
+	)
 	# Absorbing violation named.
 	expect_match(err, "absV")
 })

--- a/tests/testthat/test-my-scale-vectorize-167.R
+++ b/tests/testthat/test-my-scale-vectorize-167.R
@@ -8,9 +8,10 @@
 # columns have mean 0, the scaled columns have unit sd (except where
 # the input column had zero variance, which keeps sd = 1 by the
 # zero-variance guard), and the `scaled:center` / `scaled:scale`
-# attributes match `colMeans` / `apply(x, 2, sd)` of the input. The
-# test covers a normal column, a constant (zero-variance) column,
-# and a one-row degenerate input.
+# attributes match `colMeans` / `apply(x, 2, sd)` of the input.
+# The test covers a normal column and a constant (zero-variance)
+# column. The n = 1 case is unreachable from production callers
+# (design matrices always have nrow >= 2) so it is not tested.
 
 library(testthat)
 
@@ -22,7 +23,8 @@ test_that("my_scale centers columns to mean 0 and scales to unit sd", {
 	expect_equal(unname(colMeans(out)), rep(0, 7L), tolerance = 1e-12)
 	# Each column has sd 1.
 	expect_equal(
-		unname(apply(out, 2L, sd)), rep(1, 7L),
+		unname(apply(out, 2L, sd)),
+		rep(1, 7L),
 		tolerance = 1e-12
 	)
 })
@@ -58,28 +60,26 @@ test_that("my_scale handles zero-variance columns by setting scale to 1", {
 	expect_true(all(out[, 3L] == 0))
 	# The other columns are still standardised.
 	expect_equal(
-		unname(colMeans(out[, -3L])), rep(0, 4L),
+		unname(colMeans(out[, -3L])),
+		rep(0, 4L),
 		tolerance = 1e-12
 	)
 	expect_equal(
-		unname(apply(out[, -3L], 2L, sd)), rep(1, 4L),
+		unname(apply(out[, -3L], 2L, sd)),
+		rep(1, 4L),
 		tolerance = 1e-12
 	)
 })
 
 test_that("my_scale parity against a hand-coded reference on full-rank inputs", {
-	# Hand-coded reference inlining the pre-#167 implementation. Note:
-	# on full-rank inputs (no zero-variance columns), the pre-#167 and
-	# post-#167 implementations agree up to FP reorder (~1e-15). On
-	# inputs WITH zero-variance columns, the pre-#167 implementation
-	# had a subtle bug: `apply(x, 2, sd)` returns floating-point noise
-	# (e.g., 5.11e-15) rather than exact 0 for a constant column, so
-	# the `(sds == 0)` guard at the next line did not fire, and the
-	# zero-variance column's `scaled:scale` was stored as 5e-15 rather
-	# than 1. Post-#167 computes the constant column's sd via exact
-	# algebraic zero (centering `c - c = 0` exactly), so the guard
-	# fires correctly and `scaled:scale` is 1. The zero-variance test
-	# above pins the post-#167 (correct) contract.
+	# Hand-coded reference inlining the pre-#167 implementation. On
+	# full-rank inputs (no zero-variance columns), the pre-#167 and
+	# post-#167 implementations agree up to floating-point reorder
+	# (~1e-15). The zero-variance branch is exercised by the
+	# preceding test_that block; both implementations end up storing
+	# `scaled:scale = 1` on a constant column (base R's two-pass
+	# `var()` returns exact 0 on a constant column, so the
+	# `(sds == 0)` guard fires the same way in both code paths).
 	old_my_scale <- function(x) {
 		ctr <- colMeans(x)
 		sds <- apply(x, 2L, sd)

--- a/tests/testthat/test-my-scale-vectorize-167.R
+++ b/tests/testthat/test-my-scale-vectorize-167.R
@@ -1,0 +1,116 @@
+# Regression test for #167: `my_scale()` was rewritten to use
+# vectorised colMeans / colSums / broadcasting instead of
+# `apply(x, 2, sd)` and `sweep(...)`. Algebraically identical; the
+# floating-point reorder gives differences at the ~1e-15 level on
+# realistic inputs (verified pre-merge via a manual parity run).
+#
+# These tests assert the externally-observable contract: the centered
+# columns have mean 0, the scaled columns have unit sd (except where
+# the input column had zero variance, which keeps sd = 1 by the
+# zero-variance guard), and the `scaled:center` / `scaled:scale`
+# attributes match `colMeans` / `apply(x, 2, sd)` of the input. The
+# test covers a normal column, a constant (zero-variance) column,
+# and a one-row degenerate input.
+
+library(testthat)
+
+test_that("my_scale centers columns to mean 0 and scales to unit sd", {
+	set.seed(1L)
+	x <- matrix(rnorm(200L * 7L), nrow = 200L, ncol = 7L)
+	out <- fetwfe:::my_scale(x)
+	# Each column has mean 0 within FP reorder noise.
+	expect_equal(unname(colMeans(out)), rep(0, 7L), tolerance = 1e-12)
+	# Each column has sd 1.
+	expect_equal(
+		unname(apply(out, 2L, sd)), rep(1, 7L),
+		tolerance = 1e-12
+	)
+})
+
+test_that("my_scale's attributes match base::scale's contract", {
+	set.seed(2L)
+	x <- matrix(rnorm(50L * 4L), nrow = 50L, ncol = 4L)
+	out <- fetwfe:::my_scale(x)
+	# scaled:center == colMeans(x)
+	expect_equal(
+		attr(out, "scaled:center"),
+		colMeans(x),
+		tolerance = 1e-12
+	)
+	# scaled:scale == apply(x, 2, sd) (un-guarded path; no zero columns)
+	expect_equal(
+		unname(attr(out, "scaled:scale")),
+		unname(apply(x, 2L, sd)),
+		tolerance = 1e-12
+	)
+})
+
+test_that("my_scale handles zero-variance columns by setting scale to 1", {
+	# Mix of normal and constant columns; the constant column must end
+	# up with center = its constant value, scale = 1, and zeros after
+	# centering+scaling (not NaN from a divide-by-zero).
+	set.seed(3L)
+	x <- matrix(rnorm(80L * 5L), nrow = 80L, ncol = 5L)
+	x[, 3L] <- 3.5 # constant
+	out <- fetwfe:::my_scale(x)
+	expect_equal(attr(out, "scaled:center")[3L], 3.5, tolerance = 1e-12)
+	expect_equal(attr(out, "scaled:scale")[3L], 1, tolerance = 1e-12)
+	expect_true(all(out[, 3L] == 0))
+	# The other columns are still standardised.
+	expect_equal(
+		unname(colMeans(out[, -3L])), rep(0, 4L),
+		tolerance = 1e-12
+	)
+	expect_equal(
+		unname(apply(out[, -3L], 2L, sd)), rep(1, 4L),
+		tolerance = 1e-12
+	)
+})
+
+test_that("my_scale parity against a hand-coded reference on full-rank inputs", {
+	# Hand-coded reference inlining the pre-#167 implementation. Note:
+	# on full-rank inputs (no zero-variance columns), the pre-#167 and
+	# post-#167 implementations agree up to FP reorder (~1e-15). On
+	# inputs WITH zero-variance columns, the pre-#167 implementation
+	# had a subtle bug: `apply(x, 2, sd)` returns floating-point noise
+	# (e.g., 5.11e-15) rather than exact 0 for a constant column, so
+	# the `(sds == 0)` guard at the next line did not fire, and the
+	# zero-variance column's `scaled:scale` was stored as 5e-15 rather
+	# than 1. Post-#167 computes the constant column's sd via exact
+	# algebraic zero (centering `c - c = 0` exactly), so the guard
+	# fires correctly and `scaled:scale` is 1. The zero-variance test
+	# above pins the post-#167 (correct) contract.
+	old_my_scale <- function(x) {
+		ctr <- colMeans(x)
+		sds <- apply(x, 2L, sd)
+		zero_sd <- (sds == 0)
+		ctr2 <- ctr
+		sds2 <- sds
+		sds2[zero_sd] <- 1
+		scaled <- sweep(x, 2L, ctr2, FUN = "-")
+		scaled <- sweep(scaled, 2L, sds2, FUN = "/")
+		attr(scaled, "scaled:center") <- ctr2
+		attr(scaled, "scaled:scale") <- sds2
+		scaled
+	}
+	set.seed(4L)
+	x <- matrix(rnorm(400L * 12L), nrow = 400L, ncol = 12L)
+	# No zero-variance columns here -- the parity check works.
+	old_out <- old_my_scale(x)
+	new_out <- fetwfe:::my_scale(x)
+	expect_equal(
+		as.vector(new_out),
+		as.vector(old_out),
+		tolerance = 1e-12
+	)
+	expect_equal(
+		attr(new_out, "scaled:center"),
+		attr(old_out, "scaled:center"),
+		tolerance = 1e-12
+	)
+	expect_equal(
+		attr(new_out, "scaled:scale"),
+		attr(old_out, "scaled:scale"),
+		tolerance = 1e-12
+	)
+})


### PR DESCRIPTION
Vectorises `my_scale()` in `R/utility.R`. Closes #167. Version bump 1.13.2 → 1.13.3 (patch — pure performance).

## What changes

`R/utility.R:813-835` was:

```r
my_scale <- function(x) {
  ctr <- colMeans(x)
  sds <- apply(x, 2, sd)              # per-column R-level loop
  zero_sd <- (sds == 0)
  ctr2 <- ctr; sds2 <- sds; sds2[zero_sd] <- 1
  scaled <- sweep(x, 2, ctr2, FUN = "-")   # dispatches through match.fun
  scaled <- sweep(scaled, 2, sds2, FUN = "/")
  ...
}
```

becomes:

```r
my_scale <- function(x) {
  n <- nrow(x)
  ctr <- colMeans(x)
  scaled <- x - rep(ctr, each = n)                          # broadcasted subtract
  sds <- sqrt(colSums(scaled * scaled) / (n - 1))           # single-pass variance
  zero_sd <- (sds == 0); sds2 <- sds; sds2[zero_sd] <- 1
  scaled <- scaled / rep(sds2, each = n)                    # broadcasted divide
  ...
}
```

## Speedup

10000 × 50 fixture, 10-iter mean:

| Implementation | Per call |
|---|---:|
| Pre-#167 (`apply` + `sweep`) | 0.008s |
| **Post-#167 (vectorised)** | **0.003s** |

→ **~2.4× speedup on the function itself.** Carries to every `fetwfe()` / `etwfe()` / `betwfe()` / `twfeCovs()` call since they all reach `my_scale()` via `prep_for_etwfe_regression()`.

## Numerical agreement on production paths

On realistic full-rank inputs (no zero-variance columns), the new path agrees with the old path to **~1e-15 max abs diff** (pure FP reorder). Specifically:

- Values: `8.88e-16` max abs diff on a 10000 × 50 fixture
- `scaled:center`: `0` (both paths use `colMeans`)
- `scaled:scale`: `2.22e-16` max abs diff (variance formula identical up to FP-reorder)

The byte-identical-BIC test in `test-lambda-selection-164.R` continues to match the hardcoded reference values (`att_hat = 0.4480082058461672`, etc.) at 1e-12 tolerance — confirms the production pipeline is numerically untouched.

## Validation

- **Existing tests pass unchanged**, including the byte-identical BIC reference (`test-lambda-selection-164.R`), the GLS-Kronecker regression (`test-gls-kronecker-block-apply-165.R`), and the idCohorts violations suite (`test-idcohorts-collect-violations.R`).
- **New dedicated test** at `tests/testthat/test-my-scale-vectorize-167.R` (4 cases): standardisation contract, `base::scale` attribute contract, zero-variance column handling, hand-coded-reference parity on full-rank inputs.
- **CRAN gate**: `_R_CHECK_SYSTEM_CLOCK_=false Rscript -e 'devtools::check(args="--as-cran")'` returns **0 errors / 0 warnings / 0 notes** (1:26).

## Workflow audit trail

Post-execution review subagent (round 1) returned `LGTM with fixes` — primary finding: the original PR description and NEWS entry claimed the rewrite fixed a "subtle zero-variance FP bug" where `apply(x, 2, sd)` allegedly returned ~5e-15 on constant columns and the `(sds == 0)` guard failed to fire. That claim doesn't survive a 30-second R session: `base::var()` is two-pass and `c - c = 0` is exact in IEEE 754, so `apply(x, 2, sd)` returns *exact* 0 on constant columns and the pre-PR guard *did* fire. Round-2 commit (`c1676fb`) retracted the bug-fix claim from the PR description, NEWS, the inline comments, and the test file; corrected a separate "Welford-style" comment to "two-pass"; trimmed a stale "one-row degenerate input" test-header claim; added three PR-introduced tokens to `inst/WORDLIST`.

Drift sentinel returned `CLEAN` on both rounds (no copy-paste, no cross-method contract issues, no test anti-patterns).

## References

- Issue: #167 (closes on merge).
- Predecessor perf items: #165 (GLS-Kronecker; merged), #166 (`idCohorts`; merged).
- Remaining perf queue from the profiling investigation: #168 (`sse_bridge` NA-check), #169 (`getBetaBIC` loop vectorize).
