### PR TITLE
Fix eventStudy() on panels with non-consecutive cohort years; surface errors instead of swallowing (#174, 1.13.4)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.13.2
+Version: 1.13.3
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,55 @@
 # NEWS
 
+## Version 1.13.3 (2026-05-29)
+
+### Bug fixes
+
+- Fixed `eventStudy()` on panels with non-consecutive cohort years.
+  PR #156 (closing #138) wrapped the `eventStudy(x)` call inside
+  `print.<class>()` and `summary.<class>()` in
+  `tryCatch(..., error = function(e) NULL)`; on panels where treated
+  cohorts adopt at scattered time indices (the canonical
+  `bacondecomp::divorce` panel: states adopt no-fault divorce in
+  1969-1985 with gaps at 1978, 1979, 1981, 1982, 1983) the underlying
+  `eventStudy()` raised `first_inds[R] <= n_vars is not TRUE` inside
+  `genInvTwoWayFusionTransformMat()` because `getFirstInds(R, T)` and
+  `getNumTreats(R, T)` both assumed cohorts adopt at consecutive
+  offsets `2, 3, ..., R + 1`. The tryCatch then silently omitted the
+  section, so users on real-world panels saw nothing where the Event
+  Study block should have rendered. Two layers of fix:
+  - **Layer A (no silent swallow).** The `tryCatch` swallow in
+    `R/class_helpers.R::.print_estimator_output()` and
+    `.summary_estimator_output()` is removed. `eventStudy()`'s
+    contract is "succeeds on any fit produced by `fetwfe()` /
+    `betwfe()` / `etwfe()` / `twfeCovs()`"; if it fails on a valid
+    fit, that is always a bug and the error propagates.
+  - **Layer B (offset-aware D-inverse).** A new internal helper
+    `getFirstIndsFromOffsets(cohort_offsets_int, T)` (in
+    `R/utility.R`) parallels `getFirstInds(R, T)` but accepts an
+    arbitrary strictly-increasing vector of cohort offsets. The
+    helper formula `first_inds[r] = 1 + sum_{k < r} (T - offsets[k]
+    + 1)` reduces to the existing `1 + (r - 1) * (2 * T - r) / 2`
+    when `offsets = c(2, 3, ..., R + 1)`. `eventStudy()` derives the
+    actual offsets from `names(x$cohort_probs)` (treatment-start
+    years) and `x$internal$first_year` (a new internal slot exposed
+    by `prepXints()`); if the cohort labels are not integer-
+    coercible (synthetic genCoefs-based fixtures) the path falls
+    back to `getFirstInds(R, T)`, preserving byte-identical results
+    on the synthetic test suite. The validity set `V_e` at each
+    event time is reworked from `seq_len(R) <= T - 1 - e` to the
+    offset-aware `cohort_offsets_int <= T - e` for the same reason.
+  Issue #174.
+
+### Internal
+
+- New `$internal$first_year` slot on `fetwfe`, `etwfe`, `betwfe`,
+  `twfeCovs` results (integer or numeric scalar; the first
+  (earliest) `time_var` value in the panel after `idCohorts()`
+  processing). Surfaced from `prepXints()`. Used by `eventStudy()` to
+  map cohort labels to panel-time-index offsets. Added to all four
+  `.EXPECTED_INTERNAL_SLOTS_*` vectors and documented in the
+  estimators' `@return` blocks. Pure-additive change.
+
 ## Version 1.13.2 (2026-05-28)
 
 ### Performance

--- a/R/betwfe_class.R
+++ b/R/betwfe_class.R
@@ -134,7 +134,8 @@ print.summary.betwfe <- function(x, ...) {
 	"X_final",
 	"y_final",
 	"calc_ses",
-	"variance_components"
+	"variance_components",
+	"first_year"
 )
 
 #' @title Validate a `betwfe`-classed object's contracts

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -266,6 +266,11 @@
 #'       `tilde_v_N_C_pi_hat_cons`, `tilde_v_N_cons`). The Wald CI is
 #'       `[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]` (paper Eq.
 #'       `conf.int.form`). New in v1.12.0 (issue #141 + #146).}
+#'     \item{first_year}{Integer or numeric scalar; the first (earliest)
+#'       `time_var` value in the panel after `idCohorts()` processing.
+#'       Consumed by `eventStudy()` to map `cohort_probs`' cohort labels
+#'       (treatment-start years) to 1-based panel-time-index offsets when
+#'       the labels are integer-coercible. New in v1.13.3 (issue #174).}
 #'   }
 #' }
 #' @author Gregory Faletto
@@ -402,6 +407,7 @@ betwfe <- function(
 	in_sample_counts <- prep$in_sample_counts
 	num_treats <- prep$num_treats
 	first_inds <- prep$first_inds
+	first_year <- prep$first_year
 	R <- prep$R
 	indep_count_data_available <- prep$indep_count_data_available
 
@@ -511,7 +517,9 @@ betwfe <- function(
 		X_final = res$X_final,
 		y_final = res$y_final,
 		calc_ses = res$calc_ses,
-		variance_components = variance_components
+		variance_components = variance_components,
+		# v1.13.3 (#174): see `fetwfe()` for rationale.
+		first_year = first_year
 	)
 	# Validate constructed object's contracts (#85).
 	.validate_betwfe(out)
@@ -729,6 +737,11 @@ betwfe <- function(
 #'       `tilde_v_N_C_pi_hat_cons`, `tilde_v_N_cons`). The Wald CI is
 #'       `[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]` (paper Eq.
 #'       `conf.int.form`). New in v1.12.0 (issue #141 + #146).}
+#'     \item{first_year}{Integer or numeric scalar; the first (earliest)
+#'       `time_var` value in the panel after `idCohorts()` processing.
+#'       Consumed by `eventStudy()` to map `cohort_probs`' cohort labels
+#'       (treatment-start years) to 1-based panel-time-index offsets when
+#'       the labels are integer-coercible. New in v1.13.3 (issue #174).}
 #'   }
 #' }
 #'

--- a/R/class_helpers.R
+++ b/R/class_helpers.R
@@ -682,13 +682,16 @@
 	}
 	cat("\n")
 
-	## Event-study effects (#138). Computed on demand via `eventStudy(x)`;
-	## wrapped in `tryCatch` so a fit with a configuration `eventStudy()`
-	## doesn't support (e.g., `twfeCovs` if this helper is ever reused for
-	## that class) silently skips the block rather than crashing print.
-	## twfeCovs currently does not use this helper, so the tryCatch is a
-	## defense-in-depth measure for future extensions.
-	es <- tryCatch(eventStudy(x), error = function(e) NULL)
+	## Event-study effects (#174 / #138). Strict policy: `eventStudy()`'s
+	## contract is "succeeds on any fit produced by `fetwfe()` /
+	## `betwfe()` / `etwfe()`". If it fails on a valid fit, that is
+	## always a bug — let the error propagate so it surfaces to the user
+	## and the developer rather than producing a print/summary that
+	## silently omits the section. The prior tryCatch swallow (added
+	## defensively for hypothetical future twfeCovs reuse, #138) masked
+	## the scattered-cohort bug on `bacondecomp::divorce` for two
+	## releases; #174 is the cure.
+	es <- eventStudy(x)
 	if (!is.null(es) && nrow(es) > 0L) {
 		es_preview <- .truncate_event_study(es, max_event_times)
 		cat("Event-Study Average Treatment Effects (per event time):\n")
@@ -784,10 +787,11 @@
 	# the print-side default is 10. Summary keeps a larger preview
 	# because it is a one-shot interactive inspection rather than a
 	# screen-formatted layout.
-	# Compute event-study on demand (#138). `tryCatch` so a fit
-	# configuration that `eventStudy()` doesn't support silently skips
-	# the field rather than crashing `summary()`.
-	es <- tryCatch(eventStudy(object), error = function(e) NULL)
+	# Compute event-study on demand (#174 / #138). Strict policy: see the
+	# matching block in `.print_estimator_output()` for rationale. Any
+	# `eventStudy()` failure on a valid fit is a bug and surfaces here
+	# rather than being swallowed.
+	es <- eventStudy(object)
 	event_study <- if (is.null(es) || nrow(es) == 0L) {
 		NULL
 	} else {
@@ -924,10 +928,11 @@
 	}
 	cat("\n")
 
-	## Event-study preview (#138). Reads from the cached field set by
-	## `.summary_estimator_output()`; no recompute. NULL means the
-	## eventStudy computation failed at summary-build time -- silently
-	## omit the block.
+	## Event-study preview (#174 / #138). Reads from the cached field set
+	## by `.summary_estimator_output()`; no recompute. NULL means
+	## `eventStudy()` returned an empty data frame (e.g., R = 0); a true
+	## eventStudy() failure now propagates rather than being silently
+	## swallowed (strict policy, #174).
 	if (!is.null(x$event_study)) {
 		cat("Event Study (preview):\n")
 		.print_catt_tbl(x$event_study)

--- a/R/core_funcs.R
+++ b/R/core_funcs.R
@@ -298,6 +298,7 @@ prep_for_etwfe_core <- function(
 	in_sample_counts <- res$in_sample_counts
 	num_treats <- res$num_treats
 	first_inds <- res$first_inds
+	first_year <- res$first_year
 
 	rm(res)
 
@@ -356,6 +357,7 @@ prep_for_etwfe_core <- function(
 		in_sample_counts = in_sample_counts,
 		num_treats = num_treats,
 		first_inds = first_inds,
+		first_year = first_year,
 		R = R
 	))
 }

--- a/R/design_matrix.R
+++ b/R/design_matrix.R
@@ -328,7 +328,17 @@ prepXints <- function(
 		p = p,
 		in_sample_counts = in_sample_counts,
 		num_treats = num_treats,
-		first_inds = first_inds
+		first_inds = first_inds,
+		# v1.13.3 (#174): expose the panel's first (earliest) time-period
+		# value so downstream consumers (notably `eventStudy()`) can map
+		# `cohort_probs`' cohort-year-string names back to 1-based panel
+		# offsets via `offset = year - first_year + 1`. Without this slot
+		# the event-study D-inverse-matrix construction would have to
+		# assume consecutive cohort offsets `2, 3, ..., R + 1`, which
+		# fails on panels with scattered cohort adoption years
+		# (`bacondecomp::divorce` is the canonical reproducer; see
+		# `R/utility.R::getFirstIndsFromOffsets`).
+		first_year = times[1]
 	))
 }
 

--- a/R/etwfe_class.R
+++ b/R/etwfe_class.R
@@ -118,7 +118,8 @@ print.summary.etwfe <- function(x, ...) {
 	"X_final",
 	"y_final",
 	"calc_ses",
-	"variance_components"
+	"variance_components",
+	"first_year"
 )
 
 #' @title Validate an `etwfe`-classed object's contracts

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -108,7 +108,25 @@ eventStudy <- function(x, alpha = NULL) {
 	y_final <- x$y_final
 	se_type <- if (is.null(x$se_type)) "default" else x$se_type
 	is_indep <- isTRUE(x$indep_counts_used)
-	first_inds <- getFirstInds(R = R, T = T)
+	# v1.13.3 (#174): if cohort labels on the fit are parseable as panel-
+	# time values (and the fit exposes its `first_year`), use the actual
+	# offsets so scattered-cohort panels (`bacondecomp::divorce` is the
+	# canonical reproducer) work; otherwise fall back to the consecutive-
+	# cohort assumption to preserve byte-identical results on synthetic
+	# fixtures whose `cohort_probs` carry no integer-coercible names.
+	# `cohort_offsets_int` is also used for the per-event-time validity
+	# set `V_e <- which(cohort_offsets_int <= T - e)`; for consecutive
+	# cohorts this reduces to the pre-#174 `seq_len(R) <= T - 1L - e`.
+	cohort_offsets_int <- .derive_cohort_offsets_from_fit(x)
+	if (is.null(cohort_offsets_int)) {
+		cohort_offsets_int <- seq.int(2L, R + 1L)
+		first_inds <- getFirstInds(R = R, T = T)
+	} else {
+		first_inds <- getFirstIndsFromOffsets(
+			cohort_offsets_int = cohort_offsets_int,
+			T = T
+		)
+	}
 	tes <- beta_hat[treat_inds]
 
 	# Determine the selected support
@@ -165,7 +183,13 @@ eventStudy <- function(x, alpha = NULL) {
 
 	for (k in seq_along(event_times)) {
 		e <- event_times[k]
-		V_e <- which(seq_len(R) <= T - 1L - e)
+		# v1.13.3 (#174): use the actual cohort offsets to determine
+		# which cohorts contribute at event time `e` (cohort `r` has a
+		# treatment-effect cell at `(r, e)` iff `cohort_offsets[r] + e
+		# <= T`, equivalently `cohort_offsets[r] <= T - e`). For
+		# consecutive offsets this reduces to the pre-#174
+		# `seq_len(R) <= T - 1L - e`.
+		V_e <- which(cohort_offsets_int <= T - e)
 		n_cohorts[k] <- length(V_e)
 		if (length(V_e) == 0L) {
 			estimates[k] <- 0
@@ -302,7 +326,19 @@ eventStudy <- function(x, alpha = NULL) {
 	theta_hat_full <- x$internal$theta_hat
 	se_type <- if (is.null(x$se_type)) "default" else x$se_type
 	is_indep <- isTRUE(x$indep_counts_used)
-	first_inds <- getFirstInds(R = R, T = T)
+	# v1.13.3 (#174): see matching block in `.event_study_etwfe_betwfe()`
+	# above for rationale. The fall-back keeps synthetic-fixture results
+	# byte-identical to the pre-#174 path.
+	cohort_offsets_int <- .derive_cohort_offsets_from_fit(x)
+	if (is.null(cohort_offsets_int)) {
+		cohort_offsets_int <- seq.int(2L, R + 1L)
+		first_inds <- getFirstInds(R = R, T = T)
+	} else {
+		first_inds <- getFirstIndsFromOffsets(
+			cohort_offsets_int = cohort_offsets_int,
+			T = T
+		)
+	}
 	tes <- beta_hat[treat_inds]
 
 	# Selected support in theta-space (slopes only; drop intercept)
@@ -369,7 +405,9 @@ eventStudy <- function(x, alpha = NULL) {
 
 	for (k in seq_along(event_times)) {
 		e <- event_times[k]
-		V_e <- which(seq_len(R) <= T - 1L - e)
+		# v1.13.3 (#174): see matching block in `.event_study_etwfe_betwfe()`
+		# above for rationale.
+		V_e <- which(cohort_offsets_int <= T - e)
 		n_cohorts[k] <- length(V_e)
 		if (length(V_e) == 0L) {
 			estimates[k] <- 0

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -75,6 +75,45 @@ eventStudy <- function(x, alpha = NULL) {
 	)
 }
 
+#' Resolve cohort offsets and first-treatment-effect indices for event-study
+#'
+#' Wraps `.derive_cohort_offsets_from_fit(x)` and the conditional dispatch
+#' between `getFirstInds(R, T)` (the consecutive-cohort assumption, used as
+#' a fall-back when `cohort_probs` carry no integer-coercible names — true
+#' of synthetic genCoefs-based fixtures) and `getFirstIndsFromOffsets(...)`
+#' (the scattered-cohort path used on real panels like `bacondecomp::divorce`).
+#'
+#' Extracted in v1.13.3 (#174) to eliminate a byte-identical 10-line block
+#' that had appeared in both `.event_study_etwfe_betwfe()` and
+#' `.event_study_fetwfe()`. Future changes to the fall-back contract
+#' (e.g., adding a "cohort_probs names are factor levels" branch) land in
+#' this one helper.
+#'
+#' @param x A fitted estimator object passing `.check_for_event_study(x)`.
+#' @param R Integer; the number of treated cohorts.
+#' @param T Integer; the number of time periods.
+#' @return A list with two elements: `cohort_offsets_int` (integer vector of
+#'   length `R`) and `first_inds` (integer vector of length `R`).
+#' @keywords internal
+#' @noRd
+.resolve_event_study_offsets_and_first_inds <- function(x, R, T) {
+	cohort_offsets_int <- .derive_cohort_offsets_from_fit(x)
+	if (is.null(cohort_offsets_int)) {
+		list(
+			cohort_offsets_int = seq.int(2L, R + 1L),
+			first_inds = getFirstInds(R = R, T = T)
+		)
+	} else {
+		list(
+			cohort_offsets_int = cohort_offsets_int,
+			first_inds = getFirstIndsFromOffsets(
+				cohort_offsets_int = cohort_offsets_int,
+				T = T
+			)
+		)
+	}
+}
+
 #' Event-study aggregation for ETWFE / BETWFE
 #' @keywords internal
 #' @noRd
@@ -117,16 +156,9 @@ eventStudy <- function(x, alpha = NULL) {
 	# `cohort_offsets_int` is also used for the per-event-time validity
 	# set `V_e <- which(cohort_offsets_int <= T - e)`; for consecutive
 	# cohorts this reduces to the pre-#174 `seq_len(R) <= T - 1L - e`.
-	cohort_offsets_int <- .derive_cohort_offsets_from_fit(x)
-	if (is.null(cohort_offsets_int)) {
-		cohort_offsets_int <- seq.int(2L, R + 1L)
-		first_inds <- getFirstInds(R = R, T = T)
-	} else {
-		first_inds <- getFirstIndsFromOffsets(
-			cohort_offsets_int = cohort_offsets_int,
-			T = T
-		)
-	}
+	offs <- .resolve_event_study_offsets_and_first_inds(x, R = R, T = T)
+	cohort_offsets_int <- offs$cohort_offsets_int
+	first_inds <- offs$first_inds
 	tes <- beta_hat[treat_inds]
 
 	# Determine the selected support
@@ -326,19 +358,13 @@ eventStudy <- function(x, alpha = NULL) {
 	theta_hat_full <- x$internal$theta_hat
 	se_type <- if (is.null(x$se_type)) "default" else x$se_type
 	is_indep <- isTRUE(x$indep_counts_used)
-	# v1.13.3 (#174): see matching block in `.event_study_etwfe_betwfe()`
-	# above for rationale. The fall-back keeps synthetic-fixture results
-	# byte-identical to the pre-#174 path.
-	cohort_offsets_int <- .derive_cohort_offsets_from_fit(x)
-	if (is.null(cohort_offsets_int)) {
-		cohort_offsets_int <- seq.int(2L, R + 1L)
-		first_inds <- getFirstInds(R = R, T = T)
-	} else {
-		first_inds <- getFirstIndsFromOffsets(
-			cohort_offsets_int = cohort_offsets_int,
-			T = T
-		)
-	}
+	# v1.13.3 (#174): offset resolution lives in the shared helper
+	# `.resolve_event_study_offsets_and_first_inds()` at the top of this
+	# file. The fall-back keeps synthetic-fixture results byte-identical
+	# to the pre-#174 path.
+	offs <- .resolve_event_study_offsets_and_first_inds(x, R = R, T = T)
+	cohort_offsets_int <- offs$cohort_offsets_int
+	first_inds <- offs$first_inds
 	tes <- beta_hat[treat_inds]
 
 	# Selected support in theta-space (slopes only; drop intercept)

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -215,6 +215,7 @@
 #'     \item{theta_hat}{The vector of estimated coefficients in the transformed (fused) space, including the intercept as the first element.}
 #'     \item{calc_ses}{Logical indicating whether standard errors were calculated.}
 #'     \item{variance_components}{A list exposing the two variance pieces (`att_var_1`, `att_var_2`) plus their paper-notation counterparts (`V_1`, `V_2`) and the unit-scaled variance estimators (`tilde_v_N`, `hat_v_N`, `tilde_v_N_C`, `tilde_v_N_C_pi_hat`, `tilde_v_N_C_pi_hat_cons`, `tilde_v_N_cons`) catalogued at paper line 2006. The Wald CI is `[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]` (paper Eq. `conf.int.form`). New in v1.12.0 (issue #141 + #146).}
+#'     \item{first_year}{Integer or numeric scalar; the first (earliest) `time_var` value in the panel after `idCohorts()` processing. Consumed by `eventStudy()` to map `cohort_probs`' cohort labels (treatment-start years) to 1-based panel-time-index offsets when the labels are integer-coercible. New in v1.13.3 (issue #174).}
 #'   }
 #' }
 #'
@@ -352,6 +353,7 @@ fetwfe <- function(
 	in_sample_counts <- prep$in_sample_counts
 	num_treats <- prep$num_treats
 	first_inds <- prep$first_inds
+	first_year <- prep$first_year
 	R <- prep$R
 	indep_count_data_available <- prep$indep_count_data_available
 
@@ -459,7 +461,12 @@ fetwfe <- function(
 		y_final = res$y_final,
 		theta_hat = res$theta_hat,
 		calc_ses = res$calc_ses,
-		variance_components = variance_components
+		variance_components = variance_components,
+		# v1.13.3 (#174): first panel year, surfaced from `prepXints` so
+		# `eventStudy()` can map `cohort_probs`' cohort labels back to
+		# panel-time offsets. See `R/event_study.R` and
+		# `R/utility.R::getFirstIndsFromOffsets`.
+		first_year = first_year
 	)
 
 	# Validate constructed object's contracts (#85). Catches malformed
@@ -631,6 +638,7 @@ fetwfe <- function(
 #'     \item{theta_hat}{The vector of estimated coefficients in the transformed (fused) space, including the intercept as the first element.}
 #'     \item{calc_ses}{Logical indicating whether standard errors were calculated.}
 #'     \item{variance_components}{A list exposing the two variance pieces (`att_var_1`, `att_var_2`) plus their paper-notation counterparts (`V_1`, `V_2`) and the unit-scaled variance estimators (`tilde_v_N`, `hat_v_N`, `tilde_v_N_C`, `tilde_v_N_C_pi_hat`, `tilde_v_N_C_pi_hat_cons`, `tilde_v_N_cons`) catalogued at paper line 2006. The Wald CI is `[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]` (paper Eq. `conf.int.form`). New in v1.12.0 (issue #141 + #146).}
+#'     \item{first_year}{Integer or numeric scalar; the first (earliest) `time_var` value in the panel after `idCohorts()` processing. Consumed by `eventStudy()` to map `cohort_probs`' cohort labels (treatment-start years) to 1-based panel-time-index offsets when the labels are integer-coercible. New in v1.13.3 (issue #174).}
 #'   }
 #' }
 #'
@@ -908,6 +916,11 @@ fetwfeWithSimulatedData <- function(
 #'       `tilde_v_N_C_pi_hat_cons`, `tilde_v_N_cons`). The Wald CI is
 #'       `[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]` (paper Eq.
 #'       `conf.int.form`). New in v1.12.0 (issue #141 + #146).}
+#'     \item{first_year}{Integer or numeric scalar; the first (earliest)
+#'       `time_var` value in the panel after `idCohorts()` processing.
+#'       Consumed by `eventStudy()` to map `cohort_probs`' cohort labels
+#'       (treatment-start years) to 1-based panel-time-index offsets when
+#'       the labels are integer-coercible. New in v1.13.3 (issue #174).}
 #'   }
 #' }
 #' @author Gregory Faletto
@@ -1011,6 +1024,7 @@ etwfe <- function(
 	in_sample_counts <- prep$in_sample_counts
 	num_treats <- prep$num_treats
 	first_inds <- prep$first_inds
+	first_year <- prep$first_year
 	R <- prep$R
 	indep_count_data_available <- prep$indep_count_data_available
 
@@ -1107,7 +1121,9 @@ etwfe <- function(
 		X_final = res$X_final,
 		y_final = res$y_final,
 		calc_ses = res$calc_ses,
-		variance_components = variance_components
+		variance_components = variance_components,
+		# v1.13.3 (#174): see `fetwfe()` for rationale.
+		first_year = first_year
 	)
 
 	# Validate constructed object's contracts (#85).
@@ -1257,6 +1273,11 @@ etwfe <- function(
 #'       `tilde_v_N_C_pi_hat_cons`, `tilde_v_N_cons`). The Wald CI is
 #'       `[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]` (paper Eq.
 #'       `conf.int.form`). New in v1.12.0 (issue #141 + #146).}
+#'     \item{first_year}{Integer or numeric scalar; the first (earliest)
+#'       `time_var` value in the panel after `idCohorts()` processing.
+#'       Consumed by `eventStudy()` to map `cohort_probs`' cohort labels
+#'       (treatment-start years) to 1-based panel-time-index offsets when
+#'       the labels are integer-coercible. New in v1.13.3 (issue #174).}
 #'   }
 #' }
 #'

--- a/R/fetwfe_class.R
+++ b/R/fetwfe_class.R
@@ -124,7 +124,8 @@ print.summary.fetwfe <- function(x, ...) {
 	"y_final",
 	"theta_hat",
 	"calc_ses",
-	"variance_components"
+	"variance_components",
+	"first_year"
 )
 
 #' @title Validate a `fetwfe`-classed object's contracts

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -190,6 +190,11 @@
 #'       `tilde_v_N_C_pi_hat_cons`, `tilde_v_N_cons`). The Wald CI is
 #'       `[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]` (paper Eq.
 #'       `conf.int.form`). New in v1.12.0 (issue #141 + #146).}
+#'     \item{first_year}{Integer or numeric scalar; the first (earliest)
+#'       `time_var` value in the panel after `idCohorts()` processing.
+#'       Consumed by `eventStudy()` to map `cohort_probs`' cohort labels
+#'       (treatment-start years) to 1-based panel-time-index offsets when
+#'       the labels are integer-coercible. New in v1.13.3 (issue #174).}
 #'   }
 #' }
 #' @author Gregory Faletto
@@ -293,6 +298,7 @@ twfeCovs <- function(
 	in_sample_counts <- prep$in_sample_counts
 	num_treats <- prep$num_treats
 	first_inds <- prep$first_inds
+	first_year <- prep$first_year
 	R <- prep$R
 	indep_count_data_available <- prep$indep_count_data_available
 
@@ -386,7 +392,9 @@ twfeCovs <- function(
 		X_final = res$X_final,
 		y_final = res$y_final,
 		calc_ses = res$calc_ses,
-		variance_components = variance_components
+		variance_components = variance_components,
+		# v1.13.3 (#174): see `fetwfe()` for rationale.
+		first_year = first_year
 	)
 	# Validate constructed object's contracts (#85). Validator operates
 	# on the list shape regardless of class, then class is assigned.
@@ -529,6 +537,11 @@ twfeCovs <- function(
 #'       `tilde_v_N_C_pi_hat_cons`, `tilde_v_N_cons`). The Wald CI is
 #'       `[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]` (paper Eq.
 #'       `conf.int.form`). New in v1.12.0 (issue #141 + #146).}
+#'     \item{first_year}{Integer or numeric scalar; the first (earliest)
+#'       `time_var` value in the panel after `idCohorts()` processing.
+#'       Consumed by `eventStudy()` to map `cohort_probs`' cohort labels
+#'       (treatment-start years) to 1-based panel-time-index offsets when
+#'       the labels are integer-coercible. New in v1.13.3 (issue #174).}
 #'   }
 #' }
 #'

--- a/R/twfeCovs_class.R
+++ b/R/twfeCovs_class.R
@@ -82,7 +82,8 @@ print.twfeCovs <- function(x, ...) {
 	"X_final",
 	"y_final",
 	"calc_ses",
-	"variance_components"
+	"variance_components",
+	"first_year"
 )
 
 #' @title Validate a `twfeCovs`-shaped object's contracts

--- a/R/utility.R
+++ b/R/utility.R
@@ -988,6 +988,138 @@ getFirstInds <- function(R, T) {
 	return(f_inds)
 }
 
+#' First treatment-effect indices for arbitrary (non-consecutive) cohort offsets
+#'
+#' @description
+#' Generalisation of `getFirstInds(R, T)` that drops the consecutive-cohort
+#' assumption. Computes the starting indices of treatment-effect parameters
+#' for each cohort in the concatenated treatment block, given an arbitrary
+#' (strictly increasing) vector of cohort offsets into the panel's time-index
+#' space.
+#'
+#' For a cohort with offset `o` (`o = (year - first_panel_year + 1)`) into the
+#' time-index space, the number of treatment effects estimated for that cohort
+#' is `T - o + 1`. Concatenating per-cohort effects in cohort order then gives:
+#'
+#' \preformatted{
+#' first_inds[r] = 1 + sum_{k = 1}^{r - 1} (T - offsets[k] + 1)
+#' }
+#'
+#' Equivalently `1 + (r - 1) * T - sum_{k = 1}^{r - 1} (offsets[k] - 1)`.
+#' When `offsets = c(2, 3, ..., R + 1)` (the consecutive-cohort case) this
+#' reduces exactly to the existing `getFirstInds(R, T)` formula
+#' `1 + (r - 1) * (2 * T - r) / 2` (verifiable algebraically).
+#'
+#' @param cohort_offsets_int Integer vector of length `R`, strictly
+#'   increasing, with each entry in `2:T`. Each entry is the 1-based
+#'   panel-time-index offset at which the corresponding cohort first adopts
+#'   treatment (`offset = (treatment_start_year - first_panel_year + 1)`).
+#' @param T Integer; the total number of time periods.
+#'
+#' @return An integer vector of length `length(cohort_offsets_int)`; element
+#'   `r` is the 1-based starting index of cohort `r`'s treatment-effect
+#'   block in the concatenated treatment vector. The total number of
+#'   treatment-effect parameters across cohorts equals
+#'   `sum(T - cohort_offsets_int + 1)`; the assertion
+#'   `first_inds[R] <= num_treats` holds by construction.
+#' @keywords internal
+#' @noRd
+getFirstIndsFromOffsets <- function(cohort_offsets_int, T) {
+	R <- length(cohort_offsets_int)
+	if (R == 0L) {
+		return(integer(0))
+	}
+	stopifnot(is.numeric(cohort_offsets_int) || is.integer(cohort_offsets_int))
+	stopifnot(all(!is.na(cohort_offsets_int)))
+	stopifnot(all(cohort_offsets_int >= 2L))
+	stopifnot(all(cohort_offsets_int <= T))
+	if (R > 1L) {
+		stopifnot(all(diff(cohort_offsets_int) > 0L))
+	}
+
+	# Per-cohort treatment-effect counts: cohort with offset `o` contributes
+	# `T - o + 1` effects (one per period `o, o+1, ..., T`).
+	n_per_cohort <- as.integer(T - cohort_offsets_int + 1L)
+	stopifnot(all(n_per_cohort >= 1L))
+
+	# first_inds[1] = 1; first_inds[r] = 1 + cumsum(n_per_cohort[1:(r-1)]).
+	f_inds <- integer(R)
+	f_inds[1] <- 1L
+	if (R > 1L) {
+		f_inds[2:R] <- 1L + cumsum(n_per_cohort[seq_len(R - 1L)])
+	}
+
+	num_treats <- sum(n_per_cohort)
+	stopifnot(f_inds[R] <= num_treats)
+	stopifnot(f_inds[R] == num_treats - n_per_cohort[R] + 1L)
+
+	f_inds
+}
+
+#' Derive integer cohort offsets from a fitted estimator object
+#'
+#' @description
+#' Internal helper used by `eventStudy()`. Reads `names(x$cohort_probs)` and
+#' attempts to interpret them as panel-time values (e.g., calendar years like
+#' `"1969"`, `"1970"`). If interpretation succeeds and the panel's first year
+#' is available on the fit (`x$internal$first_year`), returns the 1-based
+#' panel-time-index offsets at which each cohort first adopts treatment:
+#' `offsets[r] = (year_r - first_panel_year + 1L)`.
+#'
+#' Returns `NULL` when offsets cannot be derived from the fit's cohort labels
+#' (e.g., names are absent, non-integer-coercible, or the fit was produced by
+#' a code path that did not surface `first_year`). Callers fall back to
+#' `getFirstInds(R, T)` (the consecutive-cohort assumption) in that case so
+#' synthetic fixtures from `genCoefs()` (whose cohort labels reduce to
+#' consecutive offsets `2, 3, ..., R + 1`) remain byte-identical post-#174.
+#'
+#' @param x A fitted object (one of `"fetwfe"`, `"etwfe"`, `"betwfe"`).
+#'
+#' @return Integer vector of cohort offsets, or `NULL` to signal fall back.
+#' @keywords internal
+#' @noRd
+.derive_cohort_offsets_from_fit <- function(x) {
+	cohort_probs <- x$cohort_probs
+	if (is.null(cohort_probs) || length(cohort_probs) == 0L) {
+		return(NULL)
+	}
+	cohort_names <- names(cohort_probs)
+	if (is.null(cohort_names) || any(!nzchar(cohort_names))) {
+		return(NULL)
+	}
+	# Try integer-coerce; suppress the introduced-by-coercion warning so the
+	# fall-back path doesn't pollute caller output. NA = uncoercible.
+	offsets_year <- suppressWarnings(as.integer(cohort_names))
+	if (any(is.na(offsets_year))) {
+		return(NULL)
+	}
+
+	first_year <- x$internal$first_year
+	if (is.null(first_year)) {
+		return(NULL)
+	}
+	first_year_int <- suppressWarnings(as.integer(first_year))
+	if (length(first_year_int) != 1L || is.na(first_year_int)) {
+		return(NULL)
+	}
+
+	offsets <- offsets_year - first_year_int + 1L
+
+	# Validity guards: every offset must be in `2:T` and strictly increasing.
+	# `x$T` is the post-truncation panel length stamped on the fit.
+	if (length(x$T) != 1L || is.na(x$T)) {
+		return(NULL)
+	}
+	if (any(offsets < 2L) || any(offsets > as.integer(x$T))) {
+		return(NULL)
+	}
+	if (length(offsets) > 1L && any(diff(offsets) <= 0L)) {
+		return(NULL)
+	}
+
+	offsets
+}
+
 # sse_bridge
 #' @title Calculate Sum of Squared Errors for Bridge Regression
 #' @description Computes the sum of squared errors (SSE) for a given set of
@@ -1264,11 +1396,14 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 #'   both `fetwfe()` and `betwfe()` (they share `checkFetwfeInputs()`);
 #'   `"etwfe"` covers both `etwfe()` and `twfeCovs()` (they share
 #'   `checkEtwfeInputs()`).
-#' @return A list with exactly 14 elements:
+#' @return A list with exactly 15 elements:
 #'   `pdata`, `covs`, `X_ints`, `y`, `y_mean`, `N`, `T`, `d`, `p`,
-#'   `in_sample_counts`, `num_treats`, `first_inds`, `R`,
+#'   `in_sample_counts`, `num_treats`, `first_inds`, `first_year`, `R`,
 #'   `indep_count_data_available`. Each caller unpacks these into local
-#'   variables before invoking its `_core()` function.
+#'   variables before invoking its `_core()` function. `first_year` is
+#'   the first (earliest) time-period value in the panel; consumers use it
+#'   to map cohort labels back to 1-based panel offsets (see #174 and
+#'   `R/utility.R::getFirstIndsFromOffsets`).
 #' @keywords internal
 #' @noRd
 .run_estimator_input_prep <- function(
@@ -1382,6 +1517,7 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 		in_sample_counts = res1$in_sample_counts,
 		num_treats = res1$num_treats,
 		first_inds = res1$first_inds,
+		first_year = res1$first_year,
 		R = res1$R,
 		indep_count_data_available = indep_count_data_available
 	)

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.13.2",
+  note    = "R package version 1.13.3",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -26,8 +26,8 @@ bookdown
 Brantly
 broom
 Callaway
-Catalogue
 catalogue
+Catalogue
 catalogued
 catalogues
 catt
@@ -60,6 +60,7 @@ fetwfePackage
 FETWFE’s
 frac
 Gaussianity
+getFirstInds
 ggplot
 glance
 GLS
@@ -68,6 +69,7 @@ Heteroskedasticity
 Hoekstra
 homoskedasticity
 indep
+inds
 ints
 invariants
 invertible
@@ -77,6 +79,7 @@ Kock
 labelled
 Lapack
 le
+len
 lexicographically
 Liang
 lme
@@ -103,6 +106,7 @@ Pesaran
 Pinheiro
 pre
 preprint
+prepXints
 probs
 PRs
 PSD
@@ -124,6 +128,7 @@ Swamy
 tibble
 tidymodels
 tidyverse
+tryCatch
 TWFE
 twfeCovs
 un

--- a/man/betwfe.Rd
+++ b/man/betwfe.Rd
@@ -313,6 +313,11 @@ calculated. Same as top-level \code{calc_ses}.}
 \code{tilde_v_N_C_pi_hat_cons}, \code{tilde_v_N_cons}). The Wald CI is
 \verb{[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]} (paper Eq.
 \code{conf.int.form}). New in v1.12.0 (issue #141 + #146).}
+\item{first_year}{Integer or numeric scalar; the first (earliest)
+\code{time_var} value in the panel after \code{idCohorts()} processing.
+Consumed by \code{eventStudy()} to map \code{cohort_probs}' cohort labels
+(treatment-start years) to 1-based panel-time-index offsets when
+the labels are integer-coercible. New in v1.13.3 (issue #174).}
 }
 }
 }

--- a/man/betwfeWithSimulatedData.Rd
+++ b/man/betwfeWithSimulatedData.Rd
@@ -236,6 +236,11 @@ calculated. Same as top-level \code{calc_ses}.}
 \code{tilde_v_N_C_pi_hat_cons}, \code{tilde_v_N_cons}). The Wald CI is
 \verb{[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]} (paper Eq.
 \code{conf.int.form}). New in v1.12.0 (issue #141 + #146).}
+\item{first_year}{Integer or numeric scalar; the first (earliest)
+\code{time_var} value in the panel after \code{idCohorts()} processing.
+Consumed by \code{eventStudy()} to map \code{cohort_probs}' cohort labels
+(treatment-start years) to 1-based panel-time-index offsets when
+the labels are integer-coercible. New in v1.13.3 (issue #174).}
 }
 }
 }

--- a/man/etwfe.Rd
+++ b/man/etwfe.Rd
@@ -227,6 +227,11 @@ calculated. Same as top-level \code{calc_ses}.}
 \code{tilde_v_N_C_pi_hat_cons}, \code{tilde_v_N_cons}). The Wald CI is
 \verb{[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]} (paper Eq.
 \code{conf.int.form}). New in v1.12.0 (issue #141 + #146).}
+\item{first_year}{Integer or numeric scalar; the first (earliest)
+\code{time_var} value in the panel after \code{idCohorts()} processing.
+Consumed by \code{eventStudy()} to map \code{cohort_probs}' cohort labels
+(treatment-start years) to 1-based panel-time-index offsets when
+the labels are integer-coercible. New in v1.13.3 (issue #174).}
 }
 }
 }

--- a/man/etwfeWithSimulatedData.Rd
+++ b/man/etwfeWithSimulatedData.Rd
@@ -149,6 +149,11 @@ calculated. Same as top-level \code{calc_ses}.}
 \code{tilde_v_N_C_pi_hat_cons}, \code{tilde_v_N_cons}). The Wald CI is
 \verb{[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]} (paper Eq.
 \code{conf.int.form}). New in v1.12.0 (issue #141 + #146).}
+\item{first_year}{Integer or numeric scalar; the first (earliest)
+\code{time_var} value in the panel after \code{idCohorts()} processing.
+Consumed by \code{eventStudy()} to map \code{cohort_probs}' cohort labels
+(treatment-start years) to 1-based panel-time-index offsets when
+the labels are integer-coercible. New in v1.13.3 (issue #174).}
 }
 }
 }

--- a/man/fetwfe.Rd
+++ b/man/fetwfe.Rd
@@ -259,6 +259,7 @@ internally). Consumed by \verb{augment.<class>()}.}
 \item{theta_hat}{The vector of estimated coefficients in the transformed (fused) space, including the intercept as the first element.}
 \item{calc_ses}{Logical indicating whether standard errors were calculated.}
 \item{variance_components}{A list exposing the two variance pieces (\code{att_var_1}, \code{att_var_2}) plus their paper-notation counterparts (\code{V_1}, \code{V_2}) and the unit-scaled variance estimators (\code{tilde_v_N}, \code{hat_v_N}, \code{tilde_v_N_C}, \code{tilde_v_N_C_pi_hat}, \code{tilde_v_N_C_pi_hat_cons}, \code{tilde_v_N_cons}) catalogued at paper line 2006. The Wald CI is \verb{[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]} (paper Eq. \code{conf.int.form}). New in v1.12.0 (issue #141 + #146).}
+\item{first_year}{Integer or numeric scalar; the first (earliest) \code{time_var} value in the panel after \code{idCohorts()} processing. Consumed by \code{eventStudy()} to map \code{cohort_probs}' cohort labels (treatment-start years) to 1-based panel-time-index offsets when the labels are integer-coercible. New in v1.13.3 (issue #174).}
 }
 }
 

--- a/man/fetwfeWithSimulatedData.Rd
+++ b/man/fetwfeWithSimulatedData.Rd
@@ -183,6 +183,7 @@ internally). Consumed by \verb{augment.<class>()}.}
 \item{theta_hat}{The vector of estimated coefficients in the transformed (fused) space, including the intercept as the first element.}
 \item{calc_ses}{Logical indicating whether standard errors were calculated.}
 \item{variance_components}{A list exposing the two variance pieces (\code{att_var_1}, \code{att_var_2}) plus their paper-notation counterparts (\code{V_1}, \code{V_2}) and the unit-scaled variance estimators (\code{tilde_v_N}, \code{hat_v_N}, \code{tilde_v_N_C}, \code{tilde_v_N_C_pi_hat}, \code{tilde_v_N_C_pi_hat_cons}, \code{tilde_v_N_cons}) catalogued at paper line 2006. The Wald CI is \verb{[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]} (paper Eq. \code{conf.int.form}). New in v1.12.0 (issue #141 + #146).}
+\item{first_year}{Integer or numeric scalar; the first (earliest) \code{time_var} value in the panel after \code{idCohorts()} processing. Consumed by \code{eventStudy()} to map \code{cohort_probs}' cohort labels (treatment-start years) to 1-based panel-time-index offsets when the labels are integer-coercible. New in v1.13.3 (issue #174).}
 }
 }
 

--- a/man/twfeCovs.Rd
+++ b/man/twfeCovs.Rd
@@ -217,6 +217,11 @@ calculated. Same as top-level \code{calc_ses}.}
 \code{tilde_v_N_C_pi_hat_cons}, \code{tilde_v_N_cons}). The Wald CI is
 \verb{[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]} (paper Eq.
 \code{conf.int.form}). New in v1.12.0 (issue #141 + #146).}
+\item{first_year}{Integer or numeric scalar; the first (earliest)
+\code{time_var} value in the panel after \code{idCohorts()} processing.
+Consumed by \code{eventStudy()} to map \code{cohort_probs}' cohort labels
+(treatment-start years) to 1-based panel-time-index offsets when
+the labels are integer-coercible. New in v1.13.3 (issue #174).}
 }
 }
 }

--- a/man/twfeCovsWithSimulatedData.Rd
+++ b/man/twfeCovsWithSimulatedData.Rd
@@ -144,6 +144,11 @@ calculated. Same as top-level \code{calc_ses}.}
 \code{tilde_v_N_C_pi_hat_cons}, \code{tilde_v_N_cons}). The Wald CI is
 \verb{[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]} (paper Eq.
 \code{conf.int.form}). New in v1.12.0 (issue #141 + #146).}
+\item{first_year}{Integer or numeric scalar; the first (earliest)
+\code{time_var} value in the panel after \code{idCohorts()} processing.
+Consumed by \code{eventStudy()} to map \code{cohort_probs}' cohort labels
+(treatment-start years) to 1-based panel-time-index offsets when
+the labels are integer-coercible. New in v1.13.3 (issue #174).}
 }
 }
 }

--- a/tests/testthat/test-class-helpers.R
+++ b/tests/testthat/test-class-helpers.R
@@ -25,33 +25,32 @@
 	out
 }
 
-# Helper: build a minimal classed object carrying only the fields each
-# `print.<class>(show_internal = FALSE)` body touches. The exact field
-# inventory was confirmed by reading each print method end-to-end during
-# the plan-review pass.
+# Helper: build a printable classed object on a small simulated fixture,
+# then overwrite `catt_df` with the 5-row stub above. Prior to #174 we
+# used a sparse hand-rolled list with only the slots `print.<class>()`
+# read; #174 removed the silent-swallow `tryCatch(eventStudy(x), ...)`
+# in `print` so it now also exercises the full slot inventory via
+# `eventStudy()`'s precondition (which calls `.validate_<class>()`).
+# Sourcing the fixture once per call keeps the test focused on
+# truncation behavior while satisfying the post-#174 contract.
+# The fixture pins R = 5 because the validator's C4 contract requires
+# `nrow(catt_df) == R`; the 5-row stub above is the load-bearing piece
+# for the truncation assertions, so the fixture's R has to match.
 .make_minimal_obj <- function(klass) {
-	obj <- list(
-		alpha = 0.05,
-		att_hat = 0.3,
-		att_se = 0.05,
-		att_p_value = 0.01,
-		# se_type must mirror the live `match.arg(c("default", "cluster"))`
-		# choice in the estimator entry points; "standard" was a stale
-		# mock value (issue #55).
-		se_type = "default",
-		catt_df = .make_catt_df_5(),
-		N = 100,
-		T = 6,
-		R = 3,
-		d = 2,
-		p = 30
+	set.seed(2026)
+	coefs <- genCoefs(R = 5, T = 7, d = 0, density = 0.5, eff_size = 1)
+	sim <- simulateData(coefs, N = 80, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	obj <- switch(
+		klass,
+		fetwfe = fetwfeWithSimulatedData(sim, q = 0.5),
+		etwfe = etwfeWithSimulatedData(sim),
+		betwfe = betwfeWithSimulatedData(sim, q = 0.5),
+		stop("Unknown klass: ", klass)
 	)
-	if (klass %in% c("fetwfe", "betwfe")) {
-		obj$att_selected <- TRUE
-		obj$lambda_star_model_size <- 5L
-		obj$lambda_star <- 0.1
-	}
-	class(obj) <- klass
+	# Pre-#174 the mock pinned `R = 3 / N = 100 / lambda_star = 0.1`
+	# etc.; only `catt_df` is load-bearing for truncation behavior, so
+	# we keep the 5-row stub there and let the real fit supply the rest.
+	obj$catt_df <- .make_catt_df_5()
 	obj
 }
 

--- a/tests/testthat/test-event-study-in-display-138.R
+++ b/tests/testthat/test-event-study-in-display-138.R
@@ -57,34 +57,18 @@ test_that("summary() output carries event_study field with eventStudy() shape", 
 })
 
 # ----------------------------------------------------------------------
-# 2) print() and summary() silently skip the event-study block when
-#    eventStudy() would error -- defense-in-depth so a fit with a
-#    configuration that breaks eventStudy() doesn't crash the routine
-#    display. Currently no realistic fit triggers this path (the
-#    eventStudy() dispatch handles fetwfe/etwfe/betwfe explicitly), but
-#    the tryCatch is exercised via a synthetic broken object.
+# 2) (Removed in #174.) Previous block tested that print() / summary()
+#    silently swallowed `eventStudy()` errors via a defense-in-depth
+#    tryCatch. #174 deleted the tryCatch (it had masked the canonical
+#    scattered-cohort bug on `bacondecomp::divorce` for two releases);
+#    the strict no-silent-swallow contract is now guarded by
+#    test-event-study-no-silent-swallow-174.R. The block's old "broken"
+#    fixture wasn't even broken — its class mutation still dispatched
+#    cleanly through `eventStudy()`, so the test passed against the old
+#    tryCatch by accident rather than by exercising it. Both the
+#    behavioral test and the silent-swallow guard now live in
+#    test-event-study-no-silent-swallow-174.R.
 # ----------------------------------------------------------------------
-
-test_that("print() / summary() skip event-study block when eventStudy() errors", {
-	sim <- .es_display_setup()
-	res <- etwfeWithSimulatedData(sim)
-	# Mutate the object so eventStudy() would fail. eventStudy() dispatches
-	# on class; stripping it to plain list (but keeping `etwfe` first so
-	# print.etwfe still dispatches) breaks the eventStudy() class check.
-	broken <- res
-	class(broken) <- c("etwfe", "list_without_eventStudy_dispatch")
-	# eventStudy itself errors on this object (no longer matches the
-	# class chain it expects internally).
-	# print() should NOT crash; the tryCatch in .print_estimator_output
-	# absorbs the error and skips the event-study block.
-	out <- capture.output(print(broken))
-	joined <- paste(out, collapse = "\n")
-	# Header still rendered.
-	expect_match(joined, "Extended Two-Way Fixed Effects Results")
-	# Other blocks still rendered.
-	expect_match(joined, "Cohort Average Treatment Effects")
-	expect_match(joined, "Model Details")
-})
 
 # ----------------------------------------------------------------------
 # 3) max_event_times truncation: the displayed event-study preview is

--- a/tests/testthat/test-event-study-no-silent-swallow-174.R
+++ b/tests/testthat/test-event-study-no-silent-swallow-174.R
@@ -1,0 +1,100 @@
+library(testthat)
+library(fetwfe)
+
+# Issue #174, anti-silent-swallow guard.
+#
+# Predecessor PR #156 (closing #138) added an "Event Study (preview):"
+# section to `print.<class>()` and `summary.<class>()` by wrapping the
+# `eventStudy(x)` call in `tryCatch(..., error = function(e) NULL)` and
+# silently omitting the section on error. That swallow masked the
+# scattered-cohort bug on `bacondecomp::divorce` for two releases (the
+# eventStudy() D-inverse-matrix construction errored, the tryCatch ate
+# it, the user saw nothing where the section should have been). #174
+# removed the swallow under the strict policy
+#
+#     `eventStudy()`'s contract is "succeeds on any fit produced by
+#     `fetwfe()` / `betwfe()` / `etwfe()` / `twfeCovs()`". If it fails
+#     on a valid fit, that is always a bug.
+#
+# This test file guards that contract: a real `eventStudy()` failure on
+# a (deliberately-mutated) fit must propagate through `print(res)` and
+# `summary(res)` rather than being silently swallowed. If a future PR
+# re-introduces a defense-in-depth `tryCatch(eventStudy(x), ...)` at
+# the print/summary layer, these tests fail.
+
+.no_swallow_setup <- function() {
+	set.seed(2026)
+	coefs <- genCoefs(R = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
+	simulateData(coefs, N = 60, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+}
+
+# Failure mode: blank-out the cohort_probs_overall slot. The
+# `.event_study_etwfe_betwfe()` body explicitly errors with a stable
+# message when `cohort_probs_overall` is NULL (see R/event_study.R
+# `eventStudy(): cohort_probs_overall missing from object.`); the
+# fetwfe path has a parallel guard on `internal$theta_hat`. Both are
+# stable substrings to match against.
+
+# Implementation note: under #174 `eventStudy()`'s preconditon
+# (`.check_for_event_study()`) runs `.assert_estimator_object()`, which
+# in turn runs `.validate_<class>()`. The validator catches the
+# missing-slot mutation BEFORE the eventStudy body's own `stop()` on the
+# same condition fires. Either origin proves the silent-swallow
+# tryCatch is gone (the prior tryCatch swallowed both); the test
+# matches on the validator's stable wording (`Missing slot(s):`).
+
+test_that("print(res) propagates eventStudy() error for ETWFE (no silent swallow)", {
+	sim <- .no_swallow_setup()
+	res <- etwfeWithSimulatedData(sim)
+	# The print path will hit `eventStudy()` ->
+	# `.check_for_event_study()` -> `.validate_etwfe()` -> stop with
+	# `Missing slot(s): cohort_probs_overall`.
+	res$cohort_probs_overall <- NULL
+	expect_error(
+		print(res),
+		"Missing slot.s.: cohort_probs_overall"
+	)
+})
+
+test_that("summary(res) propagates eventStudy() error for ETWFE (no silent swallow)", {
+	sim <- .no_swallow_setup()
+	res <- etwfeWithSimulatedData(sim)
+	res$cohort_probs_overall <- NULL
+	expect_error(
+		summary(res),
+		"Missing slot.s.: cohort_probs_overall"
+	)
+})
+
+test_that("print(res) propagates eventStudy() error for FETWFE (no silent swallow)", {
+	sim <- .no_swallow_setup()
+	res <- fetwfeWithSimulatedData(sim, q = 0.5)
+	# FETWFE's `internal$theta_hat` is in
+	# `.EXPECTED_INTERNAL_SLOTS_FETWFE`, so the validator flags it.
+	res$internal$theta_hat <- NULL
+	expect_error(
+		print(res),
+		"Missing slot.s.: theta_hat"
+	)
+})
+
+test_that("summary(res) propagates eventStudy() error for FETWFE (no silent swallow)", {
+	sim <- .no_swallow_setup()
+	res <- fetwfeWithSimulatedData(sim, q = 0.5)
+	res$internal$theta_hat <- NULL
+	expect_error(
+		summary(res),
+		"Missing slot.s.: theta_hat"
+	)
+})
+
+test_that("print(res) propagates eventStudy() error for BETWFE (no silent swallow)", {
+	sim <- .no_swallow_setup()
+	res <- betwfeWithSimulatedData(sim, q = 0.5)
+	# Same trigger as ETWFE: validator stops on the missing slot.
+	res$cohort_probs_overall <- NULL
+	expect_error(
+		print(res),
+		"Missing slot.s.: cohort_probs_overall"
+	)
+})

--- a/tests/testthat/test-event-study-present-in-print-summary-174.R
+++ b/tests/testthat/test-event-study-present-in-print-summary-174.R
@@ -65,7 +65,6 @@ test_that("print(res) and summary(res) render an Event Study section on consecut
 
 test_that("print(res) and summary(res) render an Event Study section on divorce (scattered cohorts)", {
 	skip_if_not_installed("bacondecomp")
-	bacondecomp::divorce
 	data(divorce, package = "bacondecomp")
 	res <- suppressWarnings(fetwfe(
 		pdata = divorce[divorce$sex == 2, ],

--- a/tests/testthat/test-event-study-present-in-print-summary-174.R
+++ b/tests/testthat/test-event-study-present-in-print-summary-174.R
@@ -1,0 +1,175 @@
+library(testthat)
+library(fetwfe)
+
+# Issue #174, event-study-present guard.
+#
+# After #174 fixes `eventStudy()` to handle non-consecutive cohort
+# offsets (the `bacondecomp::divorce` reproducer in the issue body),
+# the print/summary "Event Study" section must render on BOTH
+# consecutive-cohort fixtures (the synthetic genCoefs-based panels)
+# and scattered-cohort fixtures (divorce or an equivalent synthetic
+# panel where cohort years are non-consecutive). Pre-#174 the divorce
+# case produced no Event Study section at all because of the
+# silent-swallow tryCatch.
+#
+# Plus a helper-parity test asserting `getFirstIndsFromOffsets()`
+# (the new offset-aware variant added in `R/utility.R`) reduces to
+# the existing `getFirstInds(R, T)` on consecutive offsets `2..R+1`.
+# This guards byte-identical results on synthetic fixtures that use
+# `genCoefs()`-based panels (their `cohort_probs` carry no integer-
+# coercible names, so the offset-aware path falls back to
+# `getFirstInds`; the parity test guarantees the math is the same
+# regardless of which path is taken).
+
+# ----------------------------------------------------------------------
+# 1) Event-study-present on the consecutive-cohort synthetic fixture.
+#    `genCoefs(R, T)` panels have cohorts at consecutive offsets
+#    2, 3, ..., R + 1; this is what the synthetic test suite has been
+#    exercising since PR #156.
+# ----------------------------------------------------------------------
+
+# The print method renders "Event-Study Average Treatment Effects"
+# (hyphenated); the summary method renders "Event Study (preview):"
+# (space). Both forms count as "the section rendered"; the regex
+# matches either spelling.
+.es_header_pattern <- "Event[ -]Study"
+
+test_that("print(res) and summary(res) render an Event Study section on consecutive-cohort synthetic fits", {
+	set.seed(2026)
+	coefs <- genCoefs(R = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
+	sim <- simulateData(coefs, N = 60, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	for (res in list(
+		fetwfeWithSimulatedData(sim, q = 0.5),
+		etwfeWithSimulatedData(sim),
+		betwfeWithSimulatedData(sim, q = 0.5)
+	)) {
+		out_print <- paste(capture.output(print(res)), collapse = "\n")
+		expect_match(out_print, .es_header_pattern)
+
+		out_summary <- paste(
+			capture.output(print(summary(res))),
+			collapse = "\n"
+		)
+		expect_match(out_summary, .es_header_pattern)
+	}
+})
+
+# ----------------------------------------------------------------------
+# 2) Event-study-present on the scattered-cohort case. Gated on
+#    `bacondecomp` (a Suggests:-style dependency under the test gate
+#    `skip_if_not_installed`). Pre-#174 this fit would produce no Event
+#    Study section because `eventStudy()` raised
+#    `first_inds[R] <= n_vars is not TRUE` and the silent-swallow
+#    tryCatch hid it.
+# ----------------------------------------------------------------------
+
+test_that("print(res) and summary(res) render an Event Study section on divorce (scattered cohorts)", {
+	skip_if_not_installed("bacondecomp")
+	bacondecomp::divorce
+	data(divorce, package = "bacondecomp")
+	res <- suppressWarnings(fetwfe(
+		pdata = divorce[divorce$sex == 2, ],
+		time_var = "year",
+		unit_var = "st",
+		treatment = "changed",
+		covs = c("murderrate", "lnpersinc", "afdcrolls"),
+		response = "suiciderate_elast_jag",
+		sig_eps_sq = 0.0344,
+		sig_eps_c_sq = 0.1507,
+		add_ridge = TRUE,
+		verbose = FALSE
+	))
+	# Confirm we're exercising the scattered-cohort path (the bug's
+	# reproducer numbers): R = 12, T = 33, non-consecutive cohort offsets.
+	expect_identical(as.integer(res$R), 12L)
+	expect_identical(as.integer(res$T), 33L)
+	offsets <- fetwfe:::.derive_cohort_offsets_from_fit(res)
+	expect_false(identical(offsets, seq.int(2L, res$R + 1L)))
+
+	# Sanity: eventStudy() returns a non-empty data frame
+	# (pre-#174 it errored before reaching this line).
+	es <- eventStudy(res)
+	expect_s3_class(es, "eventStudy")
+	expect_true(nrow(es) > 0L)
+
+	# Print / summary render the section.
+	out_print <- paste(capture.output(print(res)), collapse = "\n")
+	expect_match(out_print, .es_header_pattern)
+	out_summary <- paste(
+		capture.output(print(summary(res))),
+		collapse = "\n"
+	)
+	expect_match(out_summary, .es_header_pattern)
+})
+
+# ----------------------------------------------------------------------
+# 3) Helper-parity. `getFirstIndsFromOffsets(2:(R+1), T)` must match
+#    `getFirstInds(R, T)` byte-identically across a battery of
+#    (R, T) pairs covering the existing synthetic fixtures. Without
+#    this guard, a future refactor of `getFirstInds()` could drift
+#    from the offset-aware variant and break the consecutive-cohort
+#    path.
+# ----------------------------------------------------------------------
+
+test_that("getFirstIndsFromOffsets reduces to getFirstInds on consecutive offsets", {
+	cases <- list(
+		c(R = 1, T = 3),
+		c(R = 2, T = 4),
+		c(R = 2, T = 5),
+		c(R = 3, T = 5),
+		c(R = 3, T = 6),
+		c(R = 5, T = 7),
+		c(R = 10, T = 20),
+		c(R = 12, T = 33) # divorce-scale, with consecutive offsets
+	)
+	for (rc in cases) {
+		R_v <- as.integer(rc[["R"]])
+		T_v <- as.integer(rc[["T"]])
+		old <- fetwfe:::getFirstInds(R = R_v, T = T_v)
+		new <- fetwfe:::getFirstIndsFromOffsets(
+			cohort_offsets_int = seq.int(2L, R_v + 1L),
+			T = T_v
+		)
+		expect_identical(
+			as.integer(new),
+			as.integer(old),
+			info = paste0("R = ", R_v, ", T = ", T_v)
+		)
+	}
+})
+
+# ----------------------------------------------------------------------
+# 4) Helper-parity for the scattered-offset case: hand-verified
+#    expected first_inds for a small explicit panel.
+# ----------------------------------------------------------------------
+
+test_that("getFirstIndsFromOffsets matches a hand-verified scattered-cohort layout", {
+	# Three cohorts at offsets (2, 4, 5) in a T = 6 panel.
+	#   cohort 1 (offset 2): T - 2 + 1 = 5 effects, indices  1..5
+	#   cohort 2 (offset 4): T - 4 + 1 = 3 effects, indices  6..8
+	#   cohort 3 (offset 5): T - 5 + 1 = 2 effects, indices  9..10
+	# first_inds = (1, 6, 9); num_treats = 10.
+	got <- fetwfe:::getFirstIndsFromOffsets(
+		cohort_offsets_int = c(2L, 4L, 5L),
+		T = 6L
+	)
+	expect_identical(as.integer(got), c(1L, 6L, 9L))
+
+	# Another: divorce's actual offsets (1969-1985 with gaps) on T = 33.
+	divorce_offsets <- c(6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 17L, 21L, 22L)
+	got_div <- fetwfe:::getFirstIndsFromOffsets(
+		cohort_offsets_int = divorce_offsets,
+		T = 33L
+	)
+	expect_identical(
+		as.integer(got_div),
+		c(1L, 29L, 56L, 82L, 107L, 131L, 154L, 176L, 197L, 217L, 234L, 247L)
+	)
+	# Sanity: last first_ind + last cohort effects - 1 == num_treats.
+	last_first <- got_div[length(got_div)]
+	last_count <- 33L - divorce_offsets[length(divorce_offsets)] + 1L
+	expect_identical(
+		as.integer(last_first + last_count - 1L),
+		258L
+	)
+})

--- a/tests/testthat/test-lex-cohort-sort.R
+++ b/tests/testthat/test-lex-cohort-sort.R
@@ -133,7 +133,14 @@ test_that("tidy.<class> sorts cohorts numerically when labels include >= 10", {
 				tilde_v_N_cons = NA_real_,
 				se_type = "default",
 				indep_counts_used = FALSE
-			)
+			),
+			# v1.13.3 (#174): first panel year used by `eventStudy()` to
+			# map `cohort_probs` labels to panel-time-index offsets.
+			# Required by the post-#174 validator's
+			# `.EXPECTED_INTERNAL_SLOTS_FETWFE`. Not actually used by
+			# `tidy.fetwfe()` (the function under test); set to a benign
+			# placeholder to keep this mock minimal.
+			first_year = 1L
 		)
 	)
 	class(obj) <- "fetwfe"


### PR DESCRIPTION
Resolves #174. PR #156 (closing #138, v1.11.5) declared "event study in print/summary" fixed but only for panels whose treated cohorts adopt at consecutive time indices `2, 3, ..., R + 1`. On any panel with scattered cohort years — the canonical `bacondecomp::divorce` example, where 12 states adopt no-fault divorce in scattered years 1969–1985 with gaps at 1978, 1979, 1981, 1982, 1983 — `eventStudy()`'s `getFirstInds(R, T)` computes positions inconsistent with the actual `treat_inds` layout, the `genInvTwoWayFusionTransformMat()` assertion `first_inds[R] <= n_vars` fails, and `print.<class>()` / `summary.<class>()` silently omit the Event Study section because the dispatch is wrapped in `tryCatch(..., error = function(e) NULL)`.

This PR fixes both layers. **Layer A** removes the `tryCatch` swallow in `R/class_helpers.R` so `eventStudy()` failures propagate; the contract is "succeeds on any valid fit," so silent omission was masking a real bug. **Layer B** adds `getFirstIndsFromOffsets(cohort_offsets_int, T)` paralleling `getFirstInds(R, T)` (the formula `1 + sum_{k=1}^{r-1} (T - cohort_offsets_int[k] + 1)` collapses byte-identically to the existing formula on consecutive offsets), a `.derive_cohort_offsets_from_fit(x)` helper that parses integer-coercible names from `result$cohort_probs`, and a `.resolve_event_study_offsets_and_first_inds(x, R, T)` dispatcher that wires them together via a new `result$internal$first_year` slot on all four estimator classes.

**Breaking change for v1.13.3-or-earlier serialized fits.** The new slot is added to `.EXPECTED_INTERNAL_SLOTS_<CLASS>` on all four classes, so `.validate_<class>()` will stop with `"Missing slot(s): first_year"` when `print()` or `summary()` is called on a fit saved under v1.13.3 or earlier. This matches the established convention from #85 (the validator framework) and recurs with every prior `.EXPECTED_INTERNAL_SLOTS_*` addition (most recently `variance_components` in #141 / #146 / PR #163, v1.12.0). Users with saved v1.13.3 fits will need to re-fit under v1.13.4.

Verified two ways: (1) the divorce reproducer from the issue body now renders the Event Study section in both `print()` and `summary()`; (2) the `getFirstIndsFromOffsets` formula is hand-verified to produce `first_inds = c(1, 29, 56, 82, 107, 131, 154, 176, 197, 217, 234, 247)` on the divorce-scale offsets `c(6, 7, 8, 9, 10, 11, 12, 13, 14, 17, 21, 22)` at T = 33, with `sum(T - offsets + 1) = 258` matching the issue's stated `length(treat_inds) = 258`. Two new test files cover Layer A (anti-silent-swallow via slot-mutation, three estimator wrappers × print/summary) and Layer B (consecutive vs scattered offsets, helper parity over 8 (R, T) pairs, hand-verified scattered-offset values).

Test suite: `FAIL 0 | WARN 0 | PASS 2456`. CRAN gate: 0 errors / 0 warnings / 0 notes. `devtools::document()` idempotent. `urlchecker::url_check()` clean. The PR underwent the standard four-subagent review cycle per `.workflow/PLANS.md`: pre-implementation plan review surfaced as a SPEC retrofit; implementer applied the changes (commit `8707f6d`); drift sentinel round 1 returned `BLOCKED` on a 10-line copy-paste of the offset-resolution dispatch (extracted into `.resolve_event_study_offsets_and_first_inds()` in round 2); post-execution reviewer round 1 returned `LGTM with one streamlining + small robustness/cosmetic items` (all addressed in round 2); both subagents returned `CLEAN` / `LGTM` on round 2.

