### PR TITLE
Save/restore caller's .Random.seed in getBetaCV() (#177, 1.13.5)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.13.4
+Version: 1.13.5
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # NEWS
 
+## Version 1.13.5 (2026-05-29)
+
+### Bug fixes
+
+- Fixed a silent RNG-state regression introduced in v1.13.0 (#177):
+  every default-path `fetwfe()` / `betwfe()` call was overwriting
+  the caller's `.GlobalEnv$.Random.seed` because `getBetaCV()` in
+  `R/fetwfe_core.R` called `set.seed(cv_seed)` without saving and
+  restoring the previous state. Wrapped the `set.seed` call in an
+  `on.exit({ assign(".Random.seed", old, envir = .GlobalEnv) })`
+  guard so the caller's RNG state is preserved across the fit. The
+  v1.12.x default BIC path was unaffected (it never set a seed);
+  this fix restores RNG semantics to that prior behavior on the
+  CV-default path. Estimator output is unchanged.
+
 ## Version 1.13.4 (2026-05-29)
 
 ### Bug fixes

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -473,7 +473,32 @@ getBetaCV <- function(
 	# `set.seed()` here drives the fold assignment for cv.grpreg(). We use
 	# this rather than cv.grpreg's own `seed` argument because the latter
 	# changed semantics across grpreg versions; the global RNG approach is
-	# version-stable.
+	# version-stable. We save and restore the caller's .Random.seed via
+	# on.exit() so the call leaves the caller's RNG state untouched
+	# (issue #177 — without this, every default-path fetwfe() / betwfe()
+	# call would silently mutate the user's seed, a v1.13.0 regression
+	# vs the v1.12.x BIC default).
+	old_rng <- if (
+		exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+	) {
+		.GlobalEnv$.Random.seed
+	} else {
+		NULL
+	}
+	on.exit(
+		{
+			if (is.null(old_rng)) {
+				if (
+					exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+				) {
+					rm(".Random.seed", envir = .GlobalEnv)
+				}
+			} else {
+				assign(".Random.seed", old_rng, envir = .GlobalEnv)
+			}
+		},
+		add = TRUE
+	)
 	set.seed(cv_seed)
 
 	cv_fit <- grpreg::cv.grpreg(

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.13.4",
+  note    = "R package version 1.13.5",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-lambda-selection-164.R
+++ b/tests/testthat/test-lambda-selection-164.R
@@ -368,3 +368,33 @@ test_that("CV path has |bias| < 0.10 on a representative DGP (smoke test)", {
 	# Tolerance 0.10 is loose enough to absorb 10-rep Monte Carlo error.
 	expect_lt(abs(mean_bias), 0.10)
 })
+
+# ------------------------------------------------------------------------------
+# Test: getBetaCV() preserves caller's .Random.seed (regression for #177).
+#
+# Before the fix, `set.seed(cv_seed)` inside getBetaCV() leaked into the
+# caller's .GlobalEnv$.Random.seed, so a second set.seed(K) + runif() after
+# the fit would diverge from a baseline set.seed(K) + runif() without the
+# fit. The BIC path never mutated RNG (no set.seed call); we lock BOTH paths
+# now so a future regression on either is caught.
+# ------------------------------------------------------------------------------
+
+test_that("CV path preserves caller's .Random.seed (#177)", {
+	sim <- .lambda_sel_fixture()
+	set.seed(42L)
+	before <- runif(3L)
+	set.seed(42L)
+	invisible(fetwfeWithSimulatedData(sim))
+	after <- runif(3L)
+	expect_identical(before, after)
+})
+
+test_that("BIC path preserves caller's .Random.seed (#177)", {
+	sim <- .lambda_sel_fixture()
+	set.seed(42L)
+	before <- runif(3L)
+	set.seed(42L)
+	invisible(fetwfeWithSimulatedData(sim, lambda_selection = "bic"))
+	after <- runif(3L)
+	expect_identical(before, after)
+})


### PR DESCRIPTION

Resolves #177. PR #170 made cross-validation the default `lambda_selection` in v1.13.0, introducing a silent regression: every default-path `fetwfe()` / `betwfe()` call overwrote the caller's `.GlobalEnv$.Random.seed` because `getBetaCV()` in `R/fetwfe_core.R` called `set.seed(cv_seed)` without saving and restoring the previous state. Wrapped the `set.seed` call in an `on.exit({ assign(".Random.seed", old, envir = .GlobalEnv) })` guard so the caller's RNG state is preserved across the fit; the v1.12.x default BIC path was unaffected (it never set a seed), and estimator output is byte-identical to the pre-fix function on any given input. Added two regression tests in `test-lambda-selection-164.R` (CV path and BIC path) that assert `identical(before, after)` on `runif(3)` draws around a fit; the CV-path test fails on pre-fix code and passes post-fix.
