### PR TITLE
Tests + fix: GLS-Kronecker direct call, sharp conf.level, BIC overflow (#178, 1.13.6)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.13.5
+Version: 1.13.6
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,35 @@
 # NEWS
 
+## Version 1.13.6 (2026-05-29)
+
+### Bug fixes
+
+- Guarded against integer overflow in `getBetaBIC()`'s BIC formula
+  (`R/fetwfe_core.R`) at panels with `N * T > .Machine$integer.max ≈
+  2.15e9` (#178). Coerces `N * T` to numeric before multiplying,
+  mirroring the existing `getBetaCV()` safeguard. No user-visible
+  change at realistic panel sizes; the BIC opt-in path on
+  >2.15e9-cell panels now computes correctly instead of failing
+  with an unhelpful `stopifnot` trace.
+
+### Internal
+
+- Rewrote `test-gls-kronecker-block-apply-165.R` (#178) to call
+  `.estimate_variance_and_gls()` directly rather than re-deriving
+  both sides of the block-apply identity inline. The previous test
+  asserted an algebraic identity that holds by construction; the
+  new test pins the production function's `y_gls` / `X_gls` against
+  an explicit-Kronecker reference, so a future refactor that
+  silently breaks the GLS reshape step is caught here rather than
+  via downstream end-to-end tests.
+
+- Sharpened the `tidy.eventStudy(es, conf.level = ...)` regression
+  test in `test-broom-methods.R` (#178). The previous parametric
+  assertion `(td_99 width) >= (td_95 width)` held even if
+  `conf.level` were completely ignored; the new sharp
+  `expect_equal((qnorm(0.995) - qnorm(0.975)) * std.error)` form
+  pins the exact CI half-width formula.
+
 ## Version 1.13.5 (2026-05-29)
 
 ### Bug fixes

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -360,7 +360,19 @@ getBetaBIC <- function(fit, N, T, p, X_mod, y, scale_center, scale_scale) {
 		model_sizes[k] <- s
 
 		stopifnot(is.na(BICs[k]))
-		BICs[k] <- N * T * log(mse_hat) + s * log(N * T)
+		# Coerce N * T to numeric before multiplying. `N * T` is integer
+		# arithmetic and overflows at .Machine$integer.max ≈ 2.15e9
+		# (panels with N * T > ~2.15e9, e.g. 50,000 x 50,000). On
+		# overflow, R returns NA_integer_ and downstream
+		# `which(BICs == min(BICs))` is empty, tripping the
+		# `stopifnot(length(lambda_star_final_ind) == 1)` at line ~378
+		# with an unhelpful message. The CV path already handles this
+		# safely at lines ~460-471 (clip to integer.max with a warning);
+		# mirror the same as.numeric() coercion here. No regression test:
+		# the bug fires only at panel sizes too large to construct in CI
+		# (#178).
+		nt_double <- as.numeric(N) * as.numeric(T)
+		BICs[k] <- nt_double * log(mse_hat) + s * log(nt_double)
 	}
 
 	lambda_star_ind <- which(BICs == min(BICs))

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.13.5",
+  note    = "R package version 1.13.6",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-broom-methods.R
+++ b/tests/testthat/test-broom-methods.R
@@ -537,12 +537,23 @@ test_that("tidy.eventStudy recomputes CIs at a custom conf.level", {
 	es <- eventStudy(res)
 	td_95 <- broom::tidy(es, conf.level = 0.95)
 	td_99 <- broom::tidy(es, conf.level = 0.99)
-	# 99% widths should be wider than 95% widths everywhere (allowing
-	# tiny floating-point slack).
-	expect_true(all(
-		(td_99$conf.high - td_99$conf.low) >=
-			(td_95$conf.high - td_95$conf.low) - 1e-10
-	))
+	# Sharp check: the CI half-width is `qnorm(1 - alpha/2) * std.error`,
+	# so the difference between 99% and 95% high bounds is
+	# `(qnorm(0.995) - qnorm(0.975)) * std.error` at every row. The pre-
+	# #178 parametric `width_99 >= width_95 - 1e-10` assertion held even
+	# if `conf.level` were ignored entirely (two equal widths satisfy
+	# `>=`); the sharp form pins the exact formula. `td_95$std.error`
+	# is used because it equals `td_99$std.error` (`std.error` doesn't
+	# depend on `conf.level`).
+	z_diff <- stats::qnorm(0.995) - stats::qnorm(0.975)
+	expect_equal(
+		td_99$conf.high - td_95$conf.high,
+		z_diff * td_95$std.error
+	)
+	expect_equal(
+		td_95$conf.low - td_99$conf.low,
+		z_diff * td_95$std.error
+	)
 })
 
 test_that("tidy.eventStudy localizes error when required columns are missing", {

--- a/tests/testthat/test-gls-kronecker-block-apply-165.R
+++ b/tests/testthat/test-gls-kronecker-block-apply-165.R
@@ -1,79 +1,146 @@
-# Regression test for #165: the GLS whitening step in
+# Regression tests for #165 / hardened in #178: the GLS whitening step in
 # `.estimate_variance_and_gls()` (R/core_funcs.R) uses the block-apply
 # identity (I_N kron A) %*% vec_{T,N}(M) = vec_{T,N}(A %*% M) instead of
-# materialising the (N*T) x (N*T) Kronecker matrix. This test asserts
-# the algebraic identity directly on a small randomised fixture, so a
-# future refactor that breaks the row-ordering invariant or the
-# block-apply form is caught with byte-identical localisation rather
-# than via a downstream end-to-end test.
+# materialising the (N*T) x (N*T) Kronecker matrix.
+#
+# Block 1 (sanity prologue): the algebraic identity `(I_N kron A) %*% vec(M)
+# = vec(A %*% M)` holds for a small numeric fixture. Documents the math the
+# optimisation relies on; this assertion is necessary but not sufficient.
+#
+# Block 2 (load-bearing): directly call `fetwfe:::.estimate_variance_and_gls()`
+# and assert its `y_gls` / `X_gls` are byte-equal (`tolerance = 0`) to an
+# explicit-Kronecker reference computed inline. A future refactor that
+# silently breaks the production reshape — e.g. uses the wrong variance
+# component in `A`'s scale, drops the `matrix(..., nrow = T)` reshape, or
+# any other change that makes the transform not equal to (I_N kron A) %*% y
+# — fails this assertion. The pre-#178 test re-derived both sides inline
+# and so passed regardless of what the production code did.
+#
+# Block 3 (sig_eps_c_sq = 0 edge case): same production-call shape as
+# Block 2, exercising the degenerate-covariance branch where the closed
+# form collapses to `(1/sqrt(sig_eps_sq)) * I_T`.
 
 library(testthat)
 
-test_that("block-apply form equals explicit Kronecker on (unit, time)-ordered data", {
-	# Tiny fixture: small enough that the explicit Kronecker is cheap to
-	# materialise as a parity reference.
+test_that("block-apply identity `(I_N kron A) %*% vec(M) = vec(A %*% M)` holds (sanity prologue)", {
+	# The mathematical identity that justifies the block-apply form. Holds
+	# for any conformable `A` (T x T), `y` (N*T-vector in (unit, time)
+	# order), `X` (N*T x p in the same order). This is a sanity check on
+	# the math, NOT a check on the production code (the production code's
+	# correctness is locked by Block 2 below).
+	set.seed(1L)
+	N <- 7L
+	T <- 4L
+	p <- 3L
+	A <- matrix(rnorm(T * T), nrow = T, ncol = T)
+	y <- rnorm(N * T)
+	X <- matrix(rnorm(N * T * p), nrow = N * T, ncol = p)
+
+	# Explicit Kronecker form.
+	y_kron <- as.vector(kronecker(diag(N), A) %*% y)
+	X_kron <- kronecker(diag(N), A) %*% X
+
+	# Block-apply form.
+	y_block <- as.vector(A %*% matrix(y, nrow = T))
+	X_block <- matrix(A %*% matrix(X, nrow = T), nrow = N * T, ncol = p)
+
+	expect_equal(y_block, y_kron, tolerance = 0)
+	expect_equal(
+		X_block,
+		matrix(X_kron, nrow = N * T, ncol = p),
+		tolerance = 0
+	)
+})
+
+test_that(".estimate_variance_and_gls() matches explicit Kronecker GLS form (load-bearing)", {
+	# Tiny fixture. Variance components supplied so the REML path in
+	# `estOmegaSqrtInv()` doesn't fire; we're testing the GLS transform,
+	# not the variance-component estimator.
 	set.seed(42L)
-	N <- 80L
-	T <- 6L
-	p <- 17L
+	N <- 12L
+	T <- 5L
+	p <- 7L
 	y <- rnorm(N * T)
 	X_mod <- matrix(rnorm(N * T * p), nrow = N * T, ncol = p)
-
+	# X_ints is the input to the REML estimator and only consulted when
+	# variance components are NA; any conformable matrix works here.
+	X_ints <- X_mod
 	sig_eps_sq <- 2.3
 	sig_eps_c_sq <- 1.1
+
+	res <- fetwfe:::.estimate_variance_and_gls(
+		y = y,
+		X_ints = X_ints,
+		X_mod = X_mod,
+		sig_eps_sq = sig_eps_sq,
+		sig_eps_c_sq = sig_eps_c_sq,
+		N = N,
+		T = T,
+		p = p,
+		verbose = FALSE
+	)
+
+	# Explicit-Kronecker reference. Mirrors `R/core_funcs.R:437-440`'s
+	# closed form for `Omega_sqrt_inv` and `R/core_funcs.R:463`'s scaling
+	# `A <- sqrt(sig_eps_sq) * Omega_sqrt_inv`.
 	J_over_T <- matrix(1 / T, nrow = T, ncol = T)
 	Omega_sqrt_inv <- (1 / sqrt(sig_eps_sq)) *
 		(diag(T) - J_over_T) +
 		(1 / sqrt(sig_eps_sq + T * sig_eps_c_sq)) * J_over_T
 	A <- sqrt(sig_eps_sq) * Omega_sqrt_inv
+	big_kron <- kronecker(diag(N), A)
+	y_gls_ref <- big_kron %*% y # (N*T) x 1 matrix
+	X_gls_ref <- big_kron %*% X_mod # (N*T) x p matrix
 
-	# Explicit Kronecker form (the pre-#165 implementation).
-	y_gls_explicit <- as.vector(kronecker(diag(N), A) %*% y)
-	X_gls_explicit <- kronecker(diag(N), A) %*% X_mod
-
-	# Block-apply form (the post-#165 implementation).
-	y_gls_block <- as.vector(A %*% matrix(y, nrow = T))
-	X_gls_block <- matrix(
-		A %*% matrix(X_mod, nrow = T),
-		nrow = N * T,
-		ncol = ncol(X_mod)
-	)
-
-	expect_equal(y_gls_block, y_gls_explicit, tolerance = 0)
-	expect_equal(
-		X_gls_block,
-		matrix(X_gls_explicit, nrow = N * T, ncol = ncol(X_mod)),
-		tolerance = 0
-	)
+	# Production return shapes per `R/core_funcs.R:464-475`: `y_gls` is
+	# (N*T) x 1 matrix (NOT a length-N*T vector); `X_gls` is (N*T) x p
+	# matrix. `ignore_attr = TRUE` because `kronecker(...)` returns
+	# matrices without dimnames whereas the production return may carry
+	# names.
+	expect_equal(res$y_gls, y_gls_ref, tolerance = 0, ignore_attr = TRUE)
+	expect_equal(res$X_gls, X_gls_ref, tolerance = 0, ignore_attr = TRUE)
+	expect_identical(res$sig_eps_sq, sig_eps_sq)
+	expect_identical(res$sig_eps_c_sq, sig_eps_c_sq)
 })
 
-test_that("block-apply form is invariant to the trivial sig_eps_c_sq=0 case", {
-	# Edge case from `R/core_funcs.R` lines 432-434's docstring: when
-	# `sig_eps_c_sq = 0`, the two scaled projectors recombine into
-	# `(1/sqrt(sig_eps_sq)) * I_T`. The block-apply form must still
-	# match the explicit Kronecker form. Smaller N is enough.
+test_that(".estimate_variance_and_gls() handles sig_eps_c_sq = 0 (edge case)", {
+	# Degenerate-covariance branch: when `sig_eps_c_sq = 0`, the closed
+	# form for `Omega_sqrt_inv` reduces to `(1/sqrt(sig_eps_sq)) * I_T`
+	# (per the comment at R/core_funcs.R:434-436). Verify the production
+	# function still matches the explicit Kronecker form on this branch.
 	set.seed(7L)
 	N <- 30L
 	T <- 4L
 	p <- 5L
 	y <- rnorm(N * T)
 	X_mod <- matrix(rnorm(N * T * p), nrow = N * T, ncol = p)
-
+	X_ints <- X_mod
 	sig_eps_sq <- 1.5
+	sig_eps_c_sq <- 0
+
+	res <- fetwfe:::.estimate_variance_and_gls(
+		y = y,
+		X_ints = X_ints,
+		X_mod = X_mod,
+		sig_eps_sq = sig_eps_sq,
+		sig_eps_c_sq = sig_eps_c_sq,
+		N = N,
+		T = T,
+		p = p,
+		verbose = FALSE
+	)
+
 	J_over_T <- matrix(1 / T, nrow = T, ncol = T)
 	Omega_sqrt_inv <- (1 / sqrt(sig_eps_sq)) *
 		(diag(T) - J_over_T) +
-		(1 / sqrt(sig_eps_sq + T * 0)) * J_over_T # sig_eps_c_sq = 0
+		(1 / sqrt(sig_eps_sq + T * sig_eps_c_sq)) * J_over_T
 	A <- sqrt(sig_eps_sq) * Omega_sqrt_inv
+	big_kron <- kronecker(diag(N), A)
 
+	expect_equal(res$y_gls, big_kron %*% y, tolerance = 0, ignore_attr = TRUE)
 	expect_equal(
-		as.vector(A %*% matrix(y, nrow = T)),
-		as.vector(kronecker(diag(N), A) %*% y),
-		tolerance = 0
-	)
-	expect_equal(
-		matrix(A %*% matrix(X_mod, nrow = T), nrow = N * T, ncol = ncol(X_mod)),
-		kronecker(diag(N), A) %*% X_mod,
+		res$X_gls,
+		big_kron %*% X_mod,
 		tolerance = 0,
 		ignore_attr = TRUE
 	)


### PR DESCRIPTION

Resolves #178. Three correctness-hardening items bundled per the 2026-05-29 periodic review's PR-B grouping: (a) **WT1** — `test-gls-kronecker-block-apply-165.R` now calls `fetwfe:::.estimate_variance_and_gls()` directly and pins its `y_gls` / `X_gls` against an explicit-Kronecker reference at `tolerance = 0` (the pre-PR test re-derived both sides of the algebraic identity inline and so passed regardless of what the production code did; a `sqrt(sig_eps_c_sq)` injection at `R/core_funcs.R:463` fails the new Block 2 with 60/60 mismatches); (b) **WT2** — the `tidy.eventStudy(es, conf.level = ...)` test now uses the sharp `(qnorm(0.995) - qnorm(0.975)) * std.error` formula on both `conf.high` and `conf.low` (carried from the 2026-05-19 / 2026-05-20 reviews; the pre-PR `width_99 >= width_95` form held even if `conf.level` were ignored); (c) **SB3** — coerced `N * T` to numeric before multiplying in `getBetaBIC()`'s BIC formula to guard against integer overflow at panels with `N * T > .Machine$integer.max ≈ 2.15e9`, mirroring the existing `getBetaCV()` safeguard. No math change, no public API change. Estimator output is byte-identical at realistic panel sizes (BIC byte-identity tests in `test-lambda-selection-164.R` confirm).
