### PR TITLE
Docs: se_type @return, "five sub-slots" framing, checkFetwfeInputs @param (#179, 1.13.7)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.13.6
+Version: 1.13.7
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # NEWS
 
+## Version 1.13.7 (2026-05-30)
+
+### Documentation
+
+- Fixed three roxygen documentation issues in the four estimator
+  entry points and their `*WithSimulatedData()` wrappers (#179):
+  (a) eight `@return \item{se_type}{}` parenthetical notes across
+  `R/fetwfe.R` / `R/betwfe_core.R` / `R/twfeCovs.R` listed only
+  `"default"` and `"cluster"`, dropping `"conservative"` (added in
+  v1.12.0 / PR #163); they now correctly list all three values;
+  (b) six `@return $internal` describe-blocks said "The five
+  sub-slots are also duplicated at top level" but the describe-list
+  contained seven sub-slots; the framing now correctly notes that
+  `variance_components` and `first_year` live only under
+  `$internal`; (c) the internal helper `checkFetwfeInputs()` was
+  missing `@param` lines for `lambda_selection`, `cv_folds`, and
+  `cv_seed`. Zero behavior change; affects rendered help pages
+  only.
+
 ## Version 1.13.6 (2026-05-29)
 
 ### Bug fixes

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -243,12 +243,15 @@
 #' argument was provided and used for asymptotically-exact ATT inference,
 #' `FALSE` otherwise.}
 #' \item{se_type}{Character scalar; the `se_type` argument the user passed
-#' (`"default"` or `"cluster"`).}
+#' (`"default"`, `"conservative"`, or `"cluster"`).}
 #' \item{internal}{A list containing internal outputs that are typically
 #'   not needed for interpretation, packaged here for parity with
 #'   `fetwfe()` so downstream consumers can use a single canonical
-#'   access path across all four estimator classes (#144). The five
-#'   sub-slots are also duplicated at top level for backward compat:
+#'   access path across all four estimator classes (#144). The first
+#'   five sub-slots (`X_ints`, `y`, `X_final`, `y_final`, `calc_ses`)
+#'   are also duplicated at top level for backward compat;
+#'   `variance_components` and `first_year` live only under
+#'   `$internal`:
 #'   \describe{
 #'     \item{X_ints}{The design matrix containing all interactions,
 #'       time and cohort dummies, etc. Same value as top-level `X_ints`.}
@@ -709,7 +712,7 @@ betwfe <- function(
 #' argument was provided and used for asymptotically-exact ATT inference,
 #' `FALSE` otherwise.}
 #' \item{se_type}{Character scalar; the `se_type` argument the user passed
-#' (`"default"` or `"cluster"`).}
+#' (`"default"`, `"conservative"`, or `"cluster"`).}
 #' \item{y_mean}{Numeric scalar; mean of the original (pre-centering) response.
 #' Stored so downstream methods (`augment()`, `predict()`) can return fitted
 #' values on the original-response scale.}
@@ -722,8 +725,11 @@ betwfe <- function(
 #' \item{internal}{A list containing internal outputs that are typically
 #'   not needed for interpretation, packaged here for parity with
 #'   `fetwfe()` so downstream consumers can use a single canonical
-#'   access path across all four estimator classes (#144). The five
-#'   sub-slots are also duplicated at top level for backward compat:
+#'   access path across all four estimator classes (#144). The first
+#'   five sub-slots (`X_ints`, `y`, `X_final`, `y_final`, `calc_ses`)
+#'   are also duplicated at top level for backward compat;
+#'   `variance_components` and `first_year` live only under
+#'   `$internal`:
 #'   \describe{
 #'     \item{X_ints}{The design matrix containing all interactions,
 #'       time and cohort dummies, etc. Same value as top-level `X_ints`.}

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -191,7 +191,7 @@
 #' argument was provided and used for asymptotically-exact ATT inference,
 #' `FALSE` otherwise.}
 #' \item{se_type}{Character scalar; the `se_type` argument the user passed
-#' (`"default"` or `"cluster"`).}
+#' (`"default"`, `"conservative"`, or `"cluster"`).}
 #' \item{y_mean}{Numeric scalar; the mean of the original (pre-centering)
 #'   response. Stored so downstream methods (`augment()`, `predict()`)
 #'   can return fitted values on the original-response scale.}
@@ -618,7 +618,7 @@ fetwfe <- function(
 #' argument was provided and used for asymptotically-exact ATT inference,
 #' `FALSE` otherwise.}
 #' \item{se_type}{Character scalar; the `se_type` argument the user passed
-#' (`"default"` or `"cluster"`).}
+#' (`"default"`, `"conservative"`, or `"cluster"`).}
 #' \item{y_mean}{Numeric scalar; the mean of the original (pre-centering)
 #'   response. Stored so downstream methods (`augment()`, `predict()`)
 #'   can return fitted values on the original-response scale.}
@@ -885,7 +885,7 @@ fetwfeWithSimulatedData <- function(
 #' argument was provided and used for asymptotically-exact ATT inference,
 #' `FALSE` otherwise.}
 #' \item{se_type}{Character scalar; the `se_type` argument the user passed
-#' (`"default"` or `"cluster"`).}
+#' (`"default"`, `"conservative"`, or `"cluster"`).}
 #' \item{y_mean}{Numeric scalar; the mean of the original (pre-centering)
 #'   response. Stored so downstream methods (`augment()`, `predict()`)
 #'   can return fitted values on the original-response scale.}
@@ -901,8 +901,11 @@ fetwfeWithSimulatedData <- function(
 #' \item{internal}{A list containing internal outputs that are typically
 #'   not needed for interpretation, packaged here for parity with
 #'   `fetwfe()` so downstream consumers can use a single canonical
-#'   access path across all four estimator classes (#144). The five
-#'   sub-slots are also duplicated at top level for backward compat:
+#'   access path across all four estimator classes (#144). The first
+#'   five sub-slots (`X_ints`, `y`, `X_final`, `y_final`, `calc_ses`)
+#'   are also duplicated at top level for backward compat;
+#'   `variance_components` and `first_year` live only under
+#'   `$internal`:
 #'   \describe{
 #'     \item{X_ints}{The design matrix containing all interactions,
 #'       time and cohort dummies, etc. Same value as top-level `X_ints`.}
@@ -1244,7 +1247,7 @@ etwfe <- function(
 #' argument was provided and used for asymptotically-exact ATT inference,
 #' `FALSE` otherwise.}
 #' \item{se_type}{Character scalar; the `se_type` argument the user passed
-#' (`"default"` or `"cluster"`).}
+#' (`"default"`, `"conservative"`, or `"cluster"`).}
 #' \item{y_mean}{Numeric scalar; the mean of the original (pre-centering)
 #'   response. Stored so downstream methods (`augment()`, `predict()`) can
 #'   return fitted values on the original-response scale.}
@@ -1258,8 +1261,11 @@ etwfe <- function(
 #' \item{internal}{A list containing internal outputs that are typically
 #'   not needed for interpretation, packaged here for parity with
 #'   `fetwfe()` so downstream consumers can use a single canonical
-#'   access path across all four estimator classes (#144). The five
-#'   sub-slots are also duplicated at top level for backward compat:
+#'   access path across all four estimator classes (#144). The first
+#'   five sub-slots (`X_ints`, `y`, `X_final`, `y_final`, `calc_ses`)
+#'   are also duplicated at top level for backward compat;
+#'   `variance_components` and `first_year` live only under
+#'   `$internal`:
 #'   \describe{
 #'     \item{X_ints}{The design matrix containing all interactions,
 #'       time and cohort dummies, etc. Same value as top-level `X_ints`.}

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -24,6 +24,16 @@
 #' @param verbose Logical; if TRUE, print progress. Default `FALSE`.
 #' @param alpha Numeric; significance level for confidence intervals. Default `0.05`.
 #' @param add_ridge Logical; if TRUE, add small ridge penalty. Default `FALSE`.
+#' @param lambda_selection Character scalar; either `"cv"` (10-fold
+#'   cross-validation, the v1.13.0+ default) or `"bic"` (BIC over the
+#'   `grpreg`-generated lambda path). Default `"cv"`.
+#' @param cv_folds Integer; number of CV folds when `lambda_selection
+#'   = "cv"`. Default `10L`.
+#' @param cv_seed Integer or NULL; the seed to pass to `set.seed()`
+#'   before calling `grpreg::cv.grpreg()` so CV fold assignment is
+#'   reproducible. `NULL` defaults to `as.integer(N * T)` (clipped to
+#'   `.Machine$integer.max` with a warning on overflow). Default
+#'   `NULL`.
 #' @return A list with two elements:
 #'   - `pdata`: the (possibly tibble-coerced) panel data frame.
 #'   - `indep_count_data_available`: logical; `TRUE` if a valid

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -167,12 +167,15 @@
 #' argument was provided and used for asymptotically-exact ATT inference,
 #' `FALSE` otherwise.}
 #' \item{se_type}{Character scalar; the `se_type` argument the user passed
-#' (`"default"` or `"cluster"`).}
+#' (`"default"`, `"conservative"`, or `"cluster"`).}
 #' \item{internal}{A list containing internal outputs that are typically
 #'   not needed for interpretation, packaged here for parity with
 #'   `fetwfe()` so downstream consumers can use a single canonical
-#'   access path across all four estimator classes (#144). The five
-#'   sub-slots are also duplicated at top level for backward compat:
+#'   access path across all four estimator classes (#144). The first
+#'   five sub-slots (`X_ints`, `y`, `X_final`, `y_final`, `calc_ses`)
+#'   are also duplicated at top level for backward compat;
+#'   `variance_components` and `first_year` live only under
+#'   `$internal`:
 #'   \describe{
 #'     \item{X_ints}{The design matrix containing all interactions,
 #'       time and cohort dummies, etc. Same value as top-level `X_ints`.}
@@ -505,7 +508,7 @@ twfeCovs <- function(
 #' argument was provided and used for asymptotically-exact ATT inference,
 #' `FALSE` otherwise.}
 #' \item{se_type}{Character scalar; the `se_type` argument the user passed
-#' (`"default"` or `"cluster"`).}
+#' (`"default"`, `"conservative"`, or `"cluster"`).}
 #' \item{y_mean}{Numeric scalar; mean of the original (pre-centering) response.
 #' Stored so downstream methods (`augment()`, `predict()`) can return fitted
 #' values on the original-response scale.}
@@ -518,8 +521,11 @@ twfeCovs <- function(
 #' \item{internal}{A list containing internal outputs that are typically
 #'   not needed for interpretation, packaged here for parity with
 #'   `fetwfe()` so downstream consumers can use a single canonical
-#'   access path across all four estimator classes (#144). The five
-#'   sub-slots are also duplicated at top level for backward compat:
+#'   access path across all four estimator classes (#144). The first
+#'   five sub-slots (`X_ints`, `y`, `X_final`, `y_final`, `calc_ses`)
+#'   are also duplicated at top level for backward compat;
+#'   `variance_components` and `first_year` live only under
+#'   `$internal`:
 #'   \describe{
 #'     \item{X_ints}{The design matrix containing all interactions,
 #'       time and cohort dummies, etc. Same value as top-level `X_ints`.}

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.13.6",
+  note    = "R package version 1.13.7",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/man/betwfe.Rd
+++ b/man/betwfe.Rd
@@ -290,12 +290,15 @@ variance of the overall ATT.}
 argument was provided and used for asymptotically-exact ATT inference,
 \code{FALSE} otherwise.}
 \item{se_type}{Character scalar; the \code{se_type} argument the user passed
-(\code{"default"} or \code{"cluster"}).}
+(\code{"default"}, \code{"conservative"}, or \code{"cluster"}).}
 \item{internal}{A list containing internal outputs that are typically
 not needed for interpretation, packaged here for parity with
 \code{fetwfe()} so downstream consumers can use a single canonical
-access path across all four estimator classes (#144). The five
-sub-slots are also duplicated at top level for backward compat:
+access path across all four estimator classes (#144). The first
+five sub-slots (\code{X_ints}, \code{y}, \code{X_final}, \code{y_final}, \code{calc_ses})
+are also duplicated at top level for backward compat;
+\code{variance_components} and \code{first_year} live only under
+\verb{$internal}:
 \describe{
 \item{X_ints}{The design matrix containing all interactions,
 time and cohort dummies, etc. Same value as top-level \code{X_ints}.}

--- a/man/betwfeWithSimulatedData.Rd
+++ b/man/betwfeWithSimulatedData.Rd
@@ -204,7 +204,7 @@ variance of the overall ATT.}
 argument was provided and used for asymptotically-exact ATT inference,
 \code{FALSE} otherwise.}
 \item{se_type}{Character scalar; the \code{se_type} argument the user passed
-(\code{"default"} or \code{"cluster"}).}
+(\code{"default"}, \code{"conservative"}, or \code{"cluster"}).}
 \item{y_mean}{Numeric scalar; mean of the original (pre-centering) response.
 Stored so downstream methods (\code{augment()}, \code{predict()}) can return fitted
 values on the original-response scale.}
@@ -217,8 +217,11 @@ expansion).}
 \item{internal}{A list containing internal outputs that are typically
 not needed for interpretation, packaged here for parity with
 \code{fetwfe()} so downstream consumers can use a single canonical
-access path across all four estimator classes (#144). The five
-sub-slots are also duplicated at top level for backward compat:
+access path across all four estimator classes (#144). The first
+five sub-slots (\code{X_ints}, \code{y}, \code{X_final}, \code{y_final}, \code{calc_ses})
+are also duplicated at top level for backward compat;
+\code{variance_components} and \code{first_year} live only under
+\verb{$internal}:
 \describe{
 \item{X_ints}{The design matrix containing all interactions,
 time and cohort dummies, etc. Same value as top-level \code{X_ints}.}

--- a/man/etwfe.Rd
+++ b/man/etwfe.Rd
@@ -192,7 +192,7 @@ variance of the overall ATT.}
 argument was provided and used for asymptotically-exact ATT inference,
 \code{FALSE} otherwise.}
 \item{se_type}{Character scalar; the \code{se_type} argument the user passed
-(\code{"default"} or \code{"cluster"}).}
+(\code{"default"}, \code{"conservative"}, or \code{"cluster"}).}
 \item{y_mean}{Numeric scalar; the mean of the original (pre-centering)
 response. Stored so downstream methods (\code{augment()}, \code{predict()})
 can return fitted values on the original-response scale.}
@@ -208,8 +208,11 @@ internally). Consumed by \verb{augment.<class>()}.}
 \item{internal}{A list containing internal outputs that are typically
 not needed for interpretation, packaged here for parity with
 \code{fetwfe()} so downstream consumers can use a single canonical
-access path across all four estimator classes (#144). The five
-sub-slots are also duplicated at top level for backward compat:
+access path across all four estimator classes (#144). The first
+five sub-slots (\code{X_ints}, \code{y}, \code{X_final}, \code{y_final}, \code{calc_ses})
+are also duplicated at top level for backward compat;
+\code{variance_components} and \code{first_year} live only under
+\verb{$internal}:
 \describe{
 \item{X_ints}{The design matrix containing all interactions,
 time and cohort dummies, etc. Same value as top-level \code{X_ints}.}

--- a/man/etwfeWithSimulatedData.Rd
+++ b/man/etwfeWithSimulatedData.Rd
@@ -116,7 +116,7 @@ variance of the overall ATT.}
 argument was provided and used for asymptotically-exact ATT inference,
 \code{FALSE} otherwise.}
 \item{se_type}{Character scalar; the \code{se_type} argument the user passed
-(\code{"default"} or \code{"cluster"}).}
+(\code{"default"}, \code{"conservative"}, or \code{"cluster"}).}
 \item{y_mean}{Numeric scalar; the mean of the original (pre-centering)
 response. Stored so downstream methods (\code{augment()}, \code{predict()}) can
 return fitted values on the original-response scale.}
@@ -130,8 +130,11 @@ internally).}
 \item{internal}{A list containing internal outputs that are typically
 not needed for interpretation, packaged here for parity with
 \code{fetwfe()} so downstream consumers can use a single canonical
-access path across all four estimator classes (#144). The five
-sub-slots are also duplicated at top level for backward compat:
+access path across all four estimator classes (#144). The first
+five sub-slots (\code{X_ints}, \code{y}, \code{X_final}, \code{y_final}, \code{calc_ses})
+are also duplicated at top level for backward compat;
+\code{variance_components} and \code{first_year} live only under
+\verb{$internal}:
 \describe{
 \item{X_ints}{The design matrix containing all interactions,
 time and cohort dummies, etc. Same value as top-level \code{X_ints}.}

--- a/man/fetwfe.Rd
+++ b/man/fetwfe.Rd
@@ -235,7 +235,7 @@ variance of the overall ATT.}
 argument was provided and used for asymptotically-exact ATT inference,
 \code{FALSE} otherwise.}
 \item{se_type}{Character scalar; the \code{se_type} argument the user passed
-(\code{"default"} or \code{"cluster"}).}
+(\code{"default"}, \code{"conservative"}, or \code{"cluster"}).}
 \item{y_mean}{Numeric scalar; the mean of the original (pre-centering)
 response. Stored so downstream methods (\code{augment()}, \code{predict()})
 can return fitted values on the original-response scale.}

--- a/man/fetwfeWithSimulatedData.Rd
+++ b/man/fetwfeWithSimulatedData.Rd
@@ -159,7 +159,7 @@ variance of the overall ATT.}
 argument was provided and used for asymptotically-exact ATT inference,
 \code{FALSE} otherwise.}
 \item{se_type}{Character scalar; the \code{se_type} argument the user passed
-(\code{"default"} or \code{"cluster"}).}
+(\code{"default"}, \code{"conservative"}, or \code{"cluster"}).}
 \item{y_mean}{Numeric scalar; the mean of the original (pre-centering)
 response. Stored so downstream methods (\code{augment()}, \code{predict()})
 can return fitted values on the original-response scale.}

--- a/man/twfeCovs.Rd
+++ b/man/twfeCovs.Rd
@@ -194,12 +194,15 @@ variance of the overall ATT.}
 argument was provided and used for asymptotically-exact ATT inference,
 \code{FALSE} otherwise.}
 \item{se_type}{Character scalar; the \code{se_type} argument the user passed
-(\code{"default"} or \code{"cluster"}).}
+(\code{"default"}, \code{"conservative"}, or \code{"cluster"}).}
 \item{internal}{A list containing internal outputs that are typically
 not needed for interpretation, packaged here for parity with
 \code{fetwfe()} so downstream consumers can use a single canonical
-access path across all four estimator classes (#144). The five
-sub-slots are also duplicated at top level for backward compat:
+access path across all four estimator classes (#144). The first
+five sub-slots (\code{X_ints}, \code{y}, \code{X_final}, \code{y_final}, \code{calc_ses})
+are also duplicated at top level for backward compat;
+\code{variance_components} and \code{first_year} live only under
+\verb{$internal}:
 \describe{
 \item{X_ints}{The design matrix containing all interactions,
 time and cohort dummies, etc. Same value as top-level \code{X_ints}.}

--- a/man/twfeCovsWithSimulatedData.Rd
+++ b/man/twfeCovsWithSimulatedData.Rd
@@ -112,7 +112,7 @@ variance of the overall ATT.}
 argument was provided and used for asymptotically-exact ATT inference,
 \code{FALSE} otherwise.}
 \item{se_type}{Character scalar; the \code{se_type} argument the user passed
-(\code{"default"} or \code{"cluster"}).}
+(\code{"default"}, \code{"conservative"}, or \code{"cluster"}).}
 \item{y_mean}{Numeric scalar; mean of the original (pre-centering) response.
 Stored so downstream methods (\code{augment()}, \code{predict()}) can return fitted
 values on the original-response scale.}
@@ -125,8 +125,11 @@ expansion).}
 \item{internal}{A list containing internal outputs that are typically
 not needed for interpretation, packaged here for parity with
 \code{fetwfe()} so downstream consumers can use a single canonical
-access path across all four estimator classes (#144). The five
-sub-slots are also duplicated at top level for backward compat:
+access path across all four estimator classes (#144). The first
+five sub-slots (\code{X_ints}, \code{y}, \code{X_final}, \code{y_final}, \code{calc_ses})
+are also duplicated at top level for backward compat;
+\code{variance_components} and \code{first_year} live only under
+\verb{$internal}:
 \describe{
 \item{X_ints}{The design matrix containing all interactions,
 time and cohort dummies, etc. Same value as top-level \code{X_ints}.}


### PR DESCRIPTION

Resolves #179. Three roxygen-only doc fixes per the 2026-05-29 periodic review's PR-C grouping. Zero behavior change; affects rendered help pages only. (a) **DG1 (Medium — user-misleading):** eight `@return \item{se_type}{}` parenthetical notes across `R/fetwfe.R` / `R/betwfe_core.R` / `R/twfeCovs.R` listed only `"default"` and `"cluster"`, dropping `"conservative"` (added in PR #163 / v1.12.0); they now correctly list all three values. (b) **DG2:** six `@return $internal` describe-blocks said "The five sub-slots are also duplicated at top level" but the describe-list contained seven sub-slots; the framing now correctly identifies the first five (`X_ints`, `y`, `X_final`, `y_final`, `calc_ses`) as duplicated and notes that `variance_components` and `first_year` live only under `$internal`. (c) **DG3:** `checkFetwfeInputs()` (internal helper, `@noRd`) was missing `@param` lines for the `lambda_selection` / `cv_folds` / `cv_seed` arguments added in PR #170; added.
