### PR TITLE
Cleanup sweep: idCohorts dead stop, sel_inds vestige, FETWFE calc_ses parity, #154 comment fix (#180, 1.13.8)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.13.7
+Version: 1.13.8
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,55 @@
 # NEWS
 
+## Version 1.13.8 (2026-05-30)
+
+### Internal
+
+- Deleted an unreachable `if (length(cohorts) == 0) stop(...)` block
+  in `idCohorts()` (#180 DC1). The block sits AFTER an unconditional
+  `cohorts[[as.character(times[1])]] <- character()` insertion, so
+  `length(cohorts) >= 1` always by the time it runs. The actual
+  "all units treated in first period" catch lives earlier in the
+  function at `if (length(units) == 0) stop(...)`. Zero behavior
+  change; 5 lines deleted.
+
+- Dropped a vestigial `sel_inds` list and the now-unused `first_inds`
+  parameter from `getSecondVarTermOLS()` in `R/variance_machinery.R`
+  (#180 DC2). The list was built solely to feed a tautological
+  `stopifnot(all.equal(...))` assertion; the Jacobian construction
+  below it never read the list. Both call sites
+  (`getTeResultsOLS()` and the `eventStudy()` dispatcher) updated to
+  stop passing `first_inds`. The sibling function
+  `getSecondVarTermDataApp()` keeps its own `sel_inds` — there it
+  is genuinely used to slice `d_inv_treat_sel`. Zero behavior
+  change.
+
+- Closed the cross-estimator parity gap from PR #144 (#180). FETWFE
+  fits now expose `fit$calc_ses` at top level, matching `etwfe()` /
+  `betwfe()` / `twfeCovs()`. Value is identical to
+  `fit$internal$calc_ses` (already present). `.EXPECTED_SLOTS_FETWFE`
+  and the `@return` doc updated. Pure addition; no existing slot
+  removed.
+
+### Documentation
+
+- Reworded the misleading "canonical path is `$internal` going
+  forward" comment in `R/etwfe_class.R`, `R/betwfe_class.R`,
+  `R/twfeCovs_class.R` to match what the code actually does (#180).
+  PR #154's `$internal` migration was paused without ever being
+  completed — the print extractors in each class file still read
+  top-level — so "going forward" was forward-looking but inaccurate.
+  The new comment correctly identifies which sub-slots are duplicated
+  at top level (the first five: `X_ints`, `y`, `X_final`, `y_final`,
+  `calc_ses`) and which live only under `$internal`
+  (`variance_components`, `first_year`).
+
+- Reworded 3 inline-source "The five slots" comments at
+  `R/fetwfe.R`, `R/betwfe_core.R`, `R/twfeCovs.R` to match the
+  post-#179 roxygen wording (#180 carry-over from #179). Both
+  reviewers of #179 flagged these as scope-appropriate for #180
+  because they contained both the now-stale "five slots" wording
+  and the now-retired "canonical going forward" claim.
+
 ## Version 1.13.7 (2026-05-30)
 
 ### Documentation

--- a/R/betwfe_class.R
+++ b/R/betwfe_class.R
@@ -125,9 +125,11 @@ print.summary.betwfe <- function(x, ...) {
 # Inner slots under `$internal` (#144). Parallel to
 # `.EXPECTED_INTERNAL_SLOTS_FETWFE` in `R/fetwfe_class.R`. The OLS-family
 # `$internal` omits `theta_hat` (bridge-selection-only, no analog here).
-# Same values are also duplicated at top level for backward compat per
-# the pure-additive strategy adopted in PR #154; the canonical path is
-# `$internal` going forward.
+# The first five sub-slots (`X_ints`, `y`, `X_final`, `y_final`,
+# `calc_ses`) are also duplicated at top level for backward compat per
+# the pure-additive strategy adopted in PR #154; `variance_components`
+# and `first_year` live only under `$internal`. Both top-level and
+# `$internal` are canonical and kept in sync (#180).
 .EXPECTED_INTERNAL_SLOTS_BETWFE <- c(
 	"X_ints",
 	"y",

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -516,8 +516,10 @@ betwfe <- function(
 		covs = covs_orig
 	)
 	# Add internal outputs in a separate list for parity with `fetwfe()` (#144).
-	# The five slots are also duplicated at top level for backward compat;
-	# `$internal` is the canonical access path going forward.
+	# The first five sub-slots (`X_ints`, `y`, `X_final`, `y_final`,
+	# `calc_ses`) are also duplicated at top level for backward compat;
+	# `variance_components` and `first_year` live only under `$internal`
+	# (#179, #180).
 	out$internal <- list(
 		X_ints = res$X_ints,
 		y = res$y,

--- a/R/etwfe_class.R
+++ b/R/etwfe_class.R
@@ -109,9 +109,11 @@ print.summary.etwfe <- function(x, ...) {
 # Inner slots under `$internal` (#144). Parallel to
 # `.EXPECTED_INTERNAL_SLOTS_FETWFE` in `R/fetwfe_class.R`. The OLS-family
 # `$internal` omits `theta_hat` (bridge-selection-only, no analog here).
-# Same values are also duplicated at top level for backward compat per
-# the pure-additive strategy adopted in PR #154; the canonical path is
-# `$internal` going forward.
+# The first five sub-slots (`X_ints`, `y`, `X_final`, `y_final`,
+# `calc_ses`) are also duplicated at top level for backward compat per
+# the pure-additive strategy adopted in PR #154; `variance_components`
+# and `first_year` live only under `$internal`. Both top-level and
+# `$internal` are canonical and kept in sync (#180).
 .EXPECTED_INTERNAL_SLOTS_ETWFE <- c(
 	"X_ints",
 	"y",

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -298,7 +298,6 @@ eventStudy <- function(x, alpha = NULL) {
 				psi_mat = psi_e_mat,
 				tes = tes,
 				cohort_probs_overall = masked_probs,
-				first_inds = first_inds,
 				num_treats = num_treats,
 				N = N,
 				T = T,

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -184,6 +184,7 @@
 #' \item{d}{The final number of covariates that appear in the final data set (after any covariates may have been removed because they contained missing values or all contained the same value for every unit).}
 #' \item{p}{The final number of columns in the full set of covariates used to estimate the model.}
 #' \item{alpha}{The alpha level used for confidence intervals.}
+#' \item{calc_ses}{Logical indicating whether standard errors were calculated. Same as `$internal$calc_ses`; duplicated at top level for parity with `etwfe()`, `betwfe()`, and `twfeCovs()` (#180).}
 #' \item{cohort_probs_overall}{A vector of the estimated cohort probabilities
 #' on the overall sample (treated and untreated), used in computing the
 #' variance of the overall ATT.}
@@ -447,6 +448,7 @@ fetwfe <- function(
 		d = res$d,
 		p = res$p,
 		alpha = alpha,
+		calc_ses = res$calc_ses,
 		se_type = se_type,
 		indep_counts_used = indep_count_data_available,
 		y_mean = y_mean,
@@ -611,6 +613,7 @@ fetwfe <- function(
 #' \item{d}{The final number of covariates that appear in the final data set (after any covariates may have been removed because they contained missing values or all contained the same value for every unit).}
 #' \item{p}{The final number of columns in the full set of covariates used to estimate the model.}
 #' \item{alpha}{The alpha level used for confidence intervals.}
+#' \item{calc_ses}{Logical indicating whether standard errors were calculated. Same as `$internal$calc_ses`; duplicated at top level for parity with `etwfe()`, `betwfe()`, and `twfeCovs()` (#180).}
 #' \item{cohort_probs_overall}{A vector of the estimated cohort probabilities
 #' on the overall sample (treated and untreated), used in computing the
 #' variance of the overall ATT.}
@@ -1120,8 +1123,10 @@ etwfe <- function(
 	)
 
 	# Add internal outputs in a separate list for parity with `fetwfe()` (#144).
-	# The five slots are also duplicated at top level for backward compat;
-	# `$internal` is the canonical access path going forward.
+	# The first five sub-slots (`X_ints`, `y`, `X_final`, `y_final`,
+	# `calc_ses`) are also duplicated at top level for backward compat;
+	# `variance_components` and `first_year` live only under `$internal`
+	# (#179, #180).
 	out$internal <- list(
 		X_ints = res$X_ints,
 		y = res$y,

--- a/R/fetwfe_class.R
+++ b/R/fetwfe_class.R
@@ -106,6 +106,7 @@ print.summary.fetwfe <- function(x, ...) {
 	"d",
 	"p",
 	"alpha",
+	"calc_ses",
 	"indep_counts_used",
 	"se_type",
 	"y_mean",

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -387,8 +387,10 @@ twfeCovs <- function(
 		covs = covs_orig
 	)
 	# Add internal outputs in a separate list for parity with `fetwfe()` (#144).
-	# The five slots are also duplicated at top level for backward compat;
-	# `$internal` is the canonical access path going forward.
+	# The first five sub-slots (`X_ints`, `y`, `X_final`, `y_final`,
+	# `calc_ses`) are also duplicated at top level for backward compat;
+	# `variance_components` and `first_year` live only under `$internal`
+	# (#179, #180).
 	out$internal <- list(
 		X_ints = res$X_ints,
 		y = res$y,

--- a/R/twfeCovs_class.R
+++ b/R/twfeCovs_class.R
@@ -73,9 +73,11 @@ print.twfeCovs <- function(x, ...) {
 # Inner slots under `$internal` (#144). Parallel to
 # `.EXPECTED_INTERNAL_SLOTS_FETWFE` in `R/fetwfe_class.R`. The OLS-family
 # `$internal` omits `theta_hat` (bridge-selection-only, no analog here).
-# Same values are also duplicated at top level for backward compat per
-# the pure-additive strategy adopted in PR #154; the canonical path is
-# `$internal` going forward.
+# The first five sub-slots (`X_ints`, `y`, `X_final`, `y_final`,
+# `calc_ses`) are also duplicated at top level for backward compat per
+# the pure-additive strategy adopted in PR #154; `variance_components`
+# and `first_year` live only under `$internal`. Both top-level and
+# `$internal` are canonical and kept in sync (#180).
 .EXPECTED_INTERNAL_SLOTS_TWFECOVS <- c(
 	"X_ints",
 	"y",

--- a/R/utility.R
+++ b/R/utility.R
@@ -315,12 +315,6 @@ idCohorts <- function(df, time_var, unit_var, treat_var) {
 		cohorts <- cohorts[order(as.numeric(names(cohorts)))]
 	}
 
-	# If after removing first-period treated, there are no treated cohorts left:
-	if (length(cohorts) == 0) {
-		# This implies all treated units were treated in the first period.
-		stop("all units appear to have been treated in the first period")
-	}
-
 	# This should have been the first cohort
 	stopifnot(length(cohorts[[1]]) == 0)
 

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -162,7 +162,6 @@ getTeResultsOLS <- function(
 			psi_mat = psi_mat,
 			tes = tes,
 			cohort_probs_overall = cohort_probs_overall,
-			first_inds = first_inds,
 			num_treats = num_treats,
 			N = N,
 			T = T,
@@ -219,8 +218,6 @@ getTeResultsOLS <- function(
 #'   `num_treats` possible cohort-time combinations.
 #' @param cohort_probs_overall Numeric vector; estimated marginal probabilities
 #'   of belonging to each treated cohort (P(W=r)). Length `R`.
-#' @param first_inds Integer vector; indices of the first treatment effect for
-#'   each cohort within the `num_treats` block.
 #' @param num_treats Integer; total number of base treatment effect parameters.
 #' @param N Integer; total number of units.
 #' @param T Integer; total number of time periods.
@@ -239,7 +236,6 @@ getSecondVarTermOLS <- function(
 	psi_mat,
 	tes,
 	cohort_probs_overall,
-	first_inds,
 	num_treats,
 	N,
 	T,
@@ -252,20 +248,6 @@ getSecondVarTermOLS <- function(
 
 	stopifnot(nrow(Sigma_pi_hat) == R)
 	stopifnot(ncol(Sigma_pi_hat) == R)
-
-	# Gather a list of the indices corresponding to the treatment coefficients
-	# for each cohort. (Will be used to construct the Jacobian matrix.)
-	sel_inds <- list()
-
-	for (r in 1:R) {
-		sel_inds[[r]] <- .cohort_block_inds(r, R, first_inds, num_treats)
-		if (r > 1) {
-			stopifnot(min(sel_inds[[r]]) > max(sel_inds[[r - 1]]))
-			stopifnot(length(sel_inds[[r]]) <= length(sel_inds[[r - 1]]))
-		}
-	}
-
-	stopifnot(all.equal(unlist(sel_inds), 1:num_treats))
 
 	# Construct Jacobian matrix corresponding to the mapping from the
 	# individual cohort probabilities to the proportions calculated for the ATT.

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.13.7",
+  note    = "R package version 1.13.8",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/man/fetwfe.Rd
+++ b/man/fetwfe.Rd
@@ -228,6 +228,7 @@ An object of class \code{fetwfe} containing the following elements:
 \item{d}{The final number of covariates that appear in the final data set (after any covariates may have been removed because they contained missing values or all contained the same value for every unit).}
 \item{p}{The final number of columns in the full set of covariates used to estimate the model.}
 \item{alpha}{The alpha level used for confidence intervals.}
+\item{calc_ses}{Logical indicating whether standard errors were calculated. Same as \verb{$internal$calc_ses}; duplicated at top level for parity with \code{etwfe()}, \code{betwfe()}, and \code{twfeCovs()} (#180).}
 \item{cohort_probs_overall}{A vector of the estimated cohort probabilities
 on the overall sample (treated and untreated), used in computing the
 variance of the overall ATT.}

--- a/man/fetwfeWithSimulatedData.Rd
+++ b/man/fetwfeWithSimulatedData.Rd
@@ -152,6 +152,7 @@ An object of class \code{fetwfe} containing the following elements:
 \item{d}{The final number of covariates that appear in the final data set (after any covariates may have been removed because they contained missing values or all contained the same value for every unit).}
 \item{p}{The final number of columns in the full set of covariates used to estimate the model.}
 \item{alpha}{The alpha level used for confidence intervals.}
+\item{calc_ses}{Logical indicating whether standard errors were calculated. Same as \verb{$internal$calc_ses}; duplicated at top level for parity with \code{etwfe()}, \code{betwfe()}, and \code{twfeCovs()} (#180).}
 \item{cohort_probs_overall}{A vector of the estimated cohort probabilities
 on the overall sample (treated and untreated), used in computing the
 variance of the overall ATT.}

--- a/tests/testthat/test-internal-slot-parity.R
+++ b/tests/testthat/test-internal-slot-parity.R
@@ -67,14 +67,19 @@ test_that("OLS-family: $internal slots equal top-level slots (parity)", {
 })
 
 # ----------------------------------------------------------------------
-# 3) fetwfe: the inner slots are EXCLUSIVELY under `$internal` (existing
-#    behavior, regression guard). Documents the asymmetry that #144
-#    consciously preserves: fetwfe gates these slots through
-#    `$internal` as the only access path; the OLS-family duplicates for
-#    backward compat.
+# 3) fetwfe: inner slots are EXCLUSIVELY under `$internal` EXCEPT
+#    `calc_ses` (added at top level in #180 / PR-D IB1 for parity with
+#    the OLS-family). Documents the post-#180 asymmetry: fetwfe gates
+#    `X_ints` / `y` / `X_final` / `y_final` / `theta_hat` / `variance_components` /
+#    `first_year` through `$internal` as the only access path, but
+#    `calc_ses` is duplicated at top level to match `etwfe()` /
+#    `betwfe()` / `twfeCovs()`. The pre-#180 test ("$internal slots
+#    are NOT duplicated at top level") explicitly locked the
+#    calc_ses-included asymmetry; this rewrite reflects the IB1
+#    parity-closing.
 # ----------------------------------------------------------------------
 
-test_that("fetwfe: $internal slots are NOT duplicated at top level", {
+test_that("fetwfe: $internal slots are NOT duplicated at top level (except calc_ses, #180)", {
 	sim <- .parity_setup()
 	res <- fetwfeWithSimulatedData(sim)
 	expect_true(!is.null(res$internal$X_ints))
@@ -86,7 +91,11 @@ test_that("fetwfe: $internal slots are NOT duplicated at top level", {
 	expect_null(res[["X_final"]])
 	expect_null(res[["y_final"]])
 	expect_null(res[["theta_hat"]])
-	expect_null(res[["calc_ses"]])
+	# IB1 (#180): calc_ses IS duplicated at top level for parity with
+	# the OLS-family; lock the parity invariant (mirrors the OLS-family
+	# `expect_identical(res$internal$calc_ses, res$calc_ses)` at the
+	# OLS-family-parity test above).
+	expect_identical(res$internal$calc_ses, res$calc_ses)
 })
 
 # ----------------------------------------------------------------------

--- a/tests/testthat/test-lex-cohort-sort.R
+++ b/tests/testthat/test-lex-cohort-sort.R
@@ -105,6 +105,9 @@ test_that("tidy.<class> sorts cohorts numerically when labels include >= 10", {
 		d = d_test,
 		p = p_test,
 		alpha = 0.05,
+		# IB1 (#180): calc_ses is now at top level for parity with the
+		# OLS-family; the validator's .EXPECTED_SLOTS_FETWFE requires it.
+		calc_ses = TRUE,
 		indep_counts_used = FALSE,
 		se_type = "default",
 		y_mean = 0,

--- a/tests/testthat/test-soft-bugs-56.R
+++ b/tests/testthat/test-soft-bugs-56.R
@@ -49,13 +49,15 @@ test_that(".assemble_event_study_df masks zero and negative SEs to NA p-value", 
 # ------------------------------------------------------------------------------
 
 .minimal_ols_call <- function(cohort_probs_overall) {
-	# Minimal valid call shape for getSecondVarTermOLS: R=2, num_treats=3,
-	# first_inds = c(1, 3) so sel_inds = list(1:2, 3:3) and unlist = 1:3.
+	# Minimal valid call shape for getSecondVarTermOLS: R=2, num_treats=3.
+	# Post-#180 (DC2) the function no longer accepts `first_inds` — the
+	# pre-#180 helper passed `first_inds = c(1L, 3L)` only to feed a
+	# tautological `stopifnot(all.equal(unlist(sel_inds), 1:num_treats))`
+	# assertion inside the function, which was dropped.
 	fetwfe:::getSecondVarTermOLS(
 		psi_mat = matrix(c(0.5, 0.5, 0, 0, 0, 1), nrow = 3, ncol = 2),
 		tes = c(1, 2, 3),
 		cohort_probs_overall = cohort_probs_overall,
-		first_inds = c(1L, 3L),
 		num_treats = 3L,
 		N = 100L,
 		T = 3L,


### PR DESCRIPTION

Resolves #180. Closes the 2026-05-29 periodic review queue. Five small items bundled per the synthesis's PR-D grouping; zero behavior change at realistic inputs (one additive top-level slot on FETWFE). (a) **DC1** — deleted 5 lines of unreachable `if (length(cohorts) == 0) stop(...)` in `idCohorts()` (the catch lives earlier at `if (length(units) == 0) stop(...)`). (b) **DC2** — dropped a vestigial `sel_inds` list + the now-unused `first_inds` parameter from `getSecondVarTermOLS()`; updated both call sites (`getTeResultsOLS`, `eventStudy()` dispatcher). The `sel_inds` list existed only to feed a tautological `stopifnot(all.equal(unlist(sel_inds), 1:num_treats))` assertion; the Jacobian never read it. Sibling `getSecondVarTermDataApp()` keeps its own `sel_inds` (legitimately used there). (c) **IB1** — closed PR #144's parity gap: FETWFE fits now expose `fit$calc_ses` at top level matching `etwfe()` / `betwfe()` / `twfeCovs()`. Value identical to `fit$internal$calc_ses` (already present); `.EXPECTED_SLOTS_FETWFE` + `@return` doc updated. (d) **ST3 Option B** — reworded the misleading "canonical path is `$internal` going forward" comment in `R/etwfe_class.R` / `R/betwfe_class.R` / `R/twfeCovs_class.R`; PR #154's `$internal` migration was paused without completion (the print extractors in each class file still read top-level), so "going forward" was forward-looking but inaccurate. Option A (finish the migration) deferred to a future RFC. (e) **#179 carry-over** — reworded 3 inline-source "five slots" comments to match the post-#179 roxygen wording. Three pre-existing tests updated to reflect the IB1 + DC2 contract changes (the rewritten parity assertion in `test-internal-slot-parity.R` is strictly stronger than the assertion it replaces).
