### PR TITLE
feat: assignment_interactions + assignment_interaction_strength on genCoefs() for nonlinear propensity DGPs (#191, 1.14.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.14.0
+Version: 1.14.1
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,10 +14,15 @@
   `c(min, max)` and silently deduplicated. The `assignment_coefs` slot
   on `FETWFE_coefs` gains `$interactions` and `$delta` sub-slots; a
   new top-level `$assignment_interaction_strength` slot mirrors
-  `$assignment_strength`. Unlocks adversarial-propensity Monte Carlo
-  DGPs for the FETWFE vs Callaway-Sant'Anna comparison work tracked
-  at #140. Default `assignment_interactions = NULL` preserves v1.14.0
-  behavior byte-identically on every existing test.
+  `$assignment_strength`. `genCoefs()` also gains a `verbose = FALSE`
+  argument; setting `verbose = TRUE` emits a `message()` when
+  canonicalization removes duplicate or unordered pairs (default is
+  silent — users can verify the final canonical list via
+  `coefs$assignment_coefs$interactions`). Unlocks adversarial-
+  propensity Monte Carlo DGPs for the FETWFE vs Callaway-Sant'Anna
+  comparison work tracked at #140. Default
+  `assignment_interactions = NULL` preserves v1.14.0 behavior
+  byte-identically on every existing test.
 
 ## Version 1.14.0 (2026-05-30)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # NEWS
 
+## Version 1.14.1 (2026-05-31)
+
+### New features
+
+- Added optional `assignment_interactions` and
+  `assignment_interaction_strength` arguments to `genCoefs()` (#191).
+  When non-`NULL`, the covariate-dependent propensity DGPs introduced
+  in 1.14.0 gain pairwise multiplicative interaction terms (including
+  self-interactions / quadratic terms via `c(j, j)`) in the linear
+  predictor — only inside the propensity model; the outcome model
+  continues to use the original `X`. Pairs are canonicalized to
+  `c(min, max)` and silently deduplicated. The `assignment_coefs` slot
+  on `FETWFE_coefs` gains `$interactions` and `$delta` sub-slots; a
+  new top-level `$assignment_interaction_strength` slot mirrors
+  `$assignment_strength`. Unlocks adversarial-propensity Monte Carlo
+  DGPs for the FETWFE vs Callaway-Sant'Anna comparison work tracked
+  at #140. Default `assignment_interactions = NULL` preserves v1.14.0
+  behavior byte-identically on every existing test.
+
 ## Version 1.14.0 (2026-05-30)
 
 ### New features

--- a/R/cohort_assignment.R
+++ b/R/cohort_assignment.R
@@ -560,15 +560,17 @@
 				R,
 				d
 			)
-			# When the user passed a non-default assignment_interaction_strength
-			# (per round-1 Q2 + RC1: stored on assignment_coefs by
-			# .gen_assignment_coefs() when K > 0L), name it so they know which
-			# knob to lower.
+			# When interactions are present (K > 0L), .gen_assignment_coefs()
+			# stores the effective interaction strength on assignment_coefs.
+			# Surface it so the user knows which knob to lower; the value is
+			# the effective (post-fallthrough) value, which equals
+			# assignment_strength when assignment_interaction_strength was
+			# left at its NULL default (per round-1 Q2 + RC1).
 			if (!is.null(assignment_coefs$interaction_strength)) {
 				msg <- paste0(
 					msg,
 					sprintf(
-						" (assignment_interaction_strength = %g was also set; consider lowering it.)",
+						" (effective assignment_interaction_strength = %g; consider lowering it or assignment_strength.)",
 						assignment_coefs$interaction_strength
 					)
 				)

--- a/R/cohort_assignment.R
+++ b/R/cohort_assignment.R
@@ -36,28 +36,45 @@
 #'   normal) gamma draw. `strength = 0` yields gamma = 0 so the
 #'   cohort-probability distribution reduces to uniform 1/(R+1) by
 #'   construction.
+#' @param interactions Optional. A list of canonicalized length-2
+#'   integer-pair vectors `list(c(j, k), ...)` whose elementwise products
+#'   `X[, j] * X[, k]` augment the propensity linear predictor. The list
+#'   is assumed to be canonicalized + deduplicated by the caller
+#'   (`genCoefs()`). Defaults to `NULL` (no interactions; v1.14.0
+#'   behavior is preserved byte-identically, including RNG ordering).
+#'   New in 1.14.1.
+#' @param interaction_strength Optional non-negative numeric scalar.
+#'   Scales the Gaussian draws of the interaction coefficients
+#'   independently of `strength`. Defaults to `NULL`, which falls
+#'   through to `strength`. New in 1.14.1.
 #' @param seed Optional integer for reproducibility.
 #'
-#' @return A list with elements `type`, `strength`, `coefs`, and (for
-#'   `"ordered"`) `cutpoints`. For multinomial, `coefs` is a `d x R`
-#'   matrix; column `r` is `gamma_r` (the never-treated reference
-#'   cohort has `gamma_0 = 0` implicitly). For ordered, `coefs` is a
-#'   length-`d` vector (one shared `gamma`) and `cutpoints` is a
+#' @return A list with elements `type`, `strength`, `coefs`, `interactions`,
+#'   `delta`, `interaction_strength`, and (for `"ordered"`) `cutpoints`.
+#'   For multinomial, `coefs` is a `d x R` matrix; column `r` is
+#'   `gamma_r` (the never-treated reference cohort has `gamma_0 = 0`
+#'   implicitly), and `delta` is a `K x R` matrix of per-cohort
+#'   interaction coefficients (or `NULL` when no interactions). For
+#'   ordered, `coefs` is a length-`d` vector (one shared `gamma`),
+#'   `delta` is a length-`K` vector (or `NULL`), and `cutpoints` is a
 #'   length-`R` vector of cutpoints chosen so the marginal cohort
-#'   probabilities are uniform 1/(R+1).
+#'   probabilities are uniform 1/(R+1). `interaction_strength` is
+#'   `NULL` when no interactions; otherwise the effective scaling
+#'   factor used for the `delta` draws.
 #'
 #' @details
 #' The ordered cutpoints are chosen by root-finding on the
 #' marginal-uniform condition: for each `r` in `1..R`, solve
-#' `E_X[plogis(alpha_r - gamma^T X)] = r / (R + 1)` via
-#' `uniroot()` over a Monte Carlo reference sample of `gamma^T X`
-#' (standard McCullagh proportional-odds parameterization with the
-#' subtraction convention: high `gamma^T x` shifts mass UP the ordinal
-#' scale toward never-treated; low `gamma^T x` shifts mass toward the
-#' earliest-adopting cohort). At `strength = 0` (gamma = 0) the
-#' cutpoints collapse to `qlogis((1:R) / (R + 1))` and the marginal
-#' probabilities are exactly uniform. At positive strength the marginal
-#' probabilities are approximately uniform up to MC noise.
+#' `E_X[plogis(alpha_r - gamma^T X - delta^T X_int)] = r / (R + 1)` via
+#' `uniroot()` over a Monte Carlo reference sample of the augmented
+#' linear predictor (standard McCullagh proportional-odds parameterization
+#' with the subtraction convention: high augmented linpred shifts mass UP
+#' the ordinal scale toward never-treated; low augmented linpred shifts
+#' mass toward the earliest-adopting cohort). At `strength = 0` (gamma = 0)
+#' AND no interactions the cutpoints collapse to `qlogis((1:R) / (R + 1))`
+#' and the marginal probabilities are exactly uniform. At positive
+#' strength the marginal probabilities are approximately uniform up to
+#' MC noise.
 #'
 #' The `uniroot()` search interval is `c(-200, 200)` to accommodate
 #' stress-test usage at very high strength (linpred ranges scale with
@@ -65,9 +82,24 @@
 #' cutpoints can land near +/- 50, which would exceed a narrower
 #' interval).
 #'
+#' The augmented linear predictor extends the standard multinomial-logit
+#' / proportional-odds parameterization (see Faletto 2025 line 1016 for
+#' the linear-in-X form). Interaction terms are user-specified pairwise
+#' products of covariate columns and remain within the paper's framework
+#' because the multinomial-logit MLE with interaction features still
+#' satisfies Assumption (Psi-IF) (line 2018) via M-estimator theory.
+#'
 #' @keywords internal
 #' @noRd
-.gen_assignment_coefs <- function(R, d, type, strength, seed = NULL) {
+.gen_assignment_coefs <- function(
+	R,
+	d,
+	type,
+	strength,
+	interactions = NULL,
+	interaction_strength = NULL,
+	seed = NULL
+) {
 	if (!is.null(seed)) {
 		set.seed(seed)
 	}
@@ -85,24 +117,51 @@
 			"Covariate-dependent cohort assignment requires d >= 1 (at least one covariate)"
 		)
 	}
+	K <- if (is.null(interactions)) 0L else length(interactions)
+	effective_int_strength <- if (is.null(interaction_strength)) {
+		strength
+	} else {
+		interaction_strength
+	}
 	if (type == "multinomial") {
 		coefs_mat <- matrix(
 			rnorm(d * R) * strength,
 			nrow = d,
 			ncol = R
 		)
+		delta_mat <- if (K > 0L) {
+			matrix(
+				rnorm(K * R) * effective_int_strength,
+				nrow = K,
+				ncol = R
+			)
+		} else {
+			NULL
+		}
 		return(list(
 			type = "multinomial",
 			strength = strength,
-			coefs = coefs_mat
+			coefs = coefs_mat,
+			interactions = interactions,
+			delta = delta_mat,
+			interaction_strength = if (K > 0L) effective_int_strength else NULL
 		))
 	}
 	# type == "ordered"
 	gamma <- rnorm(d) * strength
+	delta <- if (K > 0L) {
+		rnorm(K) * effective_int_strength
+	} else {
+		NULL
+	}
 	# Root-find on the marginal-uniform condition: solve for alpha_r such
-	# that mean(plogis(alpha_r - linpred_mc)) = r / (R + 1). At strength = 0,
-	# linpred_mc is identically 0 and the cutpoints reduce to
-	# qlogis((1:R) / (R + 1)) by construction.
+	# that mean(plogis(alpha_r - linpred_mc)) = r / (R + 1). At strength = 0
+	# and no interactions, linpred_mc is identically 0 and the cutpoints
+	# reduce to qlogis((1:R) / (R + 1)) by construction. With interactions,
+	# the MC sample integrates over the augmented covariate distribution so
+	# the marginal-uniform invariant is preserved up to MC noise. See
+	# Faletto 2025 line 1016 for the linear-in-X form; this extends the
+	# parameterization to include user-specified pairwise interactions.
 	M_cutpoints <- 5000L
 	X_mc <- matrix(
 		rnorm(M_cutpoints * d),
@@ -110,6 +169,10 @@
 		ncol = d
 	)
 	linpred_mc <- as.numeric(X_mc %*% gamma)
+	if (K > 0L) {
+		X_int_mc <- .build_x_int(X_mc, interactions)
+		linpred_mc <- linpred_mc + as.numeric(X_int_mc %*% delta)
+	}
 	solve_cutpoint <- function(target_prob) {
 		stats::uniroot(
 			function(alpha) {
@@ -127,8 +190,47 @@
 		type = "ordered",
 		strength = strength,
 		coefs = gamma,
-		cutpoints = cutpoints
+		cutpoints = cutpoints,
+		interactions = interactions,
+		delta = delta,
+		interaction_strength = if (K > 0L) effective_int_strength else NULL
 	)
+}
+
+
+#' Build the per-pair pairwise-product augmentation matrix `X_int`
+#'
+#' Returns the `N x K` matrix whose column `k` is the elementwise product
+#' `X[, j_k] * X[, k_k]` for the `k`-th pair `c(j_k, k_k)` in
+#' `interactions`. Used only inside the propensity model — the outcome
+#' design matrix never sees `X_int`.
+#'
+#' Centralized to one helper so the live propensity computation in
+#' `.compute_cohort_prob_matrix()` and the ordered cutpoint root-finder's
+#' Monte Carlo sample in `.gen_assignment_coefs()` use byte-identical
+#' construction logic. See `.workflow/WORKFLOW_LESSONS.md` §14 (Class A
+#' drift discipline).
+#'
+#' @param X Numeric matrix, `N x d`.
+#' @param interactions A list of canonicalized length-2 integer-pair
+#'   vectors. `NULL` or empty list returns `NULL`.
+#'
+#' @return Numeric matrix `N x K`, or `NULL` when no interactions are
+#'   specified.
+#'
+#' @keywords internal
+#' @noRd
+.build_x_int <- function(X, interactions) {
+	if (is.null(interactions) || length(interactions) == 0L) {
+		return(NULL)
+	}
+	K <- length(interactions)
+	X_int <- matrix(NA_real_, nrow = nrow(X), ncol = K)
+	for (k in seq_len(K)) {
+		pair <- interactions[[k]]
+		X_int[, k] <- X[, pair[1L]] * X[, pair[2L]]
+	}
+	X_int
 }
 
 
@@ -158,9 +260,19 @@
 	stopifnot(is.matrix(X))
 	stopifnot(!is.null(assignment_coefs))
 	type <- assignment_coefs$type
+	# Interactions (NULL or empty list -> no augmentation; v1.14.0 byte path).
+	# See Faletto 2025 line 1016 for the linear-in-X form; this extends the
+	# parameterization to include user-specified pairwise interactions.
+	interactions <- assignment_coefs$interactions
+	delta <- assignment_coefs$delta
+	has_int <- !is.null(interactions) && length(interactions) > 0L
 	if (type == "multinomial") {
 		# linpred is N x R; the never-treated reference column is identically 0.
 		linpred <- X %*% assignment_coefs$coefs
+		if (has_int) {
+			X_int <- .build_x_int(X, interactions)
+			linpred <- linpred + X_int %*% delta
+		}
 		log_probs_unnorm <- cbind(0, linpred)
 		# Subtract row maxima for numerical stability (invariant under softmax).
 		row_max <- apply(log_probs_unnorm, 1, max)
@@ -170,6 +282,10 @@
 	}
 	if (type == "ordered") {
 		linpred <- as.numeric(X %*% assignment_coefs$coefs)
+		if (has_int) {
+			X_int <- .build_x_int(X, interactions)
+			linpred <- linpred + as.numeric(X_int %*% delta)
+		}
 		cutpoints <- assignment_coefs$cutpoints
 		# Ordinal scale W' = 1..R+1 in temporal-adoption order with never-
 		# treated at the top:
@@ -426,7 +542,7 @@
 			break
 		}
 		if (attempt >= max_iters) {
-			stop(sprintf(
+			msg <- sprintf(
 				paste0(
 					"Failed to draw %scohort assignments satisfying the rank condition ",
 					"(min count >= d + 1) after %d attempts at assignment_type = '%s', ",
@@ -443,7 +559,21 @@
 				N,
 				R,
 				d
-			))
+			)
+			# When the user passed a non-default assignment_interaction_strength
+			# (per round-1 Q2 + RC1: stored on assignment_coefs by
+			# .gen_assignment_coefs() when K > 0L), name it so they know which
+			# knob to lower.
+			if (!is.null(assignment_coefs$interaction_strength)) {
+				msg <- paste0(
+					msg,
+					sprintf(
+						" (assignment_interaction_strength = %g was also set; consider lowering it.)",
+						assignment_coefs$interaction_strength
+					)
+				)
+			}
+			stop(msg)
 		}
 	}
 	list(

--- a/R/cohort_assignment.R
+++ b/R/cohort_assignment.R
@@ -11,6 +11,47 @@
 # and ordered-cumprobs logic in both the sampler and the truth-
 # derivation MC integrator (round-1 reviewer / sentinel convergence).
 
+#' Validate a non-negative numeric scalar argument (with optional NULL allowance)
+#'
+#' Shared validator for the `assignment_strength` and
+#' `assignment_interaction_strength` arguments on `genCoefs()` and the
+#' `strength` argument on `.gen_assignment_coefs()`. Centralises the
+#' "non-negative numeric scalar" check that existed at three sites
+#' before #191 added `assignment_interaction_strength`. Errors with a
+#' user-readable message naming the offending argument.
+#'
+#' @param x The value to validate.
+#' @param name Character; the user-facing name of the argument (used in
+#'   the error message).
+#' @param allow_null Logical; if `TRUE`, `x = NULL` is accepted as a
+#'   valid default. Used for `assignment_interaction_strength`'s
+#'   `NULL` fall-through to `assignment_strength`. Default `FALSE`.
+#'
+#' @return Invisibly `NULL`. Called for its side-effect (`stop()` on
+#'   invalid input).
+#'
+#' @keywords internal
+#' @noRd
+.validate_strength_arg <- function(x, name, allow_null = FALSE) {
+	if (is.null(x)) {
+		if (allow_null) {
+			return(invisible(NULL))
+		}
+		stop(sprintf("%s must be a non-negative numeric scalar", name))
+	}
+	if (!is.numeric(x) || length(x) != 1 || x < 0) {
+		if (allow_null) {
+			stop(sprintf(
+				"%s must be a non-negative numeric scalar (or NULL)",
+				name
+			))
+		}
+		stop(sprintf("%s must be a non-negative numeric scalar", name))
+	}
+	invisible(NULL)
+}
+
+
 #' Generate assignment-coefficient object for covariate-dependent cohorts
 #'
 #' Returns the (gamma, cutpoints) object that parameterizes the
@@ -103,9 +144,7 @@
 	if (!is.null(seed)) {
 		set.seed(seed)
 	}
-	if (!is.numeric(strength) || length(strength) != 1 || strength < 0) {
-		stop("assignment_strength must be a non-negative numeric scalar")
-	}
+	.validate_strength_arg(strength, "assignment_strength")
 	if (!(type %in% c("multinomial", "ordered"))) {
 		stop(sprintf(
 			"Internal error: .gen_assignment_coefs() called with type = '%s'",

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -53,6 +53,31 @@
 #'   non-marginal types to the uniform marginal distribution by construction.
 #'   Larger values produce stronger covariate-cohort coupling. Defaults to
 #'   \code{1.0}. Ignored when \code{assignment_type = "marginal"}.
+#' @param assignment_interactions Optional. A list of length-2 integer
+#'   vectors, each naming a pair of covariate indices \eqn{(j, k)} in
+#'   \eqn{[1, d]} whose elementwise product \eqn{x_{i,j} \cdot x_{i,k}}
+#'   enters the propensity model as an additional column. Self-interactions
+#'   \code{c(j, j)} are allowed and yield a quadratic term \eqn{x_j^2}.
+#'   Unordered pairs are canonicalized to \code{c(min(j, k), max(j, k))}
+#'   and duplicates are silently deduplicated (inspect
+#'   \code{coefs$assignment_coefs$interactions} on the returned object to
+#'   verify the retained list). The interaction columns enter the
+#'   propensity model only; the outcome model continues to use the
+#'   original covariates. Defaults to \code{NULL} (no interactions —
+#'   v1.14.0 behavior is preserved byte-identically). Passing \code{list()}
+#'   (empty list) is treated as equivalent to \code{NULL} — no interactions
+#'   specified, behavior is identical to the v1.14.0 marginal-cohort path
+#'   within \code{multinomial} / \code{ordered} DGPs. Errors when
+#'   \code{assignment_type = "marginal"} (the marginal DGP has no
+#'   propensity model to augment). New in 1.14.1.
+#' @param assignment_interaction_strength Optional non-negative numeric
+#'   scalar. Scales the Gaussian draws of the interaction coefficients
+#'   independently of \code{assignment_strength}. Defaults to \code{NULL},
+#'   which means "fall through to \code{assignment_strength}". Useful when
+#'   stress-testing whether the nonlinear-propensity angle alone drives
+#'   downstream differences (without simultaneously cranking the linear
+#'   angle). Ignored when \code{assignment_interactions = NULL}. New in
+#'   1.14.1.
 #' @param seed (Optional) Integer. Seed for reproducibility. Three
 #'   deterministic offsets share this seed: the main coefficient draw uses
 #'   \code{seed}; the assignment coefficients use \code{seed + 1L}; the
@@ -75,10 +100,22 @@
 #'         New in 1.14.0.}
 #'   \item{assignment_strength}{The scaling factor applied to the assignment
 #'         coefficients. New in 1.14.0.}
+#'   \item{assignment_interaction_strength}{The scaling factor applied to
+#'         the interaction coefficients. \code{NULL} when no interactions
+#'         were specified or when the user passed \code{NULL} (the
+#'         fall-through default). New in 1.14.1.}
 #'   \item{assignment_coefs}{\code{NULL} when
 #'         \code{assignment_type = "marginal"}; otherwise a list with elements
 #'         \code{type}, \code{strength}, \code{coefs} (the gamma matrix or
-#'         vector), and (for ordered) \code{cutpoints}. New in 1.14.0.}
+#'         vector), and (for ordered) \code{cutpoints}. Starting in 1.14.1,
+#'         \code{assignment_coefs} also carries the sub-slots
+#'         \code{interactions} (the canonicalized + deduplicated list of
+#'         pairs, or \code{NULL}), \code{delta} (the interaction coefficient
+#'         matrix for multinomial or vector for ordered, or \code{NULL}),
+#'         and \code{interaction_strength} (the effective scaling factor
+#'         used for the \code{delta} draws, or \code{NULL} when no
+#'         interactions). New in 1.14.0; \code{interactions}, \code{delta},
+#'         and \code{interaction_strength} sub-slots new in 1.14.1.}
 #' }
 #'
 #' @details
@@ -123,6 +160,17 @@
 #'     seed = 123
 #'   )
 #'   sim_mn <- simulateData(coefs_mn, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5)
+#'
+#'   # Covariate-dependent cohort assignment with nonlinear propensity
+#'   # (multinomial-logit + a single x1*x2 interaction term in the propensity
+#'   # model only; outcome model continues to use plain X):
+#'   coefs_int <- genCoefs(
+#'     R = 5, T = 30, d = 12, density = 0.1, eff_size = 2,
+#'     assignment_type = "multinomial",
+#'     assignment_interactions = list(c(1, 2)),
+#'     assignment_interaction_strength = 1.5,
+#'     seed = 123
+#'   )
 #' }
 #'
 #' @export
@@ -134,6 +182,8 @@ genCoefs <- function(
 	eff_size,
 	assignment_type = c("marginal", "multinomial", "ordered"),
 	assignment_strength = 1.0,
+	assignment_interactions = NULL,
+	assignment_interaction_strength = NULL,
 	seed = NULL
 ) {
 	# Check that T is a numeric scalar and at least 3.
@@ -188,6 +238,85 @@ genCoefs <- function(
 		))
 	}
 
+	# Interactions × marginal cross-check
+	if (!is.null(assignment_interactions) && assignment_type == "marginal") {
+		stop(paste0(
+			"assignment_interactions can only be specified when assignment_type ",
+			"is 'multinomial' or 'ordered'; the marginal DGP does not use a ",
+			"propensity model."
+		))
+	}
+
+	# Interactions structural validation + canonicalize + dedupe
+	if (!is.null(assignment_interactions)) {
+		if (!is.list(assignment_interactions)) {
+			stop(
+				"assignment_interactions must be a list of length-2 integer-pair vectors (or NULL)"
+			)
+		}
+		canon <- vector("list", length(assignment_interactions))
+		for (k in seq_along(assignment_interactions)) {
+			p <- assignment_interactions[[k]]
+			if (!is.numeric(p) || length(p) != 2L) {
+				stop(sprintf(
+					"assignment_interactions[[%d]] must be a length-2 numeric vector; got length %d",
+					k,
+					length(p)
+				))
+			}
+			j <- as.integer(p[1L])
+			k_idx <- as.integer(p[2L])
+			if (anyNA(c(j, k_idx))) {
+				stop(sprintf(
+					"assignment_interactions[[%d]] coerced to NA; must be integer indices",
+					k
+				))
+			}
+			if (j < 1L || j > d || k_idx < 1L || k_idx > d) {
+				stop(sprintf(
+					"assignment_interactions[[%d]] = c(%d, %d) has an index outside [1, d = %d]",
+					k,
+					j,
+					k_idx,
+					d
+				))
+			}
+			canon[[k]] <- c(min(j, k_idx), max(j, k_idx))
+		}
+		# Dedupe silently (no message() — per Decision Log Q1; users verify
+		# via coefs$assignment_coefs$interactions inspection).
+		deduped <- list()
+		for (k in seq_along(canon)) {
+			already <- FALSE
+			for (existing in deduped) {
+				if (identical(canon[[k]], existing)) {
+					already <- TRUE
+					break
+				}
+			}
+			if (!already) {
+				deduped[[length(deduped) + 1L]] <- canon[[k]]
+			}
+		}
+		assignment_interactions <- deduped
+		# Note: assignment_interactions = list() (empty list, e.g. from a
+		# user passing list() directly) is treated as equivalent to NULL
+		# downstream — see Decision Log RC2 maintainer override.
+	}
+
+	# Interaction strength validation
+	if (!is.null(assignment_interaction_strength)) {
+		if (
+			!is.numeric(assignment_interaction_strength) ||
+				length(assignment_interaction_strength) != 1L ||
+				assignment_interaction_strength < 0
+		) {
+			stop(
+				"assignment_interaction_strength must be a non-negative numeric scalar (or NULL)"
+			)
+		}
+	}
+
 	stopifnot(R >= 2)
 	stopifnot(T >= 3)
 	stopifnot(R <= T - 1)
@@ -218,6 +347,8 @@ genCoefs <- function(
 			d = d,
 			type = assignment_type,
 			strength = assignment_strength,
+			interactions = assignment_interactions,
+			interaction_strength = assignment_interaction_strength,
 			seed = assignment_seed
 		)
 	}
@@ -232,6 +363,7 @@ genCoefs <- function(
 		seed = seed,
 		assignment_type = assignment_type,
 		assignment_strength = assignment_strength,
+		assignment_interaction_strength = assignment_interaction_strength,
 		assignment_coefs = assignment_coefs
 	)
 	class(obj) <- "FETWFE_coefs"

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -82,6 +82,11 @@
 #'   deterministic offsets share this seed: the main coefficient draw uses
 #'   \code{seed}; the assignment coefficients use \code{seed + 1L}; the
 #'   Monte Carlo integration in \code{getTes()} uses \code{seed + 2L}.
+#' @param verbose Logical. If \code{TRUE}, emit a \code{message()} when
+#'   \code{assignment_interactions} canonicalization removes duplicate or
+#'   unordered pairs (e.g., when the user passes both \code{c(1, 2)} and
+#'   \code{c(2, 1)}). Default \code{FALSE} (silent — users can verify the
+#'   final canonical list via \code{coefs$assignment_coefs$interactions}).
 #'
 #' @return An object of class \code{"FETWFE_coefs"}, which is a list containing:
 #' \describe{
@@ -184,7 +189,8 @@ genCoefs <- function(
 	assignment_strength = 1.0,
 	assignment_interactions = NULL,
 	assignment_interaction_strength = NULL,
-	seed = NULL
+	seed = NULL,
+	verbose = FALSE
 ) {
 	# Check that T is a numeric scalar and at least 3.
 	if (!is.numeric(T) || length(T) != 1 || T < 3) {
@@ -224,13 +230,7 @@ genCoefs <- function(
 	}
 
 	assignment_type <- match.arg(assignment_type)
-	if (
-		!is.numeric(assignment_strength) ||
-			length(assignment_strength) != 1 ||
-			assignment_strength < 0
-	) {
-		stop("assignment_strength must be a non-negative numeric scalar")
-	}
+	.validate_strength_arg(assignment_strength, "assignment_strength")
 	if (assignment_type != "marginal" && d < 1) {
 		stop(sprintf(
 			"assignment_type = '%s' requires d >= 1 (at least one covariate)",
@@ -283,8 +283,10 @@ genCoefs <- function(
 			}
 			canon[[k]] <- c(min(j, k_idx), max(j, k_idx))
 		}
-		# Dedupe silently (no message() — per Decision Log Q1; users verify
-		# via coefs$assignment_coefs$interactions inspection).
+		# Dedupe. Silent by default (per Decision Log Q1: users verify via
+		# coefs$assignment_coefs$interactions inspection); when verbose =
+		# TRUE the canonicalize/dedup step emits a message naming the
+		# count of removed pairs.
 		deduped <- list()
 		for (k in seq_along(canon)) {
 			already <- FALSE
@@ -298,6 +300,12 @@ genCoefs <- function(
 				deduped[[length(deduped) + 1L]] <- canon[[k]]
 			}
 		}
+		if (verbose && length(canon) > length(deduped)) {
+			message(sprintf(
+				"Deduplicated %d assignment_interactions pair(s) after canonicalization.",
+				length(canon) - length(deduped)
+			))
+		}
 		assignment_interactions <- deduped
 		# Note: assignment_interactions = list() (empty list, e.g. from a
 		# user passing list() directly) is treated as equivalent to NULL
@@ -305,17 +313,11 @@ genCoefs <- function(
 	}
 
 	# Interaction strength validation
-	if (!is.null(assignment_interaction_strength)) {
-		if (
-			!is.numeric(assignment_interaction_strength) ||
-				length(assignment_interaction_strength) != 1L ||
-				assignment_interaction_strength < 0
-		) {
-			stop(
-				"assignment_interaction_strength must be a non-negative numeric scalar (or NULL)"
-			)
-		}
-	}
+	.validate_strength_arg(
+		assignment_interaction_strength,
+		"assignment_interaction_strength",
+		allow_null = TRUE
+	)
 
 	stopifnot(R >= 2)
 	stopifnot(T >= 3)

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.14.0",
+  note    = "R package version 1.14.1",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -148,8 +148,10 @@ YYYY
 YYYYMM
 YYYYMMDD
 Zeger
+canonicalized
 cutpoint
 cutpoints
+deduplicated
 expit
 ldots
 logit

--- a/man/genCoefs.Rd
+++ b/man/genCoefs.Rd
@@ -14,7 +14,8 @@ genCoefs(
   assignment_strength = 1,
   assignment_interactions = NULL,
   assignment_interaction_strength = NULL,
-  seed = NULL
+  seed = NULL,
+  verbose = FALSE
 )
 }
 \arguments{
@@ -90,6 +91,12 @@ angle). Ignored when \code{assignment_interactions = NULL}. New in
 deterministic offsets share this seed: the main coefficient draw uses
 \code{seed}; the assignment coefficients use \code{seed + 1L}; the
 Monte Carlo integration in \code{getTes()} uses \code{seed + 2L}.}
+
+\item{verbose}{Logical. If \code{TRUE}, emit a \code{message()} when
+\code{assignment_interactions} canonicalization removes duplicate or
+unordered pairs (e.g., when the user passes both \code{c(1, 2)} and
+\code{c(2, 1)}). Default \code{FALSE} (silent — users can verify the
+final canonical list via \code{coefs$assignment_coefs$interactions}).}
 }
 \value{
 An object of class \code{"FETWFE_coefs"}, which is a list containing:

--- a/man/genCoefs.Rd
+++ b/man/genCoefs.Rd
@@ -12,6 +12,8 @@ genCoefs(
   eff_size,
   assignment_type = c("marginal", "multinomial", "ordered"),
   assignment_strength = 1,
+  assignment_interactions = NULL,
+  assignment_interaction_strength = NULL,
   seed = NULL
 )
 }
@@ -57,6 +59,33 @@ non-marginal types to the uniform marginal distribution by construction.
 Larger values produce stronger covariate-cohort coupling. Defaults to
 \code{1.0}. Ignored when \code{assignment_type = "marginal"}.}
 
+\item{assignment_interactions}{Optional. A list of length-2 integer
+vectors, each naming a pair of covariate indices \eqn{(j, k)} in
+\eqn{[1, d]} whose elementwise product \eqn{x_{i,j} \cdot x_{i,k}}
+enters the propensity model as an additional column. Self-interactions
+\code{c(j, j)} are allowed and yield a quadratic term \eqn{x_j^2}.
+Unordered pairs are canonicalized to \code{c(min(j, k), max(j, k))}
+and duplicates are silently deduplicated (inspect
+\code{coefs$assignment_coefs$interactions} on the returned object to
+verify the retained list). The interaction columns enter the
+propensity model only; the outcome model continues to use the
+original covariates. Defaults to \code{NULL} (no interactions —
+v1.14.0 behavior is preserved byte-identically). Passing \code{list()}
+(empty list) is treated as equivalent to \code{NULL} — no interactions
+specified, behavior is identical to the v1.14.0 marginal-cohort path
+within \code{multinomial} / \code{ordered} DGPs. Errors when
+\code{assignment_type = "marginal"} (the marginal DGP has no
+propensity model to augment). New in 1.14.1.}
+
+\item{assignment_interaction_strength}{Optional non-negative numeric
+scalar. Scales the Gaussian draws of the interaction coefficients
+independently of \code{assignment_strength}. Defaults to \code{NULL},
+which means "fall through to \code{assignment_strength}". Useful when
+stress-testing whether the nonlinear-propensity angle alone drives
+downstream differences (without simultaneously cranking the linear
+angle). Ignored when \code{assignment_interactions = NULL}. New in
+1.14.1.}
+
 \item{seed}{(Optional) Integer. Seed for reproducibility. Three
 deterministic offsets share this seed: the main coefficient draw uses
 \code{seed}; the assignment coefficients use \code{seed + 1L}; the
@@ -80,10 +109,22 @@ restrictions encoded in the FETWFE model are sparse. \code{beta} is derived from
 New in 1.14.0.}
 \item{assignment_strength}{The scaling factor applied to the assignment
 coefficients. New in 1.14.0.}
+\item{assignment_interaction_strength}{The scaling factor applied to
+the interaction coefficients. \code{NULL} when no interactions
+were specified or when the user passed \code{NULL} (the
+fall-through default). New in 1.14.1.}
 \item{assignment_coefs}{\code{NULL} when
 \code{assignment_type = "marginal"}; otherwise a list with elements
 \code{type}, \code{strength}, \code{coefs} (the gamma matrix or
-vector), and (for ordered) \code{cutpoints}. New in 1.14.0.}
+vector), and (for ordered) \code{cutpoints}. Starting in 1.14.1,
+\code{assignment_coefs} also carries the sub-slots
+\code{interactions} (the canonicalized + deduplicated list of
+pairs, or \code{NULL}), \code{delta} (the interaction coefficient
+matrix for multinomial or vector for ordered, or \code{NULL}),
+and \code{interaction_strength} (the effective scaling factor
+used for the \code{delta} draws, or \code{NULL} when no
+interactions). New in 1.14.0; \code{interactions}, \code{delta},
+and \code{interaction_strength} sub-slots new in 1.14.1.}
 }
 }
 \description{
@@ -137,6 +178,17 @@ Eq. \code{att.estimator.weighted} (line 837).
     seed = 123
   )
   sim_mn <- simulateData(coefs_mn, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5)
+
+  # Covariate-dependent cohort assignment with nonlinear propensity
+  # (multinomial-logit + a single x1*x2 interaction term in the propensity
+  # model only; outcome model continues to use plain X):
+  coefs_int <- genCoefs(
+    R = 5, T = 30, d = 12, density = 0.1, eff_size = 2,
+    assignment_type = "multinomial",
+    assignment_interactions = list(c(1, 2)),
+    assignment_interaction_strength = 1.5,
+    seed = 123
+  )
 }
 
 }

--- a/tests/testthat/test-logit-dgp.R
+++ b/tests/testthat/test-logit-dgp.R
@@ -3,9 +3,10 @@ library(fetwfe)
 
 # ------------------------------------------------------------------------------
 # Tests for covariate-dependent cohort-assignment DGPs introduced in 1.14.0
-# (issue #162).
+# (issue #162) and the assignment_interactions augmentation in 1.14.1
+# (issue #191).
 #
-# Six tests:
+# Eleven tests:
 #   1. Marginal DGP byte-identity (lock-in for backward compatibility).
 #   2. Multinomial DGP: empirical cohort proportions match the MC expectation.
 #   3. Ordered DGP: empirical cohort proportions are approximately uniform
@@ -18,6 +19,19 @@ library(fetwfe)
 #      computed inside the test with a different seed).
 #   6. High-strength sanity: covariates strongly predict cohort at
 #      strength = 10 (max-row P(W|X) is well above the uniform baseline).
+#   7. (#191) Interactions-augmented multinomial DGP yields propensity a
+#      linear-in-X logit cannot fit (LOAD-BEARING; seed-pinned).
+#   8. (#191) getTes() accounts for interactions in MC integration
+#      (LOAD-BEARING; independent MC reference at fresh seed).
+#   9. (#191) Marginal-uniform invariant holds under ordered DGP with
+#      interactions + paired no-interactions baseline contrast
+#      (LOAD-BEARING at strength = 2, tolerance = 0.015; both assertions
+#      load-bearing at seed=42).
+#  10. (#191) Canonicalization + deduplication of pair list (lightweight).
+#  11. (#191) v1.14.0 backward-compat: hand-constructed FETWFE_coefs missing
+#      the new $assignment_interaction_strength + $assignment_coefs$interactions
+#      + $assignment_coefs$delta slots round-trips through simulateData()
+#      and getTes() without error.
 # ------------------------------------------------------------------------------
 
 # ------------------------------------------------------------------------------
@@ -228,4 +242,329 @@ test_that("high-strength assignment: covariates strongly predict cohort", {
 	)
 	max_row_probs <- apply(probs, 1, max)
 	expect_gt(mean(max_row_probs), 0.85)
+})
+
+# ------------------------------------------------------------------------------
+# Test 7 (#191, LOAD-BEARING, seed-pinned): interactions-augmented multinomial
+# DGP yields propensity a linear-in-X logit cannot fit.
+#
+# Fit per-cohort one-vs-rest binomial logits on the simulated data — once with
+# `~ cov1 + cov2` (linear-in-X), once with `~ cov1 + cov2 + I(cov1 * cov2)`
+# (augmented). At the pinned seed = 42 with assignment_strength =
+# assignment_interaction_strength = 2.0 the linear-truth gap is empirically
+# 67 and the augmented gap is empirically 2005; the threshold of 500 provides
+# seed-specific separation (not cross-seed safety — the test is seed-pinned).
+# The cross-seed linear-truth gap varies in [18, 593] (30-seed round-2 sweep)
+# but the seed-pinned test pass/fail is unaffected.
+# ------------------------------------------------------------------------------
+test_that("interactions-augmented multinomial DGP injects propensity nonlinearity (#191)", {
+	skip_on_cran()
+	coefs <- genCoefs(
+		R = 3,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		assignment_type = "multinomial",
+		assignment_strength = 2.0,
+		assignment_interactions = list(c(1L, 2L)),
+		assignment_interaction_strength = 2.0,
+		seed = 42
+	)
+	sim <- suppressWarnings(simulateData(
+		coefs,
+		N = 5000,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5
+	))
+	# Per-unit cohort labels (first observation per unit; treatment is an
+	# absorbing state, so the unit's cohort is encoded in the panel's
+	# `treatment` column — we extract via first-period rows).
+	pdata <- sim$pdata
+	first_period <- min(pdata$time)
+	first_rows <- pdata[pdata$time == first_period, ]
+	# `cohort` is encoded as the unit's adoption-period label (or NA for
+	# never-treated). simulateData() exposes per-unit assignment via the
+	# panel structure; reconstruct W from the treatment column.
+	cohort_by_unit <- tapply(
+		pdata$treatment,
+		pdata$unit,
+		function(v) {
+			treated_inds <- which(v == 1)
+			if (length(treated_inds) == 0L) {
+				0L
+			} else {
+				as.integer(min(treated_inds))
+			}
+		}
+	)
+	# Align X with cohort label.
+	X1 <- first_rows$cov1
+	X2 <- first_rows$cov2
+	cohort_aligned <- cohort_by_unit[as.character(first_rows$unit)]
+
+	# One-vs-rest binomial logits, summed deviance across cohorts.
+	linear_dev <- 0
+	augmented_dev <- 0
+	cohort_levels <- unique(cohort_aligned)
+	treated_levels <- sort(cohort_levels[cohort_levels > 0L])
+	for (r in treated_levels) {
+		y <- as.integer(cohort_aligned == r)
+		df_r <- data.frame(y = y, cov1 = X1, cov2 = X2)
+		fit_lin <- suppressWarnings(stats::glm(
+			y ~ cov1 + cov2,
+			data = df_r,
+			family = stats::binomial()
+		))
+		fit_aug <- suppressWarnings(stats::glm(
+			y ~ cov1 + cov2 + I(cov1 * cov2),
+			data = df_r,
+			family = stats::binomial()
+		))
+		linear_dev <- linear_dev + fit_lin$deviance
+		augmented_dev <- augmented_dev + fit_aug$deviance
+	}
+	# A meaningful deviance reduction means the augmented model explains
+	# nonlinearity that the linear-in-X logit cannot. Threshold 500 chosen
+	# for seed-specific separation at seed = 42.
+	expect_gt(linear_dev - augmented_dev, 500)
+})
+
+# ------------------------------------------------------------------------------
+# Test 8 (#191, LOAD-BEARING): getTes() accounts for interactions in MC
+# integration.
+#
+# Compare getTes()'s production output against an INDEPENDENT MC reference
+# computed inside the test with a fresh seed (99L), matching the precedent
+# set by Test 5. Pinned at strength = int_strength = 2.0, seed = 42 for
+# consistency with Tests 7 + 9.
+# ------------------------------------------------------------------------------
+test_that("getTes() accounts for interactions in MC integration (#191)", {
+	skip_on_cran()
+	coefs <- genCoefs(
+		R = 3,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		assignment_type = "multinomial",
+		assignment_strength = 2.0,
+		assignment_interactions = list(c(1L, 2L)),
+		assignment_interaction_strength = 2.0,
+		seed = 42
+	)
+	tes <- getTes(coefs)
+	# Independent reference computed with a fresh MC sample.
+	set.seed(99L)
+	X_ref <- matrix(rnorm(50000 * 2), nrow = 50000, ncol = 2)
+	probs_ref <- fetwfe:::.compute_cohort_prob_matrix(
+		X_ref,
+		coefs$assignment_coefs
+	)
+	expected_ref <- colMeans(probs_ref)
+	treated_probs_ref <- expected_ref[2:4]
+	cohort_weights_ref <- as.numeric(
+		treated_probs_ref / sum(treated_probs_ref)
+	)
+	att_ref <- sum(cohort_weights_ref * tes$actual_cohort_tes)
+	expect_equal(tes$att_true, att_ref, tolerance = 0.02)
+	expect_equal(
+		tes$cohort_weights,
+		cohort_weights_ref,
+		tolerance = 0.02
+	)
+})
+
+# ------------------------------------------------------------------------------
+# Test 9 (#191, LOAD-BEARING at strength = 2 + tol = 0.015): marginal-uniform
+# invariant holds under ordered DGP with interactions; paired with a
+# no-interactions baseline contrast.
+#
+# Two assertions, both load-bearing at seed = 42:
+# (a) Marginal-uniform: at strength = int_strength = 2.0, the buggy un-
+#     augmented cutpoint solver gives max_dev = 0.0188 (fails tolerance =
+#     0.015) while the correct path gives max_dev = 0.0097 (passes with ~55%
+#     headroom). Catches Failure-mode A (root-finder forgets augmentation).
+# (b) Baseline contrast: a no-interactions baseline panel at the same seed
+#     differs from the with-interactions panel by mean|diff| ~ 10 at seed =
+#     42 (correct case). Catches Failure-mode C (both root-finder and
+#     runtime silently drop the augmentation -> WITH and WITHOUT are
+#     byte-identical -> mean|diff| == 0).
+# ------------------------------------------------------------------------------
+test_that("ordered DGP with interactions preserves marginal uniformity + baseline contrast (#191)", {
+	skip_on_cran()
+	coefs <- genCoefs(
+		R = 3,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		assignment_type = "ordered",
+		assignment_strength = 2.0,
+		assignment_interactions = list(c(1L, 2L)),
+		assignment_interaction_strength = 2.0,
+		seed = 42
+	)
+	sim_ord <- suppressWarnings(simulateData(
+		coefs,
+		N = 10000,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5
+	))
+	empirical_probs <- sim_ord$assignments / sum(sim_ord$assignments)
+	max_dev <- max(abs(as.numeric(empirical_probs) - 1 / 4))
+	# (a) Marginal-uniform invariant.
+	expect_lt(max_dev, 0.015)
+
+	# (b) No-interactions baseline contrast — identical inputs except
+	# assignment_interactions = NULL. Same seed for reproducibility.
+	coefs_baseline <- genCoefs(
+		R = 3,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		assignment_type = "ordered",
+		assignment_strength = 2.0,
+		seed = 42
+	)
+	sim_ord_baseline <- suppressWarnings(simulateData(
+		coefs_baseline,
+		N = 10000,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5
+	))
+	diff_means <- mean(abs(
+		as.numeric(sim_ord$assignments) -
+			as.numeric(sim_ord_baseline$assignments)
+	))
+	# Threshold of 5 has ~2x headroom against the empirical correct-case
+	# value of ~10 at seed = 42; fires at exactly 0 under Failure-mode C.
+	expect_gt(diff_means, 5)
+})
+
+# ------------------------------------------------------------------------------
+# Test 10 (#191, lightweight): canonicalization + deduplication of pair list.
+# ------------------------------------------------------------------------------
+test_that("assignment_interactions canonicalizes + dedupes pairs (#191)", {
+	coefs <- genCoefs(
+		R = 3,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		assignment_type = "multinomial",
+		assignment_interactions = list(c(2, 1), c(1, 2)),
+		seed = 42
+	)
+	expect_identical(
+		coefs$assignment_coefs$interactions,
+		list(c(1L, 2L))
+	)
+
+	# Self-interactions (quadratic) are allowed.
+	coefs_quad <- genCoefs(
+		R = 3,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		assignment_type = "multinomial",
+		assignment_interactions = list(c(1, 1)),
+		seed = 42
+	)
+	expect_identical(
+		coefs_quad$assignment_coefs$interactions,
+		list(c(1L, 1L))
+	)
+
+	# Index outside [1, d] errors with the informative message.
+	expect_error(
+		genCoefs(
+			R = 3,
+			T = 5,
+			d = 2,
+			density = 0.5,
+			eff_size = 2,
+			assignment_type = "multinomial",
+			assignment_interactions = list(c(0, 1))
+		),
+		regexp = "outside \\[1, d"
+	)
+	expect_error(
+		genCoefs(
+			R = 3,
+			T = 5,
+			d = 2,
+			density = 0.5,
+			eff_size = 2,
+			assignment_type = "multinomial",
+			assignment_interactions = list(c(3, 1))
+		),
+		regexp = "outside \\[1, d"
+	)
+})
+
+# ------------------------------------------------------------------------------
+# Test 11 (#191, lightweight): v1.14.0 backward-compat round-trip.
+#
+# Mirrors the v1.13.x backward-compat defensive pattern at
+# R/gen_data.R:122-129 and R/gen_coefs.R:345-352. A hand-constructed
+# FETWFE_coefs object missing the new 1.14.1 slots ($interaction_strength,
+# $assignment_coefs$interactions, $assignment_coefs$delta) must round-trip
+# through simulateData() and getTes() without error so the package's
+# defensive is.null() handling does not regress.
+# ------------------------------------------------------------------------------
+test_that("v1.14.0 FETWFE_coefs round-trips through simulateData + getTes (#191)", {
+	# Construct a minimal v1.14.0-shape multinomial coefs object. We use a
+	# small R = 3, T = 5, d = 2 panel matching the test surface.
+	R <- 3L
+	T <- 5L
+	d <- 2L
+
+	# Pull beta + theta off a freshly-constructed v1.14.1 object, then
+	# strip the new top-level + sub-slots to simulate a v1.14.0 object.
+	template <- genCoefs(
+		R = R,
+		T = T,
+		d = d,
+		density = 0.5,
+		eff_size = 2,
+		assignment_type = "multinomial",
+		assignment_strength = 1.0,
+		seed = 42
+	)
+	mock <- list(
+		beta = template$beta,
+		theta = template$theta,
+		R = R,
+		T = T,
+		d = d,
+		seed = 42L,
+		assignment_type = "multinomial",
+		assignment_strength = 1.0,
+		# v1.14.0 NO $assignment_interaction_strength,
+		# v1.14.0 NO $assignment_coefs$interactions / $delta / $interaction_strength
+		assignment_coefs = list(
+			type = "multinomial",
+			strength = 1.0,
+			coefs = template$assignment_coefs$coefs
+		)
+	)
+	class(mock) <- "FETWFE_coefs"
+
+	# Both calls must succeed (the defensive is.null() handling in the
+	# downstream code catches missing slots).
+	sim <- expect_no_error(
+		suppressWarnings(simulateData(
+			mock,
+			N = 100,
+			sig_eps_sq = 1,
+			sig_eps_c_sq = 0.5
+		))
+	)
+	tes <- expect_no_error(getTes(mock))
+	# Sanity: returned objects have the expected shapes.
+	expect_true(is.finite(tes$att_true))
+	expect_equal(length(tes$actual_cohort_tes), R)
 })

--- a/tests/testthat/test-logit-dgp.R
+++ b/tests/testthat/test-logit-dgp.R
@@ -503,6 +503,40 @@ test_that("assignment_interactions canonicalizes + dedupes pairs (#191)", {
 		),
 		regexp = "outside \\[1, d"
 	)
+
+	# verbose = TRUE emits a dedup message when canonicalization removes
+	# pairs (per post-execution review item #6 maintainer-elevation:
+	# verbose-gated message preserves silent default while giving users
+	# an opt-in signal that dedup happened).
+	expect_message(
+		genCoefs(
+			R = 3,
+			T = 5,
+			d = 2,
+			density = 0.5,
+			eff_size = 2,
+			assignment_type = "multinomial",
+			assignment_interactions = list(c(2, 1), c(1, 2)),
+			verbose = TRUE,
+			seed = 42
+		),
+		regexp = "Deduplicated 1 assignment_interactions pair"
+	)
+
+	# verbose = FALSE (default) stays silent even when dedup happens.
+	expect_silent(
+		genCoefs(
+			R = 3,
+			T = 5,
+			d = 2,
+			density = 0.5,
+			eff_size = 2,
+			assignment_type = "multinomial",
+			assignment_interactions = list(c(2, 1), c(1, 2)),
+			verbose = FALSE,
+			seed = 42
+		)
+	)
 })
 
 # ------------------------------------------------------------------------------

--- a/vignettes/simulation_vignette.Rmd
+++ b/vignettes/simulation_vignette.Rmd
@@ -294,6 +294,44 @@ for (s in c(0.0, 1.0, 5.0)) {
 
 At `assignment_strength = 0` the cohort proportions are approximately uniform $1/(R + 1) = 0.25$. At higher strength, the proportions deviate from uniform because the covariate distribution drives the assignment.
 
+## Nonlinear propensity via interactions
+
+Sometimes the propensity model needs to be nonlinear in the covariates — for example, to stress-test estimators that assume a linear propensity. The `assignment_interactions` argument injects multiplicative interaction terms into the propensity model only; the outcome model continues to use the original covariates. The argument accepts a list of integer pairs naming the columns of $X$ whose product enters the propensity:
+
+```{r}
+sim_coefs_int <- genCoefs(
+  R                               = 3,
+  T                               = 4,
+  d                               = 2,
+  density                         = 0.1,
+  eff_size                        = 2,
+  assignment_type                 = "multinomial",
+  assignment_strength             = 1.0,
+  assignment_interactions         = list(c(1, 2)),
+  assignment_interaction_strength = 1.0,
+  seed                            = 101
+)
+str(sim_coefs_int$assignment_coefs$interactions)
+str(sim_coefs_int$assignment_coefs$delta)
+```
+
+Self-interactions are allowed and produce quadratic terms $x_j^2$:
+
+```{r}
+sim_coefs_quad <- genCoefs(
+  R                       = 3,
+  T                       = 4,
+  d                       = 2,
+  density                 = 0.1,
+  eff_size                = 2,
+  assignment_type         = "multinomial",
+  assignment_interactions = list(c(1, 1)),
+  seed                    = 101
+)
+```
+
+The interaction columns are constructed internally inside the propensity model each time it is evaluated; the simulated `pdata` keeps just the original $d$ covariate columns (the outcome design matrix is unchanged). Pairs are canonicalized to `c(min, max)` and duplicates are silently deduplicated.
+
 ## Truth derivation under non-marginal DGPs
 
 Under the default marginal DGP, the overall true ATT is the equal-weighted average of the cohort-specific effects:


### PR DESCRIPTION
Extends `genCoefs()` with two optional arguments — `assignment_interactions = NULL` and `assignment_interaction_strength = NULL` — that augment the v1.14.0 covariate-dependent cohort-assignment DGPs (multinomial + ordered) with pairwise multiplicative interaction terms in the propensity-model linear predictor. Outcome model is unchanged (interactions act only inside the propensity), so the resulting DGPs adversarially mis-specify `did::att_gt(est_method = "dr")`'s default linear-logit propensity, unblocking the #140 FETWFE-vs-Callaway-Sant'Anna comparison work.

Pairs accept any `1 <= j, k <= d` (including `j == k`, which gives a quadratic `x_j²` term); unordered pairs are canonicalized to `c(min, max)` and silently deduped. Default `NULL` preserves v1.14.0 behavior byte-identically on every existing test. Patch bump 1.14.0 → 1.14.1.

Math: extends Faletto (2025) lines 826 (`pi_r(x)`), 1016 (multinomial-logit / proportional-odds reference DGPs), 837 (`att.estimator.weighted` — unchanged, augmentation flows through `.expected_cohort_probs()`), 2018 (Assumption Psi-IF still satisfied by the augmented MLE via M-estimator theory; interactions are polynomial features of `X`).

5 new tests in `tests/testthat/test-logit-dgp.R` (Tests 7-11): linear-logit-can't-fit-augmented-propensity deviance gap (Test 7, seed-pinned), `getTes()` MC integration accounts for interactions (Test 8), ordered marginal-uniform invariant under augmentation + paired baseline-contrast (Test 9), canonicalize / dedupe / quadratic-allowed / per-index validation + `verbose = TRUE` opt-in dedup message (Test 10), v1.14.0-shape `FETWFE_coefs` backward-compat round-trip (Test 11).

Also folds in two post-review maintainer-elevations:
- A new `verbose = FALSE` argument on `genCoefs()` that gates an opt-in `message()` when canonicalization removes duplicate or unordered `assignment_interactions` pairs. Default is silent (preserves the planning-reviewer's Q1 disposition).
- A small refactor consolidating the three near-duplicate `"non-negative numeric scalar"` validators for `assignment_strength` / `assignment_interaction_strength` / internal `strength` into a single `.validate_strength_arg(x, name, allow_null)` helper. Eliminates the v1.14.0 dual-validation site the round-1 drift sentinel flagged.

Resolves #191.

## Out of scope (deferred follow-ups)

- **Cubic / higher-order propensity terms**: (c) drop. Pairs are sufficient to mis-specify `did`'s default linear logit per the #140 chat discussion; higher-order would be over-engineering.
- **An *estimator* for `pi_hat_r(X)` from observed data** (the inverse of this DGP): (a) tracked at #161.
- **AIPW / doubly-robust point-estimate paths consuming estimated propensity scores**: (a) deferred to paper-side work; will be filed when methodology lands.
- **Extending `simulateData()` to accept a user-supplied propensity-score function** (vs. the multinomial / ordered presets + interaction list): (c) drop. Current API covers the canonical reference DGPs the paper names at line 1016.
- **Per-pair `delta` scaling control** (currently all interactions share one `assignment_interaction_strength`): (c) drop unless a future user case argues for it.
- **`verbose` argument on `genCoefs()` to gate the dedup message**: (b) applied in this PR (commit `4cf4158`). Maintainer elevated from initial "(c) drop" disposition during post-execution review.
- **Existing v1.14.0 latent NOTE on `assignment_strength` dual-validation**: (b) applied in this PR (commit `4cf4158`). Consolidated into `.validate_strength_arg()`; maintainer elevated from initial "(c) drop" disposition during post-execution review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
