### PR TITLE
fix: twfeCovs() honors user alpha for the default simultaneous band (#204, 1.17.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.17.0
+Version: 1.17.1
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # NEWS
 
+## Version 1.17.1
+
+### Bug fixes
+
+- Fixed: `twfeCovs()` now honors its `alpha` argument when building the default
+  simultaneous confidence band (previously the band was always computed at
+  `alpha = 0.05` regardless of the requested level). The class gains an `alpha`
+  slot. (#204)
+
 ## Version 1.17.0 (2026-06-01)
 
 ### Deprecations

--- a/R/class_helpers.R
+++ b/R/class_helpers.R
@@ -280,17 +280,13 @@
 }
 
 #' @title Resolve the alpha a fit's catt_df was built at
-#' @description `x$alpha` for fetwfe/etwfe/betwfe; `0.05` for twfeCovs
-#'   (which omits the `alpha` slot but builds its catt_df at the entry
-#'   point's `alpha = 0.05` default).
+#' @description Returns `x$alpha` for all four classes
+#'   (fetwfe/etwfe/betwfe/twfeCovs); every fit now carries an `alpha`
+#'   slot recording the level its catt_df band was built at (#204).
 #' @keywords internal
 #' @noRd
 .alpha_of <- function(x) {
-	if (inherits(x, "twfeCovs")) {
-		0.05
-	} else {
-		x$alpha
-	}
+	x$alpha
 }
 
 #' @title C10 -- Simultaneous band is never narrower than the pointwise band
@@ -421,9 +417,9 @@
 
 #' @title C8 -- Type sanity (universal across all 4 classes)
 #' @description
-#' `has_alpha` is TRUE for fetwfe/etwfe/betwfe (which all carry an `alpha`
-#' slot); FALSE for twfeCovs (which omits alpha because it has no inference
-#' output). `has_att_selected` is TRUE for fetwfe/betwfe.
+#' `has_alpha` is TRUE for all four classes (fetwfe/etwfe/betwfe/twfeCovs all
+#' carry an `alpha` slot; twfeCovs gained one in #204). `has_att_selected` is
+#' TRUE for fetwfe/betwfe.
 #' @keywords internal
 #' @noRd
 .check_type_sanity <- function(

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -641,8 +641,8 @@ simultaneousCIs.twfeCovs <- function(
 #'   unchanged).
 #' @param x A fully-classed `fetwfe`/`etwfe`/`betwfe`/`twfeCovs` object.
 #' @param alpha Numeric; the alpha the fit's `catt_df` was built at (`x$alpha`
-#'   for fetwfe/etwfe/betwfe, `0.05` for twfeCovs, which has no `alpha` slot).
-#'   Passed explicitly so all four callers agree.
+#'   for all four classes; twfeCovs gained an `alpha` slot in #204). Passed
+#'   explicitly so all four callers agree.
 #' @param has_valid_ses Logical; `res$calc_ses` from the core (read off the
 #'   classed object by the caller).
 #' @return A list with elements `ci_low` and `ci_high` (numeric vectors of
@@ -701,7 +701,7 @@ simultaneousCIs.twfeCovs <- function(
 #'   band degrades to `NULL`) it is a no-op pass-through. Hoisted out of the
 #'   four entry-point tails to avoid a 4-site copy (WORKFLOW_LESSONS §14).
 #' @param out A fully-classed `fetwfe`/`etwfe`/`betwfe`/`twfeCovs` object.
-#' @param alpha Numeric; the alpha the fit used (`0.05` for twfeCovs).
+#' @param alpha Numeric; the alpha the fit used (read from the fit's `alpha` slot).
 #' @return `out` with `catt_df` bounds overwritten when simultaneous, else
 #'   `out` unchanged.
 #' @keywords internal

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -185,6 +185,7 @@
 #' `FALSE` otherwise.}
 #' \item{se_type}{Character scalar; the `se_type` argument the user passed
 #' (`"default"`, `"conservative"`, or `"cluster"`).}
+#' \item{alpha}{The alpha level used for confidence intervals.}
 #' \item{ci_type}{Character scalar; the `ci_type` argument the user passed (`"simultaneous"` or `"pointwise"`), controlling whether the reported `catt_df` confidence-interval bounds are simultaneous (family-wise) or pointwise.}
 #' \item{internal}{A list containing internal outputs that are typically
 #'   not needed for interpretation, packaged here for parity with
@@ -399,6 +400,7 @@ twfeCovs <- function(
 		p = res$p,
 		calc_ses = res$calc_ses,
 		se_type = se_type,
+		alpha = alpha,
 		indep_counts_used = indep_count_data_available,
 		y_mean = y_mean,
 		response_col_name = response,
@@ -427,11 +429,12 @@ twfeCovs <- function(
 	# on the list shape regardless of class, then class is assigned.
 	.validate_twfeCovs(out)
 	class(out) <- "twfeCovs"
-	# Apply ci_type to the cohort-family bounds (#197). twfeCovs has no
-	# `alpha` slot; its catt_df is built at alpha = 0.05 (the entry-point
-	# default), so the finalizer must be passed alpha = 0.05 explicitly.
-	# No-op unless ci_type == "simultaneous". Re-validates internally.
-	out <- .finalize_ci_type(out, alpha = 0.05)
+	# Apply ci_type to the cohort-family bounds (#197). twfeCovs now carries
+	# its own `alpha` slot (#204), so the finalizer builds the simultaneous
+	# band at the user's requested alpha (previously it was hardcoded to
+	# 0.05, ignoring `alpha`). No-op unless ci_type == "simultaneous".
+	# Re-validates internally.
+	out <- .finalize_ci_type(out, alpha = alpha)
 	return(out)
 }
 
@@ -555,6 +558,7 @@ twfeCovs <- function(
 #' `FALSE` otherwise.}
 #' \item{se_type}{Character scalar; the `se_type` argument the user passed
 #' (`"default"`, `"conservative"`, or `"cluster"`).}
+#' \item{alpha}{The alpha level used for confidence intervals.}
 #' \item{ci_type}{Character scalar; the `ci_type` argument the user passed (`"simultaneous"` or `"pointwise"`), controlling whether the reported `catt_df` confidence-interval bounds are simultaneous (family-wise) or pointwise.}
 #' \item{y_mean}{Numeric scalar; mean of the original (pre-centering) response.
 #' Stored so downstream methods (`augment()`, `predict()`) can return fitted

--- a/R/twfeCovs_class.R
+++ b/R/twfeCovs_class.R
@@ -31,8 +31,9 @@ print.twfeCovs <- function(x, ...) {
 
 #-------------------------------------------------------------------------------
 # Constructor validator (#85). See R/fetwfe_class.R for the design rationale.
-# twfeCovs differs from etwfe in: no `alpha` slot (twfeCovs has no inference
-# output).
+# twfeCovs carries an `alpha` slot like etwfe (#204): the user's `alpha` is
+# threaded into the default simultaneous catt_df band and read by the C10
+# band-width validator.
 #-------------------------------------------------------------------------------
 
 .EXPECTED_SLOTS_TWFECOVS <- c(
@@ -62,6 +63,7 @@ print.twfeCovs <- function(x, ...) {
 	"calc_ses",
 	"indep_counts_used",
 	"se_type",
+	"alpha",
 	"y_mean",
 	"response_col_name",
 	"time_var",
@@ -102,7 +104,7 @@ print.twfeCovs <- function(x, ...) {
 		cls,
 		where = "internal"
 	)
-	.check_type_sanity(x, cls, has_alpha = FALSE, has_att_selected = FALSE)
+	.check_type_sanity(x, cls, has_alpha = TRUE, has_att_selected = FALSE)
 	.check_se_consistency(x, calc_ses_path = "calc_ses", cls)
 	.check_p_value_na(x, cls)
 	.check_catt_df_shape(x, cls)

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.17.0",
+  note    = "R package version 1.17.1",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/man/twfeCovs.Rd
+++ b/man/twfeCovs.Rd
@@ -214,6 +214,7 @@ argument was provided and used for asymptotically-exact ATT inference,
 \code{FALSE} otherwise.}
 \item{se_type}{Character scalar; the \code{se_type} argument the user passed
 (\code{"default"}, \code{"conservative"}, or \code{"cluster"}).}
+\item{alpha}{The alpha level used for confidence intervals.}
 \item{ci_type}{Character scalar; the \code{ci_type} argument the user passed (\code{"simultaneous"} or \code{"pointwise"}), controlling whether the reported \code{catt_df} confidence-interval bounds are simultaneous (family-wise) or pointwise.}
 \item{internal}{A list containing internal outputs that are typically
 not needed for interpretation, packaged here for parity with

--- a/man/twfeCovsWithSimulatedData.Rd
+++ b/man/twfeCovsWithSimulatedData.Rd
@@ -132,6 +132,7 @@ argument was provided and used for asymptotically-exact ATT inference,
 \code{FALSE} otherwise.}
 \item{se_type}{Character scalar; the \code{se_type} argument the user passed
 (\code{"default"}, \code{"conservative"}, or \code{"cluster"}).}
+\item{alpha}{The alpha level used for confidence intervals.}
 \item{ci_type}{Character scalar; the \code{ci_type} argument the user passed (\code{"simultaneous"} or \code{"pointwise"}), controlling whether the reported \code{catt_df} confidence-interval bounds are simultaneous (family-wise) or pointwise.}
 \item{y_mean}{Numeric scalar; mean of the original (pre-centering) response.
 Stored so downstream methods (\code{augment()}, \code{predict()}) can return fitted

--- a/tests/testthat/test-ci-type-197.R
+++ b/tests/testthat/test-ci-type-197.R
@@ -734,3 +734,68 @@ test_that("ci_type x allow_no_never_treated = TRUE: finalizer handles the auto-t
 	# Validator accepts the simultaneous (degenerate) object.
 	expect_silent(fetwfe:::.validate_fetwfe(fit_s))
 })
+
+# ------------------------------------------------------------------------------
+# Test 19: REGRESSION (#204) -- twfeCovs() honors a non-default `alpha` when
+# building the default simultaneous catt_df band. Before the fix, twfeCovs had
+# no `alpha` slot and the entry-point hardcoded `.finalize_ci_type(out, alpha =
+# 0.05)`, so the simultaneous band was ALWAYS the 0.05 band regardless of the
+# requested level (and C10's `.alpha_of` returned the same wrong 0.05, so the
+# band-width validator was blind). This test FAILS on the old code: it asserts
+# (i) the new `alpha` slot is set; (ii) the catt_df bounds match
+# `simultaneousCIs(fit, "cohort", alpha = 0.10)` (not the 0.05 band); (iii) the
+# 0.10 band is strictly NARROWER than the 0.05 band on >= 2 finite-SE cohorts;
+# (iv) `.validate_twfeCovs(fit)` is silent. Both the *WithSimulatedData wrapper
+# and a DIRECT twfeCovs() call are exercised.
+# ------------------------------------------------------------------------------
+test_that("twfeCovs() honors a non-default alpha for the simultaneous band (#204)", {
+	sim <- make_ci_panel()
+
+	check_alpha_honored <- function(fit, label) {
+		# (i) the new alpha slot carries the requested level.
+		expect_equal(fit$alpha, 0.1, info = label)
+		# (ii) catt_df bounds are the alpha = 0.10 simultaneous band, NOT 0.05.
+		sci10 <- simultaneousCIs(fit, family = "cohort", alpha = 0.1)
+		expect_equal(
+			fit$catt_df$ci_low,
+			sci10$ci$simultaneous_ci_low,
+			info = label
+		)
+		expect_equal(
+			fit$catt_df$ci_high,
+			sci10$ci$simultaneous_ci_high,
+			info = label
+		)
+		# (iii) the 0.10 band is strictly narrower than the 0.05 band (the bug:
+		# it was wrongly EQUAL to the 0.05 band). Gated on >= 2 finite-SE cohorts.
+		cd <- fit$catt_df
+		fin <- is.finite(cd$se) & cd$se > 0
+		skip_if_not(sum(fin) >= 2L)
+		sci05 <- simultaneousCIs(fit, family = "cohort", alpha = 0.05)
+		w10 <- (cd$ci_high - cd$ci_low)[fin]
+		w05 <- (sci05$ci$simultaneous_ci_high -
+			sci05$ci$simultaneous_ci_low)[fin]
+		expect_true(all(w10 < w05), info = label)
+		# (iv) the constructed object validates silently with alpha = 0.10.
+		expect_silent(fetwfe:::.validate_twfeCovs(fit))
+	}
+
+	# Wrapper path.
+	fit_w <- twfeCovsWithSimulatedData(sim, alpha = 0.1)
+	check_alpha_honored(fit_w, "twfeCovsWithSimulatedData")
+
+	# Direct twfeCovs() path (mirrors Test 13's direct-call construction).
+	fit_d <- twfeCovs(
+		pdata = sim$pdata,
+		time_var = sim$time_var,
+		unit_var = sim$unit_var,
+		treatment = sim$treatment,
+		response = sim$response,
+		covs = sim$covs,
+		sig_eps_sq = sim$sig_eps_sq,
+		sig_eps_c_sq = sim$sig_eps_c_sq,
+		alpha = 0.1,
+		verbose = FALSE
+	)
+	check_alpha_honored(fit_d, "twfeCovs")
+})

--- a/tests/testthat/test-doc-slot-parity.R
+++ b/tests/testthat/test-doc-slot-parity.R
@@ -216,10 +216,9 @@ test_that("cross-class slot inventory matches the documented divergence table", 
 	# Each entry's `classes` is the exact set the slot should appear in;
 	# `rationale` documents why.
 	DIVERGENT_SLOTS <- list(
-		"alpha" = list(
-			classes = c("fetwfe", "etwfe", "betwfe"),
-			rationale = "twfeCovs has no inference output (no SEs, p-values, or CIs), so no alpha."
-		),
+		# `alpha` was divergent until #204; twfeCovs now carries it too (it
+		# threads the user's alpha into the default simultaneous catt_df band),
+		# so `alpha` is a universal slot (no DIVERGENT_SLOTS entry).
 		"att_selected" = list(
 			classes = c("fetwfe", "betwfe"),
 			rationale = "Only the selection-based (bridge-penalty) estimators perform selection."


### PR DESCRIPTION
Fixes #204 (Major; surfaced by the 2026-06-02 periodic code review).

## The bug

`twfeCovs()` built its **default** `ci_type = "simultaneous"` `catt_df` band at a **hardcoded `alpha = 0.05`** (`.finalize_ci_type(out, alpha = 0.05)`), silently discarding the user's `alpha`. A call like `twfeCovs(..., alpha = 0.20)` returned a 95%-width band with no error or warning. The other three estimators (`fetwfe`/`etwfe`/`betwfe`) correctly pass `alpha = alpha`.

The dedicated band-width validator (C10, `.check_ci_band_width`) couldn't catch it: `.alpha_of()` *also* hardcoded `0.05` for twfeCovs (the class had no `alpha` slot), so the "simultaneous ≥ pointwise" invariant was checked at 0.05-vs-0.05 — the bug and its guard shared the same wrong constant.

## The fix

Give the twfeCovs class an `alpha` slot, like the other three estimators:

- **Carry `alpha`** in `twfeCovs()`'s output list; add it to `.EXPECTED_SLOTS_TWFECOVS` and both `@return` blocks (entry point + `WithSimulatedData` wrapper); flip the validator to `has_alpha = TRUE` (enforces the existing C8 `alpha ∈ (0,1)` contract).
- **Pass `alpha = alpha`** (not `0.05`) into `.finalize_ci_type`.
- **Collapse `.alpha_of()` to `x$alpha`** for all four classes, so C10 now guards the *user's* band. Correct the three now-false docstrings.
- **Regression test** (`test-ci-type-197.R`): `twfeCovs(alpha = 0.10)`'s `catt_df` band equals `simultaneousCIs(fit, "cohort", alpha = 0.10)` and is strictly narrower than the 0.05 band — it fails on the old code, and covers both the wrapper and the direct call.
- Remove the now-false `"alpha"` entry from `test-doc-slot-parity`'s `DIVERGENT_SLOTS` table (alpha is now a universal slot — itself a small instance of a guardrail that had encoded the old wrong assumption).

## Not a CRAN regression

The `ci_type` simultaneous-by-default behavior is **dev-only** (introduced in 1.16.0, not yet on CRAN), so no released version is affected — but it's in the dev HEAD, so this lands before the next submission.

## Verification

- **Empirical repro:** `twfeCovs(alpha = 0.20)` band now matches `simultaneousCIs(fit, "cohort", alpha = 0.20)` exactly and is strictly narrower than at 0.05; `fit$alpha == 0.20`; the validator is silent. `fetwfe`/`etwfe`/`betwfe` unaffected.
- **Gate:** `air` clean, `document()` idempotent (each `@return` gains exactly one `\item{alpha}`, no duplicate), `devtools::test()` **FAIL 0 | WARN 0 | PASS 2828**, `R CMD check --as-cran` **0 errors / 0 warnings / 1 acceptable NOTE** (future-timestamp), spell + URL clean.

Version 1.17.0 → 1.17.1 (patch; bug fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
