### PR TITLE
fix: getGramInv() degrades gracefully on a near-singular Gram instead of aborting (#205, 1.17.2)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.17.1
+Version: 1.17.2
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # NEWS
 
+## Version 1.17.2
+
+### Bug fixes
+
+- Fixed: `getGramInv()` now degrades gracefully (a warning plus
+  `calc_ses = FALSE`) instead of aborting with an uncaught LAPACK
+  "system is computationally singular" error when the selected-feature Gram is
+  near-singular (reciprocal condition number below `solve()`'s tolerance). The
+  singularity guard is now condition-number-aware and `solve()` is wrapped in a
+  `tryCatch()` routing to the same fallback. (#205)
+
 ## Version 1.17.1
 
 ### Bug fixes

--- a/R/core_funcs.R
+++ b/R/core_funcs.R
@@ -764,18 +764,30 @@ getGramInv <- function(
 	stopifnot(nrow(gram) == p_sel)
 	stopifnot(ncol(gram) == p_sel)
 
-	min_gram_eigen <- min(
-		eigen(gram, symmetric = TRUE, only.values = TRUE)$values
-	)
+	gram_eigvals <- eigen(gram, symmetric = TRUE, only.values = TRUE)$values
+	min_gram_eigen <- min(gram_eigvals)
+	max_gram_eigen <- max(gram_eigvals)
 
-	if (min_gram_eigen < 10^(-16)) {
-		warning(
-			"Gram matrix corresponding to selected features is not invertible. Assumptions needed for inference are not satisfied. Standard errors will not be calculated."
-		)
+	gram_singular_msg <- "Gram matrix corresponding to selected features is not invertible. Assumptions needed for inference are not satisfied. Standard errors will not be calculated."
+
+	# Guard Gram inversion with an rcond-aware relative tolerance (#205):
+	# solve() aborts on reciprocal condition number, not absolute min
+	# eigenvalue, and the old absolute floor (1e-16) sat below
+	# .Machine$double.eps, letting near-singular Grams reach an unguarded
+	# solve(). The tryCatch below backstops any residual rcond case so the
+	# fit degrades to calc_ses = FALSE rather than aborting.
+	if (
+		min_gram_eigen < max(dim(gram)) * .Machine$double.eps * max_gram_eigen
+	) {
+		warning(gram_singular_msg)
 		return(list(gram_inv = NA, calc_ses = FALSE))
 	}
 
-	gram_inv <- solve(gram)
+	gram_inv <- tryCatch(solve(gram), error = function(e) NULL)
+	if (is.null(gram_inv)) {
+		warning(gram_singular_msg)
+		return(list(gram_inv = NA, calc_ses = FALSE))
+	}
 
 	if (any(!is.na(sel_feat_inds))) {
 		# Get only the parts of gram_inv that have to do with treatment effects

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.17.1",
+  note    = "R package version 1.17.2",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/tests/testthat/test-getgraminv-singular-205.R
+++ b/tests/testthat/test-getgraminv-singular-205.R
@@ -1,0 +1,72 @@
+# Regression tests for #205. getGramInv() must degrade gracefully -- emit the
+# "not invertible" warning and return list(gram_inv = NA, calc_ses = FALSE) --
+# rather than abort with an uncaught LAPACK "system is computationally singular"
+# error (or silently invert a garbage near-singular Gram), when the
+# selected-feature Gram is (near-)singular. Pre-fix it guarded on an absolute
+# 1e-16 floor (below .Machine$double.eps) and then called an UNGUARDED solve();
+# the fix uses an rcond-aware relative tolerance and wraps solve() in a tryCatch
+# routing to the same graceful fallback.
+
+# Build an N*T x p design whose column-centered Gram, (1/(NT)) X'X, has (to high
+# precision) the requested eigenvalues, by scaling an orthonormal, already-
+# centered basis. This lets us place the smallest Gram eigenvalue exactly in the
+# rcond regime that distinguishes the fixed guard from the old 1e-16 floor --
+# the off-diagonal coupling to the tiny eigendirection is ~1e-24, so the small
+# eigenvalue is well-resolved (not lost in floating-point noise).
+.make_X_for_eigvals <- function(N, T, eigvals) {
+	n <- N * T
+	p <- length(eigvals)
+	set.seed(205)
+	M <- scale(matrix(stats::rnorm(n * p), n, p), center = TRUE, scale = FALSE)
+	Q <- qr.Q(qr(M))[, seq_len(p), drop = FALSE] # orthonormal, centered basis
+	Q %*% diag(sqrt(n * eigvals), p, p)
+}
+
+test_that("getGramInv() does not abort on a near-singular Gram (#205)", {
+	N <- 60L
+	T <- 2L
+	# Smallest Gram eigenvalue ~1.5e-16: ABOVE the old absolute 1e-16 floor (so
+	# the old guard missed it), but rcond ~1.5e-16 is BELOW solve()'s tolerance
+	# (.Machine$double.eps ~2.2e-16), so the old unguarded solve() aborted with an
+	# uncaught LAPACK error. The fix's rcond-aware guard catches it first.
+	X_final <- .make_X_for_eigvals(N, T, c(1, 1, 1.5e-16))
+
+	# On the OLD code this call either threw (solve abort) or returned
+	# calc_ses = TRUE (silent garbage inverse) -- both fail the assertions below.
+	res <- expect_warning(
+		getGramInv(
+			N = N,
+			T = T,
+			X_final = X_final,
+			treat_inds = 1L,
+			num_treats = 1L,
+			calc_ses = TRUE
+		),
+		"not invertible"
+	)
+	expect_false(res$calc_ses)
+	expect_true(length(res$gram_inv) == 1L && is.na(res$gram_inv))
+})
+
+test_that("getGramInv() degrades gracefully on an exactly-singular Gram (#205)", {
+	N <- 20L
+	T <- 2L
+	set.seed(205)
+	z1 <- stats::rnorm(N * T)
+	z2 <- stats::rnorm(N * T)
+	X_final <- cbind(z1, z1, z2) # duplicated column -> exactly rank-deficient
+
+	res <- expect_warning(
+		getGramInv(
+			N = N,
+			T = T,
+			X_final = X_final,
+			treat_inds = 1L,
+			num_treats = 1L,
+			calc_ses = TRUE
+		),
+		"not invertible"
+	)
+	expect_false(res$calc_ses)
+	expect_true(length(res$gram_inv) == 1L && is.na(res$gram_inv))
+})


### PR DESCRIPTION
Fixes #205 (Real-but-latent, Tier 2; surfaced by the 2026-06-02 periodic review).

> **Stacked on #210.** This PR is based on the #204 branch (`fix-twfecovs-alpha-204`), so its diff shows only the #205 change — please **merge #210 first**. GitHub will auto-retarget this PR to `main` once #210 merges.

## The bug

`getGramInv()` gated Gram inversion on an **absolute** eigenvalue floor — `min_gram_eigen < 1e-16` (`R/core_funcs.R`) — which sits *below* `.Machine$double.eps` (2.22e-16), then called an **unguarded** `solve(gram)`. But `solve()` aborts on *reciprocal condition number*, not absolute min eigenvalue, so a near-collinear bridge-selected support could pass the guard (min eigenvalue ≥ 1e-16) yet make `solve()` throw an uncaught LAPACK `"system is computationally singular"` error — **aborting the fit** instead of the documented graceful `list(gram_inv = NA, calc_ses = FALSE)` fallback (the guard path's own behavior). Reproduced through real `fetwfe()` (q < 1); it's rcond-governed (~15% of real Grams hit the "guard passes but solve errors" window). The sibling `.compute_cluster_robust_sandwich()` was already hardened against this; `getGramInv()` was missed, leaving the two variance routes with an incoherent failure surface.

## The fix (two parts)

1. **rcond-aware relative tolerance** — replace the absolute `1e-16` floor with the standard rcond-style cutoff `max(dim(gram)) * .Machine$double.eps * max_gram_eigen`.
2. **wrap `solve()`** in a `tryCatch` that, on any residual LAPACK singularity, routes to `getGramInv()`'s *own* graceful return (warning + `calc_ses = FALSE`) — not the sibling's `stop()`, because `getGramInv` is contracted to degrade, not error. The four callers already handle that return (it's the existing guard-path contract).

The function is **not** relocated (its `core_funcs.R` → `variance_machinery.R` move rides #186, per the R4 note there).

## Regression test

`test-getgraminv-singular-205.R` constructs a Gram with a controlled smallest eigenvalue (~1.5e-16) — above the old `1e-16` floor (so the old guard misses it) but with rcond below `solve()`'s tolerance — plus an exactly-singular case. **Proven to discriminate:** on the pre-fix code the near-singular case aborts (`Error in solve.default(gram): system is computationally singular: reciprocal condition number = 1.5e-16`); on the fix it warns and returns `calc_ses = FALSE`.

## Verification

- Well-conditioned fits are unaffected (the relative threshold is far below normal Gram eigenvalues).
- Gate: `air` clean, `document()` produces no `man/`/`NAMESPACE` change (the function is `@noRd`), `devtools::test()` **FAIL 0 / WARN 0**, `R CMD check --as-cran` **0 errors / 0 warnings / 1 acceptable NOTE** (future-timestamp), spell + URL clean.

Version 1.17.1 → 1.17.2 (patch; bug fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
