### PR TITLE
fix: remove duplicate ci_type @return item + harden doc-slot-parity test (#206, 1.17.3)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.17.2
+Version: 1.17.3
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # NEWS
 
+## Version 1.17.3
+
+### Bug fixes
+
+- Fixed: removed a duplicated `ci_type` entry from the `fetwfe()` and
+  `fetwfeWithSimulatedData()` `@return` documentation, so the slot is listed
+  once (not twice) in `?fetwfe` / `?fetwfeWithSimulatedData`. The
+  `doc-slot-parity` test now also guards against duplicate top-level `@return`
+  items. (#206)
+
 ## Version 1.17.2
 
 ### Bug fixes

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -196,7 +196,6 @@
 #' \item{lambda_selection}{Character scalar; either `"cv"` (10-fold cross-validation on `cv.grpreg`; v1.13.0+ default) or `"bic"` (BIC over the `grpreg` lambda grid; the prior default). Mirrors the `lambda_selection` argument the user passed.}
 #' \item{cv_folds}{Integer scalar; the `cv_folds` value used when `lambda_selection = "cv"`, `NA_integer_` when `lambda_selection = "bic"`.}
 #' \item{cv_seed}{Integer scalar; the seed actually fed to `set.seed()` immediately before `cv.grpreg()` was called. Defaults to `as.integer(N * T)` when the user did not pass a seed. `NA_integer_` when `lambda_selection = "bic"`.}
-#' \item{ci_type}{Character scalar; the `ci_type` argument the user passed (`"simultaneous"` or `"pointwise"`), controlling whether the reported `catt_df` / `eventStudy()` confidence-interval bounds are simultaneous (family-wise) or pointwise.}
 #' \item{N}{The final number of units that were in the data set used for estimation (after any units may have been removed because they were treated in the first time period).}
 #' \item{T}{The number of time periods in the final data set.}
 #' \item{G}{The final number of treated cohorts that appear in the final data set.}
@@ -655,7 +654,6 @@ fetwfe <- function(
 #' \item{lambda_selection}{Character scalar; either `"cv"` (10-fold cross-validation on `cv.grpreg`; v1.13.0+ default) or `"bic"` (BIC over the `grpreg` lambda grid; the prior default). Mirrors the `lambda_selection` argument the user passed.}
 #' \item{cv_folds}{Integer scalar; the `cv_folds` value used when `lambda_selection = "cv"`, `NA_integer_` when `lambda_selection = "bic"`.}
 #' \item{cv_seed}{Integer scalar; the seed actually fed to `set.seed()` immediately before `cv.grpreg()` was called. Defaults to `as.integer(N * T)` when the user did not pass a seed. `NA_integer_` when `lambda_selection = "bic"`.}
-#' \item{ci_type}{Character scalar; the `ci_type` argument the user passed (`"simultaneous"` or `"pointwise"`), controlling whether the reported `catt_df` / `eventStudy()` confidence-interval bounds are simultaneous (family-wise) or pointwise.}
 #' \item{N}{The final number of units that were in the data set used for estimation (after any units may have been removed because they were treated in the first time period).}
 #' \item{T}{The number of time periods in the final data set.}
 #' \item{G}{The final number of treated cohorts that appear in the final data set.}

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.17.2",
+  note    = "R package version 1.17.3",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/man/fetwfe.Rd
+++ b/man/fetwfe.Rd
@@ -242,7 +242,6 @@ An object of class \code{fetwfe} containing the following elements:
 \item{lambda_selection}{Character scalar; either \code{"cv"} (10-fold cross-validation on \code{cv.grpreg}; v1.13.0+ default) or \code{"bic"} (BIC over the \code{grpreg} lambda grid; the prior default). Mirrors the \code{lambda_selection} argument the user passed.}
 \item{cv_folds}{Integer scalar; the \code{cv_folds} value used when \code{lambda_selection = "cv"}, \code{NA_integer_} when \code{lambda_selection = "bic"}.}
 \item{cv_seed}{Integer scalar; the seed actually fed to \code{set.seed()} immediately before \code{cv.grpreg()} was called. Defaults to \code{as.integer(N * T)} when the user did not pass a seed. \code{NA_integer_} when \code{lambda_selection = "bic"}.}
-\item{ci_type}{Character scalar; the \code{ci_type} argument the user passed (\code{"simultaneous"} or \code{"pointwise"}), controlling whether the reported \code{catt_df} / \code{eventStudy()} confidence-interval bounds are simultaneous (family-wise) or pointwise.}
 \item{N}{The final number of units that were in the data set used for estimation (after any units may have been removed because they were treated in the first time period).}
 \item{T}{The number of time periods in the final data set.}
 \item{G}{The final number of treated cohorts that appear in the final data set.}

--- a/man/fetwfeWithSimulatedData.Rd
+++ b/man/fetwfeWithSimulatedData.Rd
@@ -166,7 +166,6 @@ An object of class \code{fetwfe} containing the following elements:
 \item{lambda_selection}{Character scalar; either \code{"cv"} (10-fold cross-validation on \code{cv.grpreg}; v1.13.0+ default) or \code{"bic"} (BIC over the \code{grpreg} lambda grid; the prior default). Mirrors the \code{lambda_selection} argument the user passed.}
 \item{cv_folds}{Integer scalar; the \code{cv_folds} value used when \code{lambda_selection = "cv"}, \code{NA_integer_} when \code{lambda_selection = "bic"}.}
 \item{cv_seed}{Integer scalar; the seed actually fed to \code{set.seed()} immediately before \code{cv.grpreg()} was called. Defaults to \code{as.integer(N * T)} when the user did not pass a seed. \code{NA_integer_} when \code{lambda_selection = "bic"}.}
-\item{ci_type}{Character scalar; the \code{ci_type} argument the user passed (\code{"simultaneous"} or \code{"pointwise"}), controlling whether the reported \code{catt_df} / \code{eventStudy()} confidence-interval bounds are simultaneous (family-wise) or pointwise.}
 \item{N}{The final number of units that were in the data set used for estimation (after any units may have been removed because they were treated in the first time period).}
 \item{T}{The number of time periods in the final data set.}
 \item{G}{The final number of treated cohorts that appear in the final data set.}

--- a/tests/testthat/test-doc-slot-parity.R
+++ b/tests/testthat/test-doc-slot-parity.R
@@ -65,6 +65,35 @@
 	unique(trimws(unlist(strsplit(result, ","))))
 }
 
+# Direct \item children of the \value{} node -- top-level @return slots only,
+# NOT the nested $internal sub-slots. A slot documented twice at the top level
+# is a bug (the #206 ci_type duplicate); the intentional top-level/$internal
+# dual-documentation of X_ints / y / X_final / y_final / calc_ses (#154, #180)
+# is not, so this deliberately does not recurse the way .extract_value_items().
+.extract_top_level_value_items <- function(rd) {
+	value_idx <- which(sapply(
+		rd,
+		function(n) identical(attr(n, "Rd_tag"), "\\value")
+	))
+	if (length(value_idx) == 0L) {
+		return(character(0))
+	}
+	keys <- character(0)
+	for (child in rd[[value_idx[1L]]]) {
+		if (
+			is.list(child) &&
+				identical(attr(child, "Rd_tag"), "\\item") &&
+				length(child) >= 1L
+		) {
+			keys <- c(
+				keys,
+				paste(unlist(lapply(child[[1L]], as.character)), collapse = "")
+			)
+		}
+	}
+	trimws(unlist(strsplit(keys, ",")))
+}
+
 # ------------------------------------------------------------------------------
 # Test 1: @return slot parity for the 4 public estimators and their 3 wrappers.
 #
@@ -150,6 +179,42 @@ test_that("public estimator @return blocks match live names()", {
 				length(extra),
 				" slot(s) documented but not in live names(): ",
 				paste(extra, collapse = ", ")
+			)
+		)
+	}
+})
+
+# ------------------------------------------------------------------------------
+# Test 1b (#206): no @return \item is documented twice at the top level.
+#
+# .extract_value_items()'s unique() (and the setequal() comparisons above) is
+# duplicate-insensitive, so a doubled top-level \item{} collapsed to one entry
+# and shipped to the rendered manual undetected (the ci_type duplicate in
+# ?fetwfe / ?fetwfeWithSimulatedData that #206 fixed). Check only the top-level
+# slots, excluding the intentional $internal dual-doc (#154, #180).
+# ------------------------------------------------------------------------------
+
+test_that("public estimator @return blocks contain no duplicate \\item names (#206)", {
+	db <- .get_rd_db()
+	rd_keys <- c(
+		"fetwfe.Rd",
+		"fetwfeWithSimulatedData.Rd",
+		"etwfe.Rd",
+		"etwfeWithSimulatedData.Rd",
+		"betwfe.Rd",
+		"betwfeWithSimulatedData.Rd",
+		"twfeCovs.Rd",
+		"twfeCovsWithSimulatedData.Rd"
+	)
+	for (rd_key in rd_keys) {
+		raw <- .extract_top_level_value_items(db[[rd_key]])
+		dups <- unique(raw[duplicated(raw)])
+		expect_true(
+			length(dups) == 0L,
+			info = paste0(
+				rd_key,
+				" documents these @return \\item(s) more than once: ",
+				paste(dups, collapse = ", ")
 			)
 		)
 	}


### PR DESCRIPTION
Fixes #206 (Real-but-latent doc render; surfaced by the 2026-06-02 periodic review).

> **Stacked on #211** (base `fix-getgraminv-205`), which is stacked on #210. Merge order: #210 → #211 → #206; each auto-retargets to `main` as the one below it merges.

## The bug

The `ci_type` `@return` slot was documented **twice** in two roxygen blocks of `R/fetwfe.R` — the `fetwfe()` block and the `fetwfeWithSimulatedData()` block — so `?fetwfe` and `?fetwfeWithSimulatedData` listed `ci_type` twice in their Value sections. The other three estimators document it once. Pure render defect; no code or return value affected.

The `doc-slot-parity` test missed it because `.extract_value_items()` calls `unique()` before comparing, collapsing the duplicate.

## The fix

- **Remove the duplicates:** each block had `ci_type` once right after `cv_seed` (the misplaced copy) and once after `se_type` (grouped with the other user-passed scalars). Deleted the `cv_seed`-adjacent copy in both blocks (one `replace_all` — the `cv_seed → ci_type → N` triple is byte-identical and unique to the two fetwfe blocks). `man/fetwfe.Rd` and `man/fetwfeWithSimulatedData.Rd` now have exactly 2 `\item{ci_type}` each (1 `@param` + 1 `@return`), matching the siblings.
- **Harden the test (WT1):** added a check that no `@return` slot is documented twice **at the top level**, via a new `.extract_top_level_value_items()` that — unlike `.extract_value_items()` — does *not* recurse into the `$internal` sublist. This is the key subtlety: `X_ints`/`y`/`X_final`/`y_final`/`calc_ses` are *intentionally* documented twice (once top-level, once under `$internal` — the #154/#180 dual-doc), so a naive flat duplicate check false-fires on them. The top-level check flags only true same-level duplicates like `ci_type`.

## Verification

- **The new test is proven to discriminate:** against the pre-fix man pages it fails naming exactly `ci_type` in the two fetwfe pages (and nothing else — no false positives on the `$internal` dual-doc); after the fix + `document()` it passes.
- **Gate:** `air`; `document()` idempotent (only the 2 fetwfe man pages change, −1 `\item` each); `devtools::test()` **FAIL 0 / WARN 0**; `R CMD check --as-cran` **0 errors / 0 warnings / 1 acceptable NOTE** (future-timestamp); spell + URL clean.

Version 1.17.2 → 1.17.3 (patch; doc bug fix + test hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
