### PR TITLE
refactor: drop two vestigial variance-fn params getTeResultsOLS(first_inds)/getTeResults2(tes) (#207)

### DIFF
--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -1350,7 +1350,6 @@ betwfe_core <- function(
 		gram_inv = gram_inv,
 		tes = tes[sel_treat_inds_shifted], # Untransformed treatment effect estimates beta_hat[treat_inds]
 		cohort_probs_overall = cohort_probs_overall, # In-sample pi_r (unconditional on treated)
-		first_inds = first_inds,
 		calc_ses = calc_ses,
 		indep_probs = FALSE,
 		se_type = se_type,
@@ -1383,7 +1382,6 @@ betwfe_core <- function(
 			gram_inv = gram_inv,
 			tes = tes[sel_treat_inds_shifted],
 			cohort_probs_overall = indep_cohort_probs_overall, # indep pi_r (unconditional)
-			first_inds = first_inds,
 			calc_ses = calc_ses,
 			indep_probs = TRUE,
 			se_type = se_type,

--- a/R/etwfe_core.R
+++ b/R/etwfe_core.R
@@ -365,7 +365,6 @@ etwfe_core <- function(
 		gram_inv = gram_inv,
 		tes = tes, # Untransformed treatment effect estimates beta_hat[treat_inds]
 		cohort_probs_overall = cohort_probs_overall, # In-sample pi_r (unconditional on treated)
-		first_inds = first_inds,
 		calc_ses = calc_ses,
 		indep_probs = FALSE,
 		se_type = se_type,
@@ -392,7 +391,6 @@ etwfe_core <- function(
 			gram_inv = gram_inv,
 			tes = tes,
 			cohort_probs_overall = indep_cohort_probs_overall, # indep pi_r (unconditional)
-			first_inds = first_inds,
 			calc_ses = calc_ses,
 			indep_probs = TRUE,
 			se_type = se_type,

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -1102,7 +1102,6 @@ fetwfe_core <- function(
 		psi_mat = psi_mat,
 		gram_inv = gram_inv,
 		sel_treat_inds_shifted = sel_treat_inds_shifted,
-		tes = tes, # Untransformed treatment effect estimates beta_hat[treat_inds]
 		d_inv_treat_sel = d_inv_treat_sel,
 		cohort_probs_overall = cohort_probs_overall, # In-sample pi_r (unconditional on treated)
 		first_inds = first_inds,
@@ -1136,7 +1135,6 @@ fetwfe_core <- function(
 			psi_mat = psi_mat,
 			gram_inv = gram_inv,
 			sel_treat_inds_shifted = sel_treat_inds_shifted,
-			tes = tes,
 			d_inv_treat_sel = d_inv_treat_sel,
 			cohort_probs_overall = indep_cohort_probs_overall, # indep pi_r (unconditional)
 			first_inds = first_inds,

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -959,7 +959,6 @@ twfeCovs_core <- function(
 		gram_inv = gram_inv,
 		tes = tes, # Untransformed treatment effect estimates beta_hat[treat_inds]
 		cohort_probs_overall = cohort_probs_overall, # In-sample pi_r (unconditional on treated)
-		first_inds = first_inds,
 		calc_ses = calc_ses,
 		indep_probs = FALSE,
 		se_type = se_type,
@@ -986,7 +985,6 @@ twfeCovs_core <- function(
 			gram_inv = gram_inv,
 			tes = tes,
 			cohort_probs_overall = indep_cohort_probs_overall, # indep pi_r (unconditional)
-			first_inds = first_inds,
 			calc_ses = calc_ses,
 			indep_probs = TRUE,
 			se_type = se_type,

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -23,8 +23,6 @@
 #'   (original parameterization).
 #' @param cohort_probs_overall Numeric vector; estimated marginal probabilities
 #'   of belonging to each treated cohort P(W=r). Length `R`.
-#' @param first_inds Integer vector; indices of the first treatment effect for
-#'   each cohort.
 #' @param calc_ses Logical; if `TRUE`, calculate standard errors.
 #' @param indep_probs Logical; if `TRUE`, assumes `cohort_probs` (and
 #'   `cohort_probs_overall`) were estimated from an independent sample, leading
@@ -102,7 +100,6 @@ getTeResultsOLS <- function(
 	gram_inv,
 	tes,
 	cohort_probs_overall,
-	first_inds,
 	calc_ses,
 	indep_probs = FALSE,
 	se_type = "default",
@@ -536,8 +533,6 @@ getPsiRUnfused <- function(
 #'   treatment effect features.
 #' @param sel_treat_inds_shifted Integer vector; indices of selected treatment
 #'   effects within the `num_treats` block (shifted to start from 1).
-#' @param tes Numeric vector; all `num_treats` estimated treatment effects
-#'   (original parameterization).
 #' @param d_inv_treat_sel Numeric matrix; block of the inverse fusion matrix for
 #'   selected treatment effects.
 #' @param cohort_probs_overall Numeric vector; estimated marginal probabilities
@@ -628,7 +623,6 @@ getTeResults2 <- function(
 	psi_mat,
 	gram_inv,
 	sel_treat_inds_shifted,
-	tes,
 	d_inv_treat_sel,
 	cohort_probs_overall,
 	first_inds,


### PR DESCRIPTION
Resolves #207 (Tier 3 cleanup; surfaced by the 2026-06-02 periodic review).

> **Stacked on #212** (base `fix-ci-type-doc-dup-206`). Merge order: #210 → #211 → #212 → #207; each auto-retargets to `main` as the one below it merges.

## What

`getTeResultsOLS()` declared a `first_inds` parameter and `getTeResults2()` declared a `tes` parameter that are **never referenced in their bodies** — a maintenance hazard: a future edit that started reading the unused arg would silently consume a wrong-length vector (the full-length form, while the function's matrices are sized to the selected support).

Removed both formals + their matching call-site arguments — 6 `getTeResultsOLS()` calls (`etwfe_core.R`, `betwfe_core.R`, `twfeCovs.R`) and 2 `getTeResults2()` calls (`fetwfe_core.R`) — plus the two `@param` roxygen lines.

## Surgical (the arg names are decoys)

`first_inds = first_inds` appears 40+ times and `tes = tes` 15+ times across the package, so the removal was kept precise. **Kept everything that is actually used:**
- `getTeResults2()`'s `first_inds` (forwarded to `getSecondVarTermDataApp`).
- `getTeResultsOLS()`'s `tes` (used via `length(tes)`, forwarded to `getSecondVarTermOLS`).
- The `getCohortATTsFinal()` `tes = tes` decoy in `fetwfe_core.R`.
- The `R`/`num_treats` `stopifnot`-guard formals.
- Every other `first_inds`/`tes` argument to other functions.

An independent review did an exhaustive full-diff deletion scan and confirmed zero decoy removals.

## Behavior unchanged (the params were unused)

- `devtools::test()` **FAIL 0 | WARN 0 | PASS 2846** — byte-identical to the pre-refactor baseline.
- `R CMD check --as-cran` **0/0/0** (a clean check proves no `object 'first_inds'/'tes' not found`).
- Both estimator paths fit with finite SEs — the OLS path (`etwfe` → `getTeResultsOLS`) and the bridge path (`fetwfe` q<1 → `getTeResults2`).
- Both functions are `@noRd`, so no `man/`/`NAMESPACE` change.

## No version bump

**Purely internal — no version bump or NEWS entry** (per `DEV_INSTRUCTIONS.md`: a refactor with no user-visible change skips both), consistent with how the #188 file-move was handled. The branch stays at #212's 1.17.3. Flagging for confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
