### PR TITLE
docs: #197/#192 doc-staleness + message sweep (#208, 1.17.4)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.17.3
+Version: 1.17.4
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # NEWS
 
+## Version 1.17.4
+
+### Documentation and messages
+
+- Doc/message sweep (#208): corrected stale documentation introduced by the
+  #192/#197 simultaneous-CI changes -- `cohortStudy()`'s `ci_low`/`ci_high` are
+  now described by the fit's `ci_type` (simultaneous by default) rather than as
+  a "Wald CI"; `simultaneousCIs()`'s `se_type` references and the `custom`-family
+  variance caveat were clarified (the `Sigma_2 = 0` simplification is
+  anti-conservative for a contrast that pools across cohorts in a
+  probability-weighted way); and notes were added on `genCoefs()`'s `G = NULL`
+  default and `simulateData()`'s deterministic re-seeding. In addition,
+  `check_etwfe_core_inputs()` now emits the same friendly single-cohort error
+  message as `prep_for_etwfe_core()` instead of a bare `stopifnot` failure.
+
 ## Version 1.17.3
 
 ### Bug fixes

--- a/R/cohort_study.R
+++ b/R/cohort_study.R
@@ -34,9 +34,11 @@
 #'     \item{se}{Numeric; standard error for the per-cohort ATT (`NA` when
 #'       the Gram matrix is singular or, for `fetwfe()` / `betwfe()`, the
 #'       bridge penalty zeroed out the cohort).}
-#'     \item{ci_low, ci_high}{Numeric; lower and upper bounds of the
-#'       `1 - alpha` Wald CI (where `alpha` is the value passed at fit
-#'       time).}
+#'     \item{ci_low, ci_high}{Numeric; the stored lower and upper
+#'       confidence-interval bounds, reflecting the fit's `ci_type` --
+#'       simultaneous (family-wise) by default, or pointwise `1 - alpha`
+#'       Wald bounds when the fit used `ci_type = "pointwise"` (`alpha` is
+#'       the value passed at fit time).}
 #'     \item{p_value}{Numeric; two-sided Wald p-value
 #'       (`2 * pnorm(-|estimate / se|)`), `NA` when `se` is `0` or `NA`.}
 #'     \item{selected}{(`fetwfe()` / `betwfe()` only.) Logical; `TRUE` when

--- a/R/core_funcs.R
+++ b/R/core_funcs.R
@@ -1040,7 +1040,14 @@ check_etwfe_core_inputs <- function(
 		)
 	}
 
-	stopifnot(R >= 2)
+	# Mirror prep_for_etwfe_core()'s friendly message (#208) so that whichever
+	# validator fires first, the user sees the same actionable text rather than
+	# an opaque `stopifnot` failure.
+	if (R < 2) {
+		stop(
+			"Only one treated cohort detected in data. Currently fetwfe and etwfe only support data sets with at least two treated cohorts."
+		)
+	}
 	stopifnot(R <= T - 1)
 
 	indep_count_data_available <- FALSE

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -20,7 +20,8 @@
 #' for worked examples.
 #'
 #' @param G Integer. The number of treated cohorts (treatment is assumed to start in periods 2 to
-#'   \code{G + 1}).
+#'   \code{G + 1}). Defaults to \code{NULL}; supply either \code{G} or the
+#'   deprecated alias \code{R} (described below).
 #' @param T Integer. The total number of time periods.
 #' @param d Integer. The number of time-invariant covariates. If \code{d > 0}, additional terms
 #'   corresponding to covariate main effects and interactions are included in \code{beta}.

--- a/R/gen_data.R
+++ b/R/gen_data.R
@@ -67,6 +67,13 @@
 #' It validates that all necessary components are returned and assigns the S3 class
 #' \code{"FETWFE_simulated"} to the output.
 #'
+#' The simulated panel is fully determined by \code{coefs_obj$seed} (the seed
+#' passed to \code{genCoefs()}): \code{simulateData()} re-seeds from it on every
+#' call, so re-calling \code{simulateData()} on the same \code{coefs_obj}
+#' returns the identical panel. To vary the panel across Monte Carlo
+#' replications, vary the \code{seed} passed to \code{genCoefs()} (re-calling
+#' \code{simulateData()} alone does not).
+#'
 #' The argument \code{distribution} controls the generation of covariates. For
 #' \code{"gaussian"}, covariates are drawn from \code{rnorm}; for \code{"uniform"},
 #' they are drawn from \code{runif} on the interval \eqn{[-\sqrt{3}, \sqrt{3}]} (which ensures that

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -58,15 +58,20 @@ utils::globalVariables(c(
 #' @param alpha Numeric in `(0, 1)`; significance level. Default `0.05`.
 #' @param contrasts For `family = "custom"`, a `K x num_treats` matrix whose
 #'   rows give the `K` linear combinations of the underlying per-`(g, t)`
-#'   treatment-effect vector (the `multcomp::glht()` convention). Ignored for
-#'   the other families.
+#'   treatment-effect vector (the `multcomp::glht()` convention; `num_treats`
+#'   is the number of estimated effects, equal to `R` for `twfeCovs`). Ignored
+#'   for the other families. Note that the `"custom"` family omits the
+#'   cohort-probability variance term (`Sigma_2 = 0`), so a custom contrast
+#'   that pools across cohorts in a probability-weighted way is
+#'   anti-conservative (its band can under-cover); use `family = "cohort"` for
+#'   cohort-pooled effects.
 #' @return An object of S3 class `"simultaneous_cis"`: a list with
 #'   \describe{
 #'     \item{ci}{A data frame with columns `effect`, `estimate`,
 #'       `simultaneous_ci_low`, `simultaneous_ci_high`, `pointwise_ci_low`,
 #'       `pointwise_ci_high` (one row per effect in the family).}
 #'     \item{critical_value}{The simultaneous critical value `c_{1 - alpha}`
-#'       (or, under `se_type = "conservative"`, the Bonferroni critical value
+#'       (or, when the fit used `se_type = "conservative"`, the Bonferroni critical value
 #'       `qnorm(1 - alpha/(2K))` -- see Details).}
 #'     \item{pointwise_critical_value}{`qnorm(1 - alpha/2)`, for reference.}
 #'     \item{bonferroni_critical_value}{`qnorm(1 - alpha/(2K))`, for reference.}
@@ -98,7 +103,7 @@ utils::globalVariables(c(
 #' cohort-sample-proportions estimator satisfies; the fixed-dim framing follows
 #' the paper's AE point 1(d).
 #'
-#' **Conservative fallback.** Under `se_type = "conservative"` the function
+#' **Conservative fallback.** When the fit was made with `se_type = "conservative"`, the function
 #' falls back to Bonferroni-corrected pointwise CIs (the Cauchy-Schwarz upper
 #' bound used for the conservative scalar SE does not generalize to a `K x K`
 #' covariance matrix) and emits a brief `message()`. The `$critical_value`
@@ -823,8 +828,11 @@ simultaneousCIs.twfeCovs <- function(
 #'   `family = "event_study"` produces non-zero Jacobians; the cohort and
 #'   all-post-treatment families have no cohort-probability weighting in a
 #'   single effect, so their Jacobians (and hence `Sigma_2`) are zero. For
-#'   `family = "custom"`, `Sigma_2` is conservatively set to zero (the user's
-#'   contrasts operate directly on the fixed per-cell effects).
+#'   `family = "custom"`, `Sigma_2` is set to zero on the assumption that the
+#'   user's contrasts operate directly on the fixed per-cell effects; note this
+#'   is anti-conservative (not conservative) for a contrast that pools across
+#'   cohorts in a probability-weighted way, which does carry cohort-probability
+#'   variance.
 #' @param family,K,R,T,num_treats,cohort_offsets_int,first_inds,cohort_probs_overall,d_inv_treat_sel
 #'   See `.simultaneous_cis_impl()`.
 #' @return A length-K list of numeric matrices (each `R x ncol(d_inv_treat_sel)`).

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.17.3",
+  note    = "R package version 1.17.4",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/man/cohortStudy.Rd
+++ b/man/cohortStudy.Rd
@@ -21,9 +21,11 @@ the cohort first received treatment).}
 \item{se}{Numeric; standard error for the per-cohort ATT (\code{NA} when
 the Gram matrix is singular or, for \code{fetwfe()} / \code{betwfe()}, the
 bridge penalty zeroed out the cohort).}
-\item{ci_low, ci_high}{Numeric; lower and upper bounds of the
-\code{1 - alpha} Wald CI (where \code{alpha} is the value passed at fit
-time).}
+\item{ci_low, ci_high}{Numeric; the stored lower and upper
+confidence-interval bounds, reflecting the fit's \code{ci_type} --
+simultaneous (family-wise) by default, or pointwise \code{1 - alpha}
+Wald bounds when the fit used \code{ci_type = "pointwise"} (\code{alpha} is
+the value passed at fit time).}
 \item{p_value}{Numeric; two-sided Wald p-value
 (\verb{2 * pnorm(-|estimate / se|)}), \code{NA} when \code{se} is \code{0} or \code{NA}.}
 \item{selected}{(\code{fetwfe()} / \code{betwfe()} only.) Logical; \code{TRUE} when

--- a/man/genCoefs.Rd
+++ b/man/genCoefs.Rd
@@ -21,7 +21,8 @@ genCoefs(
 }
 \arguments{
 \item{G}{Integer. The number of treated cohorts (treatment is assumed to start in periods 2 to
-\code{G + 1}).}
+\code{G + 1}). Defaults to \code{NULL}; supply either \code{G} or the
+deprecated alias \code{R} (described below).}
 
 \item{T}{Integer. The total number of time periods.}
 

--- a/man/simulateData.Rd
+++ b/man/simulateData.Rd
@@ -84,6 +84,13 @@ along with additional simulation parameters, to the internal function \code{simu
 It validates that all necessary components are returned and assigns the S3 class
 \code{"FETWFE_simulated"} to the output.
 
+The simulated panel is fully determined by \code{coefs_obj$seed} (the seed
+passed to \code{genCoefs()}): \code{simulateData()} re-seeds from it on every
+call, so re-calling \code{simulateData()} on the same \code{coefs_obj}
+returns the identical panel. To vary the panel across Monte Carlo
+replications, vary the \code{seed} passed to \code{genCoefs()} (re-calling
+\code{simulateData()} alone does not).
+
 The argument \code{distribution} controls the generation of covariates. For
 \code{"gaussian"}, covariates are drawn from \code{rnorm}; for \code{"uniform"},
 they are drawn from \code{runif} on the interval \eqn{[-\sqrt{3}, \sqrt{3}]} (which ensures that

--- a/man/simultaneousCIs.Rd
+++ b/man/simultaneousCIs.Rd
@@ -24,8 +24,13 @@ resolution.}
 
 \item{contrasts}{For \code{family = "custom"}, a \verb{K x num_treats} matrix whose
 rows give the \code{K} linear combinations of the underlying per-\verb{(g, t)}
-treatment-effect vector (the \code{multcomp::glht()} convention). Ignored for
-the other families.}
+treatment-effect vector (the \code{multcomp::glht()} convention; \code{num_treats}
+is the number of estimated effects, equal to \code{R} for \code{twfeCovs}). Ignored
+for the other families. Note that the \code{"custom"} family omits the
+cohort-probability variance term (\code{Sigma_2 = 0}), so a custom contrast
+that pools across cohorts in a probability-weighted way is
+anti-conservative (its band can under-cover); use \code{family = "cohort"} for
+cohort-pooled effects.}
 }
 \value{
 An object of S3 class \code{"simultaneous_cis"}: a list with
@@ -34,7 +39,7 @@ An object of S3 class \code{"simultaneous_cis"}: a list with
 \code{simultaneous_ci_low}, \code{simultaneous_ci_high}, \code{pointwise_ci_low},
 \code{pointwise_ci_high} (one row per effect in the family).}
 \item{critical_value}{The simultaneous critical value \verb{c_\{1 - alpha\}}
-(or, under \code{se_type = "conservative"}, the Bonferroni critical value
+(or, when the fit used \code{se_type = "conservative"}, the Bonferroni critical value
 \verb{qnorm(1 - alpha/(2K))} -- see Details).}
 \item{pointwise_critical_value}{\code{qnorm(1 - alpha/2)}, for reference.}
 \item{bonferroni_critical_value}{\verb{qnorm(1 - alpha/(2K))}, for reference.}
@@ -86,7 +91,7 @@ paper line 1268) is the influence-function condition the package's default
 cohort-sample-proportions estimator satisfies; the fixed-dim framing follows
 the paper's AE point 1(d).
 
-\strong{Conservative fallback.} Under \code{se_type = "conservative"} the function
+\strong{Conservative fallback.} When the fit was made with \code{se_type = "conservative"}, the function
 falls back to Bonferroni-corrected pointwise CIs (the Cauchy-Schwarz upper
 bound used for the conservative scalar SE does not generalize to a \verb{K x K}
 covariance matrix) and emits a brief \code{message()}. The \verb{$critical_value}


### PR DESCRIPTION
Resolves #208 (doc/message sweep; surfaced by the 2026-06-02 periodic review). Fresh PR off `main` — the #204–#207 stack has all merged.

A batch of small, independent doc/message fixes — mostly staleness introduced by the #192/#197 simultaneous-CI changes. No estimate or behavior change; each claim was verified against current source.

## Documentation fixes

- **DG1 — `cohortStudy()` `@return`:** `ci_low`/`ci_high` were described as the "`1 - alpha` Wald CI", but they're the simultaneous band by default now. Reworded to reflect the fit's `ci_type` (mirroring `tidy.cohortStudy()`). The `p_value` item is unchanged — it's still pointwise.
- **DG2 — `simultaneousCIs()`:** `se_type` read as if it were a `simultaneousCIs()` argument; it's `x$se_type`. Reworded to "when the fit was made with `se_type = ...`".
- **DG3 — `simultaneousCIs()` `@param contrasts`:** added that `num_treats` is the number of estimated effects (`= R` for `twfeCovs`, so a custom contrast is `K x R` there).
- **DG7 — `simultaneousCIs()` `custom`-family variance:** the `Sigma_2 = 0` simplification was documented as "conservative" — it's actually **anti-conservative** (the band can under-cover) for a contrast that pools across cohorts in a probability-weighted way. Corrected the direction in both the user-facing `@param` note and the internal `.build_j_list_for_family` description, and pointed users to `family = "cohort"` for cohort-pooled effects.
- **DG4 — `genCoefs()` `@param G`:** noted the `G = NULL` default and the `G` / deprecated-`R` relationship (it read as mandatory).
- **DG8 — `simulateData()` `@details`:** added a re-seed note — the panel is fully determined by `coefs_obj$seed`, so re-calling `simulateData()` returns the identical panel; to vary across Monte Carlo reps, vary the `seed` passed to `genCoefs()`.

## Message fix

- **API1 — `check_etwfe_core_inputs()`:** its bare `stopifnot(R >= 2)` now emits the same friendly "Only one treated cohort detected..." message as `prep_for_etwfe_core()`, so whichever validator fires first gives consistent, actionable text.

## Out of scope (per the issue)

DG5 (legacy `R`-named messages) rides #201; DG6 (harmless non-ASCII glyphs); the optional S1 note is skipped as niche. Also: `genCoefsCore()` has the identical `G = NULL` doc gap as DG4's `genCoefs()` fix — left for a future symmetry pass (DG4 scoped `genCoefs()`).

## Verification

- The `@return`/`@param` rewords add/remove **no slots**, so `test-doc-slot-parity.R` is unaffected.
- Gate: `air`; `document()` regenerates the four reworded man pages (description text only); `devtools::test()` **FAIL 0 / WARN 0**; `R CMD check --as-cran` clean; spell + URL clean.

Version 1.17.3 → 1.17.4 (patch; user-visible doc/message changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
