### PR TITLE
refactor: consolidate the SE-combination tail into .combine_att_variance() (#209)

### DIFF
--- a/R/event_study.R
+++ b/R/event_study.R
@@ -345,11 +345,12 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 		# under (Psi-IF) (Theorem (c$'$), paper line 1233 onwards); the
 		# Cauchy-Schwarz upper bound is opt-in via `se_type = "conservative"`
 		# for the rare non-(Psi-IF) propensity-score-estimator case.
-		if (is_indep || !identical(se_type, "conservative")) {
-			ses[k] <- sqrt(var_1_e + var_2_e)
-		} else {
-			ses[k] <- sqrt(var_1_e + var_2_e + 2 * sqrt(var_1_e * var_2_e))
-		}
+		ses[k] <- sqrt(.combine_att_variance(
+			var_1_e,
+			var_2_e,
+			is_indep,
+			se_type
+		))
 	}
 
 	# Simultaneous band (#197): when ci_type == "simultaneous" and SEs are
@@ -566,11 +567,12 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 		# `.event_study_etwfe_betwfe` above): tight Gaussian by default
 		# under (Psi-IF), conservative bound only via `se_type =
 		# "conservative"`.
-		if (is_indep || !identical(se_type, "conservative")) {
-			ses[k] <- sqrt(var_1_e + var_2_e)
-		} else {
-			ses[k] <- sqrt(var_1_e + var_2_e + 2 * sqrt(var_1_e * var_2_e))
-		}
+		ses[k] <- sqrt(.combine_att_variance(
+			var_1_e,
+			var_2_e,
+			is_indep,
+			se_type
+		))
 	}
 
 	# Simultaneous band (#197): see the matching block in

--- a/R/utility.R
+++ b/R/utility.R
@@ -1758,13 +1758,12 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 	# Which combination is the headline `att_se`? `att_se = sqrt(<this> / N) * N`
 	# below, i.e., `tilde_v_N = N * <this>`. Per paper line 1259, the Wald CI
 	# half-width is `qnorm * sqrt(tilde_v_N / N)`, matching `att_se` exactly.
-	att_var_headline <- if (
-		indep_counts_used || !identical(se_type, "conservative")
-	) {
-		att_var_tight
-	} else {
-		att_var_cons
-	}
+	att_var_headline <- .combine_att_variance(
+		att_var_1,
+		att_var_2,
+		indep_counts_used,
+		se_type
+	)
 
 	V_1 <- N * att_var_1
 	V_2 <- N * att_var_2

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -1,3 +1,31 @@
+# .combine_att_variance
+#' @title Combine the two ATT variance pieces into the headline variance
+#' @description Returns the tight Gaussian sum `att_var_1 + att_var_2`
+#'   (independent-sample case, or same-data (Psi-IF) case under
+#'   `se_type != "conservative"`) or the Cauchy-Schwarz upper bound
+#'   `att_var_1 + att_var_2 + 2 * sqrt(att_var_1 * att_var_2)` (same-data
+#'   non-(Psi-IF) case via `se_type = "conservative"`). Returns a VARIANCE;
+#'   callers apply `sqrt()` for a standard error. Theorem (c') / (c),
+#'   Assumption (Psi-IF); see `paper_arxiv.tex` ~ line 1233 and ~ line 2013.
+#'   Consolidates five copies of this selection (#209): `getTeResultsOLS()`,
+#'   `getTeResults2()`, `.build_variance_components()`, and the two
+#'   `.event_study_*` helpers.
+#' @param att_var_1,att_var_2 Numeric; the regression-coefficient and
+#'   cohort-probability variance pieces (applied elementwise).
+#' @param indep Logical; `TRUE` in the independent-sample case (each caller's
+#'   local flag: `indep_probs` / `indep_counts_used` / `is_indep`).
+#' @param se_type Character; the fit's `se_type`.
+#' @return Numeric; the combined variance. Apply `sqrt()` for a standard error.
+#' @keywords internal
+#' @noRd
+.combine_att_variance <- function(att_var_1, att_var_2, indep, se_type) {
+	if (indep || !identical(se_type, "conservative")) {
+		att_var_1 + att_var_2
+	} else {
+		att_var_1 + att_var_2 + 2 * sqrt(att_var_1 * att_var_2)
+	}
+}
+
 # getTeResultsOLS
 #' @title Calculate Overall ATT and its Standard Error for ETWFE
 #' @description Computes the overall Average Treatment Effect on the Treated
@@ -173,18 +201,9 @@ getTeResultsOLS <- function(
 		# non-(Psi-IF) case via `se_type = "conservative"`. See
 		# Theorem `te.asym.norm.thm`(c$'$) and Assumption (Psi-IF)
 		# (`paper_arxiv.tex` ~ line 1233 and ~ line 2013).
-		if (indep_probs || !identical(se_type, "conservative")) {
-			att_te_se <- sqrt(att_var_1 + att_var_2)
-		} else {
-			att_te_se <- sqrt(
-				att_var_1 +
-					att_var_2 +
-					2 *
-						sqrt(
-							att_var_1 * att_var_2
-						)
-			)
-		}
+		att_te_se <- sqrt(
+			.combine_att_variance(att_var_1, att_var_2, indep_probs, se_type)
+		)
 
 		att_te_se_no_prob <- sqrt(att_var_1)
 	} else {
@@ -714,18 +733,9 @@ getTeResults2 <- function(
 		# (`paper_arxiv.tex` ~ line 1233 and ~ line 2013). Prior to v1.12.0
 		# the same-data path defaulted to the Cauchy-Schwarz bound regardless
 		# of (Psi-IF); v1.12.0 inverted that default.
-		if (indep_probs || !identical(se_type, "conservative")) {
-			att_te_se <- sqrt(att_var_1 + att_var_2)
-		} else {
-			att_te_se <- sqrt(
-				att_var_1 +
-					att_var_2 +
-					2 *
-						sqrt(
-							att_var_1 * att_var_2
-						)
-			)
-		}
+		att_te_se <- sqrt(
+			.combine_att_variance(att_var_1, att_var_2, indep_probs, se_type)
+		)
 
 		att_te_se_no_prob <- sqrt(att_var_1)
 	} else {


### PR DESCRIPTION
Resolves #209 (the SE-combination consolidation RFC). Implemented after the RFC verification — see the RFC comment on the issue.

## What

The tight-vs-conservative ATT-variance selection (`if (indep || se_type != "conservative") v1 + v2 else v1 + v2 + 2*sqrt(v1*v2)`) was inlined at **five** sites. Extracted into a single `@noRd` helper `.combine_att_variance(att_var_1, att_var_2, indep, se_type)` in `R/variance_machinery.R`, returning the combined **variance** (the four SE sites wrap it in `sqrt()`; `.build_variance_components` uses it directly). Removes the five-way drift risk — a future change to the Cauchy-Schwarz formula now needs one edit, not five.

| Site | File |
|---|---|
| `getTeResultsOLS` | `variance_machinery.R` |
| `getTeResults2` | `variance_machinery.R` |
| `.build_variance_components` | `utility.R` |
| `.event_study_etwfe_betwfe` | `event_study.R` |
| `.event_study_fetwfe` | `event_study.R` |

## What was excluded (the RFC's load-bearing finding)

`simultaneous_cis.R:499` was **not** touched — it shares only the guard, but operates on K×K covariance **matrices** with a **Bonferroni** fallback (the scalar Cauchy-Schwarz bound doesn't generalize to a matrix). Folding it in would be fake-DRY. Likewise, `.build_variance_components`'s `att_var_tight`/`att_var_cons` locals are kept — they also feed the returned `tilde_v_N_*` list, so only the *selection* consolidated.

## Byte-identical — verified three independent ways

The helper inlines the identical arithmetic (same operand order/grouping), so every site's output is unchanged:
- `devtools::test()` **FAIL 0 | WARN 0 | PASS 2846** — the pre-refactor baseline; the exact-value SE suites (`test-tight-gaussian-variance-141-146.R`, `test-fetwfe-var2-fix.R`) stay green.
- A **2544-case `identical()` equivalence sweep** (helper vs both inline forms across `se_type` × `indep` × edge magnitudes including `v2=0`, `1e-30`, `9e7`) — zero mismatches, ruling out any FP reassociation from `air`'s reflow.
- `R CMD check --as-cran` **0/0/0**; `document()` empty `man/`/`NAMESPACE` diff (all `@noRd`).

## No version bump

Pure internal refactor, no behavior change → **no version bump or NEWS** (per `DEV_INSTRUCTIONS.md`, consistent with #188 / #207). Sibling of #195. Surfaced by the 2026-06-02 periodic review (R1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
