### PR TITLE
perf: vectorize getBetaBIC BIC-path selection (#168, #169)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.17.4
+Version: 1.17.5
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # NEWS
 
+## Version 1.17.5
+
+### Performance
+
+- Vectorized `getBetaBIC()`'s BIC-path coefficient selection (#168, #169):
+  the per-`lambda` loop's separate matrix-vector products are now a single
+  BLAS-3 matrix multiply, and the redundant per-`lambda` `O(N*T)` scan for
+  non-finite fitted values in `sse_bridge()` was dropped, giving roughly a
+  1.4x speedup of the selection step when `lambda_selection = "bic"`. The
+  selected coefficients and all downstream estimates are byte-identical to
+  the previous implementation.
+
 ## Version 1.17.4
 
 ### Documentation and messages

--- a/R/bridge_selection.R
+++ b/R/bridge_selection.R
@@ -76,12 +76,14 @@
 #'     that resulted in the best BIC.}
 #'   \item{lambda_star_model_size}{Integer; the number of non-zero coefficients
 #'     (excluding intercept) in the selected model.}
-#' @details The function iterates through each lambda in `fit$lambda`. For each:
-#'   1. It extracts the intercept (`eta_s`) and slopes (`beta_s`) on the scaled data.
+#' @details For every lambda in `fit$lambda` (all evaluated together rather than
+#'   in a per-lambda loop):
+#'   1. It extracts the intercepts (`eta_s`) and slopes (`beta_s`) on the scaled data.
 #'   2. It converts these coefficients back to the original data scale using
 #'      `scale_center` and `scale_scale`.
-#'   3. It calculates the Sum of Squared Errors (SSE) using `sse_bridge()` with
-#'      the original-scale coefficients, original `y`, and `X_mod`.
+#'   3. It calculates the mean squared error using `sse_bridge()` with the
+#'      original-scale coefficients, original `y`, and `X_mod` -- a single BLAS-3
+#'      matrix multiply across all lambdas.
 #'   4. It computes the BIC value: `N*T*log(SSE/(N*T)) + s*log(N*T)`, where `s`
 #'      is the number of non-zero coefficients (including intercept).
 #'   The set of coefficients corresponding to the minimum BIC is chosen. If multiple
@@ -92,49 +94,42 @@
 #' @noRd
 getBetaBIC <- function(fit, N, T, p, X_mod, y, scale_center, scale_scale) {
 	stopifnot(length(y) == N * T)
-	n_lambda <- ncol(fit$beta)
-	BICs <- rep(as.numeric(NA), n_lambda)
-	model_sizes <- rep(as.integer(NA), n_lambda)
-
 	stopifnot(nrow(fit$beta) == p + 1)
 
-	for (k in 1:n_lambda) {
-		## --- extract coefficients on the scaled data -------------
-		eta_s <- fit$beta[1, k] # intercept (scaled space)
-		beta_s <- fit$beta[2:(p + 1), k] # slopes    (scaled space)
+	## --- extract coefficients on the scaled data (all lambdas) -------
+	eta_s <- fit$beta[1, ] # intercepts (scaled space), one per lambda
+	beta_s <- fit$beta[2:(p + 1), , drop = FALSE] # slopes (scaled), p x n_lambda
 
-		## --- convert to original scale ---------------------------
-		beta_hat_k <- beta_s / scale_scale
-		eta_hat_k <- eta_s - sum(scale_center * beta_hat_k)
+	## --- convert to original scale -----------------------------------
+	beta_hat <- beta_s / scale_scale # row i divided by scale_scale[i]
+	eta_hat <- eta_s - colSums(scale_center * beta_hat)
 
-		# Residual sum of squares
-		mse_hat <- sse_bridge(
-			eta_hat_k,
-			beta_hat_k,
-			y = y,
-			X_mod = X_mod,
-			N = N,
-			T = T
-		)
-		# Number of fitted coefficients
-		s <- sum(fit$beta[, k] != 0)
-		model_sizes[k] <- s
+	## --- residual MSE for every lambda in a single matmul ------------
+	mse_hat <- sse_bridge(
+		eta_hat,
+		beta_hat,
+		y = y,
+		X_mod = X_mod,
+		N = N,
+		T = T
+	)
 
-		stopifnot(is.na(BICs[k]))
-		# Coerce N * T to numeric before multiplying. `N * T` is integer
-		# arithmetic and overflows at .Machine$integer.max ≈ 2.15e9
-		# (panels with N * T > ~2.15e9, e.g. 50,000 x 50,000). On
-		# overflow, R returns NA_integer_ and downstream
-		# `which(BICs == min(BICs))` is empty, tripping the
-		# `stopifnot(length(lambda_star_final_ind) == 1)` at line ~378
-		# with an unhelpful message. The CV path already handles this
-		# safely at lines ~460-471 (clip to integer.max with a warning);
-		# mirror the same as.numeric() coercion here. No regression test:
-		# the bug fires only at panel sizes too large to construct in CI
-		# (#178).
-		nt_double <- as.numeric(N) * as.numeric(T)
-		BICs[k] <- nt_double * log(mse_hat) + s * log(nt_double)
-	}
+	## --- model sizes and BIC for every lambda ------------------------
+	# Number of fitted coefficients (including intercept), one per lambda.
+	model_sizes <- as.integer(colSums(fit$beta != 0))
+
+	# Coerce N * T to numeric before multiplying. `N * T` is integer
+	# arithmetic and overflows at .Machine$integer.max ≈ 2.15e9
+	# (panels with N * T > ~2.15e9, e.g. 50,000 x 50,000). On
+	# overflow, R returns NA_integer_ and downstream
+	# `which(BICs == min(BICs))` is empty, tripping the
+	# `stopifnot(length(lambda_star_final_ind) == 1)` below with an
+	# unhelpful message. The CV path already handles this safely (clip
+	# to integer.max with a warning); mirror the same as.numeric()
+	# coercion here. No regression test: the bug fires only at panel
+	# sizes too large to construct in CI (#178).
+	nt_double <- as.numeric(N) * as.numeric(T)
+	BICs <- nt_double * log(mse_hat) + model_sizes * log(nt_double)
 
 	lambda_star_ind <- which(BICs == min(BICs))
 	if (length(lambda_star_ind) == 1) {

--- a/R/utility.R
+++ b/R/utility.R
@@ -1171,35 +1171,46 @@ getFirstIndsFromOffsets <- function(cohort_offsets_int, T) {
 }
 
 # sse_bridge
-#' @title Calculate Sum of Squared Errors for Bridge Regression
-#' @description Computes the sum of squared errors (SSE) for a given set of
+#' @title Calculate Mean Squared Errors for Bridge Regression
+#' @description Computes the mean squared error (MSE) for one or more sets of
 #'   intercept and slope coefficients from a bridge regression model, relative
 #'   to the observed responses and the (potentially transformed) design matrix.
-#'   The result is then averaged by dividing by the total number of observations (N*T).
-#' @param eta_hat Numeric scalar; the estimated intercept term.
-#' @param beta_hat Numeric vector; the estimated slope coefficients. Its length
-#'   should match the number of columns in `X_mod`.
+#'   All coefficient sets (one per penalty value in the regularization path) are
+#'   evaluated together in a single BLAS-3 matrix multiply rather than one
+#'   matrix-vector product apiece.
+#' @param eta_hat Numeric vector; the estimated intercept term for each
+#'   coefficient set (length `L`, the number of columns of `beta_hat`).
+#' @param beta_hat Numeric matrix; the estimated slope coefficients, with
+#'   `ncol(X_mod)` rows and one column per coefficient set (`L` columns total).
+#'   A plain vector is accepted and treated as a single column.
 #' @param y Numeric vector; the observed response variable, of length `N*T`.
 #' @param X_mod Numeric matrix; the design matrix (possibly transformed, e.g.,
 #'   for FETWFE) used in the regression. It has `N*T` rows.
 #' @param N Integer; the total number of unique units.
 #' @param T Integer; the total number of time periods.
-#' @return A numeric scalar representing the mean squared error (MSE), i.e.,
-#'   SSE / (N*T).
+#' @return A numeric vector of length `L`: the mean squared error (MSE),
+#'   `SSE / (N*T)`, for each column of `beta_hat`.
 #' @keywords internal
 #' @noRd
 sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
-	stopifnot(length(eta_hat) == 1)
-	stopifnot(length(beta_hat) == ncol(X_mod))
+	beta_hat <- as.matrix(beta_hat)
+	stopifnot(nrow(beta_hat) == ncol(X_mod))
+	stopifnot(length(eta_hat) == ncol(beta_hat))
 
-	y_hat <- X_mod %*% beta_hat + eta_hat
-	stopifnot(length(y_hat) == N * T)
-	stopifnot(all(!is.na(y_hat)))
+	# One (N*T x L) fitted-value block: column j holds X_mod %*% beta_hat[, j]
+	# plus its intercept eta_hat[j]. A single matrix-matrix product (dgemm)
+	# replaces the L separate matrix-vector products the per-lambda loop used
+	# (#169).
+	y_hat <- sweep(X_mod %*% beta_hat, 2, eta_hat, "+")
+	stopifnot(nrow(y_hat) == N * T)
 
-	ret <- sum((y - y_hat)^2) / (N * T)
+	ret <- colSums((y - y_hat)^2) / (N * T)
 
-	stopifnot(!is.na(ret))
-	stopifnot(ret >= 0)
+	# A non-finite fitted value surfaces here as NA/NaN. The per-element scan of
+	# `y_hat` the scalar version used (O(N*T) work per lambda) was redundant with
+	# this O(L) check on the result, so it is dropped (#168).
+	stopifnot(!anyNA(ret))
+	stopifnot(all(ret >= 0))
 
 	return(ret)
 }

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.17.4",
+  note    = "R package version 1.17.5",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )


### PR DESCRIPTION
Resolves #168 and #169. Both target the same hot path — `getBetaBIC()`'s
per-`lambda` loop, walked once per fit when `lambda_selection = "bic"` — so they
are shipped together as one change.

## What

`getBetaBIC()` selected the BIC-optimal bridge coefficients by looping over the
~100 `lambda` values in the `grpreg` path, and for each one calling
`sse_bridge()`, which did its own `X_mod %*% beta_hat` matrix-vector product plus
an `O(N*T)` scan of the fitted values for `NA`. That is ~100 separate BLAS-2
`dgemv` calls and ~100 full-length NA-scans per fit.

This PR collapses that into:

- **One BLAS-3 matrix multiply (#169).** All `lambda` solutions are converted to
  the original scale as matrix/vector operations, and `sse_bridge()` now takes the
  full `p x L` slope matrix and length-`L` intercept vector and computes every
  column's MSE in a single `X_mod %*% beta_hat` (`dgemm`) followed by `colSums`.
- **Dropping the redundant per-`lambda` NA-scan (#168).** The `O(N*T)`
  `stopifnot(all(!is.na(y_hat)))` inside the old per-call path is replaced by a
  single `O(L)` `anyNA()` check on the resulting MSE vector. A non-finite fitted
  value still trips an error (it propagates to the MSE), just without scanning
  `N*T` values per `lambda`.

`sse_bridge()`'s only caller is `getBetaBIC()`, so its signature was generalized
from scalar to vectorized; it remains `@noRd`.

## Byte-identical — verified three ways

The selected coefficients and every downstream estimate are unchanged:

- **Before/after on real `fetwfe(lambda_selection = "bic")` fits:** four fits
  (default + conservative SE, low- and high-dimensional, distinct seeds) compared
  with `identical()` on the *entire* result object — `att_hat`, `att_se`,
  `catt_hat`, all coefficients, every field — **TRUE** for all four.
- **40-case algebraic sweep** (10 seeds x 4 dimension regimes incl. `p > N*T`):
  the vectorized MSE is bit-for-bit equal to the loop's (`max abs diff = 0`), and
  the min-BIC `lambda` selection never differs.
- **Existing exact-value suites stay green** — the BIC path is covered by
  `test-lambda-selection-164.R`, `test-betwfe.R`,
  `test-betwfe-add-ridge-basis.R`, and `test-print-method-snapshot.R`.

The equivalence is expected: `dgemm` column `j` reduces to the same dot products
as the old per-column `dgemv`, and `colSums` accumulates in the same order as the
old per-column `sum`, so no floating-point reassociation occurs on this BLAS.

## Speedup

Head-to-head timing of the selection inner work (identical output asserted):

| `N*T` | `p` | speedup |
|------:|----:|--------:|
| 600   | 80  | 1.51x |
| 1200  | 120 | 1.47x |
| 2400  | 150 | 1.45x |
| 300   | 250 | 1.56x |
| 5000  | 60  | 1.36x |

This affects only the `lambda_selection = "bic"` path; the default
`lambda_selection = "cv"` path is untouched.

## Version

Treated as a **minor enhancement** (user-visible performance improvement, output
unchanged) → patch bump **1.17.4 -> 1.17.5** + NEWS entry, per
`DEV_INSTRUCTIONS.md`. This differs from the recent pure-refactor PRs
(#188/#207/#209), which changed nothing observable and so took no bump. **Flag:**
if you would rather treat byte-identical-output perf work as internal-only (no
bump/NEWS), say so and I will revert the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
