### PR TITLE
docs: genCoefsCore G=NULL note + simultaneousCIs se=0 sentinel (#215 items 1-2)

### DIFF
--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -582,7 +582,8 @@ getTes <- function(coefs_obj) {
 #' scaled by \code{eff_size}. See the simulation studies section of Faletto (2025) for details.
 #'
 #' @param G Integer. The number of treated cohorts (treatment is assumed to start in periods 2 to
-#' \code{G + 1}).
+#' \code{G + 1}). Defaults to \code{NULL}; supply either \code{G} or the
+#' deprecated alias \code{R} (described below).
 #' @param T Integer. The total number of time periods.
 #' @param d Integer. The number of time-invariant covariates. If \code{d > 0}, additional terms
 #' corresponding to covariate main effects and interactions are included in \code{beta}.

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -96,6 +96,17 @@ utils::globalVariables(c(
 #' for the corresponding effects. The `Sigma` blocks are not persisted on the
 #' fit; re-derivation is sub-second.
 #'
+#' **Degenerate (zero-variance) effects.** An effect whose entire contribution
+#' to the selected support is zeroed by the bridge penalty -- or, in
+#' scattered-cohort panels, an event time with an empty valid-cohort set -- has
+#' a standard error of exactly 0 by construction, so its simultaneous and
+#' pointwise CIs collapse to a point at the estimate and it is excluded from the
+#' joint correlation matrix (it adds no family-wise risk; the critical value is
+#' computed over the non-degenerate sub-family). This `se = 0` convention is the
+#' simultaneous-CI analog of the `NA` standard error `eventStudy()` reports for
+#' the same structurally-degenerate event times; both assign the effect an
+#' estimate of 0.
+#'
 #' **Paper grounding.** Theorem (c') tight Gaussianity (Faletto 2025,
 #' `paper_arxiv.tex:1233`) guarantees the joint asymptotic normality; Assumption
 #' (Psi-IF) (assumption equation `paper_arxiv.tex:2013`; in-prose discussion at

--- a/man/genCoefsCore.Rd
+++ b/man/genCoefsCore.Rd
@@ -8,7 +8,8 @@ genCoefsCore(G = NULL, T, d, density, eff_size, seed = NULL, R = NULL)
 }
 \arguments{
 \item{G}{Integer. The number of treated cohorts (treatment is assumed to start in periods 2 to
-\code{G + 1}).}
+\code{G + 1}). Defaults to \code{NULL}; supply either \code{G} or the
+deprecated alias \code{R} (described below).}
 
 \item{T}{Integer. The total number of time periods.}
 

--- a/man/simultaneousCIs.Rd
+++ b/man/simultaneousCIs.Rd
@@ -84,6 +84,17 @@ machinery (the same machinery \code{eventStudy()} uses). By construction
 for the corresponding effects. The \code{Sigma} blocks are not persisted on the
 fit; re-derivation is sub-second.
 
+\strong{Degenerate (zero-variance) effects.} An effect whose entire contribution
+to the selected support is zeroed by the bridge penalty -- or, in
+scattered-cohort panels, an event time with an empty valid-cohort set -- has
+a standard error of exactly 0 by construction, so its simultaneous and
+pointwise CIs collapse to a point at the estimate and it is excluded from the
+joint correlation matrix (it adds no family-wise risk; the critical value is
+computed over the non-degenerate sub-family). This \code{se = 0} convention is the
+simultaneous-CI analog of the \code{NA} standard error \code{eventStudy()} reports for
+the same structurally-degenerate event times; both assign the effect an
+estimate of 0.
+
 \strong{Paper grounding.} Theorem (c') tight Gaussianity (Faletto 2025,
 \code{paper_arxiv.tex:1233}) guarantees the joint asymptotic normality; Assumption
 (Psi-IF) (assumption equation \code{paper_arxiv.tex:2013}; in-prose discussion at


### PR DESCRIPTION
Refs #215. Ships the two actionable doc items from the bundled cleanup issue;
item 3 (non-ASCII roxygen) is deferred -- see the issue comment and the note
below.

## Item 1 -- `genCoefsCore()` `@param G` note

`genCoefsCore(G = NULL, ..., R = NULL)` has the identical `G = NULL` / deprecated-
`R`-alias semantics as `genCoefs()`, but #208 (DG4) added the explanatory note to
`genCoefs()` only. Mirrored the same note onto `genCoefsCore()`'s `@param G`
(verified `genCoefsCore` documents `@param R` as deprecated, so the "described
below" reference resolves). One-line doc fix; regenerates `man/genCoefsCore.Rd`.

## Item 2 -- `simultaneousCIs()` `se = 0` degenerate-effect sentinel

The review flagged that for a degenerate event time `eventStudy()` reports
`se = NA` while `simultaneousCIs(family = "event_study")` reports `se = 0`, and
asked to either align both on `NA` or document the `se = 0` behavior.

**Decision: document `se = 0` (the issue's option b), not NA-align.** The audit
showed NA-alignment is infeasible and would be wrong:

- `simultaneousCIs()` already has deliberate, documented degenerate-effect
  machinery: a zero-variance effect gets `se = 0`, its CI collapses to a point,
  and it is excluded from the joint correlation matrix (the critical value is
  computed over the non-degenerate sub-family). That `se = 0` is load-bearing.
- It reconstructs everything from `Sigma`, where a structurally-empty-cohort
  event time and a bridge-zeroed effect **both** appear as `diag(Sigma) = 0` --
  they are indistinguishable, so it cannot selectively emit `NA` for the
  empty-cohort sub-case without breaking the uniform degenerate handling.

So the right resolution is to document the `se = 0` convention as the
simultaneous-CI analog of `eventStudy()`'s `NA`. Added a "Degenerate
(zero-variance) effects" paragraph to the `@details`. No behavior change;
regenerates `man/simultaneousCIs.Rd`. (The case is unreachable in the
consecutive-cohort enumeration anyway; the bridge-zeroed degenerate case it also
covers **is** reachable, so the note is genuinely useful.)

## Item 3 -- non-ASCII roxygen: deferred

The issue described item 3 as "a few roxygen blocks" of em-dashes / curly quotes
and flagged it "not worth a standalone PR -- sweep only if/when an ASCII-hygiene
pass runs for other reasons." The actual scope is **56 non-ASCII occurrences
across 13 files**, and critically it is **not** a uniform typographic sweep: 17
of those are intentional math symbols in `fusion_transforms.R` roxygen -- `⊗`
(Kronecker), `𝓡` (script-R), `τ` (tau), `×` -- that a blind ASCII conversion
would mangle. There is also **zero CRAN pressure**: `R CMD check --as-cran` is
`0/0/0` with them present. Deferred per the issue's own guidance; #215 stays open
as its tracking home.

## No version bump

Pure doc fix (roxygen only, no code or message change) -> **no version bump or
NEWS** per `DEV_INSTRUCTIONS.md`. Distinct from #208, which changed user-facing
*messages*. **Flag:** say so if you'd prefer a patch bump for the manual-page
changes.

## Gate

`document()` regenerates exactly `man/genCoefsCore.Rd` + `man/simultaneousCIs.Rd`
(no `NAMESPACE` change); `R CMD check --as-cran` `0/0/0`; `spell_check` /
`url_check` clean; R code untouched so the test suite is unaffected
(`FAIL 0 | WARN 0 | PASS 2846`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
