### PR TITLE
refactor: consolidate save/restore .Random.seed idiom into .with_preserved_rng() (#195)

### DIFF
--- a/R/bridge_selection.R
+++ b/R/bridge_selection.R
@@ -241,41 +241,20 @@ getBetaCV <- function(
 	# `set.seed()` here drives the fold assignment for cv.grpreg(). We use
 	# this rather than cv.grpreg's own `seed` argument because the latter
 	# changed semantics across grpreg versions; the global RNG approach is
-	# version-stable. We save and restore the caller's .Random.seed via
-	# on.exit() so the call leaves the caller's RNG state untouched
+	# version-stable. `.with_preserved_rng()` saves and restores the caller's
+	# .Random.seed so the call leaves the caller's RNG state untouched
 	# (issue #177 — without this, every default-path fetwfe() / betwfe()
 	# call would silently mutate the user's seed, a v1.13.0 regression
 	# vs the v1.12.x BIC default).
-	old_rng <- if (
-		exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
-	) {
-		.GlobalEnv$.Random.seed
-	} else {
-		NULL
-	}
-	on.exit(
-		{
-			if (is.null(old_rng)) {
-				if (
-					exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
-				) {
-					rm(".Random.seed", envir = .GlobalEnv)
-				}
-			} else {
-				assign(".Random.seed", old_rng, envir = .GlobalEnv)
-			}
-		},
-		add = TRUE
-	)
-	set.seed(cv_seed)
-
-	cv_fit <- grpreg::cv.grpreg(
-		X = X_final_scaled,
-		y = y_final,
-		penalty = "gBridge",
-		gamma = gamma,
-		nfolds = cv_folds
-	)
+	cv_fit <- .with_preserved_rng(cv_seed, {
+		grpreg::cv.grpreg(
+			X = X_final_scaled,
+			y = y_final,
+			penalty = "gBridge",
+			gamma = gamma,
+			nfolds = cv_folds
+		)
+	})
 
 	lambda_star <- cv_fit$lambda.min
 	lam_idx <- which(cv_fit$fit$lambda == lambda_star)

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -582,56 +582,31 @@ simultaneousCIs.twfeCovs <- function(
 			#
 			# mvtnorm::GenzBretz() (mvtnorm's default; quasi-Monte Carlo) is
 			# sub-second through K ~ 100. Byte-determinism across calls is
-			# preserved by save/restoring the caller's .Random.seed + a fixed
-			# internal set.seed(1L) immediately before the qmvnorm() call. This
-			# matches the in-package precedent at PR #181 / v1.13.5
-			# (R/fetwfe_core.R::getBetaCV() lines 503-524), which uses the same
-			# pattern for internal RNG use without mutating caller-side RNG
-			# state.
-			old_rng <- if (
-				exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
-			) {
-				.GlobalEnv$.Random.seed
-			} else {
-				NULL
-			}
-			on.exit(
-				{
-					if (is.null(old_rng)) {
-						if (
-							exists(
-								".Random.seed",
-								envir = .GlobalEnv,
-								inherits = FALSE
-							)
-						) {
-							rm(".Random.seed", envir = .GlobalEnv)
-						}
-					} else {
-						assign(".Random.seed", old_rng, envir = .GlobalEnv)
-					}
-				},
-				add = TRUE
-			)
-			set.seed(1L)
-			qmv <- mvtnorm::qmvnorm(
-				p = 1 - alpha,
-				corr = rho,
-				tail = "both.tails",
-				algorithm = mvtnorm::GenzBretz()
-			)
-			crit <- qmv$quantile
-
-			# Single-step max-T adjusted p-values over the non-degenerate
-			# sub-family -- the exact dual of the qmvnorm band, in the same
-			# RNG-protected region (the caller's .Random.seed is restored
-			# on exit).
-			adjusted_p_values <- .maxt_adjusted_p_nd(
-				estimates,
-				ses,
-				nondeg,
-				rho
-			)
+			# preserved by `.with_preserved_rng()`, which save/restores the
+			# caller's .Random.seed around a fixed internal set.seed(1L) (the
+			# same helper getBetaCV() uses; #195).
+			rng_out <- .with_preserved_rng(1L, {
+				qmv <- mvtnorm::qmvnorm(
+					p = 1 - alpha,
+					corr = rho,
+					tail = "both.tails",
+					algorithm = mvtnorm::GenzBretz()
+				)
+				# Single-step max-T adjusted p-values over the
+				# non-degenerate sub-family -- the exact dual of the qmvnorm
+				# band, in the same RNG-protected region.
+				list(
+					crit = qmv$quantile,
+					adjusted_p_values = .maxt_adjusted_p_nd(
+						estimates,
+						ses,
+						nondeg,
+						rho
+					)
+				)
+			})
+			crit <- rng_out$crit
+			adjusted_p_values <- rng_out$adjusted_p_values
 		}
 	} else {
 		# Conservative same-data: the Cauchy-Schwarz upper bound does not

--- a/R/utility.R
+++ b/R/utility.R
@@ -1243,6 +1243,47 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 	)
 }
 
+# .with_preserved_rng
+#' @title Evaluate RNG-consuming code under a fixed seed, preserving caller state
+#' @description Runs `expr` after `set.seed(seed)` so the result is deterministic
+#'   in its inputs, while saving and restoring the caller's `.Random.seed` (via
+#'   `on.exit()`) so the call does not perturb the caller's random stream. Both
+#'   the "caller had a seed at entry" and "caller had none" cases are handled.
+#'   Consolidates the idiom shared by `getBetaCV()` (#181, the CV-fold
+#'   assignment) and `.simultaneous_cis_impl()` (#192 / #200, the `mvtnorm`
+#'   Genz-Bretz quasi-Monte-Carlo integration). (#195)
+#' @param seed Integer seed passed to `set.seed()` immediately before `expr`.
+#' @param expr Expression to evaluate (lazily -- it runs after the caller's seed
+#'   is saved and `set.seed(seed)` is applied). Its value is returned.
+#' @return The value of `expr`.
+#' @keywords internal
+#' @noRd
+.with_preserved_rng <- function(seed, expr) {
+	old_rng <- if (
+		exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+	) {
+		.GlobalEnv$.Random.seed
+	} else {
+		NULL
+	}
+	on.exit(
+		{
+			if (is.null(old_rng)) {
+				if (
+					exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+				) {
+					rm(".Random.seed", envir = .GlobalEnv)
+				}
+			} else {
+				assign(".Random.seed", old_rng, envir = .GlobalEnv)
+			}
+		},
+		add = TRUE
+	)
+	set.seed(seed)
+	force(expr)
+}
+
 #' @title Auto-truncate a panel that has no never-treated units
 #'
 #' @description


### PR DESCRIPTION
Resolves #195. Consolidates the duplicated RNG save/restore idiom into a single
helper.

## What

The idiom -- save the caller's `.Random.seed`, `set.seed()` a fixed internal
seed, run RNG-consuming work, then restore the caller's seed `on.exit()` so the
call is deterministic-in-inputs **and** leaves the caller's random stream
untouched -- appeared in two functions, byte-identical modulo the seed value:

| Site | RNG work | Seed |
|---|---|---|
| `getBetaCV()` (`bridge_selection.R`) | `grpreg::cv.grpreg()` CV folds (#181, **#177-sensitive**) | `cv_seed` |
| `.simultaneous_cis_impl()` (`simultaneous_cis.R`) | `mvtnorm::qmvnorm()` + the #200 `pmvnorm()` loop (#192/#200) | `1L` |

Extracted the ~21-line idiom into one `@noRd` helper
`.with_preserved_rng(seed, expr)` in `utility.R` and rewired both sites. `expr`
runs after the seed is saved and `set.seed(seed)` applied; its value is returned
(the simultaneous site returns a `list(crit, adjusted_p_values)` and unpacks).

## Byte-identical -- verified

A before/after `identical()` sweep (helper vs the two inline copies on `main`) on
real fits:

- **CV path (#177-sensitive):** the CV-selected `beta_hat`, `att_hat`, and
  `catt_df` are unchanged.
- **Simultaneous path:** the BIC-path `catt_df`, `eventStudy()` frame, and
  `simultaneousCIs()`'s `adjusted_p_values` + `critical_value` are unchanged.
- **Caller-RNG preservation:** a `fetwfe(lambda_selection = "cv")` /
  `eventStudy()` / `simultaneousCIs()` call leaves the caller's `.Random.seed`
  untouched (the property the idiom exists for) -- `runif()` after a fit matches
  `runif()` from a fresh `set.seed()`.

Whole-object `identical()` across all of the above: **TRUE**. Plus the full suite
(`FAIL 0`, unchanged count -- no behavior change), `R CMD check --as-cran`
`0/0/0`, spell/url clean, empty `man/` / `NAMESPACE` diff (helper is `@noRd`).

## No version bump

Pure internal refactor, no user-visible change -> **no version bump or NEWS**
(per `DEV_INSTRUCTIONS.md`, consistent with #188 / #207 / #209). Sibling of #209.

## Note on the third-copy rule

`WORKFLOW_LESSONS.md` §14 deferred this until a **third** copy appeared; there are
still only two (#200 reused the simultaneous site's existing region rather than
adding a copy). Done now at the maintainer's explicit request -- the idiom is
delicate (global RNG-state manipulation that must stay in sync), so collapsing
the two copies to one removes a real drift risk even below the rule-of-three
threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
