### PR TITLE
docs: ASCII-sweep non-ASCII roxygen glyphs (#215 item 3)

### DIFF
--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -963,7 +963,7 @@ betwfeWithSimulatedData <- function(
 #'     (scaled version of `X_final`) and `y_final` are augmented to add an L2
 #'     penalty. The augmentation uses the identity basis (via
 #'     `prep_for_etwfe_regression(..., is_fetwfe = FALSE)`) because BETWFE's
-#'     design is untransformed — same as ETWFE and `twfeCovs`, and unlike FETWFE
+#'     design is untransformed --- same as ETWFE and `twfeCovs`, and unlike FETWFE
 #'     which uses the inverse fusion-transform basis.
 #'   \item **Cohort Probabilities:** Calculates cohort membership probabilities
 #'     conditional on being treated, using `in_sample_counts` and `indep_counts`

--- a/R/broom_methods.R
+++ b/R/broom_methods.R
@@ -199,7 +199,7 @@ NULL
 #' stashed at fit time, which drops units treated in the first time
 #' period (their treatment effect is unidentifiable). The returned data
 #' frame therefore corresponds to the panel the estimator actually fit
-#' on — broom's `augment.lm` convention of returning the model frame
+#' on --- broom's `augment.lm` convention of returning the model frame
 #' rather than the user's input.
 #' @keywords internal
 #' @noRd
@@ -622,7 +622,7 @@ tidy.cohortStudy <- function(x, ...) {
 #' convention that cohort `r` adopts at calendar time `r + 1`, so
 #' the labels match what `tidy.<estimator>` uses on a fitted panel
 #' generated from the same `FETWFE_coefs`). Standard error /
-#' statistic / p-value columns are always `NA_real_` — there is no
+#' statistic / p-value columns are always `NA_real_` --- there is no
 #' sampling distribution for a population truth. When
 #' `conf.int = TRUE` (default, matching the sibling tidy methods),
 #' `conf.low` / `conf.high` columns are included and also set to
@@ -708,7 +708,7 @@ glance.fetwfe <- function(x, ...) {
 #' Glance an `etwfe` fitted object
 #'
 #' Like [glance.fetwfe()] but omits the `lambda_star` /
-#' `lambda_star_model_size` columns — ETWFE has no regularization.
+#' `lambda_star_model_size` columns --- ETWFE has no regularization.
 #'
 #' @param x An object of class `"etwfe"`.
 #' @param ... Unused.
@@ -763,13 +763,13 @@ glance.betwfe <- function(x, ...) {
 #' by `(unit, time)`, and any first-period-treated units (whose treatment
 #' effect cannot be identified by the estimator) are auto-trimmed via
 #' `idCohorts()`. So you can pass the same raw `pdata` you handed to
-#' `fetwfe()` — the method takes care of alignment. The only hard
+#' `fetwfe()` --- the method takes care of alignment. The only hard
 #' requirement is that `data` contains the response column under its
 #' original name.
 #'
 #' @param x An object of class `"fetwfe"`.
 #' @param data A panel `data.frame` with one row per unit-period (any
-#'   sort order — augment auto-sorts), containing the response column
+#'   sort order --- augment auto-sorts), containing the response column
 #'   under the same name used at fit time (see `x$response_col_name`).
 #'   First-period-treated units, if present, are auto-trimmed.
 #' @param ... Unused.

--- a/R/cohort_assignment.R
+++ b/R/cohort_assignment.R
@@ -241,13 +241,13 @@
 #'
 #' Returns the `N x K` matrix whose column `k` is the elementwise product
 #' `X[, j_k] * X[, k_k]` for the `k`-th pair `c(j_k, k_k)` in
-#' `interactions`. Used only inside the propensity model — the outcome
+#' `interactions`. Used only inside the propensity model --- the outcome
 #' design matrix never sees `X_int`.
 #'
 #' Centralized to one helper so the live propensity computation in
 #' `.compute_cohort_prob_matrix()` and the ordered cutpoint root-finder's
 #' Monte Carlo sample in `.gen_assignment_coefs()` use byte-identical
-#' construction logic. See `.workflow/WORKFLOW_LESSONS.md` §14 (Class A
+#' construction logic. See `.workflow/WORKFLOW_LESSONS.md` section 14 (Class A
 #' drift discipline).
 #'
 #' @param X Numeric matrix, `N x d`.
@@ -528,7 +528,7 @@
 #' user-actionable error).
 #'
 #' Each iteration draws a fresh (X, W) pair via `.drawCovariates()` +
-#' `.sample_cohort_assignments()`. The RNG state advances per iteration —
+#' `.sample_cohort_assignments()`. The RNG state advances per iteration ---
 #' retries are deterministic given the initial seed but use fresh random
 #' draws each time.
 #'
@@ -545,7 +545,7 @@
 #'   the indep_assignments path). Lets the same loop emit a contextually
 #'   accurate message at each call site.
 #'
-#' @return List with `X` (N × d matrix), `X_long` (N*T × d matrix),
+#' @return List with `X` (N x d matrix), `X_long` (N*T x d matrix),
 #'   `W` (length-N integer vector, values 0..R), and `counts` (length-(R+1)
 #'   integer vector).
 #' @keywords internal

--- a/R/convert_dfs.R
+++ b/R/convert_dfs.R
@@ -4,7 +4,7 @@
 #' formatted for `did::att_gt()` (Callaway and Sant'Anna 2021) so that it can be
 #' passed directly to `fetwfe()` or `etwfe()` from the `fetwfe` package. In
 #' particular, it
-#'   * creates an *absorbing‑state* treatment dummy that equals 1 from the
+#'   * creates an *absorbing-state* treatment dummy that equals 1 from the
 #'     first treated period onward* and 0 otherwise,
 #'   * (optionally) drops units that are already treated in the very first
 #'     period of the sample (because `fetwfe()` removes them internally), and
@@ -13,15 +13,15 @@
 #'
 #' @param data A `data.frame` in **long** format containing at least the four
 #'   columns used by `did::att_gt()`: outcome `yname`, time `tname`, unit id
-#'   `idname`, and the first‑treatment period `gname` (which is 0 for the
-#'   never‑treated group).
+#'   `idname`, and the first-treatment period `gname` (which is 0 for the
+#'   never-treated group).
 #' @param yname  Character scalar. Name of the outcome column.
 #' @param tname  Character scalar. Name of the time variable (numeric or
 #'   integer). This becomes `time_var` in the returned dataframe.
 #' @param idname Character scalar. Name of the unit identifier. Converted to
 #'   character and returned as `unit_var`.
 #' @param gname  Character scalar. Name of the *group* variable holding the
-#'   first period of treatment. Values must be 0 for never‑treated, or a
+#'   first period of treatment. Values must be 0 for never-treated, or a
 #'   positive integer representing the first treated period.
 #' @param covars Character vector of additional covariate column names to carry
 #'   through (default `character(0)`). These columns are left untouched and
@@ -112,7 +112,7 @@ attgtToFetwfeDf <- function(
 #' formatted for `etwfe::etwfe()` (McDermott 2024) so that it can be
 #' passed directly to `fetwfe()` or `etwfe()` from the `fetwfe` package. In
 #' particular, it
-#'   * creates an *absorbing‑state* treatment dummy that equals 1 from the
+#'   * creates an *absorbing-state* treatment dummy that equals 1 from the
 #'     first treated period onward* and 0 otherwise,
 #'   * (optionally) drops units that are already treated in the very first
 #'     period of the sample (because `fetwfe()` removes them internally), and
@@ -124,7 +124,7 @@ attgtToFetwfeDf <- function(
 #' @param tvar Character. Column name of the time variable that you pass to `etwfe()` as `tvar`.
 #' @param idvar Character. Column name of the unit identifier (the variable you would
 #'   cluster on, or pass to `etwfe(..., ivar = idvar)` if you were using unit FEs).
-#' @param gvar Character. Column name of the “first treated” cohort variable passed to `etwfe()` as `gvar`.
+#' @param gvar Character. Column name of the "first treated" cohort variable passed to `etwfe()` as `gvar`.
 #'   Must be `0` for never-treated units, or the (strictly positive) first treated period.
 #' @param covars Character vector of *additional* covariate columns to keep (default `character(0)`).
 #' @param drop_first_period_treated Logical. Should units already treated in the very first
@@ -132,7 +132,7 @@ attgtToFetwfeDf <- function(
 #'   here keeps the returned dataframe clean.)  Default `TRUE`.
 #' @param out_names Named list giving the column names that the returned dataframe should have.
 #'   The default (`time_var`, `unit_var`, `treatment`, `response`) matches the arguments usually supplied to
-#'   `fetwfe()`. **Do not change the *names* of this list** – only the *values* – and keep all four.
+#'   `fetwfe()`. **Do not change the *names* of this list** -- only the *values* -- and keep all four.
 #' @param verbose Logical. If `TRUE`, a `message()` reports the count of
 #'   first-period-treated unit-period rows dropped when
 #'   `drop_first_period_treated = TRUE`. Default `FALSE` (silent).

--- a/R/core_funcs.R
+++ b/R/core_funcs.R
@@ -846,8 +846,8 @@ getGramInv <- function(
 #'   restricted maximum likelihood. Requires `lme4` to be installed
 #'   (`Suggests:` dependency, gated by `requireNamespace`); errors with a
 #'   clear message if not. lme4's "different scales" warning and
-#'   "rank deficient" message — expected on FETWFE-scale designs where
-#'   cohort dummies are 0/1 and covariates are arbitrary — are suppressed.
+#'   "rank deficient" message --- expected on FETWFE-scale designs where
+#'   cohort dummies are 0/1 and covariates are arbitrary --- are suppressed.
 #'
 #'   Prior versions of this package implemented the within-estimator
 #'   procedure of Pesaran (2015, Section 26.5.1). That implementation

--- a/R/etwfe_core.R
+++ b/R/etwfe_core.R
@@ -31,7 +31,7 @@
 #'   `is.character(time_var) is not TRUE` style to named, actionable
 #'   lines naming the arg, the expected shape, and (when feasible) the
 #'   received shape (GitHub #84). The message header is
-#'   `"Invalid inputs:"` — deliberately caller-agnostic so error text
+#'   `"Invalid inputs:"` --- deliberately caller-agnostic so error text
 #'   stays byte-identical across the four entry points (locked by the
 #'   PR #103 snapshot tests).
 #' @keywords internal

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -117,7 +117,7 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 #'
 #' Wraps `.derive_cohort_offsets_from_fit(x)` and the conditional dispatch
 #' between `getFirstInds(R, T)` (the consecutive-cohort assumption, used as
-#' a fall-back when `cohort_probs` carry no integer-coercible names — true
+#' a fall-back when `cohort_probs` carry no integer-coercible names --- true
 #' of synthetic genCoefs-based fixtures) and `getFirstIndsFromOffsets(...)`
 #' (the scattered-cohort path used on real panels like `bacondecomp::divorce`).
 #'
@@ -681,7 +681,7 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 #'   `estimate +/- z * se`. When `ci_low` / `ci_high` are supplied (the
 #'   `ci_type = "simultaneous"` path, #197), those override the pointwise
 #'   computation --- the single-function-with-optional-args form keeps the two
-#'   bound-construction paths in ONE place (WORKFLOW_LESSONS §14, avoiding a
+#'   bound-construction paths in ONE place (WORKFLOW_LESSONS section 14, avoiding a
 #'   sibling `_with_bounds()` copy). `se` is always the same pointwise quantity;
 #'   `p_value` defaults to the pointwise Wald p but is overridden when the
 #'   `p_value` argument is supplied --- the `ci_type = "simultaneous"`

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -142,8 +142,8 @@
 #'   moderate sample sizes, producing 95% confidence intervals whose
 #'   empirical coverage was as low as 0.00 in some regimes.
 #'   Cross-validation restores near-nominal coverage in every regime
-#'   tested. To recover the prior behavior — for example, when
-#'   reproducing analyses run against v1.12.0 or earlier — pass
+#'   tested. To recover the prior behavior --- for example, when
+#'   reproducing analyses run against v1.12.0 or earlier --- pass
 #'   `lambda_selection = "bic"`. See the inference vignette section
 #'   "Choosing the bridge penalty parameter" for details.
 #' @param cv_folds Integer; number of folds for the CV path. Ignored when
@@ -603,8 +603,8 @@ fetwfe <- function(
 #'   moderate sample sizes, producing 95% confidence intervals whose
 #'   empirical coverage was as low as 0.00 in some regimes.
 #'   Cross-validation restores near-nominal coverage in every regime
-#'   tested. To recover the prior behavior — for example, when
-#'   reproducing analyses run against v1.12.0 or earlier — pass
+#'   tested. To recover the prior behavior --- for example, when
+#'   reproducing analyses run against v1.12.0 or earlier --- pass
 #'   `lambda_selection = "bic"`. See the inference vignette section
 #'   "Choosing the bridge penalty parameter" for details.
 #' @param cv_folds Integer; number of folds for the CV path. Ignored when

--- a/R/fusion_transforms.R
+++ b/R/fusion_transforms.R
@@ -718,13 +718,13 @@ genInvTwoWayFusionTransformMat <- function(n_vars, first_inds, R) {
 
 #' Build the **entire** inverse-fusion matrix \(D_N^{-1}\)
 #'
-#' Constructs the \eqn{p\times p} block–diagonal matrix that sends the sparse
+#' Constructs the \eqn{p\times p} block-diagonal matrix that sends the sparse
 #' coefficient vector \(\theta\) used in the bridge loss back to the original
 #' coefficient scale \(\beta\), and is also used to multiply \(Z\) on the right
 #' to transform the features into a transformed feature space:
 #' \deqn{\beta \;=\;D_N^{-1}\,\theta.}
 #' The block layout follows the factorisation proved in the
-#' paper – repeated here using the helper generators already available in the
+#' paper -- repeated here using the helper generators already available in the
 #' package.
 #'
 #' \preformatted{
@@ -746,8 +746,8 @@ genInvTwoWayFusionTransformMat <- function(n_vars, first_inds, R) {
 #'   \item Treatment blocks: \( \mathfrak W \times \mathfrak W\) with
 #'         \(\mathfrak W = \texttt{num_treats}\)
 #' }
-#' All non–identity blocks contain only 0/1 entries, so the determinant of
-#' the whole matrix is 1 (volume–preserving transform).
+#' All non-identity blocks contain only 0/1 entries, so the determinant of
+#' the whole matrix is 1 (volume-preserving transform).
 #'
 #' @param first_inds Integer vector (length \code{R}).
 #'   `first_inds[r]` is the 1-based column index of the first base
@@ -767,7 +767,7 @@ genInvTwoWayFusionTransformMat <- function(n_vars, first_inds, R) {
 #' R  <- 3; T <- 6; d <- 2
 #' nt <- getNumTreats(R, T)
 #' Dinv <- genFullInvFusionTransformMat(getFirstInds(R,T), T, R, d, nt)
-#' dim(Dinv)   # should be p × p
+#' dim(Dinv)   # should be p x p
 #'
 #' @keywords internal
 #' @noRd

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -13,7 +13,7 @@
 #' Optional arguments \code{assignment_type} and \code{assignment_strength}
 #' control whether cohort membership in the simulated panel is drawn
 #' marginally (independent of the covariates, the original behavior) or from
-#' a covariate-dependent propensity-score model — either a multinomial-logit
+#' a covariate-dependent propensity-score model --- either a multinomial-logit
 #' or an ordered-logit (proportional-odds) model. The default
 #' \code{assignment_type = "marginal"} preserves the pre-1.14.0 behavior
 #' byte-identically. See \code{vignette("simulation_vignette", package = "fetwfe")}
@@ -64,9 +64,9 @@
 #'   \code{coefs$assignment_coefs$interactions} on the returned object to
 #'   verify the retained list). The interaction columns enter the
 #'   propensity model only; the outcome model continues to use the
-#'   original covariates. Defaults to \code{NULL} (no interactions —
+#'   original covariates. Defaults to \code{NULL} (no interactions ---
 #'   v1.14.0 behavior is preserved byte-identically). Passing \code{list()}
-#'   (empty list) is treated as equivalent to \code{NULL} — no interactions
+#'   (empty list) is treated as equivalent to \code{NULL} --- no interactions
 #'   specified, behavior is identical to the v1.14.0 marginal-cohort path
 #'   within \code{multinomial} / \code{ordered} DGPs. Errors when
 #'   \code{assignment_type = "marginal"} (the marginal DGP has no
@@ -86,7 +86,7 @@
 #' @param verbose Logical. If \code{TRUE}, emit a \code{message()} when
 #'   \code{assignment_interactions} canonicalization removes duplicate or
 #'   unordered pairs (e.g., when the user passes both \code{c(1, 2)} and
-#'   \code{c(2, 1)}). Default \code{FALSE} (silent — users can verify the
+#'   \code{c(2, 1)}). Default \code{FALSE} (silent --- users can verify the
 #'   final canonical list via \code{coefs$assignment_coefs$interactions}).
 #' @param R Deprecated. The former name for \code{G}; still accepted with a
 #'   deprecation warning, and will be removed in a future release. Use

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -770,7 +770,7 @@ simultaneousCIs.twfeCovs <- function(
 #'   simultaneous band (via `.apply_simultaneous_catt_band()`), re-validates,
 #'   and returns the updated object. For `ci_type == "pointwise"` (or when the
 #'   band degrades to `NULL`) it is a no-op pass-through. Hoisted out of the
-#'   four entry-point tails to avoid a 4-site copy (WORKFLOW_LESSONS §14).
+#'   four entry-point tails to avoid a 4-site copy (WORKFLOW_LESSONS section 14).
 #' @param out A fully-classed `fetwfe`/`etwfe`/`betwfe`/`twfeCovs` object.
 #' @param alpha Numeric; the alpha the fit used (read from the fit's `alpha` slot).
 #' @return `out` with `catt_df` bounds overwritten when simultaneous, else

--- a/R/utility.R
+++ b/R/utility.R
@@ -409,10 +409,10 @@ idCohorts <- function(df, time_var, unit_var, treat_var) {
 #'     `indep_counts` argument was provided, `FALSE` otherwise.
 #' @details Within a single argument's check chain (e.g., `time_var`
 #'   must be character, length 1, present in `pdata`, integer column),
-#'   the first failure short-circuits — downstream checks for that arg
+#'   the first failure short-circuits --- downstream checks for that arg
 #'   are unsafe to run (e.g., `time_var %in% colnames(pdata)` cannot
 #'   sensibly be evaluated if `time_var` is not a length-1 character).
-#'   Across DIFFERENT arguments, violations collect independently — if
+#'   Across DIFFERENT arguments, violations collect independently --- if
 #'   both `time_var` and `unit_var` are malformed, BOTH violations
 #'   appear in the final list. This is "cascade within arg, collect
 #'   across args".
@@ -800,7 +800,7 @@ idCohorts <- function(df, time_var, unit_var, treat_var) {
 #'   lines as a multi-line `stop()` body. Centralising the header /
 #'   prefix here means both validators speak with one voice, and the
 #'   four entry points (`fetwfe`, `etwfe`, `betwfe`, `twfeCovs`)
-#'   continue to produce byte-identical messages — a property the
+#'   continue to produce byte-identical messages --- a property the
 #'   PR #103 snapshot guardrail asserts.
 #' @keywords internal
 #' @noRd

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -319,7 +319,7 @@ getSecondVarTermOLS <- function(
 #'   the Treated (ATT). Specifically, `psi_r` places the constant
 #'   `1 / k_full` (where `k_full = last_ind_r - first_ind_r + 1` is the
 #'   cohort's full treatment-block size) at each position corresponding to a
-#'   selected treatment effect in cohort `r`, and zero elsewhere — so that
+#'   selected treatment effect in cohort `r`, and zero elsewhere --- so that
 #'   `t(psi_r) %*% theta_hat_treat_sel == cohort_tes[r]`.
 #' @param first_ind_r Integer; the index of the first treatment effect for
 #'   cohort `r` within the `num_treats` block of treatment effects.
@@ -1019,7 +1019,7 @@ getSecondVarTermDataApp <- function(
 #' three pre-#192 inline Jacobian-build sites
 #' (`getSecondVarTermOLS()`, `getSecondVarTermDataApp()`, and
 #' `.event_study_var2_fetwfe()` in `R/event_study.R`) plus the new
-#' `simultaneousCIs()` call site into one helper (WORKFLOW_LESSONS §14 Class A:
+#' `simultaneousCIs()` call site into one helper (WORKFLOW_LESSONS section 14 Class A:
 #' the third copy triggers a refactor). All four sites implement the same
 #' delta-method gradient of \eqn{f_r(\pi)=\pi_r/\sum_k \pi_k}; the column-index
 #' off-diagonal coefficient \eqn{J_{rs}=-\pi_s/S^2} matches paper Theorem 6.3
@@ -1241,7 +1241,7 @@ getSecondVarTermDataApp <- function(
 #' `var_2(e)` scalars). Per-effect Jacobians (each masked to its own valid
 #' cohort set) reproduce the existing scalars exactly. Per-family `J_list`
 #' construction lives in `.simultaneous_cis_impl()`. Round-2 N3: the single
-#' global `Sigma_pi_hat` is correct — the zero-rows of `J_k` for cohorts not in
+#' global `Sigma_pi_hat` is correct --- the zero-rows of `J_k` for cohorts not in
 #' effect `k`'s valid set zero out the relevant `Sigma_pi_hat` entries
 #' automatically, so a per-effect masked `Sigma_pi_hat` is unnecessary.
 #' @param J_list Length-K list of per-effect Jacobian matrices (each R x p_sel
@@ -1311,7 +1311,7 @@ getSecondVarTermDataApp <- function(
 #' @param sel_feat_inds Integer vector OR `NULL`. Indices of all features
 #'   selected by the penalized regression in the transformed space. Pass
 #'   `NULL` for OLS callers (`etwfe()` / `twfeCovs()`) where no penalized
-#'   selection occurred — the unified function treats `NULL` as a sentinel
+#'   selection occurred --- the unified function treats `NULL` as a sentinel
 #'   for "use all features" and dispatches the OLS code path inside
 #'   `getGramInv()` and `.assemble_cluster_robust_sandwich()`.
 #' @param treat_inds Integer vector; indices in the original (untransformed)

--- a/man/attgtToFetwfeDf.Rd
+++ b/man/attgtToFetwfeDf.Rd
@@ -20,8 +20,8 @@ attgtToFetwfeDf(
 \arguments{
 \item{data}{A \code{data.frame} in \strong{long} format containing at least the four
 columns used by \code{did::att_gt()}: outcome \code{yname}, time \code{tname}, unit id
-\code{idname}, and the first‑treatment period \code{gname} (which is 0 for the
-never‑treated group).}
+\code{idname}, and the first-treatment period \code{gname} (which is 0 for the
+never-treated group).}
 
 \item{yname}{Character scalar. Name of the outcome column.}
 
@@ -32,7 +32,7 @@ integer). This becomes \code{time_var} in the returned dataframe.}
 character and returned as \code{unit_var}.}
 
 \item{gname}{Character scalar. Name of the \emph{group} variable holding the
-first period of treatment. Values must be 0 for never‑treated, or a
+first period of treatment. Values must be 0 for never-treated, or a
 positive integer representing the first treated period.}
 
 \item{covars}{Character vector of additional covariate column names to carry
@@ -67,7 +67,7 @@ formatted for \code{did::att_gt()} (Callaway and Sant'Anna 2021) so that it can 
 passed directly to \code{fetwfe()} or \code{etwfe()} from the \code{fetwfe} package. In
 particular, it
 \itemize{
-\item creates an \emph{absorbing‑state} treatment dummy that equals 1 from the
+\item creates an \emph{absorbing-state} treatment dummy that equals 1 from the
 first treated period onward* and 0 otherwise,
 \item (optionally) drops units that are already treated in the very first
 period of the sample (because \code{fetwfe()} removes them internally), and

--- a/man/augment.fetwfe.Rd
+++ b/man/augment.fetwfe.Rd
@@ -10,7 +10,7 @@
 \item{x}{An object of class \code{"fetwfe"}.}
 
 \item{data}{A panel \code{data.frame} with one row per unit-period (any
-sort order — augment auto-sorts), containing the response column
+sort order --- augment auto-sorts), containing the response column
 under the same name used at fit time (see \code{x$response_col_name}).
 First-period-treated units, if present, are auto-trimmed.}
 
@@ -33,7 +33,7 @@ scale without the caller having to remember either.
 by \verb{(unit, time)}, and any first-period-treated units (whose treatment
 effect cannot be identified by the estimator) are auto-trimmed via
 \code{idCohorts()}. So you can pass the same raw \code{pdata} you handed to
-\code{fetwfe()} — the method takes care of alignment. The only hard
+\code{fetwfe()} --- the method takes care of alignment. The only hard
 requirement is that \code{data} contains the response column under its
 original name.
 }

--- a/man/etwfeToFetwfeDf.Rd
+++ b/man/etwfeToFetwfeDf.Rd
@@ -28,7 +28,7 @@ etwfeToFetwfeDf(
 \item{idvar}{Character. Column name of the unit identifier (the variable you would
 cluster on, or pass to \code{etwfe(..., ivar = idvar)} if you were using unit FEs).}
 
-\item{gvar}{Character. Column name of the “first treated” cohort variable passed to \code{etwfe()} as \code{gvar}.
+\item{gvar}{Character. Column name of the "first treated" cohort variable passed to \code{etwfe()} as \code{gvar}.
 Must be \code{0} for never-treated units, or the (strictly positive) first treated period.}
 
 \item{covars}{Character vector of \emph{additional} covariate columns to keep (default \code{character(0)}).}
@@ -39,7 +39,7 @@ here keeps the returned dataframe clean.)  Default \code{TRUE}.}
 
 \item{out_names}{Named list giving the column names that the returned dataframe should have.
 The default (\code{time_var}, \code{unit_var}, \code{treatment}, \code{response}) matches the arguments usually supplied to
-\code{fetwfe()}. \strong{Do not change the \emph{names} of this list} – only the \emph{values} – and keep all four.}
+\code{fetwfe()}. \strong{Do not change the \emph{names} of this list} -- only the \emph{values} -- and keep all four.}
 
 \item{verbose}{Logical. If \code{TRUE}, a \code{message()} reports the count of
 first-period-treated unit-period rows dropped when
@@ -62,7 +62,7 @@ formatted for \code{etwfe::etwfe()} (McDermott 2024) so that it can be
 passed directly to \code{fetwfe()} or \code{etwfe()} from the \code{fetwfe} package. In
 particular, it
 \itemize{
-\item creates an \emph{absorbing‑state} treatment dummy that equals 1 from the
+\item creates an \emph{absorbing-state} treatment dummy that equals 1 from the
 first treated period onward* and 0 otherwise,
 \item (optionally) drops units that are already treated in the very first
 period of the sample (because \code{fetwfe()} removes them internally), and

--- a/man/fetwfe.Rd
+++ b/man/fetwfe.Rd
@@ -183,8 +183,8 @@ BIC default, the overall-ATT estimator was biased toward zero at
 moderate sample sizes, producing 95\% confidence intervals whose
 empirical coverage was as low as 0.00 in some regimes.
 Cross-validation restores near-nominal coverage in every regime
-tested. To recover the prior behavior — for example, when
-reproducing analyses run against v1.12.0 or earlier — pass
+tested. To recover the prior behavior --- for example, when
+reproducing analyses run against v1.12.0 or earlier --- pass
 \code{lambda_selection = "bic"}. See the inference vignette section
 "Choosing the bridge penalty parameter" for details.}
 

--- a/man/fetwfeWithSimulatedData.Rd
+++ b/man/fetwfeWithSimulatedData.Rd
@@ -107,8 +107,8 @@ BIC default, the overall-ATT estimator was biased toward zero at
 moderate sample sizes, producing 95\% confidence intervals whose
 empirical coverage was as low as 0.00 in some regimes.
 Cross-validation restores near-nominal coverage in every regime
-tested. To recover the prior behavior — for example, when
-reproducing analyses run against v1.12.0 or earlier — pass
+tested. To recover the prior behavior --- for example, when
+reproducing analyses run against v1.12.0 or earlier --- pass
 \code{lambda_selection = "bic"}. See the inference vignette section
 "Choosing the bridge penalty parameter" for details.}
 

--- a/man/genCoefs.Rd
+++ b/man/genCoefs.Rd
@@ -72,9 +72,9 @@ and duplicates are silently deduplicated (inspect
 \code{coefs$assignment_coefs$interactions} on the returned object to
 verify the retained list). The interaction columns enter the
 propensity model only; the outcome model continues to use the
-original covariates. Defaults to \code{NULL} (no interactions —
+original covariates. Defaults to \code{NULL} (no interactions ---
 v1.14.0 behavior is preserved byte-identically). Passing \code{list()}
-(empty list) is treated as equivalent to \code{NULL} — no interactions
+(empty list) is treated as equivalent to \code{NULL} --- no interactions
 specified, behavior is identical to the v1.14.0 marginal-cohort path
 within \code{multinomial} / \code{ordered} DGPs. Errors when
 \code{assignment_type = "marginal"} (the marginal DGP has no
@@ -97,7 +97,7 @@ Monte Carlo integration in \code{getTes()} uses \code{seed + 2L}.}
 \item{verbose}{Logical. If \code{TRUE}, emit a \code{message()} when
 \code{assignment_interactions} canonicalization removes duplicate or
 unordered pairs (e.g., when the user passes both \code{c(1, 2)} and
-\code{c(2, 1)}). Default \code{FALSE} (silent — users can verify the
+\code{c(2, 1)}). Default \code{FALSE} (silent --- users can verify the
 final canonical list via \code{coefs$assignment_coefs$interactions}).}
 
 \item{R}{Deprecated. The former name for \code{G}; still accepted with a
@@ -153,7 +153,7 @@ extended two-way fixed effects estimator. It returns an S3 object of class
 Optional arguments \code{assignment_type} and \code{assignment_strength}
 control whether cohort membership in the simulated panel is drawn
 marginally (independent of the covariates, the original behavior) or from
-a covariate-dependent propensity-score model — either a multinomial-logit
+a covariate-dependent propensity-score model --- either a multinomial-logit
 or an ordered-logit (proportional-odds) model. The default
 \code{assignment_type = "marginal"} preserves the pre-1.14.0 behavior
 byte-identically. See \code{vignette("simulation_vignette", package = "fetwfe")}

--- a/man/glance.etwfe.Rd
+++ b/man/glance.etwfe.Rd
@@ -16,7 +16,7 @@ A one-row data frame with 11 columns.
 }
 \description{
 Like \code{\link[=glance.fetwfe]{glance.fetwfe()}} but omits the \code{lambda_star} /
-\code{lambda_star_model_size} columns — ETWFE has no regularization.
+\code{lambda_star_model_size} columns --- ETWFE has no regularization.
 }
 \examples{
 \dontrun{

--- a/man/tidy.FETWFE_tes.Rd
+++ b/man/tidy.FETWFE_tes.Rd
@@ -36,7 +36,7 @@ object returned by \code{\link[=getTes]{getTes()}}. Row 1 is the overall true AT
 convention that cohort \code{r} adopts at calendar time 1, so
 the labels match what \verb{tidy.<estimator>} uses on a fitted panel
 generated from the same \code{FETWFE_coefs}). Standard error /
-statistic / p-value columns are always \code{NA_real_} — there is no
+statistic / p-value columns are always \code{NA_real_} --- there is no
 sampling distribution for a population truth. When
 \code{conf.int = TRUE} (default, matching the sibling tidy methods),
 \code{conf.low} / \code{conf.high} columns are included and also set to


### PR DESCRIPTION
Resolves #215 (items 1 + 2 shipped in #218; this is the deferred item 3).

## What

Swept the typographic non-ASCII glyphs out of the roxygen, across **43 lines in
13 `R/` files**:

| Glyph | -> | Notes |
|---|---|---|
| `—` em-dash | `---` | renders as em-dash in `.Rd` (the package's convention) |
| `–` en-dash (parenthetical, spaced) | `--` | |
| `–` en-dash (compound, e.g. `block–diagonal`) | `-` | |
| `‑` non-breaking hyphen | `-` | `absorbing‑state` -> `absorbing-state` |
| `“ ”` curly quotes | `" "` | |
| `×` multiplication (prose dimensions) | `x` | `N × d matrix` -> `N x d matrix` |
| `§` section sign | `section ` | `WORKFLOW_LESSONS §14` -> `... section 14` |

The **rendered manual is now 100% ASCII** -- after `document()`, no `man/*.Rd`
file contains a non-ASCII character.

## Preserved (by design)

The `genFullInvFusionTransformMat()` `\preformatted{}` block displaying the
inverse-fusion matrix `D_N^{-1}` keeps its math notation -- the Kronecker product
(`⊗`), a **script-R that is deliberately distinct from the regular `R`** in the
same formula (`D^{(1)}(R)` vs `D^{(2)}(𝓡)`), and `τ`. Two reasons it is left
intact:

1. It is `@noRd` internal roxygen, so it **never renders into a manual page** --
   outside the issue's stated scope ("non-ASCII that render into `.Rd` files").
2. A faithful ASCII transliteration would have to invent a token for the script-R
   and risk conflating it with `R`; the issue explicitly flagged the formula's
   math symbols as the "don't blindly convert" set.

`R CMD check --as-cran` accepts the package with them present (`0/0/0`), so there
is no CRAN pressure either.

## No version bump

Pure cosmetic documentation change (glyph -> ASCII, identical rendering), no
behavior change -> **no version bump or NEWS** (per `DEV_INSTRUCTIONS.md`). Each
converted line was reviewed; the sweep touched roxygen (`#'`) lines only.

## Gate

`document()` regenerated 8 `man/*.Rd` (only the affected user-facing pages);
`R CMD check --as-cran` `0/0/0`; `spell_check` / `url_check` clean; full suite
unaffected (roxygen-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
