### PR TITLE
docs: correct twfeCovs treat_inds/treat_int_inds @return slots (one effect per cohort) (#224)

### DIFF
--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -144,9 +144,9 @@
 #' rename table.}
 #' \item{beta_hat}{The full vector of estimated coefficients.}
 #' \item{treat_inds}{The indices of `beta_hat` corresponding to
-#' the treatment effects for each cohort at each time.}
+#' the treatment effects for each cohort.}
 #' \item{treat_int_inds}{The indices of `beta_hat` corresponding to the
-#' interactions between the treatment effects for each cohort at each time and
+#' interactions between the treatment effects for each cohort and
 #' the covariates.} \item{sig_eps_sq}{Either the provided `sig_eps_sq` or
 #' the estimated one, if a value wasn't provided.} \item{sig_eps_c_sq}{Either
 #' the provided `sig_eps_c_sq` or the estimated one, if a value wasn't
@@ -527,9 +527,9 @@ twfeCovs <- function(
 #' rename table.}
 #' \item{beta_hat}{The full vector of estimated coefficients.}
 #' \item{treat_inds}{The indices of `beta_hat` corresponding to
-#' the treatment effects for each cohort at each time.}
+#' the treatment effects for each cohort.}
 #' \item{treat_int_inds}{The indices of `beta_hat` corresponding to the
-#' interactions between the treatment effects for each cohort at each time and
+#' interactions between the treatment effects for each cohort and
 #' the covariates.} \item{sig_eps_sq}{Either the provided `sig_eps_sq` or
 #' the estimated one, if a value wasn't provided.} \item{sig_eps_c_sq}{Either
 #' the provided `sig_eps_c_sq` or the estimated one, if a value wasn't

--- a/man/twfeCovs.Rd
+++ b/man/twfeCovs.Rd
@@ -173,9 +173,9 @@ migration message pointing to the new name. See \code{NEWS.md} for the
 rename table.}
 \item{beta_hat}{The full vector of estimated coefficients.}
 \item{treat_inds}{The indices of \code{beta_hat} corresponding to
-the treatment effects for each cohort at each time.}
+the treatment effects for each cohort.}
 \item{treat_int_inds}{The indices of \code{beta_hat} corresponding to the
-interactions between the treatment effects for each cohort at each time and
+interactions between the treatment effects for each cohort and
 the covariates.} \item{sig_eps_sq}{Either the provided \code{sig_eps_sq} or
 the estimated one, if a value wasn't provided.} \item{sig_eps_c_sq}{Either
 the provided \code{sig_eps_c_sq} or the estimated one, if a value wasn't

--- a/man/twfeCovsWithSimulatedData.Rd
+++ b/man/twfeCovsWithSimulatedData.Rd
@@ -99,9 +99,9 @@ migration message pointing to the new name. See \code{NEWS.md} for the
 rename table.}
 \item{beta_hat}{The full vector of estimated coefficients.}
 \item{treat_inds}{The indices of \code{beta_hat} corresponding to
-the treatment effects for each cohort at each time.}
+the treatment effects for each cohort.}
 \item{treat_int_inds}{The indices of \code{beta_hat} corresponding to the
-interactions between the treatment effects for each cohort at each time and
+interactions between the treatment effects for each cohort and
 the covariates.} \item{sig_eps_sq}{Either the provided \code{sig_eps_sq} or
 the estimated one, if a value wasn't provided.} \item{sig_eps_c_sq}{Either
 the provided \code{sig_eps_c_sq} or the estimated one, if a value wasn't


### PR DESCRIPTION
## Summary

Resolves #224. Corrects four `@return` slot descriptions for `twfeCovs()` / `twfeCovsWithSimulatedData()` that wrongly inherited FETWFE's "for each cohort **at each time**" phrasing.

`twfeCovs` fits a single treatment effect per cohort — `num_treats <- G`, `first_inds <- 1:G` (`R/twfeCovs.R:862`, `:913`), with no cohort×time grid and no `eventStudy()` method. So the `treat_inds` / `treat_int_inds` index slots describe "the treatment effects for each cohort," not "...at each time." The `@param ci_type` text and the `@title`/`@description` were already correct and are unchanged.

## Changes

- `R/twfeCovs.R`: "for each cohort at each time" → "for each cohort" in the `treat_inds` and `treat_int_inds` `@return` slots, in both `twfeCovs()` (lines 147/149) and `twfeCovsWithSimulatedData()` (lines 530/532).
- `man/twfeCovs.Rd`, `man/twfeCovsWithSimulatedData.Rd`: regenerated via `devtools::document()`.

## Scope note

The optional `genCoefs()` `@param G` "(Optional.)" cosmetic from #224 was **deliberately dropped**: `G` is not optional (you must supply `G` *or* the deprecated alias `R`), so an "(Optional.)" prefix would be inaccurate. The existing "Defaults to `NULL`; supply either `G` or ..." wording is correct as-is.

## No version bump

Pure documentation correction → no version bump and no `NEWS.md` entry, per `DEV_INSTRUCTIONS.md` (doc fix = no bump; flagged here as required).

## Verification

- `air format .`: no changes
- `devtools::document()`: regenerated only the two twfeCovs man pages (diff verified to be exactly the phrasing change)
- `devtools::test()`: `FAIL 0 | WARN 0 | SKIP 0 | PASS 2864`
- `R CMD check --as-cran`: 0 errors / 0 warnings / 1 NOTE (environmental "unable to verify current time")
- `spell_check()`: clean · `urlchecker::url_check()`: all URLs correct

Surfaced by the 2026-06-03 periodic code review (`.plans/code-review-2026-06-03/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
