### PR TITLE
test: pin the conservative simultaneous-CI SE formula + broaden inference coverage (#225)

### DIFF
--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -614,7 +614,7 @@ simultaneousCIs.twfeCovs <- function(
 		# pointwise CIs on the conservative scalar SEs.
 		v1 <- pmax(diag(Sigma_1), 0)
 		v2 <- pmax(diag(Sigma_2), 0)
-		ses <- sqrt(v1 + v2 + 2 * sqrt(v1 * v2))
+		ses <- .cauchy_schwarz_se(v1, v2)
 		crit <- if (K == 1L) pointwise_crit else bonferroni_crit
 		# Bonferroni-adjusted p-values -- the dual of the Bonferroni band --
 		# computed from the same Cauchy-Schwarz ses; degenerate (se = 0)
@@ -698,6 +698,29 @@ simultaneousCIs.twfeCovs <- function(
 		adj[nd_idx[j]] <- min(1, max(0, 1 - as.numeric(prob)))
 	}
 	adj
+}
+
+# .cauchy_schwarz_se
+#' @title Conservative (Cauchy-Schwarz) combined standard error
+#' @description Combines the two per-effect variance components into the
+#'   conservative standard error used by the `se_type = "conservative"` band:
+#'   `v1` is the first-order / OLS-sandwich term (`diag(Sigma_1)`) and `v2` is
+#'   the cohort-probability term (`diag(Sigma_2)`). With the cross-covariance
+#'   left unrestricted, the Cauchy-Schwarz upper bound on
+#'   `Var(component_1 + component_2)` is `v1 + v2 + 2 * sqrt(v1 * v2)`, whose
+#'   square root equals `sqrt(v1) + sqrt(v2)` (the sum of the two component
+#'   SEs). This is the per-effect band analogue of the conservative overall-ATT
+#'   SE assembled in `getTeResults*()`.
+#' @param v1 Numeric vector (length `K`, entries `>= 0`); the first variance
+#'   component per effect (`diag(Sigma_1)`).
+#' @param v2 Numeric vector (length `K`, entries `>= 0`); the second variance
+#'   component per effect (`diag(Sigma_2)`).
+#' @return Numeric vector (length `K`): the conservative combined SE per effect,
+#'   `sqrt(v1 + v2 + 2 * sqrt(v1 * v2))` (equivalently `sqrt(v1) + sqrt(v2)`).
+#' @keywords internal
+#' @noRd
+.cauchy_schwarz_se <- function(v1, v2) {
+	sqrt(v1 + v2 + 2 * sqrt(v1 * v2))
 }
 
 #' @title Recompute a fit's cohort-family CIs as simultaneous bands (fit-time)

--- a/tests/testthat/test-ci-type-197.R
+++ b/tests/testthat/test-ci-type-197.R
@@ -667,11 +667,14 @@ test_that("ci_type x se_type = 'cluster': simultaneous band consumes the cluster
 		es_s <- eventStudy(fit_s)
 		es_p <- eventStudy(fit_p)
 		es_fin <- is.finite(es_s$se) & es_s$se > 0
-		if (sum(es_fin) >= 2L) {
-			ew_s <- (es_s$ci_high - es_s$ci_low)[es_fin]
-			ew_p <- (es_p$ci_high - es_p$ci_low)[es_fin]
-			expect_true(all(ew_s > ew_p))
-		}
+		# The AR(1) panel keeps >= 2 finite-SE event times for every estimator
+		# (mirrors the cohort-family guarantee above), so assert it rather than
+		# silently skipping: a conditionally-empty assertion would let a
+		# regression that NA-ed the event-study SEs masquerade as a pass.
+		expect_gte(sum(es_fin), 2L)
+		ew_s <- (es_s$ci_high - es_s$ci_low)[es_fin]
+		ew_p <- (es_p$ci_high - es_p$ci_low)[es_fin]
+		expect_true(all(ew_s > ew_p))
 	}
 })
 

--- a/tests/testthat/test-conservative-band-se-225.R
+++ b/tests/testthat/test-conservative-band-se-225.R
@@ -1,0 +1,147 @@
+library(testthat)
+library(fetwfe)
+
+# Issue #225: pin the conservative simultaneous-CI standard-error formula and
+# broaden coverage of the recently-added inference surface (#192/#197/#200).
+#
+# The shipped formula (`.cauchy_schwarz_se()` in R/simultaneous_cis.R, used by
+# the `se_type = "conservative"` band at the Sigma_1/Sigma_2 combine step) is
+# correct; these tests are drift sentinels.
+#
+# Why a new test was needed: the pre-existing Test 6 in test-maxt-pvalues-200.R
+# recovers the band SE from the band's OWN pointwise CI and then re-derives the
+# adjusted p-values from that same SE -- a round-trip that any (even wrong) SE
+# satisfies. It also runs under family = "cohort", where each effect is a single
+# cohort so the second variance component Sigma_2 = 0 and the conservative SE is
+# byte-identical to the tight SE. So it pins the Bonferroni-dual p-value but
+# CANNOT catch a regression in the conservative SE formula. These do.
+
+# --- Shared deterministic fixture: one simulated panel; fits built once. ---
+# G = 4, T = 6 => the event-study family has cohort-pooling event times, so the
+# second variance component Sigma_2 (hence v2) is strictly positive there.
+.cs_sim_225 <- local({
+	sc <- genCoefs(G = 4, T = 6, d = 2, density = 0.5, eff_size = 1.5, seed = 7)
+	simulateData(sc, N = 120, sig_eps_sq = 2, sig_eps_c_sq = 1)
+})
+
+.cs_fit_225 <- function(se_type) {
+	fetwfe(
+		pdata = .cs_sim_225$pdata,
+		time_var = .cs_sim_225$time_var,
+		unit_var = .cs_sim_225$unit_var,
+		treatment = .cs_sim_225$treatment,
+		covs = .cs_sim_225$covs,
+		response = .cs_sim_225$response,
+		sig_eps_sq = .cs_sim_225$sig_eps_sq,
+		sig_eps_c_sq = .cs_sim_225$sig_eps_c_sq,
+		q = 0.5,
+		se_type = se_type,
+		verbose = FALSE
+	)
+}
+
+.cs_fits_225 <- suppressMessages(list(
+	default = .cs_fit_225("default"),
+	conservative = .cs_fit_225("conservative"),
+	cluster = .cs_fit_225("cluster")
+))
+
+# Recover the per-effect SE from a simultaneous_cis object's pointwise band:
+# pointwise_ci = estimate +/- pointwise_critical_value * se.
+.cs_se_from_band <- function(sci) {
+	(sci$ci$pointwise_ci_high - sci$ci$estimate) / sci$pointwise_critical_value
+}
+
+# ---------------------------------------------------------------------------
+# 1. Unit test of the conservative-SE formula in isolation, against
+#    hand-computed values. This is the drift sentinel: any change to the
+#    formula (dropping the cross term, a wrong coefficient, a scale factor)
+#    makes it fail.
+# ---------------------------------------------------------------------------
+test_that(".cauchy_schwarz_se is sqrt(v1)+sqrt(v2) and matches hand values (#225)", {
+	v1 <- c(4, 0, 1, 9)
+	v2 <- c(9, 5, 0, 16)
+	got <- fetwfe:::.cauchy_schwarz_se(v1, v2)
+
+	# The Cauchy-Schwarz upper bound sqrt(v1 + v2 + 2*sqrt(v1*v2)) is exactly
+	# the sum of the two component SEs sqrt(v1) + sqrt(v2).
+	expect_equal(got, sqrt(v1) + sqrt(v2))
+	# Hand-computed: (2+3, 0+sqrt(5), 1+0, 3+4).
+	expect_equal(got, c(5, sqrt(5), 1, 7))
+
+	# Degenerate components: one term zero collapses to the other's SE.
+	expect_equal(fetwfe:::.cauchy_schwarz_se(c(4, 0), c(0, 9)), c(2, 3))
+	expect_equal(fetwfe:::.cauchy_schwarz_se(0, 0), 0)
+
+	# It strictly exceeds the TIGHT combined SE sqrt(v1 + v2) exactly where both
+	# components are positive (the cross term 2*sqrt(v1*v2) > 0), and equals it
+	# where a component is zero. Dropping the cross term is the regression this
+	# guards against.
+	tight <- sqrt(v1 + v2)
+	both <- v1 > 0 & v2 > 0
+	expect_true(all(got[both] > tight[both]))
+	expect_equal(got[!both], tight[!both])
+})
+
+# ---------------------------------------------------------------------------
+# 2. Integration: the conservative event-study band is actually WIRED to the
+#    formula on a v2 > 0 family. se_type changes only the variance combine (not
+#    selection or point estimates), so the conservative and tight bands are
+#    row-aligned over identical v1, v2: tight = sqrt(v1 + v2), conservative =
+#    sqrt(v1 + v2 + 2*sqrt(v1*v2)). The conservative band must therefore be
+#    >= the tight band everywhere and STRICTLY wider for >= 1 cohort-pooling
+#    (v2 > 0) event time.
+# ---------------------------------------------------------------------------
+test_that("conservative event-study band exceeds the tight band where v2>0 (#225)", {
+	skip_if_not_installed("mvtnorm")
+	sci_t <- simultaneousCIs(.cs_fits_225$default, family = "event_study")
+	sci_c <- suppressMessages(
+		simultaneousCIs(.cs_fits_225$conservative, family = "event_study")
+	)
+
+	# Same selection + point estimates under both se_types -> row-aligned.
+	expect_equal(sci_c$ci$estimate, sci_t$ci$estimate)
+
+	se_t <- .cs_se_from_band(sci_t)
+	se_c <- .cs_se_from_band(sci_c)
+	fin <- is.finite(se_t) & is.finite(se_c) & se_t > 0
+	expect_gte(sum(fin), 2L)
+
+	expect_true(all(se_c[fin] >= se_t[fin] - 1e-9))
+	expect_true(any(se_c[fin] > se_t[fin] + 1e-6))
+})
+
+# ---------------------------------------------------------------------------
+# 3. family = "custom" is well-formed under cluster AND conservative se_type
+#    (previously only the default/tight custom path was covered). Row 1 pools
+#    every treatment-effect cell; row 2 picks a single cell.
+# ---------------------------------------------------------------------------
+test_that("simultaneousCIs(family='custom') is well-formed under cluster + conservative (#225)", {
+	skip_if_not_installed("mvtnorm")
+	for (st in c("cluster", "conservative")) {
+		fit <- .cs_fits_225[[st]]
+		nt <- length(fit$treat_inds)
+		C <- rbind(rep(1 / nt, nt), c(1, rep(0, nt - 1)))
+
+		sci <- suppressMessages(
+			simultaneousCIs(fit, family = "custom", contrasts = C)
+		)
+		expect_identical(sci$K, 2L)
+		# API contract: estimates are the contrast applied to the (g, t) effects.
+		expect_equal(
+			sci$ci$estimate,
+			as.numeric(C %*% fit$beta_hat[fit$treat_inds]),
+			info = st
+		)
+
+		se <- .cs_se_from_band(sci)
+		expect_true(all(is.finite(se) & se >= 0), info = st)
+
+		# Simultaneous band is at least as wide as the pointwise band (K = 2, so
+		# the multiplicity-adjusted critical value strictly exceeds z_{1-a/2}).
+		pos <- se > 0
+		w_sim <- (sci$ci$simultaneous_ci_high - sci$ci$simultaneous_ci_low)[pos]
+		w_pw <- (sci$ci$pointwise_ci_high - sci$ci$pointwise_ci_low)[pos]
+		expect_true(all(w_sim >= w_pw - 1e-9), info = st)
+	}
+})

--- a/tests/testthat/test-maxt-pvalues-200.R
+++ b/tests/testthat/test-maxt-pvalues-200.R
@@ -157,7 +157,10 @@ test_that("eventStudy p_value is adjusted under simultaneous, Wald under pointwi
 
 # ---------------------------------------------------------------------------
 # 6. Conservative se_type: the Bonferroni dual, min(1, K * pointwise_p) on the
-#    band's Cauchy-Schwarz ses.
+#    band's Cauchy-Schwarz ses. NOTE: this pins the adjusted-p / band-se DUAL,
+#    not the Cauchy-Schwarz SE formula itself (it recovers se_band from the
+#    band's own CI, a round-trip, and uses family = "cohort" where Sigma_2 = 0).
+#    The SE formula is pinned in test-conservative-band-se-225.R (#225).
 # ---------------------------------------------------------------------------
 test_that("conservative se_type yields the Bonferroni-dual adjusted p-value", {
 	skip_if_not_installed("mvtnorm")


### PR DESCRIPTION
## Summary

Addresses #225. Pins the conservative simultaneous-CI standard-error formula (the confirmed **C1** finding from the 2026-06-03 review) and closes two of the four sibling coverage gaps. **Stacked on #226** (branched from `docs-twfecovs-tes-224`); GitHub will retarget this to `main` once #226 merges.

## The core fix (C1)

The conservative band SE `sqrt(v1 + v2 + 2*sqrt(v1*v2))` had no test that could catch a regression: the pre-existing Test 6 recovers the SE from the band's *own* CI and round-trips it, under `family = "cohort"` where `Sigma_2 = 0` (so the conservative path is byte-identical to the tight path and never actually exercised).

- Extracted the combine into a documented `@noRd` helper `.cauchy_schwarz_se(v1, v2)` (behavior-preserving) so the exact formula is unit-testable in isolation.
- **Unit test** (`test-conservative-band-se-225.R`) against hand-computed values + the `sqrt(v1) + sqrt(v2)` identity. This is the drift sentinel.
- **Integration test**: on an `event_study` family (where `v2 > 0`), the conservative band must be `>=` the tight band everywhere and **strictly** wider for `>= 1` cohort-pooling effect — confirming the formula is wired to `Sigma_2`. `se_type` changes only the variance combine (not selection/estimates), so the two bands are row-aligned over identical `v1`, `v2` (asserted as a guard).

**Bite check (the issue's acceptance criterion):** temporarily dropping the cross term (`sqrt(v1 + v2)`) makes the new tests fail in 4 places (hand values, the strict-widening identity, and the integration `any(se_c > se_t)`); reverting restores green.

## Siblings included

- `family = "custom"` well-formedness under `se_type %in% {"cluster", "conservative"}` (previously only the default/tight custom path was covered).
- `test-ci-type-197.R` Test 16: the event-study cluster-widening assertion was wrapped in `if (sum(es_fin) >= 2L)` and could pass vacuously. Replaced with `expect_gte(sum(es_fin), 2L)` + unconditional widening — matching the cohort loop directly above it. (Empirically all of fetwfe/etwfe/betwfe keep 5/5 finite-SE event times on this fixture.)
- A clarifying cross-reference note on `test-maxt-pvalues-200.R` Test 6.

## Deferred (kept on #225 as standalone follow-ups)

- **K=0 degenerate path** (`simultaneous_cis.R:404-431`, all treatment effects zeroed by selection): no test exercises it, but triggering it needs a carefully hand-built `fetwfe` mock — cleaner on its own.
- **K=1 `Sigma_2` Jacobian** (`.assemble_joint_cov_var2` vs `getSecondVarTermOLS`): the two use different parameterizations (`J_list`/`theta_sel` vs `psi_mat`/`.build_jacobian`), so an equivalence test is a cross-parameterization proof, not a quick cell.

#225 stays open for these two.

## No version bump

Internal `@noRd` refactor (behavior-preserving) + tests → no version bump and no `NEWS.md`, per `DEV_INSTRUCTIONS.md`. No NAMESPACE/Rd change (`devtools::document()` is a no-op).

## Verification

- `air format .`: no changes · `devtools::document()`: no changes
- `devtools::test()`: `FAIL 0 | WARN 0 | SKIP 0 | PASS 2885` (+21)
- `R CMD check --as-cran`: 0 errors / 0 warnings / 0 notes
- `spell_check()` clean · `urlchecker::url_check()` all correct
- New tests verified to FAIL on a deliberately-broken formula, PASS on revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)
