### PR TITLE
feat: lock calc_ses parity via C11 validator contract (#187)

### DIFF
--- a/R/fetwfe_class.R
+++ b/R/fetwfe_class.R
@@ -175,5 +175,23 @@ print.summary.fetwfe <- function(x, ...) {
 		"C6 nrow(internal$X_ints) == N * T",
 		cls
 	)
+	# C11 calc_ses parity: FETWFE mirrors `calc_ses` at the top level (#180) in
+	# addition to the canonical `$internal$calc_ses`. Lock the two together so a
+	# future refactor cannot drift them apart (the #180 post-implementation
+	# sentinel's future-divergence NOTE; #187). Production sets both from the
+	# same `res$calc_ses` (R/fetwfe.R), so this only ever fires on a malformed
+	# hand-built object.
+	.assert_contract(
+		identical(x$calc_ses, x$internal$calc_ses),
+		"C11 calc_ses == internal$calc_ses",
+		cls,
+		detail = paste0(
+			"top-level calc_ses = ",
+			format(x$calc_ses),
+			"; internal$calc_ses = ",
+			format(x$internal$calc_ses),
+			"."
+		)
+	)
 	invisible(x)
 }

--- a/tests/testthat/test-class-validators.R
+++ b/tests/testthat/test-class-validators.R
@@ -3,8 +3,9 @@
 # Three sections:
 #   (a) well-formed objects pass the validator (covers q in {0.5, 1, 2}
 #       and the all-zero-theta fallback);
-#   (b) each contract C1-C8 catches its target malformation with a clear
-#       error message naming the failed contract;
+#   (b) each contract C1-C8 (and the FETWFE-only C11 calc_ses parity)
+#       catches its target malformation with a clear error message naming
+#       the failed contract;
 #   (c) cross-class consistency: the validator's expected-slots list
 #       matches `names(<live fit>)` via expect_setequal (set membership;
 #       order doesn't matter);
@@ -208,6 +209,21 @@ test_that("C8 type sanity: validator catches malformed se_type", {
 	expect_error(
 		fetwfe:::.validate_fetwfe(res),
 		"C8 se_type",
+		fixed = TRUE
+	)
+})
+
+test_that("C11 calc_ses parity: validator catches top-level calc_ses != internal$calc_ses", {
+	fx <- .validator_fixture(q = 0.5)
+	res <- fx$fetwfe
+	# A well-formed fit mirrors calc_ses at the top level and under $internal.
+	stopifnot(identical(res$calc_ses, res$internal$calc_ses))
+	# Mutate: diverge the top-level mirror from the canonical internal value
+	# (C1 reads internal$calc_ses, which stays valid, so C11 is what fires).
+	res$calc_ses <- !res$internal$calc_ses
+	expect_error(
+		fetwfe:::.validate_fetwfe(res),
+		"C11 calc_ses == internal$calc_ses",
 		fixed = TRUE
 	)
 })


### PR DESCRIPTION
## Summary

Resolves #187. Adds a constructor-validator contract (**C11**) that locks FETWFE's top-level `calc_ses` to its canonical `$internal$calc_ses`, closing the future-divergence risk the #180 post-implementation sentinel flagged when `calc_ses` was first mirrored to the top level.

## Change

- `R/fetwfe_class.R`: one `.assert_contract()` in `.validate_fetwfe()` asserting `identical(x$calc_ses, x$internal$calc_ses)` (labeled `C11`, with a `format()`-based detail matching the C1 style).
- `tests/testthat/test-class-validators.R`: the C11 mutation test alongside C1–C8 (take a real fit, diverge the top-level mirror, confirm the validator stops). Header comment updated.

## Why it's safe

- **Production can't violate it.** `fetwfe()` sets both `out$calc_ses` and `out$internal$calc_ses` from the same `res$calc_ses` (`R/fetwfe.R:477`, `:496`), so the contract holds by construction. It only fires on a malformed hand-built object — exactly the drift the issue wants to make structurally impossible.
- **No existing fit or mock violates it.** Audited every fetwfe-shaped object the suite validates (the `.validator_fixture` real fits; the `test-lex-cohort-sort.R` mock, which sets both slots `TRUE`); the full suite passes unchanged, so the §18 mock-fixture trap did not bite here.
- **Bite check (WORKFLOW_LESSONS §23):** neutering the contract to `TRUE` makes the new C11 test fail; reverting restores green. The test genuinely exercises the contract, not something incidental.

## No version bump

Internal `@noRd` validator contract that never fires on package-produced objects → no user-visible behavior change, so no version bump or `NEWS.md` entry, per `DEV_INSTRUCTIONS.md`. (Flagging in case you'd prefer a patch bump to track it as a deliberate robustness enhancement.)

## Verification

- `air format .`: no changes · `devtools::document()`: no changes (validator is `@noRd`)
- `devtools::test()`: `FAIL 0 | WARN 0 | SKIP 0 | PASS 2865` (+1)
- `R CMD check --as-cran`: 0 errors / 0 warnings / 1 NOTE (environmental "unable to verify current time")
- `spell_check()` clean · `urlchecker::url_check()` all correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)
