### PR TITLE
feat: display cohort-assignment DGP in print/summary.FETWFE_tes (#189)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.18.0
+Version: 1.18.1
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # NEWS
 
+## Version 1.18.1
+
+### User-facing
+
+- `print()` and `summary()` on a `getTes()` (`FETWFE_tes`) object now display a
+  "Cohort assignment DGP" section -- the assignment type, strength, and
+  propensity-derived cohort weights -- for objects generated under a
+  covariate-dependent DGP (`assignment_type = "multinomial"` or `"ordered"`).
+  Marginal-DGP objects print exactly as before. To support this, `getTes()`
+  output additionally carries the `assignment_type` and `assignment_strength`
+  slots, copied from the source `FETWFE_coefs` (#189).
+
 ## Version 1.18.0
 
 ### Inference

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -426,6 +426,15 @@ genCoefs <- function(
 #'         \code{assignment_type = "multinomial"} or \code{"ordered"} it is
 #'         \eqn{E[\pi_g(X)] / \sum_{g' \text{ treated}} E[\pi_{g'}(X)]}{E[pi_g(X)] / sum_{g' treated} E[pi_g'(X)]}.
 #'         New in 1.14.0.}
+#'   \item{assignment_type}{Character; the cohort-assignment DGP carried over
+#'         from \code{coefs_obj} (one of \code{"marginal"},
+#'         \code{"multinomial"}, or \code{"ordered"}). Determines whether
+#'         \code{cohort_weights} is uniform (marginal) or propensity-weighted.
+#'         New in 1.18.1.}
+#'   \item{assignment_strength}{Numeric; the assignment-strength scaling carried
+#'         over from \code{coefs_obj} (meaningful only when
+#'         \code{assignment_type != "marginal"}). \code{NULL} for
+#'         \code{FETWFE_coefs} objects saved before 1.14.0. New in 1.18.1.}
 #'   \item{G, T, d, seed}{The generating parameters carried over from
 #'         \code{coefs_obj} so that \code{print()} and \code{summary()} on the
 #'         returned object are self-describing.}
@@ -501,6 +510,10 @@ getTes <- function(coefs_obj) {
 	} else {
 		coefs_obj$assignment_type
 	}
+	# Assignment-strength scaling, carried onto the FETWFE_tes object so
+	# print()/summary() can describe the DGP (#189). NULL for FETWFE_coefs
+	# objects saved before 1.14.0; only displayed for non-marginal DGPs.
+	assignment_strength <- coefs_obj$assignment_strength
 
 	num_treats <- getNumTreats(G = G, T = T)
 
@@ -564,7 +577,9 @@ getTes <- function(coefs_obj) {
 		d = d,
 		seed = coefs_obj$seed,
 		cohort_times = cohort_times,
-		cohort_weights = cohort_weights
+		cohort_weights = cohort_weights,
+		assignment_type = assignment_type,
+		assignment_strength = assignment_strength
 	)
 	class(out) <- "FETWFE_tes"
 	return(out)

--- a/R/getTes_class.R
+++ b/R/getTes_class.R
@@ -3,6 +3,30 @@
 #' @name FETWFE_tes-class
 NULL
 
+# Render the "Cohort assignment DGP" section shared by print.FETWFE_tes and
+# print.summary.FETWFE_tes (#189). Gated on a non-marginal assignment_type, so
+# marginal objects -- and pre-1.14.0 objects that predate the slot -- render
+# nothing and their output is unchanged.
+#' @keywords internal
+#' @noRd
+.cat_tes_assignment_dgp <- function(x) {
+	if (is.null(x$assignment_type) || x$assignment_type == "marginal") {
+		return(invisible(NULL))
+	}
+	cat("Cohort assignment DGP:\n")
+	cat(sprintf("  %-16s: %s\n", "Type", x$assignment_type))
+	if (!is.null(x$assignment_strength)) {
+		cat(sprintf("  %-16s: %.4f\n", "Strength", x$assignment_strength))
+	}
+	cat(sprintf(
+		"  %-16s: %s\n",
+		"Cohort weights",
+		paste(sprintf("%.4f", x$cohort_weights), collapse = ", ")
+	))
+	cat("\n")
+	invisible(NULL)
+}
+
 #' @export
 print.FETWFE_tes <- function(x, ...) {
 	cat(
@@ -16,6 +40,7 @@ print.FETWFE_tes <- function(x, ...) {
 		cat(sprintf("  Cohort %d: %.4f\n", g, x$actual_cohort_tes[g]))
 	}
 	cat("\n")
+	.cat_tes_assignment_dgp(x)
 	cat("Generated from:\n")
 	cat(sprintf("  Cohorts (G)      : %d\n", x$G))
 	cat(sprintf("  Time periods (T) : %d\n", x$T))
@@ -41,6 +66,9 @@ summary.FETWFE_tes <- function(object, ...) {
 		T = object$T,
 		d = object$d,
 		seed = object$seed,
+		cohort_weights = object$cohort_weights,
+		assignment_type = object$assignment_type,
+		assignment_strength = object$assignment_strength,
 		cohort_te_stats = c(
 			min = min(tes),
 			max = max(tes),
@@ -77,6 +105,7 @@ print.summary.FETWFE_tes <- function(x, ...) {
 		}
 	))
 	cat("\n")
+	.cat_tes_assignment_dgp(x)
 	cat("Generated from:\n")
 	cat(sprintf("  Cohorts (G)      : %d\n", x$G))
 	cat(sprintf("  Time periods (T) : %d\n", x$T))

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -3,7 +3,7 @@ bibentry(
   title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
   author  = person("Gregory", "Faletto"),
   year    = "2025",
-  note    = "R package version 1.18.0",
+  note    = "R package version 1.18.1",
   url     = "https://cran.r-project.org/package=fetwfe",
   doi      = "10.32614/CRAN.package.fetwfe"
 )

--- a/man/getTes.Rd
+++ b/man/getTes.Rd
@@ -33,6 +33,15 @@ the marginal DGP this is uniform \code{1/G}. Under
 \code{assignment_type = "multinomial"} or \code{"ordered"} it is
 \eqn{E[\pi_g(X)] / \sum_{g' \text{ treated}} E[\pi_{g'}(X)]}{E[pi_g(X)] / sum_{g' treated} E[pi_g'(X)]}.
 New in 1.14.0.}
+\item{assignment_type}{Character; the cohort-assignment DGP carried over
+from \code{coefs_obj} (one of \code{"marginal"},
+\code{"multinomial"}, or \code{"ordered"}). Determines whether
+\code{cohort_weights} is uniform (marginal) or propensity-weighted.
+New in 1.18.1.}
+\item{assignment_strength}{Numeric; the assignment-strength scaling carried
+over from \code{coefs_obj} (meaningful only when
+\code{assignment_type != "marginal"}). \code{NULL} for
+\code{FETWFE_coefs} objects saved before 1.14.0. New in 1.18.1.}
 \item{G, T, d, seed}{The generating parameters carried over from
 \code{coefs_obj} so that \code{print()} and \code{summary()} on the
 returned object are self-describing.}

--- a/tests/testthat/test-getTes.R
+++ b/tests/testthat/test-getTes.R
@@ -214,3 +214,52 @@ test_that("summary.FETWFE_tes returns expected fields and dispersion stats", {
 	joined <- paste(out, collapse = "\n")
 	expect_match(joined, "Cohort effect dispersion")
 })
+
+# ------------------------------------------------------------------------------
+# Test 8 (#189): the "Cohort assignment DGP" section renders only for
+# non-marginal objects, and getTes() carries assignment_type /
+# assignment_strength so print()/summary() can describe the DGP.
+# ------------------------------------------------------------------------------
+test_that("print/summary.FETWFE_tes show the assignment-DGP section only when non-marginal", {
+	# Marginal: slots present, but the new section is NOT rendered, so the
+	# common-case output is unchanged.
+	tm <- getTes(genCoefs(
+		G = 3,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 1,
+		seed = 1
+	))
+	expect_identical(tm$assignment_type, "marginal")
+	pm <- paste(capture.output(print(tm)), collapse = "\n")
+	sm <- paste(capture.output(print(summary(tm))), collapse = "\n")
+	expect_no_match(pm, "Cohort assignment DGP", fixed = TRUE)
+	expect_no_match(sm, "Cohort assignment DGP", fixed = TRUE)
+
+	# Non-marginal: getTes() carries the slots, and both print() and summary()
+	# render the type, strength, and cohort weights.
+	cn <- genCoefs(
+		G = 3,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 1,
+		assignment_type = "multinomial",
+		assignment_strength = 1.0,
+		seed = 42
+	)
+	tn <- getTes(cn)
+	expect_identical(tn$assignment_type, "multinomial")
+	expect_equal(tn$assignment_strength, 1.0)
+	expect_length(tn$cohort_weights, 3L)
+
+	pn <- paste(capture.output(print(tn)), collapse = "\n")
+	expect_match(pn, "Cohort assignment DGP", fixed = TRUE)
+	expect_match(pn, "multinomial", fixed = TRUE)
+	expect_match(pn, "Cohort weights", fixed = TRUE)
+
+	sn <- paste(capture.output(print(summary(tn))), collapse = "\n")
+	expect_match(sn, "Cohort assignment DGP", fixed = TRUE)
+	expect_match(sn, "multinomial", fixed = TRUE)
+})


### PR DESCRIPTION
## Summary

Resolves #189. Surfaces the covariate-dependent cohort-assignment DGP (#162) in the default `print()` / `summary()` of a `getTes()` (`FETWFE_tes`) object, which previously required `str(tes)` / `tes$cohort_weights` to inspect.

## Changes

- **`R/gen_coefs.R` (`getTes`)**: carry `assignment_type` and `assignment_strength` from the source `FETWFE_coefs` onto the returned `FETWFE_tes` (the methods only see the object, not the parent coefs). `@return` doc updated for both new slots.
- **`R/getTes_class.R`**: a `@noRd` helper `.cat_tes_assignment_dgp()` renders a "Cohort assignment DGP" section (type, strength, propensity-derived cohort weights); wired into `print.FETWFE_tes` and `print.summary.FETWFE_tes`, with the three slots carried through `summary.FETWFE_tes`. The section is **gated on a non-marginal `assignment_type`** — marginal (and pre-1.14.0) objects print exactly as before.
- **Version 1.18.0 → 1.18.1** (DESCRIPTION, NEWS.md, inst/CITATION) + `man/getTes.Rd` regenerated.

## Example output (non-marginal)

```
Cohort assignment DGP:
  Type            : multinomial
  Strength        : 1.5000
  Cohort weights  : 0.4223, 0.3197, 0.2580
```

## Version-bump note

I took a **patch bump** because this is user-visible (new display) and adds two slots to the `getTes()` return (additive API). The issue frames it as Tier-7 polish — if you'd rather treat it as pure polish, drop the bump + NEWS/CITATION edits and the rest stands alone.

## Verification

- `air format .`: no changes · `devtools::document()`: regenerated only `man/getTes.Rd`
- `devtools::test()`: `FAIL 0 | WARN 0 | SKIP 0 | PASS 2875` — includes `test-doc-slot-parity.R`, which enforces bidirectional slot↔`@return` parity (so the two new slots are provably documented)
- `R CMD check --as-cran`: 0 errors / 0 warnings / 1 NOTE (environmental "unable to verify current time")
- `spell_check()` clean · `urlchecker::url_check()` all correct
- Marginal `print`/`summary` output is unchanged (existing Tests 6/7 pass; new Test 8 asserts the section is present for non-marginal and absent for marginal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
