### PR TITLE
test: close coverage gaps G1/G2/G5 from the 2026-05-29 review (#185)

### DIFF
--- a/tests/testthat/test-broom-methods.R
+++ b/tests/testthat/test-broom-methods.R
@@ -788,3 +788,32 @@ test_that("augment.fetwfe dispatches when indep_counts was supplied", {
 	expect_true(is.numeric(aug$.fitted))
 	expect_true(all(is.finite(aug$.fitted)))
 })
+
+# ------------------------------------------------------------------------------
+# (#185 G5): tidy.eventStudy()'s own required-columns guard. The validator path
+# (missing fit slots at eventStudy() construction) is covered in
+# test-event-study-no-silent-swallow-174.R; this exercises the guard at the
+# tidy layer, on an eventStudy frame that is missing a required column.
+# ------------------------------------------------------------------------------
+test_that("tidy.eventStudy errors clearly when a required column is missing (#185 G5)", {
+	skip_if_not_installed("broom")
+	es <- data.frame(
+		event_time = 0:1,
+		n_cohorts = c(2L, 2L),
+		estimate = c(0.10, 0.20),
+		se = c(0.05, 0.06),
+		ci_low = c(0.00, 0.08),
+		ci_high = c(0.20, 0.32),
+		p_value = c(0.045, 0.030)
+	)
+	class(es) <- c("eventStudy", "data.frame")
+	# Positive control: the complete frame tidies without error.
+	expect_no_error(broom::tidy(es))
+	# Drop a required column -> the tidy-layer guard fires with a clear message.
+	es$se <- NULL
+	expect_error(
+		broom::tidy(es),
+		"tidy.eventStudy(): input is missing required columns: se",
+		fixed = TRUE
+	)
+})

--- a/tests/testthat/test-lambda-selection-164.R
+++ b/tests/testthat/test-lambda-selection-164.R
@@ -398,3 +398,25 @@ test_that("BIC path preserves caller's .Random.seed (#177)", {
 	after <- runif(3L)
 	expect_identical(before, after)
 })
+
+# ------------------------------------------------------------------------------
+# (#185 G1): the default CV path composes with se_type = "cluster" and with
+# add_ridge = TRUE -- cross-paths the other CV tests above leave unexercised.
+# Both work empirically; this locks the cross-path behavior so a regression on
+# either the cluster sandwich or the ridge augmentation under CV is caught.
+# ------------------------------------------------------------------------------
+test_that("CV path composes with se_type = 'cluster' and with add_ridge", {
+	sim <- .lambda_sel_fixture()
+
+	res_cl <- fetwfeWithSimulatedData(sim, se_type = "cluster")
+	expect_identical(res_cl$lambda_selection, "cv")
+	expect_identical(res_cl$se_type, "cluster")
+	expect_true(is.finite(res_cl$att_hat))
+	expect_true(is.finite(res_cl$att_se))
+	expect_gt(res_cl$att_se, 0)
+
+	res_ridge <- fetwfeWithSimulatedData(sim, add_ridge = TRUE)
+	expect_identical(res_ridge$lambda_selection, "cv")
+	expect_true(is.finite(res_ridge$att_hat))
+	expect_true(is.finite(res_ridge$att_se))
+})

--- a/tests/testthat/test-tight-gaussian-variance-141-146.R
+++ b/tests/testthat/test-tight-gaussian-variance-141-146.R
@@ -542,3 +542,53 @@ test_that("tight Gaussian default delivers near-nominal 95% CI coverage on simul
 		)
 	)
 })
+
+# ------------------------------------------------------------------------------
+# (#185 G2): the REML variance-component estimator path under the tight-Gaussian
+# default. Every other test in this file SUPPLIES sig_eps_sq / sig_eps_c_sq,
+# bypassing estOmegaSqrtInv(); here we pass NA so the components are estimated
+# by REML (lme4) and the default tight formula consumes the estimates.
+# ------------------------------------------------------------------------------
+test_that("tight-Gaussian default works when variance components are REML-estimated", {
+	skip_if_not_installed("lme4")
+	set.seed(141)
+	sim_coefs <- genCoefs(
+		G = 3,
+		T = 6,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		seed = 141
+	)
+	sim <- simulateData(sim_coefs, N = 80, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+
+	res <- suppressWarnings(fetwfe(
+		pdata = sim$pdata,
+		time_var = sim$time_var,
+		unit_var = sim$unit_var,
+		treatment = sim$treatment,
+		covs = sim$covs,
+		response = sim$response,
+		sig_eps_sq = NA, # force REML estimation via estOmegaSqrtInv()
+		sig_eps_c_sq = NA,
+		q = 0.5,
+		se_type = "default"
+	))
+
+	expect_identical(res$se_type, "default")
+	# REML produced finite variance-component estimates (the path under test);
+	# the row-level noise is strictly positive, the unit-level may hit 0.
+	expect_true(is.finite(res$sig_eps_sq))
+	expect_true(is.finite(res$sig_eps_c_sq))
+	expect_gt(res$sig_eps_sq, 0)
+	# The tight formula consumed them: att_se = sqrt(V1 + V2), finite and > 0.
+	vc <- res$internal$variance_components
+	expect_true(is.finite(vc$att_var_1) && is.finite(vc$att_var_2))
+	expect_true(is.finite(res$att_se))
+	expect_gt(res$att_se, 0)
+	expect_equal(
+		res$att_se,
+		sqrt(vc$att_var_1 + vc$att_var_2),
+		tolerance = 1e-10
+	)
+})


### PR DESCRIPTION
## Summary

Addresses #185 by closing the three **test-coverage gaps** (G1, G2, G5) the 2026-05-29 periodic review flagged. Test-only — no production code, no behavior change, no version bump.

Each gap was a real path the existing fixtures bypass:

- **G1 — CV × {cluster, ridge}** (`test-lambda-selection-164.R`): the CV-selection tests never combined `lambda_selection = "cv"` (the default) with `se_type = "cluster"` or `add_ridge = TRUE`. Added a test asserting both cross-paths produce a finite, positive `att_se` under CV.
- **G2 — REML variance-component path** (`test-tight-gaussian-variance-141-146.R`): every other test in that file *supplies* `sig_eps_sq` / `sig_eps_c_sq`, bypassing `estOmegaSqrtInv()`. Added a fixture that passes `NA` for both, forcing REML estimation (lme4), and asserts the tight-Gaussian default consumes the estimated components (`att_se = sqrt(V1 + V2)`, finite and positive). `skip_if_not_installed("lme4")`.
- **G5 — `tidy.eventStudy()` required-columns guard** (`test-broom-methods.R`): the construction-time validator path is covered in `test-event-study-no-silent-swallow-174.R`, but `tidy.eventStudy()`'s own guard (`R/broom_methods.R:504`) was untested. Added a positive control + a missing-column case asserting the specific guard message.

## Scope

Retires 3 of #185's 8 items. The remaining items (soft bugs SB2/SB4/SB5/SB6, IC1, A2, and the G4 synthetic-fixture work) stay tracked in #185 — G4 in particular needs a designed synthetic scattered-cohort fixture, which is more than a coverage add.

## Verification

- `air format .`: no changes
- `devtools::test()`: `FAIL 0 | WARN 0 | SKIP 0 | PASS 2882`
- `R CMD check --as-cran`: 0 errors / 0 warnings / 0 notes
- `spell_check()` clean · `urlchecker::url_check()` all correct (unaffected — test-only)
- All three new tests confirmed to actually run (lme4 present, so G2 does not skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
