### PR TITLE
feat: warn when lambda.max/lambda.min/nlambda are ignored under cv (#185 IC1)

### DIFF
--- a/R/utility.R
+++ b/R/utility.R
@@ -2029,7 +2029,17 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 
 	# CV path. cv.grpreg builds its own lambda grid (we don't forward the
 	# user-facing lambda.max/lambda.min/nlambda knobs — those are BIC-path
-	# only).
+	# only). Warn rather than silently ignore a non-default value so the user
+	# isn't surprised that a supplied lambda grid had no effect (#185 IC1).
+	if (!is.na(lambda.max) || !is.na(lambda.min) || nlambda != 100) {
+		warning(
+			"lambda.max, lambda.min, and nlambda are ignored under ",
+			"lambda_selection = 'cv' (cross-validation builds its own lambda ",
+			"grid). Set lambda_selection = 'bic' to use a custom lambda grid, ",
+			"or omit these arguments to silence this warning.",
+			call. = FALSE
+		)
+	}
 	if (verbose) {
 		message("Estimating bridge regression with 10-fold CV...")
 		t0 <- Sys.time()

--- a/tests/testthat/test-betwfe.R
+++ b/tests/testthat/test-betwfe.R
@@ -315,6 +315,9 @@ test_that("betwfe returns expected output when lambda parameters are supplied", 
 		treatment = "treatment",
 		covs = c("cov1", "cov2"),
 		response = "y",
+		# Custom lambda grid only applies on the BIC path (CV builds its own;
+		# #185 IC1). Set bic so the supplied grid is actually exercised.
+		lambda_selection = "bic",
 		lambda.max = 5,
 		lambda.min = 0.5,
 		nlambda = 50,

--- a/tests/testthat/test-fetwfe.R
+++ b/tests/testthat/test-fetwfe.R
@@ -312,6 +312,9 @@ test_that("fetwfe returns expected output when lambda parameters are supplied", 
 		treatment = "treatment",
 		covs = c("cov1", "cov2"),
 		response = "y",
+		# Custom lambda grid only applies on the BIC path (CV builds its own;
+		# #185 IC1). Set bic so the supplied grid is actually exercised.
+		lambda_selection = "bic",
 		lambda.max = 5,
 		lambda.min = 0.5,
 		nlambda = 50,

--- a/tests/testthat/test-lambda-selection-164.R
+++ b/tests/testthat/test-lambda-selection-164.R
@@ -398,3 +398,35 @@ test_that("BIC path preserves caller's .Random.seed (#177)", {
 	after <- runif(3L)
 	expect_identical(before, after)
 })
+
+# ------------------------------------------------------------------------------
+# (#185 IC1): lambda.max / lambda.min / nlambda are silently ignored under the
+# default lambda_selection = "cv" (cross-validation builds its own grid). Warn
+# so the user isn't surprised; stay silent on the BIC path and on cv with the
+# default grid.
+# ------------------------------------------------------------------------------
+test_that("cv path warns when lambda.max / lambda.min / nlambda are supplied", {
+	sim <- .lambda_sel_fixture()
+	expect_warning(
+		fetwfeWithSimulatedData(sim, lambda.max = 5),
+		"ignored under lambda_selection = 'cv'",
+		fixed = TRUE
+	)
+	expect_warning(
+		fetwfeWithSimulatedData(sim, nlambda = 50L),
+		"ignored under lambda_selection = 'cv'",
+		fixed = TRUE
+	)
+	# betwfe() shares the same dispatch.
+	expect_warning(
+		betwfeWithSimulatedData(sim, lambda.min = 0.01),
+		"ignored under lambda_selection = 'cv'",
+		fixed = TRUE
+	)
+	# BIC path uses the supplied grid -> no IC1 warning.
+	expect_no_warning(
+		fetwfeWithSimulatedData(sim, lambda_selection = "bic", lambda.max = 5)
+	)
+	# CV with the default grid -> no warning.
+	expect_no_warning(fetwfeWithSimulatedData(sim))
+})


### PR DESCRIPTION
## Summary

Addresses #185 item **IC1**. Under the default `lambda_selection = "cv"`, the user-facing `lambda.max` / `lambda.min` / `nlambda` arguments are silently ignored — cross-validation builds its own lambda grid — so a supplied custom grid has no effect, with no signal to the user. This adds a warning.

## Changes

- **`R/utility.R` (`.dispatch_bridge_selection`)**: in the CV branch, `warning()` (once per call, `call. = FALSE`) when any of `lambda.max` / `lambda.min` is non-`NA` or `nlambda != 100`, telling the user the grid is ignored under cv and to use `lambda_selection = "bic"` (or omit the args). The BIC path is unchanged; cv with the default grid stays silent.
- **`tests/testthat/test-lambda-selection-164.R`**: new test asserting the warning fires for `fetwfe`/`betwfe` under cv with a supplied grid, and does NOT fire on the BIC path or on cv with defaults.
- **`tests/testthat/test-fetwfe.R` + `test-betwfe.R`**: the "lambda parameters are supplied" tests called the estimators with `lambda.max = 5, lambda.min = 0.5, nlambda = 50` under the **default cv path** — so their lambda args were *already silently ignored* (the very footgun IC1 describes, surfaced in the suite itself). Added `lambda_selection = "bic"` so the supplied grid is actually exercised (the tests' evident intent) and warning-free.

## Scope

Retires IC1 from #185 (4 of 8 items now closed across this PR and #230). The remaining soft bugs (SB2/SB4/SB5/SB6), A2, and G4 stay tracked.

## Version note

This is a user-visible behavior change (a new warning), which warrants a patch bump + NEWS bullet. But **#229 already bumps `main` to 1.18.1**, so I left the bump off here to avoid racing two PRs on the same version and creating a guaranteed NEWS conflict. Suggest folding a NEWS bullet under the shipping version at merge (DESCRIPTION/CITATION would auto-merge; only NEWS needs a one-line manual merge).

## Verification

- `air format .`: no changes
- `devtools::test()`: `FAIL 0 | WARN 0 | SKIP 0 | PASS 2869` (WARN 0 confirms the new warning leaks nowhere — every firing is `expect_warning`-captured)
- `R CMD check --as-cran`: 0 errors / 0 warnings / 0 notes
- Audited every call site: no example/vignette/internal caller passes these args under cv (internal callers forward `NA` / `nlambda = 100`), so no spurious warnings fire anywhere in the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
