### PR TITLE
docs: cite only the paper in inst/CITATION (#232)

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,15 +1,4 @@
 bibentry(
-  bibtype = "Manual",
-  title   = "fetwfe: Fused Extended Two-Way Fixed Effects",
-  author  = person("Gregory", "Faletto"),
-  year    = "2025",
-  note    = "R package version 1.18.1",
-  url     = "https://cran.r-project.org/package=fetwfe",
-  doi      = "10.32614/CRAN.package.fetwfe"
-)
-
-
-bibentry(
   bibtype  = "Article",
   title    = "Fused Extended Two-Way Fixed Effects for Difference-in-Differences With Staggered Adoptions",
   author   = person("Gregory", "Faletto"),


### PR DESCRIPTION
## Summary

Resolves #232. Removes the R-package (`Manual`) `bibentry` from `inst/CITATION`, leaving only the paper (`Article`) entry, so `citation("fetwfe")` directs users to cite the paper. Google Scholar doesn't track the package citation, so this consolidates citations on the paper.

## Change

- `inst/CITATION`: deleted the `bibentry(bibtype = "Manual", ...)` block (the *"fetwfe: ... R package version X"* entry). The paper `Article` entry is unchanged.

After the change, `utils::readCitationFile("inst/CITATION")` parses to a single `Article` reference (the paper).

## No other files affected

The package citation lived only in `inst/CITATION` — `README.md` and the vignettes already reference only the paper, so nothing else needed changing.

## Version-sync side benefit

The removed `Manual` entry was the only place `inst/CITATION` carried `R package version X`, so going forward `inst/CITATION` no longer needs a version bump — it can be dropped from the DESCRIPTION / NEWS.md / CITATION sync.

## No version bump

Pure citation-metadata change — no package code or behavior change — so no version bump or `NEWS.md` entry, per `DEV_INSTRUCTIONS.md`. Flagging in case you'd prefer a one-line NEWS note that `citation()` now returns only the paper.

## Verification

- `inst/CITATION` parses to a single `Article` (paper) entry via `utils::readCitationFile()`.
- `R CMD check --as-cran`: 0 errors / 0 warnings / 0 notes (the check validates the CITATION file).
- `spell_check()` clean · `urlchecker::url_check()` all correct.
- No R code touched, so the test suite is unaffected (and `check --as-cran` runs it regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
