### PR TITLE
feat: support a user-supplied fusion matrix D_N in fetwfe() (#236)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.20.0
+Version: 1.21.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,22 @@
 # NEWS
 
+## Version 1.21.0
+
+### Features
+
+- `fetwfe()` (and `fetwfeWithSimulatedData()`) gain a `fusion_matrix` argument:
+  an optional user-supplied `num_treats x num_treats` forward-differences matrix
+  `D_N` for the treatment-effect block. When supplied it overrides
+  `fusion_structure` for that block (the estimator uses `solve(fusion_matrix)`
+  internally), letting advanced users encode arbitrary identifying-restriction
+  structures beyond the two built-ins. The rows/columns follow the cohort-major
+  `(g, t)` order of `getFirstInds()` / `getTreatInds()`. A `D_N` whose singular
+  values satisfy `sigma_max <= sqrt(6)` and `sigma_min >= 1 / (T * sqrt(2 * T))`
+  inherits the paper's inferential guarantees (Faletto 2025, event-study
+  singular-value lemma); outside those bounds the fit stays a valid point
+  estimator but `fetwfe()` warns. `fusion_matrix = NULL` (the default) is
+  byte-identical to prior behavior (#236).
+
 ## Version 1.20.0
 
 ### Features

--- a/R/core_funcs.R
+++ b/R/core_funcs.R
@@ -45,6 +45,13 @@
 #'   \code{twfeCovs_core}) must pass this argument explicitly.
 #' @param is_twfe_covs Logical.  If \code{TRUE}, columns will be removed and
 #'   consolidated as required for `twfeCovs()`.  Default \code{FALSE}.
+#' @param fusion_structure Character; one of `"cohort"` (default) or
+#'   `"event_study"`. Forwarded to `.append_ridge_rows()` (and thence the
+#'   full inverse-fusion matrix) when `add_ridge = TRUE && is_fetwfe`.
+#' @param d_inv_treat Optional `num_treats x num_treats` numeric matrix; the
+#'   user-supplied already-inverted treatment-effect fusion block
+#'   (`solve(fusion_matrix)`, #236), forwarded to `.append_ridge_rows()`.
+#'   Default `NULL`.
 #'
 #' @details
 #' The routine carries out the following steps in order:
@@ -109,7 +116,8 @@ prep_for_etwfe_regression <- function(
 	indep_counts = NA,
 	is_fetwfe,
 	is_twfe_covs = FALSE,
-	fusion_structure = "cohort"
+	fusion_structure = "cohort",
+	d_inv_treat = NULL
 ) {
 	gls <- .estimate_variance_and_gls(
 		y = y,
@@ -160,7 +168,8 @@ prep_for_etwfe_regression <- function(
 		sig_eps_sq = sig_eps_sq,
 		sig_eps_c_sq = sig_eps_c_sq,
 		N = N,
-		fusion_structure = fusion_structure
+		fusion_structure = fusion_structure,
+		d_inv_treat = d_inv_treat
 	)
 	X_final_scaled <- ridge$X_scaled
 	y_final <- ridge$y_final
@@ -559,6 +568,14 @@ prep_for_etwfe_core <- function(
 #' @param sig_eps_sq,sig_eps_c_sq,N Numeric / integer; inputs to the
 #'   `lambda_ridge = 1e-5 * (sig_eps_sq + sig_eps_c_sq) * sqrt(p/(N*T))`
 #'   formula.
+#' @param fusion_structure Character; one of `"cohort"` (default) or
+#'   `"event_study"`. Forwarded to `genFullInvFusionTransformMat()`
+#'   (only used when `add_ridge = TRUE && is_fetwfe`).
+#' @param d_inv_treat Optional `num_treats x num_treats` numeric matrix; the
+#'   user-supplied already-inverted treatment-effect fusion block
+#'   (`solve(fusion_matrix)`, #236), forwarded to
+#'   `genFullInvFusionTransformMat()` so the custom block reaches the ridge
+#'   penalty rows. Default `NULL`.
 #' @return List with the (possibly-augmented) `X_scaled`, `y_final`,
 #'   and `lambda_ridge`.
 #' @keywords internal
@@ -577,7 +594,8 @@ prep_for_etwfe_core <- function(
 	sig_eps_sq,
 	sig_eps_c_sq,
 	N,
-	fusion_structure = "cohort"
+	fusion_structure = "cohort",
+	d_inv_treat = NULL
 ) {
 	if (!add_ridge) {
 		return(list(
@@ -596,7 +614,8 @@ prep_for_etwfe_core <- function(
 			G = G,
 			d = d,
 			num_treats = num_treats,
-			fusion_structure = fusion_structure
+			fusion_structure = fusion_structure,
+			d_inv_treat = d_inv_treat
 		)
 
 		stopifnot(ncol(D_inverse) == p)

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -436,12 +436,17 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 	sel_treat_inds_shifted <- which(theta_hat_slopes[treat_inds] != 0)
 	theta_hat_treat_sel <- theta_hat_slopes[treat_inds][sel_treat_inds_shifted]
 
-	# d_inv_treat: the treatment-block of D^{-1}, then restrict columns to selected
+	# d_inv_treat: the treatment-block of D^{-1}, then restrict columns to selected.
+	# A user-supplied custom fusion matrix (#236), if any, is stored inverted on
+	# `x$internal$d_inv_treat`; pass it through so this accessor uses the SAME
+	# transform as the fit (otherwise it would fall back to the built-in dispatch
+	# and silently disagree with the fitted effects).
 	d_inv_treat <- .gen_inv_treat_block(
 		num_treats = num_treats,
 		first_inds = first_inds,
 		G = G,
-		fusion_structure = x$fusion_structure
+		fusion_structure = x$fusion_structure,
+		d_inv_treat = x$internal$d_inv_treat
 	)
 	if (length(sel_treat_inds_shifted) > 0) {
 		d_inv_treat_sel <- d_inv_treat[,

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -161,6 +161,24 @@
 #'   time since treatment (event time `e = t - g`) across cohorts. The
 #'   event-study penalty carries the same theoretical guarantees as the default
 #'   (Faletto 2025); only the treatment-effect fusion structure changes.
+#' @param fusion_matrix (Optional.) Numeric matrix or `NULL` (the default). An
+#'   advanced-use override: a user-supplied `num_treats x num_treats` forward
+#'   differences matrix `D_N` for the treatment-effect block, encoding an
+#'   arbitrary fusion structure beyond the two built-ins. When non-`NULL` it
+#'   overrides `fusion_structure` for the treatment-effect block only (the
+#'   fixed-effect blocks are unchanged); the estimator uses `solve(fusion_matrix)`
+#'   internally. The rows/columns are interpreted in the cohort-major `(g, t)`
+#'   order used internally for the treatment effects (the order `getFirstInds()`
+#'   / `getTreatInds()` encode): row/column `i` corresponds to
+#'   base treatment effect `i`, with cohort `g` occupying rows
+#'   `first_inds[g]:(first_inds[g + 1] - 1)` ordered by event time. `num_treats`
+#'   equals `T * G - G * (G + 1) / 2`. `fusion_matrix` must be a finite,
+#'   invertible numeric matrix of that exact dimension (otherwise `fetwfe()`
+#'   stops). A `D_N` whose singular values satisfy `sigma_max <= sqrt(6)` and
+#'   `sigma_min >= 1 / (T * sqrt(2 * T))` inherits the paper's inferential
+#'   guarantees (Faletto 2025, event-study singular-value lemma); outside those
+#'   bounds the fit stays a valid point estimator but `fetwfe()` emits a
+#'   `warning()`. Default is `NULL` (use the built-in `fusion_structure`).
 #' @param ci_type Character; one of `"simultaneous"` (default) or
 #'   `"pointwise"`. Controls the confidence-interval bounds reported for the
 #'   cohort-specific ATTs (in `catt_df`) and the event-study effects (from
@@ -206,6 +224,7 @@
 #' \item{cv_folds}{Integer scalar; the `cv_folds` value used when `lambda_selection = "cv"`, `NA_integer_` when `lambda_selection = "bic"`.}
 #' \item{cv_seed}{Integer scalar; the seed actually fed to `set.seed()` immediately before `cv.grpreg()` was called. Defaults to `as.integer(N * T)` when the user did not pass a seed. `NA_integer_` when `lambda_selection = "bic"`.}
 #' \item{fusion_structure}{Character scalar; the `fusion_structure` argument the user passed (`"cohort"` or `"event_study"`), recording which fusion-penalty differences matrix was used for the treatment effects.}
+#' \item{fusion_matrix}{The user-supplied custom forward differences matrix `D_N` (a `num_treats x num_treats` numeric matrix), or `NULL` if none was supplied. When non-`NULL` it overrode `fusion_structure` for the treatment-effect block; the estimator used `solve(fusion_matrix)` internally. See the `fusion_matrix` argument.}
 #' \item{N}{The final number of units that were in the data set used for estimation (after any units may have been removed because they were treated in the first time period).}
 #' \item{T}{The number of time periods in the final data set.}
 #' \item{G}{The final number of treated cohorts that appear in the final data set.}
@@ -247,6 +266,7 @@
 #'     \item{calc_ses}{Logical indicating whether standard errors were calculated.}
 #'     \item{variance_components}{A list exposing the two variance pieces (`att_var_1`, `att_var_2`) plus their paper-notation counterparts (`V_1`, `V_2`) and the unit-scaled variance estimators (`tilde_v_N`, `hat_v_N`, `tilde_v_N_C`, `tilde_v_N_C_pi_hat`, `tilde_v_N_C_pi_hat_cons`, `tilde_v_N_cons`) catalogued at paper line 2006. The Wald CI is `[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]` (paper Eq. `conf.int.form`). New in v1.12.0 (issue #141 + #146).}
 #'     \item{first_year}{Integer or numeric scalar; the first (earliest) `time_var` value in the panel after `idCohorts()` processing. Consumed by `eventStudy()` to map `cohort_probs`' cohort labels (treatment-start years) to 1-based panel-time-index offsets when the labels are integer-coercible. New in v1.13.3 (issue #174).}
+#'     \item{d_inv_treat}{The inverted custom treatment-effect fusion block `solve(fusion_matrix)` (a `num_treats x num_treats` numeric matrix), or `NULL` if no `fusion_matrix` was supplied. Consumed by `eventStudy()` and `simultaneousCIs()` so the access-time bands reuse the same fusion block the fit used (#236).}
 #'   }
 #' }
 #'
@@ -328,13 +348,18 @@ fetwfe <- function(
 	cv_folds = 10L,
 	cv_seed = NULL,
 	ci_type = c("simultaneous", "pointwise"),
-	fusion_structure = c("cohort", "event_study")
+	fusion_structure = c("cohort", "event_study"),
+	fusion_matrix = NULL
 ) {
 	se_type <- match.arg(
 		se_type,
 		c("default", "conservative", "cluster")
 	)
 	ci_type <- match.arg(ci_type)
+	# Record whether the user explicitly passed `fusion_structure` so we can
+	# emit a one-line override notice when a custom `fusion_matrix` is also
+	# supplied (the matrix wins for the treatment block; #236).
+	fusion_structure_supplied <- !missing(fusion_structure)
 	fusion_structure <- match.arg(fusion_structure)
 	# `lambda_selection` is validated downstream by
 	# `checkFetwfeInputs()` as part of the collect-all-violations
@@ -394,6 +419,21 @@ fetwfe <- function(
 
 	rm(prep)
 
+	# User-supplied custom fusion matrix (#236). Validated here -- after prep
+	# (so `num_treats`, `G`, `T` are known) and before `fetwfe_core()`. When
+	# supplied, `d_inv_treat <- solve(fusion_matrix)` overrides
+	# `fusion_structure` for the treatment-effect block throughout the fit and
+	# is stored on the object for the access-time accessors (eventStudy(),
+	# simultaneousCIs()). NULL (the default) is byte-identical to omitting it.
+	d_inv_treat <- .validate_fusion_matrix(
+		fusion_matrix = fusion_matrix,
+		num_treats = num_treats,
+		G = G,
+		T = T,
+		fusion_structure_supplied = fusion_structure_supplied,
+		verbose = verbose
+	)
+
 	res <- fetwfe_core(
 		X_ints = X_ints,
 		y = y,
@@ -418,7 +458,8 @@ fetwfe <- function(
 		lambda_selection = lambda_selection,
 		cv_folds = cv_folds,
 		cv_seed = cv_seed,
-		fusion_structure = fusion_structure
+		fusion_structure = fusion_structure,
+		d_inv_treat = d_inv_treat
 	)
 
 	att_branch <- .select_att_branch(
@@ -478,6 +519,12 @@ fetwfe <- function(
 		},
 		cv_seed = res$cv_seed_used,
 		fusion_structure = fusion_structure,
+		# #236: the user-supplied forward difference matrix D_N (NULL when not
+		# supplied). Kept inside this list() literal so the slot name survives
+		# even when NULL (a post-construction `out$fusion_matrix <- NULL` would
+		# silently drop the name, breaking doc-slot parity). The inverted block
+		# `solve(fusion_matrix)` lives in `internal$d_inv_treat` below.
+		fusion_matrix = fusion_matrix,
 		N = res$N,
 		T = res$T,
 		G = res$G,
@@ -510,7 +557,14 @@ fetwfe <- function(
 		# `eventStudy()` can map `cohort_probs`' cohort labels back to
 		# panel-time offsets. See `R/event_study.R` and
 		# `R/utility.R::getFirstIndsFromOffsets`.
-		first_year = first_year
+		first_year = first_year,
+		# #236: the inverted user fusion block `solve(fusion_matrix)` (NULL when
+		# not supplied). Consumed by the access-time accessors `eventStudy()`
+		# (R/event_study.R) and `simultaneousCIs()` (R/simultaneous_cis.R), and
+		# by `.finalize_ci_type()` below (which rebuilds the simultaneous catt_df
+		# band at construction). Kept inside this list() literal so the name
+		# survives when NULL.
+		d_inv_treat = d_inv_treat
 	)
 
 	# Validate constructed object's contracts (#85). Catches malformed
@@ -633,6 +687,24 @@ fetwfe <- function(
 #'   time since treatment (event time `e = t - g`) across cohorts. The
 #'   event-study penalty carries the same theoretical guarantees as the default
 #'   (Faletto 2025); only the treatment-effect fusion structure changes.
+#' @param fusion_matrix (Optional.) Numeric matrix or `NULL` (the default). An
+#'   advanced-use override: a user-supplied `num_treats x num_treats` forward
+#'   differences matrix `D_N` for the treatment-effect block, encoding an
+#'   arbitrary fusion structure beyond the two built-ins. When non-`NULL` it
+#'   overrides `fusion_structure` for the treatment-effect block only (the
+#'   fixed-effect blocks are unchanged); the estimator uses `solve(fusion_matrix)`
+#'   internally. The rows/columns are interpreted in the cohort-major `(g, t)`
+#'   order used internally for the treatment effects (the order `getFirstInds()`
+#'   / `getTreatInds()` encode): row/column `i` corresponds to
+#'   base treatment effect `i`, with cohort `g` occupying rows
+#'   `first_inds[g]:(first_inds[g + 1] - 1)` ordered by event time. `num_treats`
+#'   equals `T * G - G * (G + 1) / 2`. `fusion_matrix` must be a finite,
+#'   invertible numeric matrix of that exact dimension (otherwise `fetwfe()`
+#'   stops). A `D_N` whose singular values satisfy `sigma_max <= sqrt(6)` and
+#'   `sigma_min >= 1 / (T * sqrt(2 * T))` inherits the paper's inferential
+#'   guarantees (Faletto 2025, event-study singular-value lemma); outside those
+#'   bounds the fit stays a valid point estimator but `fetwfe()` emits a
+#'   `warning()`. Default is `NULL` (use the built-in `fusion_structure`).
 #' @param ci_type Character; one of `"simultaneous"` (default) or
 #'   `"pointwise"`. Controls the confidence-interval bounds reported for the
 #'   cohort-specific ATTs (in `catt_df`) and the event-study effects (from
@@ -678,6 +750,7 @@ fetwfe <- function(
 #' \item{cv_folds}{Integer scalar; the `cv_folds` value used when `lambda_selection = "cv"`, `NA_integer_` when `lambda_selection = "bic"`.}
 #' \item{cv_seed}{Integer scalar; the seed actually fed to `set.seed()` immediately before `cv.grpreg()` was called. Defaults to `as.integer(N * T)` when the user did not pass a seed. `NA_integer_` when `lambda_selection = "bic"`.}
 #' \item{fusion_structure}{Character scalar; the `fusion_structure` argument the user passed (`"cohort"` or `"event_study"`), recording which fusion-penalty differences matrix was used for the treatment effects.}
+#' \item{fusion_matrix}{The user-supplied custom forward differences matrix `D_N` (a `num_treats x num_treats` numeric matrix), or `NULL` if none was supplied. When non-`NULL` it overrode `fusion_structure` for the treatment-effect block; the estimator used `solve(fusion_matrix)` internally. See the `fusion_matrix` argument.}
 #' \item{N}{The final number of units that were in the data set used for estimation (after any units may have been removed because they were treated in the first time period).}
 #' \item{T}{The number of time periods in the final data set.}
 #' \item{G}{The final number of treated cohorts that appear in the final data set.}
@@ -719,6 +792,7 @@ fetwfe <- function(
 #'     \item{calc_ses}{Logical indicating whether standard errors were calculated.}
 #'     \item{variance_components}{A list exposing the two variance pieces (`att_var_1`, `att_var_2`) plus their paper-notation counterparts (`V_1`, `V_2`) and the unit-scaled variance estimators (`tilde_v_N`, `hat_v_N`, `tilde_v_N_C`, `tilde_v_N_C_pi_hat`, `tilde_v_N_C_pi_hat_cons`, `tilde_v_N_cons`) catalogued at paper line 2006. The Wald CI is `[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]` (paper Eq. `conf.int.form`). New in v1.12.0 (issue #141 + #146).}
 #'     \item{first_year}{Integer or numeric scalar; the first (earliest) `time_var` value in the panel after `idCohorts()` processing. Consumed by `eventStudy()` to map `cohort_probs`' cohort labels (treatment-start years) to 1-based panel-time-index offsets when the labels are integer-coercible. New in v1.13.3 (issue #174).}
+#'     \item{d_inv_treat}{The inverted custom treatment-effect fusion block `solve(fusion_matrix)` (a `num_treats x num_treats` numeric matrix), or `NULL` if no `fusion_matrix` was supplied. Consumed by `eventStudy()` and `simultaneousCIs()` so the access-time bands reuse the same fusion block the fit used (#236).}
 #'   }
 #' }
 #'
@@ -751,7 +825,8 @@ fetwfeWithSimulatedData <- function(
 	cv_folds = 10L,
 	cv_seed = NULL,
 	ci_type = c("simultaneous", "pointwise"),
-	fusion_structure = c("cohort", "event_study")
+	fusion_structure = c("cohort", "event_study"),
+	fusion_matrix = NULL
 ) {
 	se_type <- match.arg(
 		se_type,
@@ -799,7 +874,8 @@ fetwfeWithSimulatedData <- function(
 		cv_folds = cv_folds,
 		cv_seed = cv_seed,
 		ci_type = ci_type,
-		fusion_structure = fusion_structure
+		fusion_structure = fusion_structure,
+		fusion_matrix = fusion_matrix
 	)
 
 	return(res)

--- a/R/fetwfe_class.R
+++ b/R/fetwfe_class.R
@@ -118,6 +118,10 @@ print.summary.fetwfe <- function(x, ...) {
 	"covs",
 	"ci_type",
 	"fusion_structure",
+	# #236: the user-supplied forward fusion matrix D_N (NULL when not
+	# supplied). Always present on freshly built fits (kept inside the
+	# `out <- list(...)` literal so the name survives a NULL value).
+	"fusion_matrix",
 	"internal"
 )
 
@@ -129,7 +133,10 @@ print.summary.fetwfe <- function(x, ...) {
 	"theta_hat",
 	"calc_ses",
 	"variance_components",
-	"first_year"
+	"first_year",
+	# #236: the inverted custom fusion block solve(fusion_matrix) (NULL when
+	# not supplied). Consumed by eventStudy() / simultaneousCIs().
+	"d_inv_treat"
 )
 
 #' @title Validate a `fetwfe`-classed object's contracts

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -308,6 +308,19 @@ checkFetwfeInputs <- function(
 #'   unit-clustered Liang-Zeger sandwich SE on the bridge-selected
 #'   support). See the exported wrapper `fetwfe()` for details. Default
 #'   is `"default"`.
+#' @param lambda_selection Character; one of `"cv"` (default) or `"bic"`.
+#'   Selects the bridge penalty via cross-validation or BIC. See `fetwfe()`.
+#' @param cv_folds Integer; number of CV folds when `lambda_selection = "cv"`.
+#'   Default `10L`.
+#' @param cv_seed Integer or `NULL`; seed for CV fold assignment. Default `NULL`.
+#' @param fusion_structure Character; one of `"cohort"` (default) or
+#'   `"event_study"`. Selects which built-in inverse treatment-effect fusion
+#'   block is used (ignored when `d_inv_treat` is supplied).
+#' @param d_inv_treat Optional `num_treats x num_treats` numeric matrix; the
+#'   user-supplied already-inverted treatment-effect fusion block
+#'   (`solve(fusion_matrix)`, #236). When non-`NULL` it overrides
+#'   `fusion_structure` for the treatment block throughout the fit (transform,
+#'   ridge, untransform, variance). Default `NULL`.
 #'
 #' @details
 #' The function executes the following main steps:
@@ -418,7 +431,8 @@ fetwfe_core <- function(
 	lambda_selection = "cv",
 	cv_folds = 10L,
 	cv_seed = NULL,
-	fusion_structure = "cohort"
+	fusion_structure = "cohort",
+	d_inv_treat = NULL
 ) {
 	se_type <- match.arg(
 		se_type,
@@ -469,7 +483,8 @@ fetwfe_core <- function(
 		d = d,
 		num_treats = num_treats,
 		first_inds = first_inds,
-		fusion_structure = fusion_structure
+		fusion_structure = fusion_structure,
+		d_inv_treat = d_inv_treat
 	)
 
 	res <- prep_for_etwfe_regression(
@@ -491,7 +506,8 @@ fetwfe_core <- function(
 		indep_count_data_available = indep_count_data_available,
 		indep_counts = indep_counts,
 		is_fetwfe = TRUE,
-		fusion_structure = fusion_structure
+		fusion_structure = fusion_structure,
+		d_inv_treat = d_inv_treat
 	)
 
 	X_final_scaled <- res$X_final_scaled
@@ -645,7 +661,8 @@ fetwfe_core <- function(
 			p = p,
 			d = d,
 			num_treats = num_treats,
-			fusion_structure = fusion_structure
+			fusion_structure = fusion_structure,
+			d_inv_treat = d_inv_treat
 		)
 		# Apply ridge adjustment locally before early-exit return; doesn't
 		# affect later code paths (they re-compute `beta_hat` separately
@@ -706,7 +723,8 @@ fetwfe_core <- function(
 		p = p,
 		d = d,
 		num_treats = num_treats,
-		fusion_structure = fusion_structure
+		fusion_structure = fusion_structure,
+		d_inv_treat = d_inv_treat
 	)
 
 	# If using ridge regularization, multiply the "naive" estimated coefficients
@@ -762,7 +780,8 @@ fetwfe_core <- function(
 		alpha = alpha,
 		se_type = se_type,
 		y_final = y_final,
-		fusion_structure = fusion_structure
+		fusion_structure = fusion_structure,
+		d_inv_treat = d_inv_treat
 	)
 
 	cohort_te_df <- res$cohort_te_df

--- a/R/fusion_transforms.R
+++ b/R/fusion_transforms.R
@@ -59,6 +59,13 @@
 #'   Starting column indices of the first treatment dummy of each cohort inside
 #'   the treatment block.  If `NA` (default) they are computed by
 #'   `getFirstInds()`.
+#' @param fusion_structure Character; one of `"cohort"` (default) or
+#'   `"event_study"`. Selects which built-in inverse treatment-effect fusion
+#'   block is used (ignored when `d_inv_treat` is supplied).
+#' @param d_inv_treat Optional `num_treats x num_treats` numeric matrix; the
+#'   user-supplied already-inverted treatment-effect fusion block
+#'   (`solve(fusion_matrix)`, #236). When non-`NULL` it overrides
+#'   `fusion_structure` for the treatment block. Default `NULL`.
 #'
 #' @return
 #' A numeric matrix `X_mod` with the **same dimensions** as `X_int` but whose
@@ -90,7 +97,8 @@ transformXintImproved <- function(
 	d,
 	num_treats,
 	first_inds = NA,
-	fusion_structure = "cohort"
+	fusion_structure = "cohort",
+	d_inv_treat = NULL
 ) {
 	p <- getP(G = G, T = T, d = d, num_treats = num_treats)
 	stopifnot(p == ncol(X_int))
@@ -178,7 +186,13 @@ transformXintImproved <- function(
 	stopifnot(all(is.na(X_mod[, feat_inds])))
 
 	X_mod[, feat_inds] <- X_int[, feat_inds] %*%
-		.gen_inv_treat_block(num_treats, first_inds, G, fusion_structure)
+		.gen_inv_treat_block(
+			num_treats,
+			first_inds,
+			G,
+			fusion_structure,
+			d_inv_treat = d_inv_treat
+		)
 
 	if (d > 0) {
 		# Lastly, penalize interactions between each treatment effect and each feature.
@@ -202,7 +216,8 @@ transformXintImproved <- function(
 					num_treats,
 					first_inds,
 					G,
-					fusion_structure
+					fusion_structure,
+					d_inv_treat = d_inv_treat
 				)
 
 			stopifnot(all(!is.na(X_mod[, inds_j])))
@@ -286,6 +301,13 @@ transformXintImproved <- function(
 #'   Starting indices (1-based, inside the treatment-dummy block) of the first
 #'   effect for each cohort.  If `NA` they are reconstructed with
 #'   **`getFirstInds()`**.
+#' @param fusion_structure Character; one of `"cohort"` (default) or
+#'   `"event_study"`. Selects which built-in inverse treatment-effect fusion
+#'   block is used (ignored when `d_inv_treat` is supplied).
+#' @param d_inv_treat Optional `num_treats x num_treats` numeric matrix; the
+#'   user-supplied already-inverted treatment-effect fusion block
+#'   (`solve(fusion_matrix)`, #236). When non-`NULL` it overrides
+#'   `fusion_structure` for the treatment block. Default `NULL`.
 #'
 #' @return Numeric vector \code{beta_hat} (length \eqn{p}) equal to
 #'   \eqn{\boldsymbol D_N^{-1}\,\widehat{\boldsymbol\theta}}.
@@ -332,7 +354,8 @@ untransformCoefImproved <- function(
 	d,
 	num_treats,
 	first_inds = NA,
-	fusion_structure = "cohort"
+	fusion_structure = "cohort",
+	d_inv_treat = NULL
 ) {
 	stopifnot(length(beta_hat_mod) == p)
 	beta_hat <- rep(as.numeric(NA), p)
@@ -428,7 +451,8 @@ untransformCoefImproved <- function(
 		num_treats,
 		first_inds,
 		G,
-		fusion_structure
+		fusion_structure,
+		d_inv_treat = d_inv_treat
 	) %*%
 		beta_hat_mod[feat_inds]
 
@@ -461,7 +485,8 @@ untransformCoefImproved <- function(
 				num_treats,
 				first_inds,
 				G,
-				fusion_structure
+				fusion_structure,
+				d_inv_treat = d_inv_treat
 			) %*%
 				beta_hat_mod[inds_j]
 
@@ -817,8 +842,20 @@ genInvEventStudyFusionTransformMat <- function(n_vars, first_inds, G) {
 #'   (`genInvEventStudyFusionTransformMat()`, #40). A single dispatch point so
 #'   every consumer (transform / untransform / variance / accessors) stays in
 #'   sync, and the `"cohort"` (default) branch is the exact pre-existing call.
+#'
+#'   When `d_inv_treat` is supplied (a user `fusion_matrix`'s already-inverted
+#'   `num_treats x num_treats` block; #236), it is returned verbatim, overriding
+#'   `fusion_structure`. This is the single override choke point: every consumer
+#'   reaches it, so threading `d_inv_treat` here makes the user's custom block
+#'   reach the transform / untransform / variance / ridge / accessor paths at
+#'   once. With `d_inv_treat = NULL` (the default) the call is byte-identical to
+#'   the prior `fusion_structure` dispatch.
 #' @param num_treats,first_inds,G As in `genInvTwoWayFusionTransformMat()`.
 #' @param fusion_structure One of `"cohort"` or `"event_study"`.
+#' @param d_inv_treat Optional `num_treats x num_treats` numeric matrix; the
+#'   already-inverted user-supplied treatment-effect fusion block
+#'   (`solve(fusion_matrix)`). If non-`NULL`, overrides `fusion_structure` and is
+#'   returned as-is. Default `NULL`.
 #' @return The `num_treats x num_treats` inverse treatment-effect fusion block.
 #' @keywords internal
 #' @noRd
@@ -826,13 +863,174 @@ genInvEventStudyFusionTransformMat <- function(n_vars, first_inds, G) {
 	num_treats,
 	first_inds,
 	G,
-	fusion_structure = "cohort"
+	fusion_structure = "cohort",
+	d_inv_treat = NULL
 ) {
+	if (!is.null(d_inv_treat)) {
+		stopifnot(identical(
+			dim(d_inv_treat),
+			c(as.integer(num_treats), as.integer(num_treats))
+		))
+		return(d_inv_treat)
+	}
 	if (identical(fusion_structure, "event_study")) {
 		genInvEventStudyFusionTransformMat(num_treats, first_inds, G)
 	} else {
 		genInvTwoWayFusionTransformMat(num_treats, first_inds, G)
 	}
+}
+
+
+# .validate_fusion_matrix
+#' @title Validate a user-supplied `fusion_matrix` and return its inverse block
+#' @description Validates the optional user `fusion_matrix` argument of
+#'   `fetwfe()` (#236) and returns the already-inverted treatment-effect block
+#'   `solve(fusion_matrix)` (a `num_treats x num_treats` matrix) that the
+#'   estimator threads through the `.gen_inv_treat_block()` choke point. When
+#'   `fusion_matrix` is `NULL` (the default) it returns `NULL` unchanged, so the
+#'   built-in `fusion_structure` dispatch is used and the fit is byte-identical
+#'   to omitting the argument.
+#'
+#'   Checks (in order), all referencing the cohort-major `(g, t)` row order of
+#'   `getFirstInds()` / `getTreatInds()`:
+#'   \enumerate{
+#'     \item type/shape: a finite numeric matrix with
+#'       `nrow == ncol == num_treats` (else `stop()`, naming the expected
+#'       `num_treats` derived from `G` and `T`);
+#'     \item invertibility: `solve(fusion_matrix)` must succeed (else `stop()`);
+#'     \item singular-value bounds (Faletto 2025 event-study singular-value
+#'       lemma): `warning()` (not error) when `sigma_max > sqrt(6)` or
+#'       `sigma_min < 1 / (T * sqrt(2 * T))` -- the fit stays a valid point
+#'       estimator but the paper's inferential guarantees may not hold.
+#'   }
+#'   When a non-default `fusion_structure` was also supplied, a `message()`
+#'   (gated on `verbose`) notes that `fusion_matrix` overrides it for the
+#'   treatment block.
+#' @param fusion_matrix The user-supplied forward difference matrix `D_N`, or
+#'   `NULL`.
+#' @param num_treats Integer; the number of base treatment effects (the required
+#'   matrix dimension).
+#' @param G Integer; number of treated cohorts (for the error message).
+#' @param T Integer; number of time periods (for the error message and the
+#'   `sigma_min` bound).
+#' @param fusion_structure_supplied Logical; `TRUE` if the user explicitly
+#'   passed `fusion_structure` (drives the override-notice message). Default
+#'   `FALSE`.
+#' @param verbose Logical; gates the override-notice `message()`. Default
+#'   `FALSE`.
+#' @return `NULL` when `fusion_matrix` is `NULL`; otherwise the
+#'   `num_treats x num_treats` numeric matrix `solve(fusion_matrix)`.
+#' @references
+#' Faletto, G (2025). Fused Extended Two-Way Fixed Effects for
+#' Difference-in-Differences with Staggered Adoptions.
+#' \emph{arXiv preprint arXiv:2312.05985}.
+#' \url{https://arxiv.org/abs/2312.05985}.
+#' @keywords internal
+#' @noRd
+.validate_fusion_matrix <- function(
+	fusion_matrix,
+	num_treats,
+	G,
+	T,
+	fusion_structure_supplied = FALSE,
+	verbose = FALSE
+) {
+	if (is.null(fusion_matrix)) {
+		return(NULL)
+	}
+
+	# --- 1. type / shape -------------------------------------------------
+	if (
+		!is.matrix(fusion_matrix) ||
+			!is.numeric(fusion_matrix) ||
+			!all(is.finite(fusion_matrix))
+	) {
+		stop(
+			"fusion_matrix must be a finite numeric matrix (it is the ",
+			"num_treats x num_treats forward-differences matrix D_N). Got an ",
+			"object of class ",
+			paste(class(fusion_matrix), collapse = "/"),
+			if (is.matrix(fusion_matrix) && !all(is.finite(fusion_matrix))) {
+				" containing non-finite (NA/NaN/Inf) entries."
+			} else {
+				"."
+			},
+			call. = FALSE
+		)
+	}
+	if (
+		nrow(fusion_matrix) != num_treats || ncol(fusion_matrix) != num_treats
+	) {
+		stop(
+			"fusion_matrix must be a num_treats x num_treats numeric matrix; ",
+			"got ",
+			nrow(fusion_matrix),
+			" x ",
+			ncol(fusion_matrix),
+			", expected num_treats = ",
+			num_treats,
+			" (from G = ",
+			G,
+			", T = ",
+			T,
+			"). The rows/columns follow the cohort-major (g, t) order of ",
+			"getFirstInds() / getTreatInds().",
+			call. = FALSE
+		)
+	}
+
+	# --- 2. invertibility ------------------------------------------------
+	d_inv_treat <- tryCatch(
+		solve(fusion_matrix),
+		error = function(e) {
+			stop(
+				"fusion_matrix is singular (or numerically non-invertible) and ",
+				"cannot be inverted: ",
+				conditionMessage(e),
+				". It must be an invertible forward-differences matrix D_N.",
+				call. = FALSE
+			)
+		}
+	)
+
+	# --- 3. singular-value bounds (warning, not error) -------------------
+	# Faletto (2025) event-study singular-value lemma: a D_N within
+	# sigma_max <= sqrt(6) and sigma_min >= 1 / (T * sqrt(2 * T)) inherits the
+	# paper's guarantees. A small absolute tolerance avoids float-edge false
+	# positives at the bound.
+	sv <- svd(fusion_matrix)$d
+	sigma_max <- max(sv)
+	sigma_min <- min(sv)
+	upper_bound <- sqrt(6)
+	lower_bound <- 1 / (T * sqrt(2 * T))
+	tol <- 1e-8
+	if (sigma_max > upper_bound + tol || sigma_min < lower_bound - tol) {
+		warning(
+			"fusion_matrix falls outside the event-study singular-value lemma's ",
+			"bounds (sigma_max = ",
+			format(sigma_max, digits = 6),
+			" vs. sqrt(6) = ",
+			format(upper_bound, digits = 6),
+			"; sigma_min = ",
+			format(sigma_min, digits = 6),
+			" vs. 1 / (T * sqrt(2 * T)) = ",
+			format(lower_bound, digits = 6),
+			"). The estimate remains a valid point estimator, but the paper's ",
+			"inferential guarantees (standard errors / confidence intervals) ",
+			"may not hold.",
+			call. = FALSE
+		)
+	}
+
+	# --- 4. override notice ----------------------------------------------
+	if (isTRUE(fusion_structure_supplied) && isTRUE(verbose)) {
+		message(
+			"fusion_matrix was supplied, so it overrides fusion_structure for ",
+			"the treatment-effect block."
+		)
+	}
+
+	d_inv_treat
 }
 
 
@@ -878,6 +1076,14 @@ genInvEventStudyFusionTransformMat <- function(n_vars, first_inds, G) {
 #' @param d Integer. Number of time-invariant covariates (can be 0).
 #' @param num_treats Integer.  Total number of base treatment-effect
 #'   coefficients \(\mathfrak W = T G - G(G+1)/2\).
+#' @param fusion_structure Character; one of `"cohort"` (default) or
+#'   `"event_study"`. Selects which built-in inverse treatment-effect fusion
+#'   block is embedded (ignored when `d_inv_treat` is supplied).
+#' @param d_inv_treat Optional `num_treats x num_treats` numeric matrix; the
+#'   user-supplied already-inverted treatment-effect fusion block
+#'   (`solve(fusion_matrix)`, #236). When non-`NULL` it overrides
+#'   `fusion_structure` for the treatment block embedded in the full
+#'   block-diagonal. Default `NULL`.
 #'
 #' @return A dense base-R matrix of size
 #'   \eqn{p \times p} with
@@ -897,7 +1103,8 @@ genFullInvFusionTransformMat <- function(
 	G,
 	d,
 	num_treats,
-	fusion_structure = "cohort"
+	fusion_structure = "cohort",
+	d_inv_treat = NULL
 ) {
 	##———— Safety checks ————————————————————————————————————————————
 	stopifnot(is.numeric(G), length(G) == 1L, G >= 2L)
@@ -933,7 +1140,8 @@ genFullInvFusionTransformMat <- function(
 		num_treats = num_treats,
 		first_inds = first_inds,
 		G = G,
-		fusion_structure = fusion_structure
+		fusion_structure = fusion_structure,
+		d_inv_treat = d_inv_treat
 	)
 
 	##———— 7. Treatment × X interactions:  I_d ⊗ (D^{(2)}(G))^{-1} ——
@@ -944,7 +1152,8 @@ genFullInvFusionTransformMat <- function(
 				num_treats = num_treats,
 				first_inds = first_inds,
 				G = G,
-				fusion_structure = fusion_structure
+				fusion_structure = fusion_structure,
+				d_inv_treat = d_inv_treat
 			)
 		)
 	} else {

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -370,11 +370,14 @@ simultaneousCIs.twfeCovs <- function(
 		sel_feat_inds <- which(theta_hat_slopes != 0)
 		sel_treat_inds_shifted <- which(theta_hat_slopes[treat_inds] != 0)
 		theta_sel <- theta_hat_slopes[treat_inds][sel_treat_inds_shifted]
+		# #236: reuse the custom inverted block stored on the fit (NULL for
+		# non-custom fits -> byte-identical `fusion_structure` dispatch).
 		d_inv_treat <- .gen_inv_treat_block(
 			num_treats = num_treats,
 			first_inds = first_inds,
 			G = G,
-			fusion_structure = x$fusion_structure
+			fusion_structure = x$fusion_structure,
+			d_inv_treat = x$internal$d_inv_treat
 		)
 		d_inv_treat_sel <- if (length(sel_treat_inds_shifted) > 0) {
 			d_inv_treat[, sel_treat_inds_shifted, drop = FALSE]

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -1357,6 +1357,15 @@ getSecondVarTermDataApp <- function(
 #'   length `N*T` (or `N*T + p` if a ridge augmentation was applied upstream).
 #'   Required when `se_type = "cluster"` and `calc_ses = TRUE`; ignored
 #'   otherwise.
+#' @param fusion_structure Character; one of `"cohort"` (default) or
+#'   `"event_study"`. Selects which built-in inverse treatment-effect fusion
+#'   block is rebuilt for the variance slices (ignored when `d_inv_treat` is
+#'   supplied).
+#' @param d_inv_treat Optional `num_treats x num_treats` numeric matrix; the
+#'   user-supplied already-inverted treatment-effect fusion block
+#'   (`solve(fusion_matrix)`, #236). When non-`NULL` it overrides
+#'   `fusion_structure` for the treatment block used in the variance path.
+#'   Default `NULL`.
 #' @return A list containing:
 #'   \item{cohort_te_df}{Data frame (with S3 class `c("catt_df", "data.frame")`)
 #'     with columns `cohort`, `estimate`, `se`, `ci_low`, `ci_high`, and a
@@ -1429,7 +1438,8 @@ getCohortATTsFinal <- function(
 	alpha = 0.05,
 	se_type = "default",
 	y_final = NULL,
-	fusion_structure = "cohort"
+	fusion_structure = "cohort",
+	d_inv_treat = NULL
 ) {
 	se_type <- match.arg(
 		se_type,
@@ -1502,12 +1512,16 @@ getCohortATTsFinal <- function(
 
 	## We need the tau sub-matrix of D^{-1} ONLY if we are in fused workflow
 	if (fused) {
-		# Get the parts of D_inv that have to do with treatment effects
+		# Get the parts of D_inv that have to do with treatment effects.
+		# `d_inv_treat` (the parameter) carries a user-supplied custom block
+		# (#236) when non-NULL; otherwise the choke point dispatches on
+		# `fusion_structure`. The result reuses the same local name.
 		d_inv_treat <- .gen_inv_treat_block(
 			num_treats,
 			first_inds,
 			G,
-			fusion_structure
+			fusion_structure,
+			d_inv_treat = d_inv_treat
 		)
 
 		## we will progressively rbind() the selected-column rows of this matrix

--- a/man/fetwfe.Rd
+++ b/man/fetwfe.Rd
@@ -27,7 +27,8 @@ fetwfe(
   cv_folds = 10L,
   cv_seed = NULL,
   ci_type = c("simultaneous", "pointwise"),
-  fusion_structure = c("cohort", "event_study")
+  fusion_structure = c("cohort", "event_study"),
+  fusion_matrix = NULL
 )
 }
 \arguments{
@@ -228,6 +229,25 @@ fusion penalty. \code{"event_study"} instead fuses treatment effects at the same
 time since treatment (event time \code{e = t - g}) across cohorts. The
 event-study penalty carries the same theoretical guarantees as the default
 (Faletto 2025); only the treatment-effect fusion structure changes.}
+
+\item{fusion_matrix}{(Optional.) Numeric matrix or \code{NULL} (the default). An
+advanced-use override: a user-supplied \verb{num_treats x num_treats} forward
+differences matrix \code{D_N} for the treatment-effect block, encoding an
+arbitrary fusion structure beyond the two built-ins. When non-\code{NULL} it
+overrides \code{fusion_structure} for the treatment-effect block only (the
+fixed-effect blocks are unchanged); the estimator uses \code{solve(fusion_matrix)}
+internally. The rows/columns are interpreted in the cohort-major \verb{(g, t)}
+order used internally for the treatment effects (the order \code{getFirstInds()}
+/ \code{getTreatInds()} encode): row/column \code{i} corresponds to
+base treatment effect \code{i}, with cohort \code{g} occupying rows
+\code{first_inds[g]:(first_inds[g + 1] - 1)} ordered by event time. \code{num_treats}
+equals \code{T * G - G * (G + 1) / 2}. \code{fusion_matrix} must be a finite,
+invertible numeric matrix of that exact dimension (otherwise \code{fetwfe()}
+stops). A \code{D_N} whose singular values satisfy \code{sigma_max <= sqrt(6)} and
+\code{sigma_min >= 1 / (T * sqrt(2 * T))} inherits the paper's inferential
+guarantees (Faletto 2025, event-study singular-value lemma); outside those
+bounds the fit stays a valid point estimator but \code{fetwfe()} emits a
+\code{warning()}. Default is \code{NULL} (use the built-in \code{fusion_structure}).}
 }
 \value{
 An object of class \code{fetwfe} containing the following elements:
@@ -254,6 +274,7 @@ An object of class \code{fetwfe} containing the following elements:
 \item{cv_folds}{Integer scalar; the \code{cv_folds} value used when \code{lambda_selection = "cv"}, \code{NA_integer_} when \code{lambda_selection = "bic"}.}
 \item{cv_seed}{Integer scalar; the seed actually fed to \code{set.seed()} immediately before \code{cv.grpreg()} was called. Defaults to \code{as.integer(N * T)} when the user did not pass a seed. \code{NA_integer_} when \code{lambda_selection = "bic"}.}
 \item{fusion_structure}{Character scalar; the \code{fusion_structure} argument the user passed (\code{"cohort"} or \code{"event_study"}), recording which fusion-penalty differences matrix was used for the treatment effects.}
+\item{fusion_matrix}{The user-supplied custom forward differences matrix \code{D_N} (a \verb{num_treats x num_treats} numeric matrix), or \code{NULL} if none was supplied. When non-\code{NULL} it overrode \code{fusion_structure} for the treatment-effect block; the estimator used \code{solve(fusion_matrix)} internally. See the \code{fusion_matrix} argument.}
 \item{N}{The final number of units that were in the data set used for estimation (after any units may have been removed because they were treated in the first time period).}
 \item{T}{The number of time periods in the final data set.}
 \item{G}{The final number of treated cohorts that appear in the final data set.}
@@ -295,6 +316,7 @@ internally). Consumed by \verb{augment.<class>()}.}
 \item{calc_ses}{Logical indicating whether standard errors were calculated.}
 \item{variance_components}{A list exposing the two variance pieces (\code{att_var_1}, \code{att_var_2}) plus their paper-notation counterparts (\code{V_1}, \code{V_2}) and the unit-scaled variance estimators (\code{tilde_v_N}, \code{hat_v_N}, \code{tilde_v_N_C}, \code{tilde_v_N_C_pi_hat}, \code{tilde_v_N_C_pi_hat_cons}, \code{tilde_v_N_cons}) catalogued at paper line 2006. The Wald CI is \verb{[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]} (paper Eq. \code{conf.int.form}). New in v1.12.0 (issue #141 + #146).}
 \item{first_year}{Integer or numeric scalar; the first (earliest) \code{time_var} value in the panel after \code{idCohorts()} processing. Consumed by \code{eventStudy()} to map \code{cohort_probs}' cohort labels (treatment-start years) to 1-based panel-time-index offsets when the labels are integer-coercible. New in v1.13.3 (issue #174).}
+\item{d_inv_treat}{The inverted custom treatment-effect fusion block \code{solve(fusion_matrix)} (a \verb{num_treats x num_treats} numeric matrix), or \code{NULL} if no \code{fusion_matrix} was supplied. Consumed by \code{eventStudy()} and \code{simultaneousCIs()} so the access-time bands reuse the same fusion block the fit used (#236).}
 }
 }
 

--- a/man/fetwfeWithSimulatedData.Rd
+++ b/man/fetwfeWithSimulatedData.Rd
@@ -19,7 +19,8 @@ fetwfeWithSimulatedData(
   cv_folds = 10L,
   cv_seed = NULL,
   ci_type = c("simultaneous", "pointwise"),
-  fusion_structure = c("cohort", "event_study")
+  fusion_structure = c("cohort", "event_study"),
+  fusion_matrix = NULL
 )
 }
 \arguments{
@@ -152,6 +153,25 @@ fusion penalty. \code{"event_study"} instead fuses treatment effects at the same
 time since treatment (event time \code{e = t - g}) across cohorts. The
 event-study penalty carries the same theoretical guarantees as the default
 (Faletto 2025); only the treatment-effect fusion structure changes.}
+
+\item{fusion_matrix}{(Optional.) Numeric matrix or \code{NULL} (the default). An
+advanced-use override: a user-supplied \verb{num_treats x num_treats} forward
+differences matrix \code{D_N} for the treatment-effect block, encoding an
+arbitrary fusion structure beyond the two built-ins. When non-\code{NULL} it
+overrides \code{fusion_structure} for the treatment-effect block only (the
+fixed-effect blocks are unchanged); the estimator uses \code{solve(fusion_matrix)}
+internally. The rows/columns are interpreted in the cohort-major \verb{(g, t)}
+order used internally for the treatment effects (the order \code{getFirstInds()}
+/ \code{getTreatInds()} encode): row/column \code{i} corresponds to
+base treatment effect \code{i}, with cohort \code{g} occupying rows
+\code{first_inds[g]:(first_inds[g + 1] - 1)} ordered by event time. \code{num_treats}
+equals \code{T * G - G * (G + 1) / 2}. \code{fusion_matrix} must be a finite,
+invertible numeric matrix of that exact dimension (otherwise \code{fetwfe()}
+stops). A \code{D_N} whose singular values satisfy \code{sigma_max <= sqrt(6)} and
+\code{sigma_min >= 1 / (T * sqrt(2 * T))} inherits the paper's inferential
+guarantees (Faletto 2025, event-study singular-value lemma); outside those
+bounds the fit stays a valid point estimator but \code{fetwfe()} emits a
+\code{warning()}. Default is \code{NULL} (use the built-in \code{fusion_structure}).}
 }
 \value{
 An object of class \code{fetwfe} containing the following elements:
@@ -178,6 +198,7 @@ An object of class \code{fetwfe} containing the following elements:
 \item{cv_folds}{Integer scalar; the \code{cv_folds} value used when \code{lambda_selection = "cv"}, \code{NA_integer_} when \code{lambda_selection = "bic"}.}
 \item{cv_seed}{Integer scalar; the seed actually fed to \code{set.seed()} immediately before \code{cv.grpreg()} was called. Defaults to \code{as.integer(N * T)} when the user did not pass a seed. \code{NA_integer_} when \code{lambda_selection = "bic"}.}
 \item{fusion_structure}{Character scalar; the \code{fusion_structure} argument the user passed (\code{"cohort"} or \code{"event_study"}), recording which fusion-penalty differences matrix was used for the treatment effects.}
+\item{fusion_matrix}{The user-supplied custom forward differences matrix \code{D_N} (a \verb{num_treats x num_treats} numeric matrix), or \code{NULL} if none was supplied. When non-\code{NULL} it overrode \code{fusion_structure} for the treatment-effect block; the estimator used \code{solve(fusion_matrix)} internally. See the \code{fusion_matrix} argument.}
 \item{N}{The final number of units that were in the data set used for estimation (after any units may have been removed because they were treated in the first time period).}
 \item{T}{The number of time periods in the final data set.}
 \item{G}{The final number of treated cohorts that appear in the final data set.}
@@ -219,6 +240,7 @@ internally). Consumed by \verb{augment.<class>()}.}
 \item{calc_ses}{Logical indicating whether standard errors were calculated.}
 \item{variance_components}{A list exposing the two variance pieces (\code{att_var_1}, \code{att_var_2}) plus their paper-notation counterparts (\code{V_1}, \code{V_2}) and the unit-scaled variance estimators (\code{tilde_v_N}, \code{hat_v_N}, \code{tilde_v_N_C}, \code{tilde_v_N_C_pi_hat}, \code{tilde_v_N_C_pi_hat_cons}, \code{tilde_v_N_cons}) catalogued at paper line 2006. The Wald CI is \verb{[hat_T_N +- qnorm(1-alpha/2) * sqrt(tilde_v_N / N)]} (paper Eq. \code{conf.int.form}). New in v1.12.0 (issue #141 + #146).}
 \item{first_year}{Integer or numeric scalar; the first (earliest) \code{time_var} value in the panel after \code{idCohorts()} processing. Consumed by \code{eventStudy()} to map \code{cohort_probs}' cohort labels (treatment-start years) to 1-based panel-time-index offsets when the labels are integer-coercible. New in v1.13.3 (issue #174).}
+\item{d_inv_treat}{The inverted custom treatment-effect fusion block \code{solve(fusion_matrix)} (a \verb{num_treats x num_treats} numeric matrix), or \code{NULL} if no \code{fusion_matrix} was supplied. Consumed by \code{eventStudy()} and \code{simultaneousCIs()} so the access-time bands reuse the same fusion block the fit used (#236).}
 }
 }
 

--- a/tests/testthat/test-doc-slot-parity.R
+++ b/tests/testthat/test-doc-slot-parity.R
@@ -335,6 +335,17 @@ test_that("cross-class slot inventory matches the documented divergence table", 
 		"fusion_structure" = list(
 			classes = c("fetwfe"),
 			rationale = "Only fetwfe applies the bridge fusion transform; fusion_structure selects which inverse-fusion differences matrix (cohort two-way vs. event-study) is used for the treatment-effect block."
+		),
+		# #236: the user-supplied custom fusion matrix D_N (and its inverted
+		# block d_inv_treat) live only on fetwfe -- the sole estimator that
+		# applies the bridge fusion transform.
+		"fusion_matrix" = list(
+			classes = c("fetwfe"),
+			rationale = "Only fetwfe applies the bridge fusion transform; fusion_matrix is the optional user-supplied forward differences matrix D_N that overrides fusion_structure for the treatment-effect block."
+		),
+		"d_inv_treat" = list(
+			classes = c("fetwfe"),
+			rationale = "Only fetwfe applies the bridge fusion transform; internal$d_inv_treat is solve(fusion_matrix), the inverted custom treatment-effect block consumed by eventStudy() / simultaneousCIs()."
 		)
 	)
 

--- a/tests/testthat/test-lex-cohort-sort.R
+++ b/tests/testthat/test-lex-cohort-sort.R
@@ -125,6 +125,10 @@ test_that("tidy.<class> sorts cohorts numerically when labels include >= 10", {
 		ci_type = "pointwise",
 		# #40: fusion_structure is a required fetwfe slot.
 		fusion_structure = "cohort",
+		# #236: fusion_matrix is a required fetwfe slot (NULL when no custom
+		# matrix was supplied). Inside this list() literal so the name
+		# survives a NULL value.
+		fusion_matrix = NULL,
 		internal = list(
 			X_ints = matrix(0, 100L * T_test, p_test),
 			y = rep(0, 100L * T_test),
@@ -152,7 +156,10 @@ test_that("tidy.<class> sorts cohorts numerically when labels include >= 10", {
 			# `.EXPECTED_INTERNAL_SLOTS_FETWFE`. Not actually used by
 			# `tidy.fetwfe()` (the function under test); set to a benign
 			# placeholder to keep this mock minimal.
-			first_year = 1L
+			first_year = 1L,
+			# #236: internal$d_inv_treat is a required fetwfe internal slot
+			# (NULL when no custom fusion_matrix was supplied).
+			d_inv_treat = NULL
 		)
 	)
 	class(obj) <- "fetwfe"

--- a/tests/testthat/test-user-fusion-matrix-236.R
+++ b/tests/testthat/test-user-fusion-matrix-236.R
@@ -1,0 +1,371 @@
+library(testthat)
+library(fetwfe)
+
+# Issue #236: user-supplied `fusion_matrix` (a num_treats x num_treats forward
+# differences matrix D_N) that overrides `fusion_structure` for the
+# treatment-effect block. The estimator inverts it once
+# (`d_inv_treat <- solve(fusion_matrix)`) and threads the inverse through the
+# single `.gen_inv_treat_block()` choke point, storing the inverse on the fit so
+# the access-time accessors (eventStudy() / simultaneousCIs()) reuse it.
+#
+# Headline guarantee: feeding the event-study built-in's forward D_N as a custom
+# matrix reproduces the `fusion_structure = "event_study"` fit byte-identically.
+#
+# The fixture below is DISCRIMINATING (per the plan-review finding): its selected
+# treatment support hits treatment columns where the cohort and event-study
+# inverse blocks differ, so the accessor-time stored-slot read is genuinely
+# exercised (a fixture selecting only coinciding columns would make the
+# mutation-check vacuous). The test asserts that intersection at RUNTIME rather
+# than hard-coding the support, so it stays valid if selection shifts.
+
+# ------------------------------------------------------------------------------
+# Shared fixture (pinned): genCoefs seed 1, density 0.9, eff_size 8, N 120,
+# data seed 101, lambda_selection = "bic", q = 0.5.
+# ------------------------------------------------------------------------------
+
+.fm236_sim <- function() {
+	coefs <- genCoefs(
+		G = 3,
+		T = 5,
+		d = 2,
+		density = 0.9,
+		eff_size = 8,
+		seed = 1
+	)
+	set.seed(101)
+	simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5)
+}
+
+.fm236_fit <- function(sim, ...) {
+	suppressWarnings(fetwfeWithSimulatedData(
+		sim,
+		q = 0.5,
+		lambda_selection = "bic",
+		...
+	))
+}
+
+# The event-study built-in's forward D_N for this fixture's dimensions.
+.fm236_event_study_DN <- function(fit) {
+	num_treats <- length(fit$treat_inds)
+	first_inds <- getFirstInds(fit$G, fit$T)
+	solve(fetwfe:::genInvEventStudyFusionTransformMat(
+		num_treats,
+		first_inds,
+		fit$G
+	))
+}
+
+# ------------------------------------------------------------------------------
+# 1. NULL no-op: fusion_matrix = NULL is byte-identical to omitting it, under
+#    both fusion_structure settings. (Choke-point else branch unchanged; every
+#    threaded d_inv_treat = NULL default leaves existing calls byte-identical.)
+# ------------------------------------------------------------------------------
+
+test_that("fusion_matrix = NULL is byte-identical to omitting it (cohort + event_study)", {
+	skip_on_cran()
+	sim <- .fm236_sim()
+
+	fit_co_omit <- .fm236_fit(sim, fusion_structure = "cohort")
+	fit_co_null <- .fm236_fit(
+		sim,
+		fusion_structure = "cohort",
+		fusion_matrix = NULL
+	)
+	expect_identical(fit_co_omit, fit_co_null)
+
+	fit_es_omit <- .fm236_fit(sim, fusion_structure = "event_study")
+	fit_es_null <- .fm236_fit(
+		sim,
+		fusion_structure = "event_study",
+		fusion_matrix = NULL
+	)
+	expect_identical(fit_es_omit, fit_es_null)
+
+	# The NULL-default still materializes the (NULL) slots, so the slot names
+	# survive for doc-slot parity.
+	expect_true("fusion_matrix" %in% names(fit_co_omit))
+	expect_null(fit_co_omit$fusion_matrix)
+	expect_true("d_inv_treat" %in% names(fit_co_omit$internal))
+	expect_null(fit_co_omit$internal$d_inv_treat)
+})
+
+# ------------------------------------------------------------------------------
+# 2. Headline cross-check: a custom D_N equal to the event-study built-in's
+#    forward matrix, supplied with fusion_structure = "cohort", reproduces the
+#    fusion_structure = "event_study" fit byte-identically -- including the
+#    SE/CI columns of eventStudy() / simultaneousCIs(), which exercise the
+#    accessor-time stored-slot read.
+# ------------------------------------------------------------------------------
+
+test_that("custom event-study D_N reproduces the event_study fit byte-identically", {
+	skip_on_cran()
+	sim <- .fm236_sim()
+
+	fit_es <- .fm236_fit(sim, fusion_structure = "event_study")
+	D_N <- .fm236_event_study_DN(fit_es)
+	fit_custom <- .fm236_fit(
+		sim,
+		fusion_structure = "cohort",
+		fusion_matrix = D_N
+	)
+
+	# Fit-time quantities.
+	expect_identical(fit_custom$beta_hat, fit_es$beta_hat)
+	expect_identical(fit_custom$att_hat, fit_es$att_hat)
+	expect_identical(fit_custom$att_se, fit_es$att_se)
+	expect_identical(fit_custom$catt_df, fit_es$catt_df)
+	expect_identical(fit_custom$catt_ses, fit_es$catt_ses)
+
+	# Confirm the fixture genuinely discriminates: the cohort fit differs, and
+	# the selected support hits columns where cohort and event-study inverse
+	# blocks differ.
+	fit_co <- .fm236_fit(sim, fusion_structure = "cohort")
+	expect_false(isTRUE(all.equal(fit_co$beta_hat, fit_es$beta_hat)))
+
+	num_treats <- length(fit_es$treat_inds)
+	first_inds <- getFirstInds(fit_es$G, fit_es$T)
+	theta_slopes <- fit_es$internal$theta_hat[2:(fit_es$p + 1)]
+	sel_treat <- which(theta_slopes[fit_es$treat_inds] != 0)
+	d_co <- fetwfe:::.gen_inv_treat_block(
+		num_treats,
+		first_inds,
+		fit_es$G,
+		"cohort"
+	)
+	d_es <- fetwfe:::.gen_inv_treat_block(
+		num_treats,
+		first_inds,
+		fit_es$G,
+		"event_study"
+	)
+	diff_cols <- which(colSums(abs(d_co - d_es)) > 0)
+	expect_gt(length(intersect(sel_treat, diff_cols)), 0)
+
+	# Accessor-time SE/CI columns (these exercise x$internal$d_inv_treat).
+	es_es <- eventStudy(fit_es)
+	es_custom <- eventStudy(fit_custom)
+	expect_identical(es_custom$se, es_es$se)
+	expect_identical(es_custom$ci_low, es_es$ci_low)
+	expect_identical(es_custom$ci_high, es_es$ci_high)
+	expect_identical(es_custom$p_value, es_es$p_value)
+
+	sc_es <- simultaneousCIs(fit_es)
+	sc_custom <- simultaneousCIs(fit_custom)
+	expect_identical(sc_custom$ci, sc_es$ci)
+	expect_identical(sc_custom$adjusted_p_values, sc_es$adjusted_p_values)
+})
+
+# ------------------------------------------------------------------------------
+# 2b. Mutation check for the accessor stored-slot read. If the eventStudy()
+#     accessor ignored x$internal$d_inv_treat, the custom fit's event-study SEs
+#     would fall back to the cohort built-in and DISAGREE with the event_study
+#     fit. We prove the assertion in test 2 bites by simulating that mutation
+#     here (recomputing the SE/CI the accessor would produce if it dropped the
+#     stored block) and confirming it differs.
+# ------------------------------------------------------------------------------
+
+test_that("the accessor stored-slot read is load-bearing (mutation bites)", {
+	skip_on_cran()
+	sim <- .fm236_sim()
+	fit_es <- .fm236_fit(sim, fusion_structure = "event_study")
+	D_N <- .fm236_event_study_DN(fit_es)
+	fit_custom <- .fm236_fit(
+		sim,
+		fusion_structure = "cohort",
+		fusion_matrix = D_N
+	)
+
+	es_custom <- eventStudy(fit_custom)
+
+	# Mutated accessor: a fit identical to fit_custom but with the stored slot
+	# emptied to NULL (kept present so the validator's slot-presence contract
+	# still holds -- `[<-` with list(NULL) preserves the name). With the value
+	# NULL the choke point falls back to fit_custom$fusion_structure ("cohort"),
+	# i.e. exactly what an accessor that ignored x$internal$d_inv_treat would do.
+	fit_mut <- fit_custom
+	fit_mut$internal["d_inv_treat"] <- list(NULL)
+	es_mut <- suppressWarnings(eventStudy(fit_mut))
+
+	# At least one SE must differ -- otherwise test 2's accessor assertions
+	# would pass even with the read removed (a vacuous test).
+	expect_false(isTRUE(all.equal(es_custom$se, es_mut$se)))
+})
+
+# ------------------------------------------------------------------------------
+# 3. Validation errors. Each malformed fusion_matrix stops with the documented
+#    message. Tested both directly against the helper (cheap, runs on CRAN) and
+#    -- for the non-square case -- end-to-end through fetwfe().
+# ------------------------------------------------------------------------------
+
+test_that(".validate_fusion_matrix() rejects malformed matrices", {
+	nt <- 9L
+	G <- 3L
+	T <- 5L
+	D <- diag(nt)
+
+	# non-square
+	expect_error(
+		fetwfe:::.validate_fusion_matrix(D[, -1], nt, G, T),
+		"num_treats x num_treats"
+	)
+	# wrong num_treats (square but wrong dimension)
+	expect_error(
+		fetwfe:::.validate_fusion_matrix(diag(nt + 1L), nt, G, T),
+		"expected num_treats = 9"
+	)
+	# non-numeric
+	expect_error(
+		fetwfe:::.validate_fusion_matrix(
+			matrix("a", nt, nt),
+			nt,
+			G,
+			T
+		),
+		"finite numeric matrix"
+	)
+	# non-finite
+	bad <- D
+	bad[1, 1] <- NA_real_
+	expect_error(
+		fetwfe:::.validate_fusion_matrix(bad, nt, G, T),
+		"finite numeric matrix"
+	)
+	# singular
+	sing <- matrix(0, nt, nt)
+	sing[1, ] <- 1
+	expect_error(
+		fetwfe:::.validate_fusion_matrix(sing, nt, G, T),
+		"singular"
+	)
+	# NULL passes through unchanged
+	expect_null(fetwfe:::.validate_fusion_matrix(NULL, nt, G, T))
+	# valid identity matrix returns its inverse (identity)
+	expect_identical(
+		fetwfe:::.validate_fusion_matrix(D, nt, G, T),
+		solve(D)
+	)
+})
+
+test_that("fetwfe() stops end-to-end on a malformed fusion_matrix", {
+	skip_on_cran()
+	sim <- .fm236_sim()
+	fit <- .fm236_fit(sim)
+	nt <- length(fit$treat_inds)
+
+	expect_error(
+		.fm236_fit(sim, fusion_matrix = diag(nt)[, -1]),
+		"num_treats x num_treats"
+	)
+	sing <- matrix(0, nt, nt)
+	sing[1, ] <- 1
+	expect_error(
+		.fm236_fit(sim, fusion_matrix = sing),
+		"singular"
+	)
+})
+
+# ------------------------------------------------------------------------------
+# 4. SVD-bound warning: a D_N outside the event-study singular-value lemma's
+#    bounds warns but still returns a finite fit.
+# ------------------------------------------------------------------------------
+
+test_that("an out-of-bounds fusion_matrix warns but still fits", {
+	skip_on_cran()
+	sim <- .fm236_sim()
+	fit <- .fm236_fit(sim)
+	nt <- length(fit$treat_inds)
+
+	# sigma_max = 10 > sqrt(6): a scaled identity blows the upper bound.
+	big <- diag(nt) * 10
+
+	# NB: not via .fm236_fit() -- that wraps in suppressWarnings(), which would
+	# swallow the very warning under test. Call fetwfeWithSimulatedData()
+	# directly (other, unrelated warnings are tolerated by expect_warning).
+	expect_warning(
+		fetwfeWithSimulatedData(
+			sim,
+			q = 0.5,
+			lambda_selection = "bic",
+			fusion_matrix = big
+		),
+		"singular-value lemma"
+	)
+	fit_w <- .fm236_fit(sim, fusion_matrix = big)
+	expect_true(is.finite(fit_w$att_hat))
+	expect_equal(dim(fit_w$fusion_matrix), c(nt, nt))
+})
+
+# ------------------------------------------------------------------------------
+# 5. add_ridge EXACT reproduction. add_ridge = TRUE is the only path that builds
+#    the FULL inverse-fusion matrix (genFullInvFusionTransformMat), so this
+#    proves the custom block reaches the ridge-penalty rows: a custom
+#    event-study D_N with add_ridge = TRUE reproduces the add_ridge = TRUE
+#    event_study fit byte-identically.
+# ------------------------------------------------------------------------------
+
+test_that("add_ridge = TRUE with a custom event-study D_N reproduces the add_ridge event_study fit", {
+	skip_on_cran()
+	sim <- .fm236_sim()
+
+	fit_es <- .fm236_fit(
+		sim,
+		fusion_structure = "event_study",
+		add_ridge = TRUE
+	)
+	D_N <- .fm236_event_study_DN(fit_es)
+	fit_custom <- .fm236_fit(
+		sim,
+		fusion_structure = "cohort",
+		fusion_matrix = D_N,
+		add_ridge = TRUE
+	)
+
+	expect_identical(fit_custom$beta_hat, fit_es$beta_hat)
+	expect_identical(fit_custom$att_hat, fit_es$att_hat)
+	expect_identical(fit_custom$att_se, fit_es$att_se)
+	expect_identical(fit_custom$catt_df, fit_es$catt_df)
+})
+
+# ------------------------------------------------------------------------------
+# 6. Composition with se_type and lambda_selection. A well-formed custom D_N
+#    composes with each se_type and lambda_selection (finite, well-formed fit).
+# ------------------------------------------------------------------------------
+
+test_that("a custom fusion_matrix composes with each se_type", {
+	skip_on_cran()
+	sim <- .fm236_sim()
+	fit <- .fm236_fit(sim)
+	D_N <- .fm236_event_study_DN(fit)
+
+	for (st in c("default", "conservative", "cluster")) {
+		f <- suppressWarnings(fetwfeWithSimulatedData(
+			sim,
+			q = 0.5,
+			lambda_selection = "bic",
+			se_type = st,
+			fusion_matrix = D_N
+		))
+		expect_true(is.finite(f$att_hat), info = st)
+		expect_equal(dim(f$fusion_matrix), dim(D_N), info = st)
+		expect_identical(f$internal$d_inv_treat, solve(D_N), info = st)
+	}
+})
+
+test_that("a custom fusion_matrix composes with each lambda_selection", {
+	skip_on_cran()
+	sim <- .fm236_sim()
+	fit <- .fm236_fit(sim)
+	D_N <- .fm236_event_study_DN(fit)
+
+	for (ls in c("cv", "bic")) {
+		f <- suppressWarnings(fetwfeWithSimulatedData(
+			sim,
+			q = 0.5,
+			lambda_selection = ls,
+			fusion_matrix = D_N
+		))
+		expect_true(is.finite(f$att_hat), info = ls)
+		expect_identical(f$internal$d_inv_treat, solve(D_N), info = ls)
+	}
+})

--- a/vignettes/fusion_structure_vignette.Rmd
+++ b/vignettes/fusion_structure_vignette.Rmd
@@ -255,6 +255,110 @@ is a safe starting point; switch to `"event_study"` when the dynamic, time-since
 treatment path is the object of interest and you expect it to be shared across
 cohorts.
 
+# Supplying your own fusion matrix `D_N` (advanced)
+
+The two built-in structures are special cases of a more general mechanism: under
+the hood, `fetwfe()` applies a **forward-differences matrix** `D_N` to the
+treatment-effect block, penalizes the differenced coordinates, and maps back via
+`solve(D_N)`. The `fusion_matrix` argument lets you supply your own
+`num_treats x num_treats` `D_N` directly --- encoding an arbitrary
+identifying-restriction structure (for example, "fuse cohorts that share an
+industry") that neither built-in expresses. When supplied, `fusion_matrix`
+**overrides** `fusion_structure` for the treatment-effect block (the fixed-effect
+blocks are unchanged).
+
+## The row/column ordering
+
+`D_N` is indexed by position, so its rows and columns must follow the same
+**cohort-major `(g, t)` order** the estimator uses for the treatment effects.
+Row/column `i` corresponds to base treatment effect `i`:
+
+- `num_treats = T * G - G * (G + 1) / 2` is the total number of base treatment
+  effects.
+- `getFirstInds(G, T)` returns, for each cohort `g`, the 1-based row of its
+  **first** effect `tau_{g, 0}`. Cohort `g` then occupies rows
+  `first_inds[g]:(first_inds[g + 1] - 1)` (the last cohort runs through
+  `num_treats`), ordered by event time within the cohort
+  (`tau_{g, 0}, tau_{g, 1}, ...`).
+- `getTreatInds(G, T, d, num_treats)` maps this block into the full
+  design-matrix columns; `fit$treat_inds` reports the same positions on a fitted
+  object.
+
+Interpreting `D_N` as forward differences: `theta = D_N %*% beta` is the
+penalized (sparse) parameterization and `beta = solve(D_N) %*% theta` recovers
+the original-scale effects. You supply `D_N`; the code uses `solve(D_N)`.
+
+## Worked example
+
+We build `first_inds` from the per-cohort effect counts `n_k` (already computed
+above; no internal helper needed) so the matrix's cohort-major layout is
+explicit, then supply a custom `D_N` and refit. (This reuses the `sim` panel from
+the side-by-side demo above.)
+
+```{r, message = FALSE, warning = FALSE}
+# first_inds in the same cohort-major order the matrix must follow: cohort 1
+# starts at row 1, and each later cohort starts after the previous cohort's
+# block (of size n_k).
+first_inds <- cumsum(c(1, head(n_k, -1)))
+first_inds # the 1-based starting row of each cohort's first effect
+
+# A within-cohort backward-differences D_N: penalize each cohort's first effect
+# directly (toward zero) and every later effect toward its within-cohort
+# predecessor. (theta_i = beta_i - beta_{i-1} within a cohort; theta = beta at
+# each cohort's first effect.) This is one transparent, hand-built example; any
+# invertible num_treats x num_treats matrix in this row order is accepted.
+D_N <- diag(num_treats)
+for (k in seq_along(first_inds)) {
+  start <- first_inds[k]
+  end <- if (k < length(first_inds)) first_inds[k + 1] - 1 else num_treats
+  if (end > start) {
+    for (i in (start + 1):end) {
+      D_N[i, i - 1] <- -1
+    }
+  }
+}
+
+fit_custom <- fetwfeWithSimulatedData(
+  sim,
+  lambda_selection = "bic",
+  fusion_matrix = D_N
+)
+
+# A finite, well-formed fit; the custom block was used throughout.
+fit_custom$att_hat
+```
+
+A genuinely bespoke `D_N` --- one that fuses your own set of effects (for example,
+the event-study structure, or "fuse cohorts that share an industry") --- is built
+the same way: choose which differences to penalize, assemble the corresponding
+forward-differences matrix in this cohort-major order, and pass it as
+`fusion_matrix`.
+
+## Staying inside the theoretical guarantees
+
+The paper's inferential guarantees (valid standard errors and confidence
+intervals) hold for any `D_N` whose singular values satisfy
+`sigma_max <= sqrt(6)` and `sigma_min >= 1 / (T * sqrt(2 * T))` (Faletto 2025,
+event-study singular-value lemma); both built-ins satisfy these bounds. If you
+supply a `D_N` **outside** those bounds, `fetwfe()` still returns a valid point
+estimator but emits a `warning()` that the inferential guarantees may not hold:
+
+```{r, warning = TRUE}
+# A poorly scaled D_N (sigma_max far above sqrt(6)) triggers the bounds warning.
+out_of_bounds <- diag(num_treats) * 10
+fit_warned <- tryCatch(
+  fetwfeWithSimulatedData(sim, lambda_selection = "bic", fusion_matrix = out_of_bounds),
+  warning = function(w) conditionMessage(w)
+)
+# The warning message (estimation still succeeds if you allow the warning):
+cat(fit_warned)
+```
+
+`fetwfe()` also **stops** (rather than warns) when `fusion_matrix` is not a
+finite, invertible numeric matrix of the exact `num_treats x num_treats`
+dimension --- a malformed restriction matrix is a usage error, not a modeling
+choice.
+
 # References
 
 - Faletto, G. (2025). *Fused Extended Two-Way Fixed Effects for


### PR DESCRIPTION
Refs #236. Adds a `fusion_matrix = NULL` argument to `fetwfe()` (and `fetwfeWithSimulatedData()`): a user-supplied `num_treats × num_treats` forward-difference matrix `D_N` that **overrides `fusion_structure`** for the treatment-effect block, letting advanced users encode arbitrary identifying-restriction structures beyond the `"cohort"` / `"event_study"` built-ins. The estimator inverts it once (`solve(D_N)`) and threads the inverse through the single `.gen_inv_treat_block()` dispatch choke point, so fit-time *and* the accessors (`eventStudy` / `simultaneousCIs` / `cohortStudy`) use the same transform.

Phase 2 of the fusion work (#40 → #234/#237 → this); **estimator-only** (not `genCoefs`). Ships under the paper's event-study singular-value lemma — a `D_N` with σ_max ≤ √6, σ_min ≥ 1/(T√(2T)) inherits the consistency/inference guarantees; outside those bounds it stays a valid point estimator but `fetwfe()` `warning()`s. Validation (after input-prep): dimensions, invertibility (`solve`), and the singular-value bounds. Stored on the fit (`$fusion_matrix` forward + `$internal$d_inv_treat` inverse).

Verification: `fusion_matrix = NULL` is byte-identical to prior behavior; feeding the event-study built-in's forward `D_N` as a custom matrix reproduces the `fusion_structure="event_study"` fit byte-identically (`beta_hat`, ATT, CATTs, both accessors incl. the construction-time simultaneous bands) on a discriminating fixture, and the test FAILS under a mutation of the accessor's stored-slot read; `add_ridge=TRUE` exact-reproduction; doc/internal-slot-parity green; `R CMD check --as-cran` 0/0/0. Minor bump (1.21.0); `inst/CITATION` untouched (paper-only).

One thing to confirm: when both a non-default `fusion_structure` and a `fusion_matrix` are supplied, the "matrix overrides structure" notice is a `verbose`-gated `message()` (silent at default, per the repo's no-chatter convention; the override is documented in `@param`). Happy to make it an unconditional `warning()` if you'd prefer louder UX.

**Stacked on #239** (it builds on #237's fusion plumbing) — retarget to `main` before #239 merges. A small rebase is expected against #243 (the `core_funcs.R` split): this PR edits `prep_for_etwfe_regression` / `.append_ridge_rows`, which #243 relocates to `input_prep.R` / `gls_machinery.R`.
