### PR TITLE
chore: address the actionable items of the #185 cleanup batch

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.21.0
+Version: 1.21.1
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # NEWS
 
+## Version 1.21.1
+
+### Minor improvements
+
+- The estimator input validation now rejects `sig_eps_sq = 0` with a clear
+  "must be positive" error. Previously only negative values were rejected, and
+  a zero noise variance produced an opaque downstream failure (the GLS
+  transform `1 / sqrt(sig_eps_sq)` is non-finite). Part of a small internal
+  cleanup batch (#185) that also hardens several internal invariants and the
+  integer return types of internal index helpers.
+
 ## Version 1.21.0
 
 ### Features

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -365,10 +365,13 @@ fetwfe <- function(
 	# supplied (the matrix wins for the treatment block; #236).
 	fusion_structure_supplied <- !missing(fusion_structure)
 	fusion_structure <- match.arg(fusion_structure)
-	# `lambda_selection` is validated downstream by
-	# `checkFetwfeInputs()` as part of the collect-all-violations
-	# pattern, so a user passing both a bad `lambda_selection` and a
-	# bad `cv_folds` / `cv_seed` sees all the violations at once.
+	# #185 A2: `se_type` (validated immediately via match.arg above) and
+	# `lambda_selection` (validated downstream) intentionally use different
+	# timing -- match.arg gives a precise, abbreviation-aware error at the call
+	# site, whereas `lambda_selection` is validated downstream by
+	# `checkFetwfeInputs()` as part of the collect-all-violations pattern, so a
+	# user passing both a bad `lambda_selection` and a bad `cv_folds` /
+	# `cv_seed` sees all the violations at once.
 
 	# Normalize `covs` to a character vector if a one-sided formula was
 	# supplied (#28). All downstream code assumes the character-vector

--- a/R/gls_machinery.R
+++ b/R/gls_machinery.R
@@ -201,9 +201,16 @@
 		mat_to_multiply <- D_inverse
 	}
 
+	# #185 SB5: sig_eps_sq > 0 here (validated for user-supplied input per SB2;
+	# REML-estimated otherwise) and sig_eps_c_sq >= 0, so `lambda_ridge` is
+	# strictly positive -- the former silent no-op (lambda_ridge = 0 when both
+	# variance components were 0) is unreachable. Assert it so a future change
+	# to the variance handling cannot silently reintroduce a no-op ridge under
+	# add_ridge = TRUE.
 	lambda_ridge <- 0.00001 *
 		(sig_eps_sq + sig_eps_c_sq) *
 		sqrt(p / (N * T))
+	stopifnot(is.finite(lambda_ridge), lambda_ridge > 0)
 
 	X_scaled <- rbind(
 		X_scaled,

--- a/R/sim_helpers.R
+++ b/R/sim_helpers.R
@@ -412,7 +412,12 @@ genTreatVarsSim <- function(
 			stopifnot(treat_ind <= n_treats)
 
 			if (t == g + 1) {
-				first_inds[g] <- treat_ind
+				# #185 SB6: keep `first_inds` an integer vector (its documented
+				# type and `as.integer(NA)` allocation). `treat_ind` is promoted
+				# to double by `treat_ind + 1`; coerce so the `identical()`
+				# assertion against `first_inds_test = getFirstInds()` (now
+				# integer) holds.
+				first_inds[g] <- as.integer(treat_ind)
 
 				stopifnot(treat_ind == first_inds_test[g])
 			}

--- a/R/utility.R
+++ b/R/utility.R
@@ -691,11 +691,15 @@ idCohorts <- function(df, time_var, unit_var, treat_var) {
 					length(sig_eps_sq)
 				)
 			)
-		} else if (sig_eps_sq < 0) {
+		} else if (sig_eps_sq <= 0) {
 			violations <- c(
 				violations,
 				sprintf(
-					"sig_eps_sq must be non-negative; got %s",
+					paste0(
+						"sig_eps_sq must be positive (strictly greater than 0); ",
+						"got %s. A value of 0 makes the GLS transform ",
+						"1 / sqrt(sig_eps_sq) non-finite (#185 SB2)."
+					),
 					format(sig_eps_sq)
 				)
 			)
@@ -905,7 +909,9 @@ my_scale <- function(x) {
 #' @keywords internal
 #' @noRd
 getNumTreats <- function(G, T) {
-	return(T * G - (G * (G + 1)) / 2)
+	# #185 SB6: coerce to integer to honor the @return contract. The formula is
+	# exact (G * (G + 1) is always even), but `/ 2` yields a double.
+	return(as.integer(T * G - (G * (G + 1)) / 2))
 }
 
 # getTreatInds
@@ -939,7 +945,9 @@ getTreatInds <- function(G, T, d, num_treats) {
 		G + (T - 1)
 	}
 
-	treat_inds <- seq(from = base_cols + 1, length.out = num_treats)
+	# #185 SB6: as.integer() so the indices honor the @return contract
+	# (`seq()` returns a double vector here).
+	treat_inds <- as.integer(seq(from = base_cols + 1, length.out = num_treats))
 
 	stopifnot(length(treat_inds) == num_treats)
 	if (d > 0) {
@@ -1027,7 +1035,10 @@ getFirstInds <- function(G, T) {
 	} # No cohorts, no first_inds
 
 	for (g in 1:G) {
-		f_inds[g] <- 1 + (g - 1) * (2 * T - g) / 2
+		# #185 SB6: as.integer() keeps `f_inds` integer (the `/ 2` would
+		# otherwise promote the preallocated integer vector to double). The
+		# value is exact -- (g - 1) * (2 * T - g) is always even.
+		f_inds[g] <- as.integer(1 + (g - 1) * (2 * T - g) / 2)
 	}
 	stopifnot(all(f_inds <= n_treats))
 	stopifnot(f_inds[1] == 1)

--- a/tests/testthat/test-cleanup-batch-185.R
+++ b/tests/testthat/test-cleanup-batch-185.R
@@ -1,0 +1,94 @@
+# Regression tests for the actionable items of the #185 cleanup batch.
+#
+# Covered here:
+#   SB2 -- the estimator input validator rejects sig_eps_sq = 0 (a zero noise
+#          variance makes the GLS transform 1 / sqrt(sig_eps_sq) non-finite).
+#          Previously only `< 0` was rejected.
+#   SB6 -- getNumTreats() / getFirstInds() / getTreatInds() return integer
+#          vectors, honoring their @return contracts (previously double via the
+#          `/ 2` divisions and `seq()`).
+#
+# Other #185 items, covered elsewhere or not actionable:
+#   SB5 (ridge no-op) -- guarded by an invariant stopifnot in
+#       R/gls_machinery.R; exercised by the existing add_ridge tests.
+#   A2  (validation-timing asymmetry) -- documentation-only.
+#   G4  (synthetic scattered-cohort fixture) -- in
+#       test-event-study-present-in-print-summary-174.R.
+#   IC1 (CV ignores lambda.* args) -- already warns; tested in
+#       test-lambda-selection-164.R.
+#   SB4 (1e-6 cohort-probs tolerance) -- won't-fix: the 1e-6 band is the
+#       deliberate, tested choice of #56 (test-soft-bugs-56.R), and firing at
+#       <= 1e-6 never-treated mass is protective, not spurious.
+
+# ------------------------------------------------------------------------------
+# SB6: the base-treatment-effect index helpers return integer.
+# ------------------------------------------------------------------------------
+
+test_that("getNumTreats / getFirstInds / getTreatInds return integer vectors (#185 SB6)", {
+	nt <- fetwfe:::getNumTreats(G = 3L, T = 6L)
+	expect_type(nt, "integer")
+	expect_identical(nt, 12L) # 6 * 3 - 3 * 4 / 2 = 12
+
+	fi <- fetwfe:::getFirstInds(G = 3L, T = 6L)
+	expect_type(fi, "integer")
+	expect_identical(fi, c(1L, 6L, 10L)) # hand-checked for G = 3, T = 6
+
+	ti <- fetwfe:::getTreatInds(G = 3L, T = 6L, d = 2L, num_treats = nt)
+	expect_type(ti, "integer")
+	expect_length(ti, 12L)
+})
+
+# ------------------------------------------------------------------------------
+# SB2: the estimator input validator rejects sig_eps_sq = 0 (not just < 0).
+# ------------------------------------------------------------------------------
+
+.fm185_panel <- function() {
+	set.seed(185)
+	mk <- function(ids, adopt) {
+		do.call(
+			rbind,
+			lapply(ids, function(u) {
+				tr <- if (is.na(adopt)) {
+					integer(4L)
+				} else {
+					as.integer(1:4 >= adopt)
+				}
+				data.frame(
+					unit = as.character(u),
+					year = 1:4,
+					x1 = rnorm(1),
+					treated = tr,
+					y = rnorm(4),
+					stringsAsFactors = FALSE
+				)
+			})
+		)
+	}
+	rbind(mk(1:8, 3L), mk(9:16, 4L), mk(17:24, NA))
+}
+
+test_that("input validator rejects sig_eps_sq = 0 with a positive-only message (#185 SB2)", {
+	pd <- .fm185_panel()
+	v0 <- fetwfe:::.collect_etwfe_input_violations(
+		pdata = pd,
+		time_var = "year",
+		unit_var = "unit",
+		treatment = "treated",
+		response = "y",
+		covs = "x1",
+		sig_eps_sq = 0
+	)
+	expect_true(any(grepl("sig_eps_sq must be positive", v0)))
+
+	# A valid positive variance produces no sig_eps_sq violation.
+	v1 <- fetwfe:::.collect_etwfe_input_violations(
+		pdata = pd,
+		time_var = "year",
+		unit_var = "unit",
+		treatment = "treated",
+		response = "y",
+		covs = "x1",
+		sig_eps_sq = 1
+	)
+	expect_false(any(grepl("sig_eps_sq", v1)))
+})

--- a/tests/testthat/test-event-study-present-in-print-summary-174.R
+++ b/tests/testthat/test-event-study-present-in-print-summary-174.R
@@ -102,6 +102,91 @@ test_that("print(res) and summary(res) render an Event Study section on divorce 
 })
 
 # ----------------------------------------------------------------------
+# 2b) Event-study-present on a SYNTHETIC scattered-cohort fixture
+#     (#185 G4). Locks the same non-consecutive-offset path as the
+#     divorce case above, but with a hand-built panel so the coverage
+#     does not depend on the optional `bacondecomp` Suggests dependency
+#     (the divorce test skips when it is absent). Cohorts adopt at
+#     offsets 3, 5, 6 in a T = 7 panel (gaps at 2 and 4), plus a
+#     never-treated group.
+# ----------------------------------------------------------------------
+
+test_that("print(res) and summary(res) render an Event Study section on a synthetic scattered-cohort fit", {
+	set.seed(174)
+	T_panel <- 7L
+	make_cohort <- function(ids, adopt) {
+		do.call(
+			rbind,
+			lapply(ids, function(uid) {
+				x1 <- rnorm(1)
+				unit_fe <- rnorm(1, sd = 0.5)
+				treated <- if (is.na(adopt)) {
+					integer(T_panel)
+				} else {
+					as.integer(seq_len(T_panel) >= adopt)
+				}
+				y <- unit_fe +
+					0.1 * seq_len(T_panel) +
+					0.6 * x1 +
+					1.5 * treated +
+					rnorm(T_panel, sd = 0.3)
+				data.frame(
+					unit = as.character(uid),
+					year = seq_len(T_panel),
+					x1 = x1,
+					treated = treated,
+					y = y,
+					stringsAsFactors = FALSE
+				)
+			})
+		)
+	}
+	pdata <- rbind(
+		make_cohort(1:30, 3L), # cohort offset 3
+		make_cohort(31:60, 5L), # cohort offset 5
+		make_cohort(61:90, 6L), # cohort offset 6
+		make_cohort(91:120, NA) # never-treated
+	)
+
+	res <- suppressWarnings(fetwfe(
+		pdata = pdata,
+		time_var = "year",
+		unit_var = "unit",
+		treatment = "treated",
+		response = "y",
+		covs = "x1",
+		sig_eps_sq = 0.09,
+		sig_eps_c_sq = 0.25,
+		add_ridge = TRUE,
+		verbose = FALSE
+	))
+
+	# Confirm we are exercising the scattered-cohort path: three cohorts at
+	# non-consecutive offsets (not seq(2, R + 1)).
+	expect_identical(as.integer(res$R), 3L)
+	expect_identical(as.integer(res$T), 7L)
+	offsets <- fetwfe:::.derive_cohort_offsets_from_fit(res)
+	expect_false(
+		identical(as.integer(offsets), seq.int(2L, as.integer(res$R) + 1L))
+	)
+
+	# eventStudy() returns a non-empty data frame (pre-#174 it errored
+	# before reaching this line on scattered cohorts).
+	es <- eventStudy(res)
+	expect_s3_class(es, "eventStudy")
+	expect_true(nrow(es) > 0L)
+
+	# Print / summary render the section.
+	out_print <- paste(capture.output(print(res)), collapse = "\n")
+	expect_match(out_print, .es_header_pattern)
+	out_summary <- paste(
+		capture.output(print(summary(res))),
+		collapse = "\n"
+	)
+	expect_match(out_summary, .es_header_pattern)
+})
+
+# ----------------------------------------------------------------------
 # 3) Helper-parity. `getFirstIndsFromOffsets(2:(R+1), T)` must match
 #    `getFirstInds(R, T)` byte-identically across a battery of
 #    (R, T) pairs covering the existing synthetic fixtures. Without


### PR DESCRIPTION
Addresses the actionable items of the #185 cleanup batch. After verifying each of the 10 bundled sub-items against current code (the issue's line numbers predate the #186 split and #225 coverage work), the accounting is **5 actionable** (done here), **4 already resolved** by intervening work, **1 won't-fix**.

## Done (5)
| Item | Change |
|------|--------|
| **SB2** | Input validation rejects `sig_eps_sq = 0` (not just `< 0`) with a clear "must be positive" error — a zero noise variance makes the GLS transform `1 / sqrt(sig_eps_sq)` non-finite, previously surfacing as an opaque downstream failure. User-visible → patch bump **1.21.1** + NEWS. |
| **SB5** | With SB2, `lambda_ridge = 0` (the silent `add_ridge` no-op when both variance components were 0) is unreachable; documented + asserted the invariant in `.append_ridge_rows()`. |
| **SB6** | `getNumTreats()` / `getFirstInds()` / `getTreatInds()` now return integer, honoring their `@return` contracts (were double via `/ 2` and `seq()`). Threaded through `genTreatVarsSim()`'s internal `first_inds` (its documented integer type) so its `identical()` self-check still holds. |
| **A2** | Documented the intentional `se_type` (immediate `match.arg`) vs `lambda_selection` (deferred collect-all) validation-timing asymmetry. |
| **G4** | Synthetic scattered-cohort fixture in `test-event-study-present-in-print-summary-174.R`, so non-consecutive-offset coverage no longer depends on the optional `bacondecomp` Suggests. |

New `test-cleanup-batch-185.R` locks SB2 (rejects 0) and SB6 (integer returns); both bite under mutation.

## Already resolved (4, verified — no action)
- **IC1** — the CV path already `warning()`s when `lambda.max` / `lambda.min` / `nlambda` are supplied (tagged `#185 IC1` in `utility.R`, tested in `test-lambda-selection-164.R`). *(A first-pass re-verification grep of mine missed this because the warning text wraps across lines — the item was already addressed.)*
- **G1, G2, G5** — the CV × cluster × add_ridge cross-test, the REML × tight-Gaussian fixture, and the `tidy.eventStudy` guard test all already exist.

## Won't-fix (1)
- **SB4** (relax the `1 - 1e-6` `cohort_probs_overall` tolerance to `1e-9`). The `1e-6` band is the **deliberate, tested** choice of #56 (`test-soft-bugs-56.R`), and a panel with one never-treated unit in N = 1e6 has genuinely degenerate never-treated mass — the guard firing there is *protective*, not spurious. Relaxing it silently reverses #56 and breaks its tests (confirmed: it did). Reverted byte-identically; `variance_machinery.R` / `class_helpers.R` are untouched.

## Verification
- Full suite **3102 pass / 0 fail**; `document()` no drift; per-item mutation checks on the new guards/tests.
- `R CMD check --as-cran` **code-clean** (every code check OK). Vignettes are unbuilt in this environment (a subprocess-build limitation that also hit `devtools::check`), but they knit cleanly via `load_all`; the change set doesn't touch vignettes.

All 10 sub-items are now accounted for, so **#185 can be closed** once you're satisfied with the SB4 won't-fix call. Using `Refs` (not `Closes`) so that stays your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
