### PR TITLE
feat: support single-treated-cohort (G=1) panels in fetwfe/etwfe/betwfe/twfeCovs (#112)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.21.1
+Version: 1.22.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.21.0
+Version: 1.21.1
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # NEWS
 
+## Version 1.21.1
+
+### Minor improvements
+
+- The estimator input validation now rejects `sig_eps_sq = 0` with a clear
+  "must be positive" error. Previously only negative values were rejected, and
+  a zero noise variance produced an opaque downstream failure (the GLS
+  transform `1 / sqrt(sig_eps_sq)` is non-finite). Part of a small internal
+  cleanup batch (#185) that also hardens several internal invariants and the
+  integer return types of internal index helpers.
+
 ## Version 1.21.0
 
 ### Features

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # NEWS
 
+## Version 1.22.0
+
+### Features
+
+- `fetwfe()`, `etwfe()`, `betwfe()`, and `twfeCovs()` (and the
+  `*WithSimulatedData()` wrappers), along with `genCoefs()` and
+  `simulateData()`, now support a single treated cohort (`G = 1`): one cohort of
+  units that adopt treatment plus never-treated units, rather than requiring at
+  least two treated cohorts (#112). At least two treatment effects (two
+  post-treatment periods for the treated cohort) are still required so the
+  dynamic-effect fusion has something to fuse; a panel with a single
+  post-treatment period (e.g. `T = 2`, or a cohort adopting in the final period)
+  is rejected with a clear message.
+
 ## Version 1.21.1
 
 ### Minor improvements

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -365,10 +365,13 @@ fetwfe <- function(
 	# supplied (the matrix wins for the treatment block; #236).
 	fusion_structure_supplied <- !missing(fusion_structure)
 	fusion_structure <- match.arg(fusion_structure)
-	# `lambda_selection` is validated downstream by
-	# `checkFetwfeInputs()` as part of the collect-all-violations
-	# pattern, so a user passing both a bad `lambda_selection` and a
-	# bad `cv_folds` / `cv_seed` sees all the violations at once.
+	# #185 A2: `se_type` (validated immediately via match.arg above) and
+	# `lambda_selection` (validated downstream) intentionally use different
+	# timing -- match.arg gives a precise, abbreviation-aware error at the call
+	# site, whereas `lambda_selection` is validated downstream by
+	# `checkFetwfeInputs()` as part of the collect-all-violations pattern, so a
+	# user passing both a bad `lambda_selection` and a bad `cv_folds` /
+	# `cv_seed` sees all the violations at once.
 
 	# Normalize `covs` to a character vector if a one-sided formula was
 	# supplied (#28). All downstream code assumes the character-vector

--- a/R/fusion_transforms.R
+++ b/R/fusion_transforms.R
@@ -1106,7 +1106,7 @@ genFullInvFusionTransformMat <- function(
 	d_inv_treat = NULL
 ) {
 	##———— Safety checks ————————————————————————————————————————————
-	stopifnot(is.numeric(G), length(G) == 1L, G >= 2L)
+	stopifnot(is.numeric(G), length(G) == 1L, G >= 1L)
 	stopifnot(is.numeric(T), length(T) == 1L, T >= 3L, G <= T - 1)
 	stopifnot(is.numeric(d), length(d) == 1L, d >= 0L)
 	stopifnot(length(first_inds) == G)

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -235,10 +235,10 @@ genCoefs <- function(
 		stop("T must be a numeric value greater than or equal to 3")
 	}
 
-	# Check that G is a numeric scalar and at least 2.
-	if (!is.numeric(G) || length(G) != 1 || G < 2) {
+	# Check that G is a numeric scalar and at least 1.
+	if (!is.numeric(G) || length(G) != 1 || G < 1) {
 		stop(
-			"G must be a numeric value greater than or equal to 2 (currently there is only support for data sets with staggered adoptions, so at least two treated cohorts)"
+			"G must be a numeric value greater than or equal to 1 (at least one treated cohort)"
 		)
 	}
 
@@ -358,7 +358,7 @@ genCoefs <- function(
 		allow_null = TRUE
 	)
 
-	stopifnot(G >= 2)
+	stopifnot(G >= 1)
 	stopifnot(T >= 3)
 	stopifnot(G <= T - 1)
 
@@ -733,10 +733,10 @@ genCoefsCore <- function(
 		stop("T must be a numeric value greater than or equal to 3")
 	}
 
-	# Check that G is a numeric scalar and at least 2.
-	if (!is.numeric(G) || length(G) != 1 || G < 2) {
+	# Check that G is a numeric scalar and at least 1.
+	if (!is.numeric(G) || length(G) != 1 || G < 1) {
 		stop(
-			"G must be a numeric value greater than or equal to 2 (currently there is only support for data sets with staggered adoptions, so at least two treated cohorts)"
+			"G must be a numeric value greater than or equal to 1 (at least one treated cohort)"
 		)
 	}
 
@@ -765,7 +765,7 @@ genCoefsCore <- function(
 		stop("eff_size must be a numeric value")
 	}
 
-	stopifnot(G >= 2)
+	stopifnot(G >= 1)
 	stopifnot(T >= 3)
 	stopifnot(G <= T - 1)
 

--- a/R/getTes_class.R
+++ b/R/getTes_class.R
@@ -55,9 +55,9 @@ print.FETWFE_tes <- function(x, ...) {
 #' @export
 summary.FETWFE_tes <- function(object, ...) {
 	tes <- object$actual_cohort_tes
-	# Defensive: genCoefs() currently enforces G >= 2, so length(tes) >= 2 is
-	# always true in practice. Guard is retained in case that validation ever
-	# changes upstream (sd() of a length-1 vector is NA).
+	# genCoefs() supports a single treated cohort (G = 1), in which case
+	# length(tes) == 1 and sd() of a length-1 vector is NA; the length(tes) >= 2
+	# guard below keeps the spread statistics well defined in that case.
 	out <- list(
 		att_true = object$att_true,
 		actual_cohort_tes = tes,

--- a/R/gls_machinery.R
+++ b/R/gls_machinery.R
@@ -201,9 +201,16 @@
 		mat_to_multiply <- D_inverse
 	}
 
+	# #185 SB5: sig_eps_sq > 0 here (validated for user-supplied input per SB2;
+	# REML-estimated otherwise) and sig_eps_c_sq >= 0, so `lambda_ridge` is
+	# strictly positive -- the former silent no-op (lambda_ridge = 0 when both
+	# variance components were 0) is unreachable. Assert it so a future change
+	# to the variance handling cannot silently reintroduce a no-op ridge under
+	# add_ridge = TRUE.
 	lambda_ridge <- 0.00001 *
 		(sig_eps_sq + sig_eps_c_sq) *
 		sqrt(p / (N * T))
+	stopifnot(is.finite(lambda_ridge), lambda_ridge > 0)
 
 	X_scaled <- rbind(
 		X_scaled,

--- a/R/input_prep.R
+++ b/R/input_prep.R
@@ -263,7 +263,7 @@ prep_for_etwfe_regression <- function(
 #'   \item **Design-matrix construction** - hands the cleaned data to
 #'     `prepXints()`, which adds unit and time dummies, interactions, etc.
 #'   \item **Cohort diagnostics** - verifies that
-#'     \eqn{G \ge 2}, at least one never-treated unit exists, cohort names are
+#'     \eqn{G \ge 1}, at least one never-treated unit exists, cohort names are
 #'     unique, and (if provided) `indep_counts` are dimensionally consistent.
 #' }
 #'
@@ -320,9 +320,24 @@ prep_for_etwfe_core <- function(
 
 	G <- length(in_sample_counts) - 1
 	stopifnot(G <= T - 1)
-	if (G < 2) {
+	if (G < 1) {
 		stop(
-			"Only one treated cohort detected in data. Currently fetwfe and etwfe only support data sets with at least two treated cohorts."
+			"No treated cohorts detected in data. fetwfe, etwfe, betwfe, and twfeCovs require at least one treated cohort (one cohort of units that adopt treatment, plus never-treated units)."
+		)
+	}
+	# Require at least two treatment effects (i.e., at least two post-treatment
+	# periods for the treated cohort) so the dynamic-effect fusion has something
+	# to fuse; with num_treats = 1 FETWFE degenerates to ordinary
+	# difference-in-differences. For G >= 2 this is implied by G <= T - 1 (which
+	# forces T >= 3 and hence num_treats >= 2), so this is a no-op there; it only
+	# binds at G = 1, where a single post-treatment period (num_treats = 1) is
+	# reachable -- either T = 2, or a late-adopting single cohort (e.g. adopting
+	# in the final period). `num_treats` here is the offset-aware count (computed
+	# in prepXints() above), so it correctly rejects a late-adopting single
+	# cohort that getNumTreats(G, T) would miscount as T - 1.
+	if (num_treats < 2) {
+		stop(
+			"Only one treatment effect (one post-treatment period) detected for the treated cohort. fetwfe, etwfe, betwfe, and twfeCovs require at least two treatment effects (at least two post-treatment periods) so that the dynamic treatment effects can be fused; with a single post-treatment period the model degenerates to ordinary difference-in-differences."
 		)
 	}
 	stopifnot(N >= G + 1)
@@ -611,9 +626,9 @@ check_etwfe_core_inputs <- function(
 	# Mirror prep_for_etwfe_core()'s friendly message (#208) so that whichever
 	# validator fires first, the user sees the same actionable text rather than
 	# an opaque `stopifnot` failure.
-	if (G < 2) {
+	if (G < 1) {
 		stop(
-			"Only one treated cohort detected in data. Currently fetwfe and etwfe only support data sets with at least two treated cohorts."
+			"No treated cohorts detected in data. fetwfe, etwfe, betwfe, and twfeCovs require at least one treated cohort (one cohort of units that adopt treatment, plus never-treated units)."
 		)
 	}
 	stopifnot(G <= T - 1)

--- a/R/sim_helpers.R
+++ b/R/sim_helpers.R
@@ -531,7 +531,7 @@ testGenRandomDataInputs <- function(
 ) {
 	stopifnot(G <= T - 1)
 	stopifnot(T >= 3)
-	stopifnot(G >= 2)
+	stopifnot(G >= 1)
 	stopifnot(N >= G + 1)
 	stopifnot(sig_eps_sq > 0)
 	stopifnot(sig_eps_c_sq >= 0)

--- a/R/sim_helpers.R
+++ b/R/sim_helpers.R
@@ -412,7 +412,12 @@ genTreatVarsSim <- function(
 			stopifnot(treat_ind <= n_treats)
 
 			if (t == g + 1) {
-				first_inds[g] <- treat_ind
+				# #185 SB6: keep `first_inds` an integer vector (its documented
+				# type and `as.integer(NA)` allocation). `treat_ind` is promoted
+				# to double by `treat_ind + 1`; coerce so the `identical()`
+				# assertion against `first_inds_test = getFirstInds()` (now
+				# integer) holds.
+				first_inds[g] <- as.integer(treat_ind)
 
 				stopifnot(treat_ind == first_inds_test[g])
 			}

--- a/R/utility.R
+++ b/R/utility.R
@@ -1398,19 +1398,21 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 	}
 
 	# After truncation, retained cohorts are those with r_i < r_max.
-	# FETWFE / ETWFE / BETWFE / twfeCovs each require G >= 2 (enforced
+	# FETWFE / ETWFE / BETWFE / twfeCovs each require G >= 1 (enforced
 	# inside `prep_for_etwfe_core()` in R/input_prep.R with a user-facing
 	# error); the guard here matches that constraint so the user gets a
-	# clear truncation-specific message rather than the deeper G >= 2
-	# error after auto-truncation.
+	# clear truncation-specific message rather than the deeper G >= 1
+	# error after auto-truncation. An R >= 2 panel that truncates to a single
+	# retained cohort is a valid R = 1 sub-panel and proceeds; only a
+	# truncation to zero retained cohorts is rejected here.
 	retained_cohorts <- setdiff(unique(unit_first_treat), r_max)
-	if (length(retained_cohorts) < 2) {
+	if (length(retained_cohorts) < 1) {
 		stop(
 			"Cannot estimate treatment effects: panel has no never-treated ",
 			"units, and the truncated panel would have only ",
 			length(retained_cohorts),
 			" treated cohort(s). FETWFE/ETWFE/BETWFE/twfeCovs each require ",
-			"at least 2 treated cohorts."
+			"at least 1 treated cohort."
 		)
 	}
 

--- a/R/utility.R
+++ b/R/utility.R
@@ -691,11 +691,15 @@ idCohorts <- function(df, time_var, unit_var, treat_var) {
 					length(sig_eps_sq)
 				)
 			)
-		} else if (sig_eps_sq < 0) {
+		} else if (sig_eps_sq <= 0) {
 			violations <- c(
 				violations,
 				sprintf(
-					"sig_eps_sq must be non-negative; got %s",
+					paste0(
+						"sig_eps_sq must be positive (strictly greater than 0); ",
+						"got %s. A value of 0 makes the GLS transform ",
+						"1 / sqrt(sig_eps_sq) non-finite (#185 SB2)."
+					),
 					format(sig_eps_sq)
 				)
 			)
@@ -905,7 +909,9 @@ my_scale <- function(x) {
 #' @keywords internal
 #' @noRd
 getNumTreats <- function(G, T) {
-	return(T * G - (G * (G + 1)) / 2)
+	# #185 SB6: coerce to integer to honor the @return contract. The formula is
+	# exact (G * (G + 1) is always even), but `/ 2` yields a double.
+	return(as.integer(T * G - (G * (G + 1)) / 2))
 }
 
 # getTreatInds
@@ -939,7 +945,9 @@ getTreatInds <- function(G, T, d, num_treats) {
 		G + (T - 1)
 	}
 
-	treat_inds <- seq(from = base_cols + 1, length.out = num_treats)
+	# #185 SB6: as.integer() so the indices honor the @return contract
+	# (`seq()` returns a double vector here).
+	treat_inds <- as.integer(seq(from = base_cols + 1, length.out = num_treats))
 
 	stopifnot(length(treat_inds) == num_treats)
 	if (d > 0) {
@@ -1027,7 +1035,10 @@ getFirstInds <- function(G, T) {
 	} # No cohorts, no first_inds
 
 	for (g in 1:G) {
-		f_inds[g] <- 1 + (g - 1) * (2 * T - g) / 2
+		# #185 SB6: as.integer() keeps `f_inds` integer (the `/ 2` would
+		# otherwise promote the preallocated integer vector to double). The
+		# value is exact -- (g - 1) * (2 * T - g) is always even.
+		f_inds[g] <- as.integer(1 + (g - 1) * (2 * T - g) / 2)
 	}
 	stopifnot(all(f_inds <= n_treats))
 	stopifnot(f_inds[1] == 1)

--- a/tests/testthat/test-betwfe.R
+++ b/tests/testthat/test-betwfe.R
@@ -476,24 +476,26 @@ test_that("betwfe works on only two cohorts", {
 })
 
 # ------------------------------------------------------------------------------
-# Test 20: Test that at least 2 treated cohorts requires
+# Test 20: A single treated cohort (G = 1) is now supported (#112).
 # ------------------------------------------------------------------------------
-test_that("at least two treated cohorts required", {
-	# Create a balanced panel with N = 3 units and T = 3 time periods.
+test_that("single treated cohort (G = 1) is supported", {
+	# A balanced panel with N = 30 units and T = 10 periods. With R = 1 the
+	# helper produces a single treated cohort (adopting at t = 2) plus
+	# never-treated units.
 	df <- generate_panel_data(N = 30, T = 10, R = 1, seed = 202)
 
-	expect_error(
-		betwfe(
-			pdata = df,
-			time_var = "time",
-			unit_var = "unit",
-			treatment = "treatment",
-			covs = c("cov1", "cov2"),
-			response = "y",
-			verbose = FALSE
-		),
-		"Only one treated cohort detected in data. Currently fetwfe and etwfe only support data sets with at least two treated cohorts."
+	res <- betwfe(
+		pdata = df,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		covs = c("cov1", "cov2"),
+		response = "y",
+		verbose = FALSE
 	)
+	expect_s3_class(res, "betwfe")
+	expect_equal(res$G, 1)
+	expect_true(is.finite(res$att_hat))
 })
 
 

--- a/tests/testthat/test-cleanup-batch-185.R
+++ b/tests/testthat/test-cleanup-batch-185.R
@@ -1,0 +1,94 @@
+# Regression tests for the actionable items of the #185 cleanup batch.
+#
+# Covered here:
+#   SB2 -- the estimator input validator rejects sig_eps_sq = 0 (a zero noise
+#          variance makes the GLS transform 1 / sqrt(sig_eps_sq) non-finite).
+#          Previously only `< 0` was rejected.
+#   SB6 -- getNumTreats() / getFirstInds() / getTreatInds() return integer
+#          vectors, honoring their @return contracts (previously double via the
+#          `/ 2` divisions and `seq()`).
+#
+# Other #185 items, covered elsewhere or not actionable:
+#   SB5 (ridge no-op) -- guarded by an invariant stopifnot in
+#       R/gls_machinery.R; exercised by the existing add_ridge tests.
+#   A2  (validation-timing asymmetry) -- documentation-only.
+#   G4  (synthetic scattered-cohort fixture) -- in
+#       test-event-study-present-in-print-summary-174.R.
+#   IC1 (CV ignores lambda.* args) -- already warns; tested in
+#       test-lambda-selection-164.R.
+#   SB4 (1e-6 cohort-probs tolerance) -- won't-fix: the 1e-6 band is the
+#       deliberate, tested choice of #56 (test-soft-bugs-56.R), and firing at
+#       <= 1e-6 never-treated mass is protective, not spurious.
+
+# ------------------------------------------------------------------------------
+# SB6: the base-treatment-effect index helpers return integer.
+# ------------------------------------------------------------------------------
+
+test_that("getNumTreats / getFirstInds / getTreatInds return integer vectors (#185 SB6)", {
+	nt <- fetwfe:::getNumTreats(G = 3L, T = 6L)
+	expect_type(nt, "integer")
+	expect_identical(nt, 12L) # 6 * 3 - 3 * 4 / 2 = 12
+
+	fi <- fetwfe:::getFirstInds(G = 3L, T = 6L)
+	expect_type(fi, "integer")
+	expect_identical(fi, c(1L, 6L, 10L)) # hand-checked for G = 3, T = 6
+
+	ti <- fetwfe:::getTreatInds(G = 3L, T = 6L, d = 2L, num_treats = nt)
+	expect_type(ti, "integer")
+	expect_length(ti, 12L)
+})
+
+# ------------------------------------------------------------------------------
+# SB2: the estimator input validator rejects sig_eps_sq = 0 (not just < 0).
+# ------------------------------------------------------------------------------
+
+.fm185_panel <- function() {
+	set.seed(185)
+	mk <- function(ids, adopt) {
+		do.call(
+			rbind,
+			lapply(ids, function(u) {
+				tr <- if (is.na(adopt)) {
+					integer(4L)
+				} else {
+					as.integer(1:4 >= adopt)
+				}
+				data.frame(
+					unit = as.character(u),
+					year = 1:4,
+					x1 = rnorm(1),
+					treated = tr,
+					y = rnorm(4),
+					stringsAsFactors = FALSE
+				)
+			})
+		)
+	}
+	rbind(mk(1:8, 3L), mk(9:16, 4L), mk(17:24, NA))
+}
+
+test_that("input validator rejects sig_eps_sq = 0 with a positive-only message (#185 SB2)", {
+	pd <- .fm185_panel()
+	v0 <- fetwfe:::.collect_etwfe_input_violations(
+		pdata = pd,
+		time_var = "year",
+		unit_var = "unit",
+		treatment = "treated",
+		response = "y",
+		covs = "x1",
+		sig_eps_sq = 0
+	)
+	expect_true(any(grepl("sig_eps_sq must be positive", v0)))
+
+	# A valid positive variance produces no sig_eps_sq violation.
+	v1 <- fetwfe:::.collect_etwfe_input_violations(
+		pdata = pd,
+		time_var = "year",
+		unit_var = "unit",
+		treatment = "treated",
+		response = "y",
+		covs = "x1",
+		sig_eps_sq = 1
+	)
+	expect_false(any(grepl("sig_eps_sq", v1)))
+})

--- a/tests/testthat/test-etwfe.R
+++ b/tests/testthat/test-etwfe.R
@@ -559,24 +559,26 @@ test_that("etwfe works on only two cohorts", {
 })
 
 # ------------------------------------------------------------------------------
-# Test 19: Test that at least 2 treated cohorts requires
+# Test 19: A single treated cohort (G = 1) is now supported (#112).
 # ------------------------------------------------------------------------------
-test_that("at least two treated cohorts required", {
-	# Create a balanced panel with N = 3 units and T = 3 time periods.
+test_that("single treated cohort (G = 1) is supported", {
+	# A balanced panel with N = 30 units and T = 10 periods. With R = 1 the
+	# helper produces a single treated cohort (adopting at t = 2) plus
+	# never-treated units.
 	df <- generate_panel_data(N = 30, T = 10, R = 1, seed = 202)
 
-	expect_error(
-		etwfe(
-			pdata = df,
-			time_var = "time",
-			unit_var = "unit",
-			treatment = "treatment",
-			covs = c("cov1", "cov2"),
-			response = "y",
-			verbose = FALSE
-		),
-		"Only one treated cohort detected in data. Currently fetwfe and etwfe only support data sets with at least two treated cohorts."
+	res <- etwfe(
+		pdata = df,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		covs = c("cov1", "cov2"),
+		response = "y",
+		verbose = FALSE
 	)
+	expect_s3_class(res, "etwfe")
+	expect_equal(res$G, 1)
+	expect_true(is.finite(res$att_hat))
 })
 
 

--- a/tests/testthat/test-event-study-present-in-print-summary-174.R
+++ b/tests/testthat/test-event-study-present-in-print-summary-174.R
@@ -102,6 +102,91 @@ test_that("print(res) and summary(res) render an Event Study section on divorce 
 })
 
 # ----------------------------------------------------------------------
+# 2b) Event-study-present on a SYNTHETIC scattered-cohort fixture
+#     (#185 G4). Locks the same non-consecutive-offset path as the
+#     divorce case above, but with a hand-built panel so the coverage
+#     does not depend on the optional `bacondecomp` Suggests dependency
+#     (the divorce test skips when it is absent). Cohorts adopt at
+#     offsets 3, 5, 6 in a T = 7 panel (gaps at 2 and 4), plus a
+#     never-treated group.
+# ----------------------------------------------------------------------
+
+test_that("print(res) and summary(res) render an Event Study section on a synthetic scattered-cohort fit", {
+	set.seed(174)
+	T_panel <- 7L
+	make_cohort <- function(ids, adopt) {
+		do.call(
+			rbind,
+			lapply(ids, function(uid) {
+				x1 <- rnorm(1)
+				unit_fe <- rnorm(1, sd = 0.5)
+				treated <- if (is.na(adopt)) {
+					integer(T_panel)
+				} else {
+					as.integer(seq_len(T_panel) >= adopt)
+				}
+				y <- unit_fe +
+					0.1 * seq_len(T_panel) +
+					0.6 * x1 +
+					1.5 * treated +
+					rnorm(T_panel, sd = 0.3)
+				data.frame(
+					unit = as.character(uid),
+					year = seq_len(T_panel),
+					x1 = x1,
+					treated = treated,
+					y = y,
+					stringsAsFactors = FALSE
+				)
+			})
+		)
+	}
+	pdata <- rbind(
+		make_cohort(1:30, 3L), # cohort offset 3
+		make_cohort(31:60, 5L), # cohort offset 5
+		make_cohort(61:90, 6L), # cohort offset 6
+		make_cohort(91:120, NA) # never-treated
+	)
+
+	res <- suppressWarnings(fetwfe(
+		pdata = pdata,
+		time_var = "year",
+		unit_var = "unit",
+		treatment = "treated",
+		response = "y",
+		covs = "x1",
+		sig_eps_sq = 0.09,
+		sig_eps_c_sq = 0.25,
+		add_ridge = TRUE,
+		verbose = FALSE
+	))
+
+	# Confirm we are exercising the scattered-cohort path: three cohorts at
+	# non-consecutive offsets (not seq(2, R + 1)).
+	expect_identical(as.integer(res$R), 3L)
+	expect_identical(as.integer(res$T), 7L)
+	offsets <- fetwfe:::.derive_cohort_offsets_from_fit(res)
+	expect_false(
+		identical(as.integer(offsets), seq.int(2L, as.integer(res$R) + 1L))
+	)
+
+	# eventStudy() returns a non-empty data frame (pre-#174 it errored
+	# before reaching this line on scattered cohorts).
+	es <- eventStudy(res)
+	expect_s3_class(es, "eventStudy")
+	expect_true(nrow(es) > 0L)
+
+	# Print / summary render the section.
+	out_print <- paste(capture.output(print(res)), collapse = "\n")
+	expect_match(out_print, .es_header_pattern)
+	out_summary <- paste(
+		capture.output(print(summary(res))),
+		collapse = "\n"
+	)
+	expect_match(out_summary, .es_header_pattern)
+})
+
+# ----------------------------------------------------------------------
 # 3) Helper-parity. `getFirstIndsFromOffsets(2:(R+1), T)` must match
 #    `getFirstInds(R, T)` byte-identically across a battery of
 #    (R, T) pairs covering the existing synthetic fixtures. Without

--- a/tests/testthat/test-fetwfe.R
+++ b/tests/testthat/test-fetwfe.R
@@ -483,24 +483,26 @@ test_that("fetwfe works on only two cohorts", {
 })
 
 # ------------------------------------------------------------------------------
-# Test 20: Test that at least 2 treated cohorts requires
+# Test 20: A single treated cohort (G = 1) is now supported (#112).
 # ------------------------------------------------------------------------------
-test_that("at least two treated cohorts required", {
-	# Create a balanced panel with N = 3 units and T = 3 time periods.
+test_that("single treated cohort (G = 1) is supported", {
+	# A balanced panel with N = 30 units and T = 10 periods. With R = 1 the
+	# helper produces a single treated cohort (adopting at t = 2) plus
+	# never-treated units.
 	df <- generate_panel_data(N = 30, T = 10, R = 1, seed = 202)
 
-	expect_error(
-		fetwfe(
-			pdata = df,
-			time_var = "time",
-			unit_var = "unit",
-			treatment = "treatment",
-			covs = c("cov1", "cov2"),
-			response = "y",
-			verbose = FALSE
-		),
-		"Only one treated cohort detected in data. Currently fetwfe and etwfe only support data sets with at least two treated cohorts."
+	res <- fetwfe(
+		pdata = df,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		covs = c("cov1", "cov2"),
+		response = "y",
+		verbose = FALSE
 	)
+	expect_s3_class(res, "fetwfe")
+	expect_equal(res$G, 1)
+	expect_true(is.finite(res$att_hat))
 })
 
 
@@ -1071,9 +1073,11 @@ test_that("fetwfe auto-truncates a panel with no never-treated units (default)",
 })
 
 # ------------------------------------------------------------------------------
-# Test: fetwfe errors cleanly when truncation would yield < 2 retained cohorts
+# Test: fetwfe errors cleanly when truncation would yield 0 retained cohorts.
+# (Under the #112 relaxation to G >= 1, a single retained cohort now succeeds;
+# this fixture leaves zero retained cohorts, which still fails.)
 # ------------------------------------------------------------------------------
-test_that("fetwfe errors cleanly when no-never-treated truncation would yield < 2 cohorts", {
+test_that("fetwfe errors cleanly when no-never-treated truncation would yield 0 cohorts", {
 	# All units share a single cohort start time, no never-treated.
 	# Five units, six time periods, every unit starts treatment at t = 4.
 	N <- 5

--- a/tests/testthat/test-genCoefs.R
+++ b/tests/testthat/test-genCoefs.R
@@ -181,11 +181,15 @@ test_that("genCoefs errors when T < 3", {
 	)
 })
 
-test_that("genCoefs errors when R < 2", {
-	expect_error(
-		genCoefs(G = 1, T = 30, density = 0.1, eff_size = 2, d = 12),
-		regexp = "G must be a numeric value greater than or equal to 2"
-	)
+test_that("genCoefs generates a single-cohort (G = 1) coefficient vector", {
+	coefs <- genCoefs(G = 1, T = 30, density = 0.1, eff_size = 2, d = 12)
+	expect_s3_class(coefs, "FETWFE_coefs")
+	expect_equal(coefs$G, 1)
+	# With a single treated cohort getTes() returns exactly one cohort effect,
+	# and the overall ATT equals that lone cohort's effect.
+	tes <- getTes(coefs)
+	expect_length(tes$actual_cohort_tes, 1L)
+	expect_equal(tes$att_true, tes$actual_cohort_tes[1])
 })
 
 test_that("genCoefs errors when R > T - 1", {

--- a/tests/testthat/test-genCoefsCore.R
+++ b/tests/testthat/test-genCoefsCore.R
@@ -199,10 +199,15 @@ test_that("genCoefsCore errors when T < 3", {
 	)
 })
 
-test_that("genCoefsCore errors when R < 2", {
-	expect_error(
-		genCoefsCore(G = 1, T = 30, density = 0.1, eff_size = 2, d = 12),
-		regexp = "G must be a numeric value greater than or equal to 2"
+test_that("genCoefsCore generates a single-cohort (G = 1) coefficient vector", {
+	core <- genCoefsCore(G = 1, T = 30, density = 0.1, eff_size = 2, d = 12)
+	expect_type(core, "list")
+	expect_true(all(c("beta", "theta") %in% names(core)))
+	# beta has length p = getP(G, T, d, num_treats) for the single cohort.
+	num_treats <- getNumTreats(G = 1, T = 30)
+	expect_length(
+		core$beta,
+		getP(G = 1, T = 30, d = 12, num_treats = num_treats)
 	)
 })
 

--- a/tests/testthat/test-single-cohort-112.R
+++ b/tests/testthat/test-single-cohort-112.R
@@ -1,0 +1,501 @@
+# ==============================================================================
+# Single-treated-cohort (G = 1) support (#112).
+#
+# Re-relaxes the historical `G >= 2` floor (re-tightened in #109) so that
+# fetwfe / etwfe / betwfe / twfeCovs and genCoefs / simulateData accept panels
+# with a SINGLE treated cohort (one cohort that adopts treatment, plus
+# never-treated units). The post-treatment side still binds: at least two
+# treatment effects (two post-treatment periods) are required so the
+# dynamic-effect fusion has something to fuse -- a new `num_treats >= 2` guard
+# in prep_for_etwfe_core() enforces that.
+#
+# Coverage:
+#   1. All four estimators recover a known ATT at G = 1 (numerical, not just
+#      finite) via a simulateData(G = 1) fixture; twfeCovs is biased by design
+#      (asserted finite + G == 1 only).
+#   2. The three fusion structures (cohort / event_study / custom fusion_matrix)
+#      all fit at G = 1, and cohort == event_study EXACTLY (no cross-cohort
+#      dimension to fuse, so both reduce to within-cohort dynamic-effect fusion).
+#   3. A hand-built SCATTERED-offset (offset 3, num_treats = 4) single-cohort
+#      panel fits -- genCoefs / simulateData force offset 2, so the scattered
+#      and late-adopting fixtures are built by hand.
+#   4. num_treats = 1 is rejected: T = 2 (any G) AND a late-adopting single
+#      cohort (offset = T) both stop with the new `num_treats >= 2` message.
+#   5. No-never-treated single-cohort panels fail via TWO distinct guards:
+#      adopting at t = 2 trips the time-period check (truncation leaves 1
+#      period); adopting at t >= 3 trips the cohort check in
+#      .truncate_if_no_never_treated() (truncation leaves 0 retained cohorts).
+#   6. An R >= 2 no-never-treated panel that truncates to a SINGLE retained
+#      cohort now SUCCEEDS as a valid G = 1 sub-panel (the real regression
+#      target for the utility.R `length(retained_cohorts) < 1` relaxation).
+#   7. The three accessors (eventStudy / cohortStudy / simultaneousCIs) and the
+#      conservative / cluster SE paths all degrade correctly at G = 1.
+#
+# Mutation-checks for each relaxed/added guard (re-tighten the source guard ->
+# the named test FAILs) were performed by the implementer and recorded in the
+# PR; they are noted in comments next to the relevant tests below.
+#
+# All assertions are on the canonical `$G` (never the deprecated `$R` compat
+# field, #41/#201).
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Shared fixtures.
+# ------------------------------------------------------------------------------
+
+# A simulateData(G = 1) panel with a known overall ATT (= the single cohort's
+# effect). Offset 2 (earliest adoption), T = 6 -> num_treats = 5.
+.sc112_sim <- function(
+	N = 200,
+	T = 6,
+	d = 2,
+	density = 0.5,
+	eff_size = 2,
+	seed = 20260605
+) {
+	coefs <- genCoefs(
+		G = 1,
+		T = T,
+		d = d,
+		density = density,
+		eff_size = eff_size,
+		seed = seed
+	)
+	tes <- getTes(coefs)
+	sim <- simulateData(coefs, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	list(sim = sim, att_true = tes$att_true)
+}
+
+.sc112_fit <- function(sim, estimator = fetwfe, ...) {
+	estimator(
+		pdata = sim$pdata,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		covs = sim$covs,
+		response = "y",
+		verbose = FALSE,
+		...
+	)
+}
+
+# A hand-built single-cohort panel: `frac` of the units adopt at calendar time
+# `adopt` (offset = adopt), the rest are never-treated. When `tau` is non-zero
+# the treated post-periods get an additive effect of size `tau`, so ATT
+# recovery is non-tautological. The seed stream is fixed for reproducibility.
+.sc112_make_panel <- function(
+	N = 240,
+	T = 6,
+	adopt = 3,
+	tau = 0,
+	frac = 0.5,
+	seed = 99
+) {
+	set.seed(seed)
+	units <- sprintf("u%03d", seq_len(N))
+	treated_units <- units[seq_len(round(N * frac))]
+	rows <- do.call(
+		rbind,
+		lapply(units, function(u) {
+			is_tr <- u %in% treated_units
+			unit_effect <- rnorm(1)
+			time_shocks <- rnorm(T)
+			cov1 <- rnorm(T)
+			cov2 <- stats::runif(T)
+			treat <- as.integer(is_tr & (seq_len(T) >= adopt))
+			y <- unit_effect +
+				time_shocks +
+				0.5 * cov1 +
+				tau * treat +
+				rnorm(T, sd = 0.3)
+			data.frame(
+				time = as.integer(seq_len(T)),
+				unit = as.character(u),
+				treatment = treat,
+				cov1 = cov1,
+				cov2 = cov2,
+				y = y
+			)
+		})
+	)
+	rows[order(rows$unit, rows$time), , drop = FALSE]
+}
+
+# A no-never-treated panel: ALL units adopt (no never-treated). `adopts` may
+# name one cohort (single-cohort cases 5a/5b) or two (case 6).
+.sc112_make_no_nt <- function(N = 200, T = 6, adopts = 2, tau = 0, seed = 7) {
+	set.seed(seed)
+	units <- sprintf("u%03d", seq_len(N))
+	n_cohorts <- length(adopts)
+	rows <- do.call(
+		rbind,
+		lapply(seq_along(units), function(i) {
+			u <- units[i]
+			a <- adopts[((i - 1L) %% n_cohorts) + 1L]
+			cov1 <- rnorm(T)
+			cov2 <- stats::runif(T)
+			treat <- as.integer(seq_len(T) >= a)
+			y <- rnorm(1) +
+				rnorm(T) +
+				0.5 * cov1 +
+				tau * treat +
+				rnorm(T, sd = 0.3)
+			data.frame(
+				time = as.integer(seq_len(T)),
+				unit = as.character(u),
+				treatment = treat,
+				cov1 = cov1,
+				cov2 = cov2,
+				y = y
+			)
+		})
+	)
+	rows[order(rows$unit, rows$time), , drop = FALSE]
+}
+
+# ------------------------------------------------------------------------------
+# 1. All four estimators recover a known ATT at G = 1.
+#
+# Mutation target for the cohort-count relaxation (input_prep.R `G < 1`): if the
+# guard is re-tightened to `G < 2`, all four fits stop with the no-treated-cohort
+# error and this test FAILs.
+# ------------------------------------------------------------------------------
+
+test_that("fetwfe recovers the known ATT at G = 1", {
+	skip_on_cran()
+	fx <- .sc112_sim()
+	res <- .sc112_fit(fx$sim, fetwfe)
+	expect_s3_class(res, "fetwfe")
+	expect_equal(res$G, 1)
+	expect_true(is.finite(res$att_hat))
+	expect_true(is.finite(res$att_se))
+	expect_gt(res$att_se, 0)
+	# Numerical recovery (true ATT = 2.4; FETWFE att_hat ~ 2.41 at this fixture).
+	expect_equal(res$att_hat, fx$att_true, tolerance = 0.3)
+})
+
+test_that("etwfe recovers the known ATT at G = 1", {
+	skip_on_cran()
+	fx <- .sc112_sim()
+	res <- .sc112_fit(fx$sim, etwfe)
+	expect_s3_class(res, "etwfe")
+	expect_equal(res$G, 1)
+	expect_true(is.finite(res$att_hat))
+	expect_equal(res$att_hat, fx$att_true, tolerance = 0.3)
+})
+
+test_that("betwfe recovers the known ATT at G = 1", {
+	skip_on_cran()
+	fx <- .sc112_sim()
+	res <- .sc112_fit(fx$sim, betwfe)
+	expect_s3_class(res, "betwfe")
+	expect_equal(res$G, 1)
+	expect_true(is.finite(res$att_hat))
+	expect_equal(res$att_hat, fx$att_true, tolerance = 0.3)
+})
+
+test_that("twfeCovs fits at G = 1 (biased by design, so finiteness only)", {
+	skip_on_cran()
+	fx <- .sc112_sim()
+	res <- .sc112_fit(fx$sim, twfeCovs)
+	expect_s3_class(res, "twfeCovs")
+	expect_equal(res$G, 1)
+	# twfeCovs is the naive TWFE-with-covariates benchmark; it does NOT recover
+	# the ATT under staggered adoption, so we assert only finiteness here.
+	expect_true(is.finite(res$att_hat))
+	expect_true(is.finite(res$att_se))
+})
+
+# ------------------------------------------------------------------------------
+# 2. The three fusion structures at G = 1, plus the cohort == event_study
+#    invariant. With a single cohort there is no cross-cohort dimension, so the
+#    cohort and event_study penalties reduce to the same within-cohort
+#    dynamic-effect fusion and must give byte-identical fits.
+# ------------------------------------------------------------------------------
+
+test_that("cohort and event_study fusion are identical at G = 1", {
+	skip_on_cran()
+	fx <- .sc112_sim()
+	res_cohort <- .sc112_fit(fx$sim, fetwfe, fusion_structure = "cohort")
+	res_es <- .sc112_fit(fx$sim, fetwfe, fusion_structure = "event_study")
+
+	expect_equal(res_cohort$G, 1)
+	expect_equal(res_es$G, 1)
+	# The defining invariant at G = 1: no cross-cohort fusion direction exists,
+	# so the two penalties coincide exactly.
+	expect_equal(res_cohort$att_hat, res_es$att_hat)
+	expect_equal(res_cohort$beta_hat, res_es$beta_hat)
+	expect_equal(res_cohort$catt_df$estimate, res_es$catt_df$estimate)
+	expect_equal(nrow(res_cohort$catt_df), 1L)
+})
+
+test_that("a custom fusion_matrix fits at G = 1", {
+	skip_on_cran()
+	fx <- .sc112_sim()
+	# num_treats = T - 1 = 5 for the offset-2 single cohort; a num_treats x
+	# num_treats fusion matrix (here the identity, i.e. a ridge-on-theta penalty)
+	# is the documented #236 shape.
+	num_treats <- 5L
+	D <- diag(num_treats)
+	res <- .sc112_fit(fx$sim, fetwfe, fusion_matrix = D)
+	expect_s3_class(res, "fetwfe")
+	expect_equal(res$G, 1)
+	expect_true(is.finite(res$att_hat))
+})
+
+# ------------------------------------------------------------------------------
+# 3. Scattered-offset single cohort (offset 3 -> num_treats = 4). This exercises
+#    the getFirstIndsFromOffsets() path (#174) at G = 1, which genCoefs /
+#    simulateData cannot produce (they force offset 2).
+# ------------------------------------------------------------------------------
+
+test_that("a scattered-offset (offset 3) single cohort fits and recovers ATT", {
+	skip_on_cran()
+	# T = 6, single cohort adopts at t = 3 -> offset 3, num_treats = 4, with a
+	# true additive effect tau = 2.
+	pdata <- .sc112_make_panel(N = 240, T = 6, adopt = 3, tau = 2, seed = 311)
+	res <- fetwfe(
+		pdata = pdata,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		covs = c("cov1", "cov2"),
+		response = "y",
+		verbose = FALSE
+	)
+	expect_s3_class(res, "fetwfe")
+	expect_equal(res$G, 1)
+	# Single cohort adopting at t = 3 -> 4 post-treatment periods (t = 3..6).
+	expect_true(is.finite(res$att_hat))
+	expect_equal(res$att_hat, 2, tolerance = 0.3)
+})
+
+# ------------------------------------------------------------------------------
+# 4. num_treats = 1 rejection (the new `num_treats >= 2` guard).
+#
+# Mutation target for the new guard: re-tighten is N/A (the guard is added, not
+# relaxed) -- instead, DELETING the `num_treats < 2` block makes both of these
+# tests FAIL (T = 2 fits silently; the late-adopting cohort fits silently).
+# The offset-aware `num_treats` is what distinguishes the late-adopting case
+# from getNumTreats(G, T) = T - 1, which would miscount it as non-degenerate.
+# ------------------------------------------------------------------------------
+
+test_that("T = 2 (num_treats = 1) is rejected at G = 1", {
+	# T = 2, single cohort adopting at t = 2 -> exactly one post-treatment
+	# period -> num_treats = 1.
+	pdata <- .sc112_make_panel(N = 60, T = 2, adopt = 2, tau = 0, seed = 12)
+	expect_error(
+		fetwfe(
+			pdata = pdata,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			verbose = FALSE
+		),
+		"at least two treatment effects"
+	)
+})
+
+test_that("a late-adopting single cohort (offset = T, num_treats = 1) is rejected", {
+	# T = 5, single cohort adopts at the FINAL period t = 5 -> one
+	# post-treatment period -> num_treats = 1, despite T >= 3. getNumTreats(G, T)
+	# would report T - 1 = 4 here; the offset-aware count correctly catches it.
+	pdata <- .sc112_make_panel(N = 80, T = 5, adopt = 5, tau = 0, seed = 13)
+	expect_error(
+		fetwfe(
+			pdata = pdata,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			verbose = FALSE
+		),
+		"at least two treatment effects"
+	)
+})
+
+# ------------------------------------------------------------------------------
+# 5. No-never-treated single-cohort panels fail via TWO distinct guards.
+# ------------------------------------------------------------------------------
+
+test_that("no-never-treated single cohort adopting at t = 2 trips the time-period check", {
+	# All units adopt at t = 2, no never-treated. Truncating to the largest
+	# all-untreated sub-panel leaves only t = 1 -> 1 time period.
+	pdata <- .sc112_make_no_nt(N = 40, T = 6, adopts = 2, seed = 71)
+	expect_error(
+		suppressWarnings(fetwfe(
+			pdata = pdata,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			verbose = FALSE
+		)),
+		"would leave only"
+	)
+})
+
+test_that("no-never-treated single cohort adopting at t = 3 trips the cohort check", {
+	# All units adopt at t = 3, no never-treated. Truncation keeps t = 1, 2
+	# (>= 2 periods, so the time-period check passes) but leaves 0 retained
+	# cohorts -> the .truncate_if_no_never_treated() cohort check fires.
+	pdata <- .sc112_make_no_nt(N = 40, T = 6, adopts = 3, seed = 72)
+	expect_error(
+		suppressWarnings(fetwfe(
+			pdata = pdata,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			verbose = FALSE
+		)),
+		"treated cohort"
+	)
+})
+
+# ------------------------------------------------------------------------------
+# 6. R >= 2 no-never-treated panel truncating to a SINGLE retained cohort now
+#    SUCCEEDS (the real regression target for the utility.R relaxation from
+#    `< 2` to `< 1`).
+#
+# Mutation target for the utility.R `length(retained_cohorts) < 1` relaxation:
+# re-tighten to `< 2` and this test FAILs (the 1-retained-cohort truncation is
+# rejected instead of fitting).
+# ------------------------------------------------------------------------------
+
+test_that("two-cohort no-never-treated panel truncating to one cohort fits (G = 1)", {
+	# Half the units adopt at t = 3, half at t = 5; no never-treated. r_max = 5,
+	# truncation keeps t = 1..4 (>= 2 periods) and retains the t = 3 cohort only
+	# -> a valid single-cohort sub-panel.
+	pdata <- .sc112_make_no_nt(
+		N = 200,
+		T = 6,
+		adopts = c(3, 5),
+		tau = 2,
+		seed = 81
+	)
+	res <- suppressWarnings(fetwfe(
+		pdata = pdata,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		covs = c("cov1", "cov2"),
+		response = "y",
+		verbose = FALSE
+	))
+	expect_s3_class(res, "fetwfe")
+	# Truncated down to a single retained cohort.
+	expect_equal(res$G, 1)
+	expect_true(res$T < 6)
+	expect_true(is.finite(res$att_hat))
+})
+
+# ------------------------------------------------------------------------------
+# 7. Accessors and SE paths degrade correctly at G = 1.
+# ------------------------------------------------------------------------------
+
+test_that("eventStudy, cohortStudy, and simultaneousCIs work at G = 1", {
+	skip_on_cran()
+	fx <- .sc112_sim()
+	res <- .sc112_fit(fx$sim, fetwfe)
+
+	es <- eventStudy(res)
+	expect_s3_class(es, "eventStudy")
+	# Single cohort -> every event time is covered by exactly one cohort.
+	expect_true(all(es$n_cohorts == 1L))
+	expect_true(all(is.finite(es$estimate)))
+
+	cs <- cohortStudy(res)
+	expect_s3_class(cs, "cohortStudy")
+	# Exactly one cohort row at G = 1.
+	expect_equal(nrow(cs), 1L)
+
+	# event_study family (K > 1) and cohort family (K = 1, the critical-value
+	# bypass) both produce valid simultaneous CIs at G = 1.
+	sci_es <- simultaneousCIs(res, family = "event_study")
+	expect_s3_class(sci_es, "simultaneous_cis")
+	expect_equal(nrow(sci_es$ci), 5L)
+	expect_true(all(is.finite(sci_es$ci$simultaneous_ci_low)))
+	expect_true(all(is.finite(sci_es$ci$simultaneous_ci_high)))
+
+	sci_cohort <- simultaneousCIs(res, family = "cohort")
+	expect_s3_class(sci_cohort, "simultaneous_cis")
+	expect_equal(sci_cohort$K, 1L)
+
+	sci_all <- simultaneousCIs(res, family = "all_post_treatment")
+	expect_s3_class(sci_all, "simultaneous_cis")
+})
+
+test_that("conservative and cluster SE paths work at G = 1", {
+	skip_on_cran()
+	fx <- .sc112_sim()
+
+	res_cons <- .sc112_fit(fx$sim, fetwfe, se_type = "conservative")
+	expect_equal(res_cons$G, 1)
+	expect_true(is.finite(res_cons$att_se))
+	expect_gt(res_cons$att_se, 0)
+
+	res_clus <- .sc112_fit(fx$sim, fetwfe, se_type = "cluster")
+	expect_equal(res_clus$G, 1)
+	expect_true(is.finite(res_clus$att_se))
+	expect_gt(res_clus$att_se, 0)
+})
+
+test_that("add_ridge and REML (sig_eps_sq = NA) paths work at G = 1", {
+	skip_on_cran()
+	fx <- .sc112_sim()
+
+	# add_ridge previously hit a cryptic `T >= 3L is not TRUE` stopifnot when a
+	# degenerate single post-period leaked through; with num_treats >= 2 enforced
+	# up front, the happy path fits.
+	res_ridge <- .sc112_fit(fx$sim, fetwfe, add_ridge = TRUE)
+	expect_equal(res_ridge$G, 1)
+	expect_true(is.finite(res_ridge$att_hat))
+
+	# REML noise-variance estimation (sig_eps_sq = NA) is cohort-count
+	# independent.
+	res_reml <- .sc112_fit(
+		fx$sim,
+		fetwfe,
+		sig_eps_sq = NA,
+		sig_eps_c_sq = NA
+	)
+	expect_equal(res_reml$G, 1)
+	expect_true(is.finite(res_reml$att_hat))
+})
+
+# ------------------------------------------------------------------------------
+# 8. genCoefs / simulateData round trip at G = 1 (the DGP side of #112).
+# ------------------------------------------------------------------------------
+
+test_that("genCoefs and simulateData round-trip at G = 1", {
+	coefs <- genCoefs(
+		G = 1,
+		T = 6,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		seed = 4242
+	)
+	expect_s3_class(coefs, "FETWFE_coefs")
+	expect_equal(coefs$G, 1)
+
+	tes <- getTes(coefs)
+	expect_length(tes$actual_cohort_tes, 1L)
+	# Overall ATT equals the lone cohort's effect.
+	expect_equal(tes$att_true, tes$actual_cohort_tes[1])
+
+	sim <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	expect_equal(sim$G, 1)
+	expect_s3_class(sim$pdata, "data.frame")
+	# One treated cohort -> exactly one unique post-adoption start time among
+	# the treated units.
+	treated <- sim$pdata[sim$pdata$treatment == 1L, , drop = FALSE]
+	first_treat <- stats::aggregate(time ~ unit, data = treated, FUN = min)
+	expect_equal(length(unique(first_treat$time)), 1L)
+})

--- a/tests/testthat/test-twfeCovs.R
+++ b/tests/testthat/test-twfeCovs.R
@@ -427,24 +427,26 @@ test_that("twfeCovs works on only two cohorts", {
 })
 
 # ------------------------------------------------------------------------------
-# Test 19: Test that at least 2 treated cohorts requires
+# Test 19: A single treated cohort (G = 1) is now supported (#112).
 # ------------------------------------------------------------------------------
-test_that("at least two treated cohorts required", {
-	# Create a balanced panel with N = 3 units and T = 3 time periods.
+test_that("single treated cohort (G = 1) is supported", {
+	# A balanced panel with N = 30 units and T = 10 periods. With R = 1 the
+	# helper produces a single treated cohort (adopting at t = 2) plus
+	# never-treated units.
 	df <- generate_panel_data(N = 30, T = 10, R = 1, seed = 202)
 
-	expect_error(
-		twfeCovs(
-			pdata = df,
-			time_var = "time",
-			unit_var = "unit",
-			treatment = "treatment",
-			covs = c("cov1", "cov2"),
-			response = "y",
-			verbose = FALSE
-		),
-		"Only one treated cohort detected in data. Currently fetwfe and etwfe only support data sets with at least two treated cohorts."
+	res <- twfeCovs(
+		pdata = df,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		covs = c("cov1", "cov2"),
+		response = "y",
+		verbose = FALSE
 	)
+	expect_s3_class(res, "twfeCovs")
+	expect_equal(res$G, 1)
+	expect_true(is.finite(res$att_hat))
 })
 
 


### PR DESCRIPTION
Refs #112. Re-relaxes the `G >= 2` floor (re-tightened in #109) so all four estimators — and `genCoefs`/`simulateData` — accept single-treated-cohort panels (one treated cohort + never-treated). The **post-treatment side binds**: a new `num_treats >= 2` guard in `prep_for_etwfe_core()` requires ≥2 post-treatment periods (≥2 dynamic treatment effects to fuse), since at one post-period FETWFE degenerates to ordinary 2×2 DiD. A spike confirmed `grpreg::gBridge` handles the single-cohort (degenerate cross-cohort) penalty group cleanly — no OLS fallback needed — and at G=1 the `cohort` and `event_study` penalties coincide exactly (no cross-cohort dimension; both reduce to within-cohort dynamic-effect fusion).

Guard relaxations: the user-facing `G < 2` rejections (`input_prep.R`, two mirrored sites), the fusion-matrix builder (`fusion_transforms.R`, `G` only — `T >= 3L` untouched), the no-never-treated auto-truncation cohort guard (`utility.R`), and the simulation side (`gen_coefs.R`, `sim_helpers.R`; the gen_coefs `T >= 3` guards are kept as the simulation analog of `num_treats >= 2`). The `num_treats >= 2` guard is placed where the **offset-aware** count is in scope, so a single cohort adopting late (one post-period despite `T >= 3`) is correctly rejected — `getNumTreats(G,T) = T-1` would miss it. `T = 2` and no-never-treated single-cohort panels (no comparison group) are rejected with clear messages.

New `tests/testthat/test-single-cohort-112.R` (68 assertions): numerical ATT recovery for all four estimators at G=1 (vs a known truth, not finiteness-only), the three fusion structures incl. the cohort≡event_study invariant, scattered/late-adopting offsets, both no-never-treated failure modes, the R≥2→R=1-via-truncation success path, and the accessors / conservative+cluster SE paths. Each relaxed/added guard is mutation-checked. The four estimator + two `genCoefs` error tests are converted to G=1-success tests. Minor bump to 1.22.0; G-internal throughout (tests assert `$G`, never the deprecated `$R`).

`R CMD check --as-cran` code-clean; full suite green (FAIL 0). **This branch is stacked on `cleanup-batch-185` (PR #247)** to avoid conflicts — rebase/retarget onto `main` once #247 merges.

## Inference calibration at G=1

A 100-rep Monte-Carlo check (`T=6, d=2, N=1000`, default CV λ-selection) confirms that overall-ATT *inference*, not just the point estimate, is well-calibrated at a single cohort:

| G | bias | mean SE | sd(att̂) | SE/sd | coverage |
|---|---:|---:|---:|---:|---:|
| **1** | −0.008 | 0.046 | 0.046 | 1.00 | **0.950** |
| 3 (matched) | +0.032 | 0.079 | 0.150 | 0.53\* | 0.920 |

G=1 Wald-CI coverage of the overall ATT is **0.950** with SE/sd 1.00 — matching the G≥2 CV behavior validated in #164/#170, so R=1 inherits correct inference rather than just consistent point estimation. (\*The matched G=3 cell's raw SE/sd is depressed only by a few outlier fits fattening the cross-seed `sd(att̂)`; its coverage — the robust metric — is near-nominal 0.920, consistent with #170's CV-calibration footnote. Back-solving the SD from coverage gives an effective SE/sd ≈ 0.89.) The variance machinery is unchanged by this PR; this is a validation of the existing CV path at the newly-supported G=1 boundary.

## Out of scope (deferred follow-ups)
- **R=1 methodology note in the paper** — Faletto (2025) is written for R≥2; a short extensions-section note on the single-cohort case. Filed as #248.
- **Vignette section** — Dropped: covered by the NEWS bullet and the relaxed `@param` docs; not user-facing enough to warrant a worked vignette example.
