### PR TITLE
feat: support num_treats = 1 (down to the 2x2 case) in fetwfe/etwfe/betwfe/twfeCovs (#251)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.22.0
+Version: 1.23.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # NEWS
 
+## Version 1.23.0
+
+### Features
+
+- `fetwfe()`, `etwfe()`, `betwfe()`, and `twfeCovs()` (and the
+  `*WithSimulatedData()` wrappers), along with `genCoefs()` and `simulateData()`,
+  now support a single treatment effect (one post-treatment period for the
+  treated cohort), down to the true 2x2 case (`T = 2`, `G = 1`) and a
+  late-adopting single cohort (`G = 1`, `T >= 3`, adopting in the final period).
+  This removes the `num_treats >= 2` requirement added in #112, giving continuity
+  for simulation sweeps over `T` (#251). At `T = 2` -- the unique configuration
+  with nothing to fuse -- `fetwfe()` now warns that no fusion penalty applies and
+  the bridge penalty reduces to individual shrinkage; the other estimators and
+  the late-adopting case (which still fuses the time fixed effects) do not warn.
+
 ## Version 1.22.0
 
 ### Features

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -426,6 +426,21 @@ fetwfe <- function(
 
 	rm(prep)
 
+	# T == 2 is the unique no-fusion configuration: it forces G = 1,
+	# num_treats = 1, and a degenerate time-FE block, so every fused block is
+	# trivial and no fusion penalty applies. The bridge penalty then reduces to
+	# individual shrinkage of the (single) treatment effect rather than fusing
+	# anything. This is fetwfe-specific (etwfe/twfeCovs are unpenalized; betwfe
+	# applies the bridge to the raw coefficients and never fuses), so the warning
+	# lives here in fetwfe() rather than in the shared input prep. A late-adopting
+	# single cohort with T >= 3 still fuses the time fixed effects, so it does NOT
+	# warn (T is known here, after prep).
+	if (T == 2) {
+		warning(
+			"No fusion penalty applies at T = 2 (a single treatment effect and a single time difference leave nothing to fuse); the bridge penalty reduces to individual shrinkage."
+		)
+	}
+
 	# User-supplied custom fusion matrix (#236). Validated here -- after prep
 	# (so `num_treats`, `G`, `T` are known) and before `fetwfe_core()`. When
 	# supplied, `d_inv_treat <- solve(fusion_matrix)` overrides

--- a/R/fusion_transforms.R
+++ b/R/fusion_transforms.R
@@ -1107,7 +1107,7 @@ genFullInvFusionTransformMat <- function(
 ) {
 	##———— Safety checks ————————————————————————————————————————————
 	stopifnot(is.numeric(G), length(G) == 1L, G >= 1L)
-	stopifnot(is.numeric(T), length(T) == 1L, T >= 3L, G <= T - 1)
+	stopifnot(is.numeric(T), length(T) == 1L, T >= 2L, G <= T - 1)
 	stopifnot(is.numeric(d), length(d) == 1L, d >= 0L)
 	stopifnot(length(first_inds) == G)
 

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -230,9 +230,9 @@ genCoefs <- function(
 	# directly.
 	G <- .resolve_cohort_count_arg(G, R, "genCoefs")
 
-	# Check that T is a numeric scalar and at least 3.
-	if (!is.numeric(T) || length(T) != 1 || T < 3) {
-		stop("T must be a numeric value greater than or equal to 3")
+	# Check that T is a numeric scalar and at least 2.
+	if (!is.numeric(T) || length(T) != 1 || T < 2) {
+		stop("T must be a numeric value greater than or equal to 2")
 	}
 
 	# Check that G is a numeric scalar and at least 1.
@@ -359,7 +359,7 @@ genCoefs <- function(
 	)
 
 	stopifnot(G >= 1)
-	stopifnot(T >= 3)
+	stopifnot(T >= 2)
 	stopifnot(G <= T - 1)
 
 	core_obj <- genCoefsCore(
@@ -728,9 +728,9 @@ genCoefsCore <- function(
 		set.seed(seed)
 	}
 
-	# Check that T is a numeric scalar and at least 3.
-	if (!is.numeric(T) || length(T) != 1 || T < 3) {
-		stop("T must be a numeric value greater than or equal to 3")
+	# Check that T is a numeric scalar and at least 2.
+	if (!is.numeric(T) || length(T) != 1 || T < 2) {
+		stop("T must be a numeric value greater than or equal to 2")
 	}
 
 	# Check that G is a numeric scalar and at least 1.
@@ -766,7 +766,7 @@ genCoefsCore <- function(
 	}
 
 	stopifnot(G >= 1)
-	stopifnot(T >= 3)
+	stopifnot(T >= 2)
 	stopifnot(G <= T - 1)
 
 	num_treats <- getNumTreats(G = G, T = T)

--- a/R/input_prep.R
+++ b/R/input_prep.R
@@ -325,21 +325,6 @@ prep_for_etwfe_core <- function(
 			"No treated cohorts detected in data. fetwfe, etwfe, betwfe, and twfeCovs require at least one treated cohort (one cohort of units that adopt treatment, plus never-treated units)."
 		)
 	}
-	# Require at least two treatment effects (i.e., at least two post-treatment
-	# periods for the treated cohort) so the dynamic-effect fusion has something
-	# to fuse; with num_treats = 1 FETWFE degenerates to ordinary
-	# difference-in-differences. For G >= 2 this is implied by G <= T - 1 (which
-	# forces T >= 3 and hence num_treats >= 2), so this is a no-op there; it only
-	# binds at G = 1, where a single post-treatment period (num_treats = 1) is
-	# reachable -- either T = 2, or a late-adopting single cohort (e.g. adopting
-	# in the final period). `num_treats` here is the offset-aware count (computed
-	# in prepXints() above), so it correctly rejects a late-adopting single
-	# cohort that getNumTreats(G, T) would miscount as T - 1.
-	if (num_treats < 2) {
-		stop(
-			"Only one treatment effect (one post-treatment period) detected for the treated cohort. fetwfe, etwfe, betwfe, and twfeCovs require at least two treatment effects (at least two post-treatment periods) so that the dynamic treatment effects can be fused; with a single post-treatment period the model degenerates to ordinary difference-in-differences."
-		)
-	}
 	stopifnot(N >= G + 1)
 	stopifnot(sum(in_sample_counts) == N)
 	stopifnot(all(in_sample_counts >= 0))

--- a/R/sim_helpers.R
+++ b/R/sim_helpers.R
@@ -530,7 +530,7 @@ testGenRandomDataInputs <- function(
 	sig_eps_c_sq
 ) {
 	stopifnot(G <= T - 1)
-	stopifnot(T >= 3)
+	stopifnot(T >= 2)
 	stopifnot(G >= 1)
 	stopifnot(N >= G + 1)
 	stopifnot(sig_eps_sq > 0)

--- a/tests/testthat/test-2x2-support-251.R
+++ b/tests/testthat/test-2x2-support-251.R
@@ -1,0 +1,355 @@
+# ==============================================================================
+# 2x2 and late-adopting single-treatment-effect support (#251, Phase 2 of #112).
+#
+# #112 added a `num_treats >= 2` guard in prep_for_etwfe_core() that rejected
+# panels with a single treatment effect (one post-treatment period). #251 removes
+# that guard so num_treats = 1 panels now FIT, down to the true 2x2 case
+# (T = 2, G = 1) and the late-adopting single cohort (G = 1, T >= 3, adopting in
+# the final period). Motivation: continuity for simulation sweeps over T.
+#
+# The crux is the warning ASYMMETRY. T == 2 is the unique no-fusion
+# configuration (it forces G = 1, num_treats = 1, and a degenerate time-FE block,
+# so every fused block is trivial), so fetwfe() warns there that no fusion
+# applies and the bridge penalty reduces to individual shrinkage. It is NOT
+# equivalent to DiD/ETWFE -- the bridge still shrinks the single effect (spike:
+# fetwfe != etwfe on identical data). A late-adopting num_treats = 1 cohort with
+# T >= 3 still fuses the TIME fixed effects, so it does NOT warn. betwfe applies
+# the bridge to the raw coefficients (never fuses) and etwfe/twfeCovs are
+# unpenalized, so none of them warn at T = 2. The warning is therefore
+# fetwfe-only, and fires at T == 2 only.
+#
+# Coverage:
+#   1. 2x2 (T = 2, G = 1) and late-adopting (G = 1, T = 5, adopt final period)
+#      fixtures: all four estimators fit, accessors return well-formed objects,
+#      SEs finite, att_hat is numerically sane (a true effect is injected).
+#   2. Warning asymmetry: fetwfe@T=2 warns "no fusion"; fetwfe@late-adopt
+#      (num_treats = 1, T >= 3) does NOT warn; fetwfe@num_treats>=2 does NOT
+#      warn; betwfe/etwfe@T=2 do NOT warn.
+#   3. T-sweep continuity (G = 1, T = 2..6): fetwfe runs at every T, only T = 2
+#      warns.
+#   4. genCoefs / simulateData round-trip at T = 2.
+#   5. Mutation-check (recorded, not executed in CI): deleting the `T == 2`
+#      warning in fetwfe() makes the "warns at T = 2" test FAIL.
+#
+# All assertions are on the canonical `$G` / `$T` (never the deprecated `$R`).
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Shared fixtures.
+# ------------------------------------------------------------------------------
+
+# A hand-built single-cohort panel: `frac` of the units adopt at calendar time
+# `adopt` (offset = adopt), the rest are never-treated. When `tau` is non-zero
+# the treated post-periods get an additive effect of size `tau`, so ATT recovery
+# is non-tautological. The seed stream is fixed for reproducibility.
+.s251_make_panel <- function(
+	N = 240,
+	T = 6,
+	adopt = 2,
+	tau = 2,
+	frac = 0.5,
+	seed = 251
+) {
+	set.seed(seed)
+	units <- sprintf("u%03d", seq_len(N))
+	treated_units <- units[seq_len(round(N * frac))]
+	rows <- do.call(
+		rbind,
+		lapply(units, function(u) {
+			is_tr <- u %in% treated_units
+			unit_effect <- rnorm(1)
+			time_shocks <- rnorm(T)
+			cov1 <- rnorm(T)
+			cov2 <- stats::runif(T)
+			treat <- as.integer(is_tr & (seq_len(T) >= adopt))
+			y <- unit_effect +
+				time_shocks +
+				0.5 * cov1 +
+				tau * treat +
+				rnorm(T, sd = 0.3)
+			data.frame(
+				time = as.integer(seq_len(T)),
+				unit = as.character(u),
+				treatment = treat,
+				cov1 = cov1,
+				cov2 = cov2,
+				y = y
+			)
+		})
+	)
+	rows[order(rows$unit, rows$time), , drop = FALSE]
+}
+
+.s251_fit <- function(pdata, estimator = fetwfe, ...) {
+	estimator(
+		pdata = pdata,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		covs = c("cov1", "cov2"),
+		response = "y",
+		verbose = FALSE,
+		...
+	)
+}
+
+# ------------------------------------------------------------------------------
+# 1a. 2x2 (T = 2, G = 1): all four estimators fit and recover the injected ATT.
+#
+# tau = 2 is injected, so att_hat recovery is numerical (tolerance), not just
+# finiteness. twfeCovs is the naive benchmark -- biased under staggering, but at
+# a clean 2x2 with one cohort it should still be in the right ballpark; we assert
+# only finiteness for it to stay robust.
+# ------------------------------------------------------------------------------
+
+test_that("all four estimators fit a 2x2 (T = 2, G = 1) panel", {
+	skip_on_cran()
+	p22 <- .s251_make_panel(N = 240, T = 2, adopt = 2, tau = 2, seed = 2202)
+
+	res_f <- suppressWarnings(.s251_fit(p22, fetwfe))
+	expect_s3_class(res_f, "fetwfe")
+	expect_equal(res_f$G, 1)
+	expect_equal(res_f$T, 2)
+	expect_equal(nrow(res_f$catt_df), 1L)
+	expect_true(is.finite(res_f$att_hat))
+	expect_true(is.finite(res_f$att_se))
+	expect_gt(res_f$att_se, 0)
+	# True effect tau = 2; bridge shrinks slightly toward 0 but stays close.
+	expect_equal(res_f$att_hat, 2, tolerance = 0.3)
+
+	res_e <- .s251_fit(p22, etwfe)
+	expect_s3_class(res_e, "etwfe")
+	expect_equal(res_e$T, 2)
+	expect_equal(res_e$att_hat, 2, tolerance = 0.3)
+
+	res_b <- .s251_fit(p22, betwfe)
+	expect_s3_class(res_b, "betwfe")
+	expect_equal(res_b$T, 2)
+	expect_equal(res_b$att_hat, 2, tolerance = 0.3)
+
+	res_t <- .s251_fit(p22, twfeCovs)
+	expect_s3_class(res_t, "twfeCovs")
+	expect_equal(res_t$T, 2)
+	expect_true(is.finite(res_t$att_hat))
+	expect_true(is.finite(res_t$att_se))
+})
+
+test_that("fetwfe add_ridge fits a 2x2 panel (the relaxed T >= 2L fusion guard)", {
+	skip_on_cran()
+	# The add_ridge path builds genFullInvFusionTransformMat, whose `T >= 3L`
+	# stopifnot used to reject T = 2; #251 relaxed it to `T >= 2L`.
+	p22 <- .s251_make_panel(N = 240, T = 2, adopt = 2, tau = 2, seed = 2203)
+	res <- suppressWarnings(.s251_fit(p22, fetwfe, add_ridge = TRUE))
+	expect_s3_class(res, "fetwfe")
+	expect_equal(res$T, 2)
+	expect_true(is.finite(res$att_hat))
+	expect_equal(res$att_hat, 2, tolerance = 0.3)
+})
+
+test_that("accessors and SE paths work at T = 2", {
+	skip_on_cran()
+	p22 <- .s251_make_panel(N = 240, T = 2, adopt = 2, tau = 2, seed = 2204)
+	res <- suppressWarnings(.s251_fit(p22, fetwfe))
+
+	es <- eventStudy(res)
+	expect_s3_class(es, "eventStudy")
+	expect_equal(nrow(es), 1L)
+	expect_true(all(es$n_cohorts == 1L))
+	expect_true(all(is.finite(es$estimate)))
+
+	cs <- cohortStudy(res)
+	expect_s3_class(cs, "cohortStudy")
+	expect_equal(nrow(cs), 1L)
+
+	# cohort family (K = 1, the critical-value bypass) and the K-row families all
+	# produce valid simultaneous CIs with a single treatment effect.
+	sci_cohort <- simultaneousCIs(res, family = "cohort")
+	expect_s3_class(sci_cohort, "simultaneous_cis")
+	expect_equal(sci_cohort$K, 1L)
+
+	sci_es <- simultaneousCIs(res, family = "event_study")
+	expect_s3_class(sci_es, "simultaneous_cis")
+	expect_equal(nrow(sci_es$ci), 1L)
+	expect_true(all(is.finite(sci_es$ci$simultaneous_ci_low)))
+	expect_true(all(is.finite(sci_es$ci$simultaneous_ci_high)))
+
+	sci_all <- simultaneousCIs(res, family = "all_post_treatment")
+	expect_s3_class(sci_all, "simultaneous_cis")
+
+	res_cons <- suppressWarnings(.s251_fit(
+		p22,
+		fetwfe,
+		se_type = "conservative"
+	))
+	expect_true(is.finite(res_cons$att_se))
+	expect_gt(res_cons$att_se, 0)
+
+	res_clus <- suppressWarnings(.s251_fit(p22, fetwfe, se_type = "cluster"))
+	expect_true(is.finite(res_clus$att_se))
+	expect_gt(res_clus$att_se, 0)
+})
+
+# ------------------------------------------------------------------------------
+# 1b. Late-adopting single cohort (G = 1, T = 5, adopt final period t = 5):
+# num_treats = 1 but T >= 3, so the time FEs still fuse. All four estimators fit
+# and recover the injected ATT.
+# ------------------------------------------------------------------------------
+
+test_that("all four estimators fit a late-adopting (G = 1, T = 5) num_treats = 1 panel", {
+	skip_on_cran()
+	plate <- .s251_make_panel(N = 240, T = 5, adopt = 5, tau = 2, seed = 2205)
+
+	res_f <- .s251_fit(plate, fetwfe)
+	expect_s3_class(res_f, "fetwfe")
+	expect_equal(res_f$G, 1)
+	expect_equal(res_f$T, 5)
+	# Adopting in the final period -> exactly one post-treatment period.
+	expect_equal(nrow(res_f$catt_df), 1L)
+	expect_true(is.finite(res_f$att_hat))
+	expect_true(is.finite(res_f$att_se))
+	expect_gt(res_f$att_se, 0)
+	expect_equal(res_f$att_hat, 2, tolerance = 0.4)
+
+	res_e <- .s251_fit(plate, etwfe)
+	expect_s3_class(res_e, "etwfe")
+	expect_equal(res_e$att_hat, 2, tolerance = 0.4)
+
+	res_b <- .s251_fit(plate, betwfe)
+	expect_s3_class(res_b, "betwfe")
+	expect_equal(res_b$att_hat, 2, tolerance = 0.4)
+
+	res_t <- .s251_fit(plate, twfeCovs)
+	expect_s3_class(res_t, "twfeCovs")
+	expect_true(is.finite(res_t$att_hat))
+})
+
+# ------------------------------------------------------------------------------
+# 2. The warning asymmetry (the whole point of #251's warning design).
+# ------------------------------------------------------------------------------
+
+test_that("fetwfe() warns about no fusion at T = 2", {
+	# MUTATION TARGET: deleting the `if (T == 2) warning(...)` block in fetwfe()
+	# makes this test FAIL (the fit succeeds silently). Verified by the
+	# implementer (recorded in the #251 PR).
+	p22 <- .s251_make_panel(N = 120, T = 2, adopt = 2, tau = 0, seed = 2210)
+	expect_warning(
+		.s251_fit(p22, fetwfe),
+		"no fusion",
+		ignore.case = TRUE
+	)
+})
+
+test_that("fetwfe() does NOT warn at a late-adopting num_treats = 1 case (T >= 3)", {
+	# T = 5, adopt at t = 5 -> num_treats = 1, but the time FEs (T - 1 = 4 of
+	# them) still fuse, so there IS fusion -> no warning.
+	plate <- .s251_make_panel(N = 120, T = 5, adopt = 5, tau = 0, seed = 2211)
+	expect_warning(.s251_fit(plate, fetwfe), NA)
+})
+
+test_that("fetwfe() does NOT warn at num_treats >= 2", {
+	# Standard multi-period single cohort (T = 6, adopt 2 -> num_treats = 5).
+	pmulti <- .s251_make_panel(N = 120, T = 6, adopt = 2, tau = 0, seed = 2212)
+	expect_warning(.s251_fit(pmulti, fetwfe), NA)
+})
+
+test_that("betwfe() and etwfe() do NOT warn at T = 2", {
+	# betwfe applies the bridge to the RAW coefficients (never fuses), and etwfe
+	# is unpenalized, so neither emits the no-fusion warning -- it is fetwfe-only.
+	p22 <- .s251_make_panel(N = 120, T = 2, adopt = 2, tau = 0, seed = 2213)
+	expect_warning(.s251_fit(p22, betwfe), NA)
+	expect_warning(.s251_fit(p22, etwfe), NA)
+	expect_warning(.s251_fit(p22, twfeCovs), NA)
+})
+
+# ------------------------------------------------------------------------------
+# 3. T-sweep continuity: fetwfe() runs at every T in 2..6 (G = 1, same DGP
+# shape), and ONLY the T = 2 step warns. This is the continuity motivation for
+# #251 -- a simulation sweep over T should not break (or spuriously warn) at the
+# T = 2 endpoint.
+# ------------------------------------------------------------------------------
+
+test_that("fetwfe() runs across a T = 2..6 sweep, warning only at T = 2", {
+	skip_on_cran()
+	for (Tval in 2:6) {
+		pdata <- .s251_make_panel(
+			N = 160,
+			T = Tval,
+			adopt = 2,
+			tau = 1,
+			seed = 2220 + Tval
+		)
+		warned <- FALSE
+		res <- withCallingHandlers(
+			.s251_fit(pdata, fetwfe),
+			warning = function(cnd) {
+				if (
+					grepl(
+						"no fusion",
+						conditionMessage(cnd),
+						ignore.case = TRUE
+					)
+				) {
+					warned <<- TRUE
+				}
+				invokeRestart("muffleWarning")
+			}
+		)
+		expect_s3_class(res, "fetwfe")
+		expect_equal(res$T, Tval)
+		expect_true(is.finite(res$att_hat))
+		# The no-fusion warning fires iff T == 2.
+		expect_equal(warned, Tval == 2L)
+	}
+})
+
+# ------------------------------------------------------------------------------
+# 4. genCoefs / simulateData round-trip at T = 2 (the DGP side of #251).
+# ------------------------------------------------------------------------------
+
+test_that("genCoefs and simulateData round-trip at T = 2", {
+	# seed = 251 yields a non-zero single treatment effect (att_true = 2), so the
+	# att_true / att_hat assertions below exercise a real effect rather than a
+	# tautological 0 ~ 0. At density 0.5 the lone num_treats = 1 effect is
+	# sparsified out for some seeds (e.g. 2230 / 99 -> att_true = 0; cf. the
+	# all-zero-block risk in the project memory); density must be strictly in
+	# (0, 1), so density = 1 is not an option.
+	coefs <- genCoefs(
+		G = 1,
+		T = 2,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		seed = 251
+	)
+	expect_s3_class(coefs, "FETWFE_coefs")
+	expect_equal(coefs$G, 1)
+	expect_equal(coefs$T, 2)
+
+	tes <- getTes(coefs)
+	expect_length(tes$actual_cohort_tes, 1L)
+	# Overall ATT equals the lone cohort's single-period effect.
+	expect_equal(tes$att_true, tes$actual_cohort_tes[1])
+
+	sim <- simulateData(coefs, N = 400, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	expect_equal(sim$G, 1)
+	expect_equal(sim$T, 2)
+	expect_s3_class(sim$pdata, "data.frame")
+	# One treated cohort -> exactly one unique post-adoption start time.
+	treated <- sim$pdata[sim$pdata$treatment == 1L, , drop = FALSE]
+	first_treat <- stats::aggregate(time ~ unit, data = treated, FUN = min)
+	expect_equal(length(unique(first_treat$time)), 1L)
+
+	# The simulated 2x2 fits and recovers the injected ATT (numerical sanity).
+	fit <- suppressWarnings(fetwfe(
+		pdata = sim$pdata,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		covs = sim$covs,
+		response = "y",
+		verbose = FALSE
+	))
+	expect_equal(fit$T, 2)
+	expect_true(is.finite(fit$att_hat))
+	expect_equal(fit$att_hat, tes$att_true, tolerance = 0.4)
+})

--- a/tests/testthat/test-ci-type-197.R
+++ b/tests/testthat/test-ci-type-197.R
@@ -306,9 +306,9 @@ test_that("ci_type = 'simultaneous' degrades gracefully when calc_ses = FALSE (q
 
 # ------------------------------------------------------------------------------
 # Test 8: K = 1 bypass via a DIRECT unit test of .apply_simultaneous_catt_band()
-# on a hand-built 1-row catt_df. genCoefs(G = 1) errors (R >= 2 required) and
-# genCoefs(T = 2) errors (T >= 3 required), so a K = 1 family is NOT
-# simulator-constructible -- the direct unit test is the only viable route.
+# on a hand-built 1-row catt_df. (Since #112/#251 a K = 1 family is also
+# simulator-constructible -- e.g. genCoefs(G = 1, T = 2) -- but the direct unit
+# test remains the most surgical way to exercise the K = 1 branch in isolation.)
 # The worker's K = 1 branch (R/simultaneous_cis.R: sum(nondeg) <= 1 ->
 # crit = pointwise_crit) makes simultaneous == pointwise.
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-genCoefs.R
+++ b/tests/testthat/test-genCoefs.R
@@ -174,11 +174,28 @@ test_that("simulateData and fetwfe work when d = 0", {
 })
 
 
-test_that("genCoefs errors when T < 3", {
+# T = 2 is now supported (down to the 2x2 case, #251); only T < 2 is rejected.
+# The historical (G = 5, T = 2) case still errors, but on the `G <= T - 1`
+# check (G = 5 > 1), not the T floor.
+test_that("genCoefs errors when T < 2", {
 	expect_error(
-		genCoefs(G = 5, T = 2, density = 0.1, eff_size = 2, d = 12),
-		regexp = "T must be a numeric value greater than or equal to 3"
+		genCoefs(G = 1, T = 1, density = 0.1, eff_size = 2, d = 12),
+		regexp = "T must be a numeric value greater than or equal to 2"
 	)
+})
+
+test_that("genCoefs accepts T = 2 (2x2) at G = 1", {
+	coefs <- genCoefs(
+		G = 1,
+		T = 2,
+		density = 0.5,
+		eff_size = 2,
+		d = 2,
+		seed = 1
+	)
+	expect_s3_class(coefs, "FETWFE_coefs")
+	expect_equal(coefs$G, 1)
+	expect_equal(coefs$T, 2)
 })
 
 test_that("genCoefs generates a single-cohort (G = 1) coefficient vector", {

--- a/tests/testthat/test-genCoefsCore.R
+++ b/tests/testthat/test-genCoefsCore.R
@@ -192,11 +192,18 @@ test_that("simulateDataCore and fetwfe work when d = 0", {
 })
 
 
-test_that("genCoefsCore errors when T < 3", {
+# T = 2 is now supported (down to the 2x2 case, #251); only T < 2 is rejected.
+test_that("genCoefsCore errors when T < 2", {
 	expect_error(
-		genCoefsCore(G = 5, T = 2, density = 0.1, eff_size = 2, d = 12),
-		regexp = "T must be a numeric value greater than or equal to 3"
+		genCoefsCore(G = 1, T = 1, density = 0.1, eff_size = 2, d = 12),
+		regexp = "T must be a numeric value greater than or equal to 2"
 	)
+})
+
+test_that("genCoefsCore accepts T = 2 (2x2) at G = 1", {
+	core <- genCoefsCore(G = 1, T = 2, density = 0.5, eff_size = 2, d = 2)
+	expect_type(core, "list")
+	expect_true(all(c("beta", "theta") %in% names(core)))
 })
 
 test_that("genCoefsCore generates a single-cohort (G = 1) coefficient vector", {

--- a/tests/testthat/test-simulateData.R
+++ b/tests/testthat/test-simulateData.R
@@ -310,10 +310,11 @@ test_that("simulateData errors when R >= T", {
 })
 
 # ------------------------------------------------------------------------------
-# Test 9: Error when T < 3
+# Test 9: T = 2 is supported (2x2); only T < 2 errors (#251)
 # ------------------------------------------------------------------------------
-test_that("simulateData errors when T < 3", {
-	# For instance, T = 2 should trigger an error (we require at least T = 3).
+test_that("simulateData accepts T = 2 (2x2) and errors only when T < 2", {
+	# T = 2 is now supported down to the 2x2 case (#251); it produces a valid
+	# single-cohort panel rather than erroring. Only T < 2 is rejected.
 	N <- 30
 	T_val <- 2
 	R_val <- 1
@@ -325,9 +326,21 @@ test_that("simulateData errors when T < 3", {
 	obj <- list(beta = beta, G = R_val, T = T_val, d = d_val, seed = 123)
 	class(obj) <- "FETWFE_coefs"
 
+	sim <- simulateData(
+		coefs_obj = obj,
+		N = N,
+		sig_eps_sq = 5,
+		sig_eps_c_sq = 2
+	)
+	expect_equal(sim$T, 2)
+	expect_equal(sim$G, 1)
+	expect_s3_class(sim$pdata, "data.frame")
+
+	# T < 2 still errors (on the genCoefs/simulateData T floor).
+	obj1 <- obj
+	obj1$T <- 1
 	expect_error(
-		simulateData(coefs_obj = obj, N = N, sig_eps_sq = 5, sig_eps_c_sq = 2),
-		regexp = "T >= 3" # Expect an error message indicating T must be at least 3
+		simulateData(coefs_obj = obj1, N = N, sig_eps_sq = 5, sig_eps_c_sq = 2)
 	)
 })
 

--- a/tests/testthat/test-simulateDataCore.R
+++ b/tests/testthat/test-simulateDataCore.R
@@ -455,10 +455,11 @@ test_that("simulateDataCore errors when R >= T", {
 })
 
 # ------------------------------------------------------------------------------
-# Test 12: Error when T < 3
+# Test 12: T = 2 is supported (2x2); only T < 2 errors (#251)
 # ------------------------------------------------------------------------------
-test_that("simulateDataCore errors when T < 3", {
-	# For instance, T = 2 should trigger an error (we require at least T = 3).
+test_that("simulateDataCore accepts T = 2 (2x2) and errors only when T < 2", {
+	# T = 2 is now supported down to the 2x2 case (#251); it produces a valid
+	# single-cohort panel rather than erroring. Only T < 2 is rejected.
 	N <- 30
 	T_val <- 2
 	R_val <- 1
@@ -467,10 +468,27 @@ test_that("simulateDataCore errors when T < 3", {
 	p_expected <- compute_p_int(T_val, R_val, d_val)
 	beta <- rnorm(p_expected)
 
+	sim <- simulateDataCore(
+		N,
+		T_val,
+		R_val,
+		d_val,
+		1,
+		1,
+		beta,
+		seed = 123,
+		gen_ints = FALSE,
+		distribution = "gaussian"
+	)
+	expect_equal(sim$T, 2)
+	expect_equal(sim$G, 1)
+	expect_s3_class(sim$pdata, "data.frame")
+
+	# T < 2 still errors (the simulateDataCore T floor).
 	expect_error(
 		simulateDataCore(
 			N,
-			T_val,
+			1,
 			R_val,
 			d_val,
 			1,
@@ -479,8 +497,7 @@ test_that("simulateDataCore errors when T < 3", {
 			seed = 123,
 			gen_ints = FALSE,
 			distribution = "gaussian"
-		),
-		regexp = "T >= 3" # Expect an error message indicating T must be at least 3
+		)
 	)
 })
 

--- a/tests/testthat/test-single-cohort-112.R
+++ b/tests/testthat/test-single-cohort-112.R
@@ -4,10 +4,14 @@
 # Re-relaxes the historical `G >= 2` floor (re-tightened in #109) so that
 # fetwfe / etwfe / betwfe / twfeCovs and genCoefs / simulateData accept panels
 # with a SINGLE treated cohort (one cohort that adopts treatment, plus
-# never-treated units). The post-treatment side still binds: at least two
-# treatment effects (two post-treatment periods) are required so the
-# dynamic-effect fusion has something to fuse -- a new `num_treats >= 2` guard
-# in prep_for_etwfe_core() enforces that.
+# never-treated units).
+#
+# NOTE (#251): #112 originally also required at least two treatment effects
+# (a `num_treats >= 2` guard in prep_for_etwfe_core()), rejecting num_treats = 1
+# panels (T = 2 and late-adopting single cohorts). #251 removed that guard so
+# those panels now FIT. The num_treats = 1 tests below (section 4) were
+# converted from rejection assertions to fits accordingly; the T == 2 warning
+# behavior is covered in detail in test-2x2-support-251.R.
 #
 # Coverage:
 #   1. All four estimators recover a known ATT at G = 1 (numerical, not just
@@ -19,8 +23,10 @@
 #   3. A hand-built SCATTERED-offset (offset 3, num_treats = 4) single-cohort
 #      panel fits -- genCoefs / simulateData force offset 2, so the scattered
 #      and late-adopting fixtures are built by hand.
-#   4. num_treats = 1 is rejected: T = 2 (any G) AND a late-adopting single
-#      cohort (offset = T) both stop with the new `num_treats >= 2` message.
+#   4. num_treats = 1 now FITS (#251 removed the #112 guard): T = 2 (fetwfe
+#      warns "no fusion") AND a late-adopting single cohort (offset = T) both
+#      produce a valid fit. (Warning asymmetries are asserted in
+#      test-2x2-support-251.R.)
 #   5. No-never-treated single-cohort panels fail via TWO distinct guards:
 #      adopting at t = 2 trips the time-period check (truncation leaves 1
 #      period); adopting at t >= 3 trips the cohort check in
@@ -271,50 +277,57 @@ test_that("a scattered-offset (offset 3) single cohort fits and recovers ATT", {
 })
 
 # ------------------------------------------------------------------------------
-# 4. num_treats = 1 rejection (the new `num_treats >= 2` guard).
+# 4. num_treats = 1 now FITS (#251 removed the #112 `num_treats >= 2` guard).
 #
-# Mutation target for the new guard: re-tighten is N/A (the guard is added, not
-# relaxed) -- instead, DELETING the `num_treats < 2` block makes both of these
-# tests FAIL (T = 2 fits silently; the late-adopting cohort fits silently).
-# The offset-aware `num_treats` is what distinguishes the late-adopting case
-# from getNumTreats(G, T) = T - 1, which would miscount it as non-degenerate.
+# Both panels previously stopped with "at least two treatment effects"; they now
+# produce a valid single-cohort fit. The T = 2 case is the unique no-fusion
+# configuration, so fetwfe warns there (asserted in test-2x2-support-251.R; here
+# we just suppress it and confirm the fit). The late-adopting case (offset = T,
+# T >= 3) still fuses the time fixed effects, so it does NOT warn.
 # ------------------------------------------------------------------------------
 
-test_that("T = 2 (num_treats = 1) is rejected at G = 1", {
+test_that("T = 2 (num_treats = 1) now fits at G = 1", {
 	# T = 2, single cohort adopting at t = 2 -> exactly one post-treatment
 	# period -> num_treats = 1.
 	pdata <- .sc112_make_panel(N = 60, T = 2, adopt = 2, tau = 0, seed = 12)
-	expect_error(
-		fetwfe(
-			pdata = pdata,
-			time_var = "time",
-			unit_var = "unit",
-			treatment = "treatment",
-			covs = c("cov1", "cov2"),
-			response = "y",
-			verbose = FALSE
-		),
-		"at least two treatment effects"
-	)
+	res <- suppressWarnings(fetwfe(
+		pdata = pdata,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		covs = c("cov1", "cov2"),
+		response = "y",
+		verbose = FALSE
+	))
+	expect_s3_class(res, "fetwfe")
+	expect_equal(res$G, 1)
+	expect_equal(res$T, 2)
+	# Single post-treatment period -> a single treatment effect (one catt row).
+	expect_equal(nrow(res$catt_df), 1L)
+	expect_true(is.finite(res$att_hat))
 })
 
-test_that("a late-adopting single cohort (offset = T, num_treats = 1) is rejected", {
+test_that("a late-adopting single cohort (offset = T, num_treats = 1) now fits", {
 	# T = 5, single cohort adopts at the FINAL period t = 5 -> one
 	# post-treatment period -> num_treats = 1, despite T >= 3. getNumTreats(G, T)
-	# would report T - 1 = 4 here; the offset-aware count correctly catches it.
+	# would report T - 1 = 4 here; the offset-aware count produces a single
+	# treatment effect.
 	pdata <- .sc112_make_panel(N = 80, T = 5, adopt = 5, tau = 0, seed = 13)
-	expect_error(
-		fetwfe(
-			pdata = pdata,
-			time_var = "time",
-			unit_var = "unit",
-			treatment = "treatment",
-			covs = c("cov1", "cov2"),
-			response = "y",
-			verbose = FALSE
-		),
-		"at least two treatment effects"
+	res <- fetwfe(
+		pdata = pdata,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		covs = c("cov1", "cov2"),
+		response = "y",
+		verbose = FALSE
 	)
+	expect_s3_class(res, "fetwfe")
+	expect_equal(res$G, 1)
+	expect_equal(res$T, 5)
+	# Adopting in the final period -> exactly one post-treatment period.
+	expect_equal(nrow(res$catt_df), 1L)
+	expect_true(is.finite(res$att_hat))
 })
 
 # ------------------------------------------------------------------------------
@@ -450,9 +463,10 @@ test_that("add_ridge and REML (sig_eps_sq = NA) paths work at G = 1", {
 	skip_on_cran()
 	fx <- .sc112_sim()
 
-	# add_ridge previously hit a cryptic `T >= 3L is not TRUE` stopifnot when a
-	# degenerate single post-period leaked through; with num_treats >= 2 enforced
-	# up front, the happy path fits.
+	# add_ridge at the standard multi-period single-cohort fixture (T = 6,
+	# num_treats = 5). The 2x2 add_ridge path (where the old `T >= 3L` stopifnot
+	# in genFullInvFusionTransformMat used to bite) is covered in
+	# test-2x2-support-251.R.
 	res_ridge <- .sc112_fit(fx$sim, fetwfe, add_ridge = TRUE)
 	expect_equal(res_ridge$G, 1)
 	expect_true(is.finite(res_ridge$att_hat))


### PR DESCRIPTION
Refs #251. Phase 2 of #112: relaxes the `num_treats >= 2` guard (added in #112) so all four estimators — and `genCoefs`/`simulateData` — accept a single treatment effect (one post-treatment period): the true 2×2 (`T = 2`) and the late-adopting single cohort (G=1, T≥3, adopting in the final period). Motivation: **continuity** for simulation sweeps over a range of T — the estimator no longer errors at the bottom of the range. A spike confirmed all four estimators (default *and* `add_ridge`) plus the three accessors already work at `num_treats = 1` once the guards relax; no OLS fallback or special handling needed.

`fetwfe()` emits a `warning()` at **T = 2** — the unique configuration where *no* fused block is non-degenerate. `genFullInvFusionTransformMat` fuses cohort FEs / time FEs / treatment effects (needing G≥2 / T≥3 / num_treats≥2 respectively), so T=2 forces all three trivial. The warning states that no *fusion* penalty applies and the bridge penalty reduces to individual shrinkage — deliberately **not** "equivalent to DiD" (fetwfe ≠ etwfe at T=2, since the bridge still shrinks). The late-adopting `num_treats=1` case (T≥3) still fuses the time FEs, so it does **not** warn; `betwfe` applies the bridge to the raw coefficients (it never fuses) and `etwfe`/`twfeCovs` aren't penalized, so the warning is fetwfe-only.

Guard changes: remove the `num_treats < 2` stop (`input_prep.R`); `T >= 3L → T >= 2L` in `genFullInvFusionTransformMat` (the only thing blocking fetwfe's `add_ridge` path at T=2); relax the simulation-side `T >= 3` guards (`gen_coefs.R`, `sim_helpers.R`) — reversing #112's deliberate "keep" so 2×2 can be simulated. The six pre-existing test files that asserted the old `T < 3` / `num_treats = 1` rejections are converted to the new success contract. New `tests/testthat/test-2x2-support-251.R` (91 assertions) locks the warning asymmetries (warns@T=2; **no** warning @late-adopting-num_treats=1 / @num_treats≥2 / @betwfe / @etwfe), a T=2..6 continuity sweep, and the genCoefs/simulateData@T=2 round-trip; the warning is mutation-checked. Minor bump to 1.23.0.

`R CMD check --as-cran` code-clean; full suite green (FAIL 0).
