### PR TITLE
feat: simulateData() gains a `seed` arg and stops reusing coefs_obj$seed (#250)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.23.0
+Version: 1.24.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,22 @@
 # NEWS
 
+## Version 1.24.0
+
+### Breaking changes
+
+- `simulateData()` now draws from the ambient random-number generator by
+  default and **no longer reuses `coefs_obj$seed`** (the seed `genCoefs()` used
+  to build the coefficients). Previously `simulateData()` silently called
+  `set.seed(coefs_obj$seed)` internally, so repeated calls on one coefficients
+  object returned byte-identical panels and a preceding `set.seed()` was
+  ignored. The new `seed` argument controls the panel RNG: the default
+  (`seed = NULL`) draws from the ambient generator (respecting any preceding
+  `set.seed()`) and emits a warning that this default changed; pass
+  `seed = <integer>` to restore reproducibility (the same integer always yields
+  the same panel), or `seed = NA` to use the ambient generator silently. To
+  vary the panel across Monte Carlo replications, pass a different `seed` each
+  replication instead of mutating `coefs_obj$seed` (#250).
+
 ## Version 1.23.0
 
 ### Features

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -820,7 +820,7 @@ betwfe <- function(
 #'   coefs <- genCoefs(G = 5, T = 30, d = 12, density = 0.1, eff_size = 2, seed = 123)
 #'
 #'   # Simulate data using the coefficients
-#'   sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5)
+#'   sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5, seed = 123)
 #'
 #'   result <- betwfeWithSimulatedData(sim_data)
 #' }

--- a/R/broom_methods.R
+++ b/R/broom_methods.R
@@ -360,7 +360,7 @@ NULL
 #' \dontrun{
 #'   res <- fetwfeWithSimulatedData(
 #'     simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2),
-#'                  N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+#'                  N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
 #'   )
 #'   broom::tidy(res)
 #' }
@@ -391,7 +391,7 @@ tidy.fetwfe <- function(
 #' \dontrun{
 #'   res <- etwfeWithSimulatedData(
 #'     simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2),
-#'                  N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+#'                  N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
 #'   )
 #'   broom::tidy(res)
 #' }
@@ -422,7 +422,7 @@ tidy.etwfe <- function(
 #' \dontrun{
 #'   res <- betwfeWithSimulatedData(
 #'     simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2),
-#'                  N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+#'                  N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
 #'   )
 #'   broom::tidy(res)
 #' }
@@ -472,7 +472,7 @@ tidy.betwfe <- function(
 #' \dontrun{
 #'   res <- fetwfeWithSimulatedData(
 #'     simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2),
-#'                  N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+#'                  N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
 #'   )
 #'   broom::tidy(eventStudy(res))
 #' }
@@ -565,7 +565,7 @@ tidy.eventStudy <- function(
 #' \dontrun{
 #'   res <- fetwfeWithSimulatedData(
 #'     simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2),
-#'                  N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+#'                  N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
 #'   )
 #'   broom::tidy(cohortStudy(res))
 #' }
@@ -696,7 +696,7 @@ tidy.FETWFE_tes <- function(x, conf.int = TRUE, conf.level = 0.95, ...) {
 #' \dontrun{
 #'   res <- fetwfeWithSimulatedData(
 #'     simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2),
-#'                  N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+#'                  N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
 #'   )
 #'   broom::glance(res)
 #' }
@@ -717,7 +717,7 @@ glance.fetwfe <- function(x, ...) {
 #' \dontrun{
 #'   res <- etwfeWithSimulatedData(
 #'     simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2),
-#'                  N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+#'                  N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
 #'   )
 #'   broom::glance(res)
 #' }
@@ -737,7 +737,7 @@ glance.etwfe <- function(x, ...) {
 #' \dontrun{
 #'   res <- betwfeWithSimulatedData(
 #'     simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2),
-#'                  N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+#'                  N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
 #'   )
 #'   broom::glance(res)
 #' }
@@ -779,7 +779,7 @@ glance.betwfe <- function(x, ...) {
 #' \dontrun{
 #'   sim <- simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5,
 #'                                eff_size = 2),
-#'                       N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+#'                       N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
 #'   res <- fetwfeWithSimulatedData(sim)
 #'   broom::augment(res, data = sim$pdata)
 #' }
@@ -804,7 +804,7 @@ augment.fetwfe <- function(x, data, ...) {
 #' \dontrun{
 #'   sim <- simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5,
 #'                                eff_size = 2),
-#'                       N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+#'                       N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
 #'   res <- etwfeWithSimulatedData(sim)
 #'   broom::augment(res, data = sim$pdata)
 #' }
@@ -829,7 +829,7 @@ augment.etwfe <- function(x, data, ...) {
 #' \dontrun{
 #'   sim <- simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5,
 #'                                eff_size = 2),
-#'                       N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+#'                       N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
 #'   res <- betwfeWithSimulatedData(sim)
 #'   broom::augment(res, data = sim$pdata)
 #' }

--- a/R/cohort_study.R
+++ b/R/cohort_study.R
@@ -58,7 +58,7 @@
 #' @examples
 #' \dontrun{
 #'   coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-#'   dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+#'   dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
 #'   res <- fetwfeWithSimulatedData(dat)
 #'   cs <- cohortStudy(res)
 #'   cs

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -76,7 +76,7 @@ utils::globalVariables(c("event_time", "estimate", "ci_low", "ci_high"))
 #' @examples
 #' \dontrun{
 #'   coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-#'   dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+#'   dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
 #'   res <- fetwfeWithSimulatedData(dat)
 #'   eventStudy(res)
 #' }

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -830,7 +830,7 @@ fetwfe <- function(
 #'   coefs <- genCoefs(G = 5, T = 30, d = 12, density = 0.1, eff_size = 2, seed = 123)
 #'
 #'   # Simulate data using the coefficients
-#'   sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5)
+#'   sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5, seed = 123)
 #'
 #'   result <- fetwfeWithSimulatedData(sim_data)
 #' }
@@ -1537,7 +1537,7 @@ etwfe <- function(
 #'   coefs <- genCoefs(G = 5, T = 30, d = 12, density = 0.1, eff_size = 2, seed = 123)
 #'
 #'   # Simulate data using the coefficients
-#'   sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5)
+#'   sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5, seed = 123)
 #'
 #'   result <- etwfeWithSimulatedData(sim_data)
 #' }

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -179,7 +179,7 @@
 #'   coefs <- genCoefs(G = 5, T = 30, d = 12, density = 0.1, eff_size = 2, seed = 123)
 #'
 #'   # Simulate data using the coefficients
-#'   sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5)
+#'   sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5, seed = 123)
 #'
 #'   # Event-study-sparse truth: treatment effects that share the same time
 #'   # since treatment are fused across cohorts (the simulation-side companion
@@ -195,7 +195,7 @@
 #'     assignment_type = "multinomial", assignment_strength = 1.0,
 #'     seed = 123
 #'   )
-#'   sim_mn <- simulateData(coefs_mn, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5)
+#'   sim_mn <- simulateData(coefs_mn, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5, seed = 123)
 #'
 #'   # Covariate-dependent cohort assignment with nonlinear propensity
 #'   # (multinomial-logit + a single x1*x2 interaction term in the propensity

--- a/R/gen_data.R
+++ b/R/gen_data.R
@@ -30,6 +30,13 @@
 #' data set is guaranteed to have at least `d + 1` units per cohort, which is
 #' necessary for the final design matrix to have full column rank. Default is
 #' FALSE, in which case no such condition is enforced.
+#' @param seed (Optional) Controls the random-number generator for the simulated
+#'   panel. As of fetwfe 1.24.0 the default is \code{NULL}, which draws from the
+#'   ambient random-number generator (respecting any preceding \code{set.seed()})
+#'   and emits a warning; pass an integer for a reproducible panel, or \code{NA}
+#'   to draw from the ambient generator silently. \code{simulateData()} no longer
+#'   reuses \code{coefs_obj$seed} (the seed \code{genCoefs()} used to build the
+#'   coefficients). Default \code{NULL}.
 #'
 #' @return An object of class \code{"FETWFE_simulated"}, which is a list containing:
 #' \describe{
@@ -67,12 +74,15 @@
 #' It validates that all necessary components are returned and assigns the S3 class
 #' \code{"FETWFE_simulated"} to the output.
 #'
-#' The simulated panel is fully determined by \code{coefs_obj$seed} (the seed
-#' passed to \code{genCoefs()}): \code{simulateData()} re-seeds from it on every
-#' call, so re-calling \code{simulateData()} on the same \code{coefs_obj}
-#' returns the identical panel. To vary the panel across Monte Carlo
-#' replications, vary the \code{seed} passed to \code{genCoefs()} (re-calling
-#' \code{simulateData()} alone does not).
+#' The random draw is controlled by the \code{seed} argument, not by
+#' \code{coefs_obj$seed}. By default (\code{seed = NULL}) \code{simulateData()}
+#' draws from the ambient random-number generator (so a preceding
+#' \code{set.seed()} is respected and repeated calls return different panels) and
+#' emits a warning noting that this default changed in fetwfe 1.24.0. Pass an
+#' integer \code{seed} for a reproducible panel (the same integer always yields
+#' the same panel), or \code{seed = NA} to use the ambient generator without the
+#' warning. To vary the panel across Monte Carlo replications, pass a different
+#' \code{seed} each replication.
 #'
 #' The argument \code{distribution} controls the generation of covariates. For
 #' \code{"gaussian"}, covariates are drawn from \code{rnorm}; for \code{"uniform"},
@@ -104,7 +114,8 @@ simulateData <- function(
 	sig_eps_sq,
 	sig_eps_c_sq,
 	distribution = "gaussian",
-	guarantee_rank_condition = FALSE
+	guarantee_rank_condition = FALSE,
+	seed = NULL
 ) {
 	if (!inherits(coefs_obj, "FETWFE_coefs")) {
 		stop("coefs_obj must be an object of class 'FETWFE_coefs'")
@@ -128,7 +139,23 @@ simulateData <- function(
 	T <- coefs_obj$T
 	d <- coefs_obj$d
 	beta <- coefs_obj$beta
-	seed <- coefs_obj$seed
+	# Resolve the noise-draw seed (#250). As of 1.24.0 simulateData() no longer
+	# reuses coefs_obj$seed: the default (NULL) draws from the ambient RNG with a
+	# warning, `seed = NA` draws from the ambient RNG silently, and a numeric seed
+	# re-seeds for a reproducible panel. NA must map to NULL here because
+	# set.seed(NA) errors; simulateDataCore() skips set.seed() when seed is NULL.
+	if (is.null(seed)) {
+		warning(
+			"As of fetwfe 1.24.0, simulateData() draws from the ambient random-number generator by default and no longer reuses coefs_obj$seed. Pass an integer to `seed` for a reproducible panel, or seed = NA to use the ambient generator without this warning."
+		)
+		effective_seed <- NULL
+	} else if (length(seed) == 1 && is.na(seed)) {
+		effective_seed <- NULL
+	} else if (is.numeric(seed) && length(seed) == 1) {
+		effective_seed <- seed
+	} else {
+		stop("seed must be NULL, NA, or a single numeric value")
+	}
 	# Backward-compat: saved-from-v1.13.x FETWFE_coefs objects don't have
 	# these slots; coerce a missing $assignment_type to "marginal" so the
 	# upgrade path doesn't crash on match.arg(NULL, c(...)) downstream.
@@ -147,7 +174,7 @@ simulateData <- function(
 		sig_eps_sq = sig_eps_sq,
 		sig_eps_c_sq = sig_eps_c_sq,
 		beta = beta,
-		seed = seed,
+		seed = effective_seed,
 		gen_ints = TRUE,
 		distribution = distribution,
 		guarantee_rank_condition = guarantee_rank_condition,

--- a/R/plot.R
+++ b/R/plot.R
@@ -79,7 +79,7 @@ utils::globalVariables(c(
 #' @examples
 #' \dontrun{
 #'   coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-#'   dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+#'   dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
 #'   res <- fetwfeWithSimulatedData(dat)
 #'   if (requireNamespace("ggplot2", quietly = TRUE)) {
 #'     plot(res)                          # default: event-study coefficients
@@ -118,7 +118,7 @@ plot.fetwfe <- function(
 #' @examples
 #' \dontrun{
 #'   coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-#'   dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+#'   dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
 #'   res <- etwfeWithSimulatedData(dat)
 #'   if (requireNamespace("ggplot2", quietly = TRUE)) {
 #'     plot(res)
@@ -154,7 +154,7 @@ plot.etwfe <- function(
 #' @examples
 #' \dontrun{
 #'   coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-#'   dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+#'   dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
 #'   res <- betwfeWithSimulatedData(dat)
 #'   if (requireNamespace("ggplot2", quietly = TRUE)) {
 #'     plot(res)

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -161,7 +161,7 @@ utils::globalVariables(c(
 #' @examples
 #' \donttest{
 #'   coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-#'   sim <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+#'   sim <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
 #'   fit <- fetwfeWithSimulatedData(sim)
 #'   sci <- simultaneousCIs(fit, family = "event_study", alpha = 0.05)
 #'   print(sci)

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -612,7 +612,7 @@ twfeCovs <- function(
 #'   coefs <- genCoefs(G = 5, T = 30, d = 12, density = 0.1, eff_size = 2, seed = 123)
 #'
 #'   # Simulate data using the coefficients
-#'   sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5)
+#'   sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5, seed = 123)
 #'
 #'   result <- twfeCovsWithSimulatedData(sim_data)
 #' }

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -181,3 +181,5 @@ GenzBretz
 multcomp
 Westfall
 Deprecations
+RNG
+reproducibility

--- a/man/augment.betwfe.Rd
+++ b/man/augment.betwfe.Rd
@@ -27,7 +27,7 @@ are auto-trimmed; pass the same raw \code{pdata} you handed to \code{betwfe()}.
 \dontrun{
   sim <- simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5,
                                eff_size = 2),
-                      N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+                      N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
   res <- betwfeWithSimulatedData(sim)
   broom::augment(res, data = sim$pdata)
 }

--- a/man/augment.etwfe.Rd
+++ b/man/augment.etwfe.Rd
@@ -27,7 +27,7 @@ are auto-trimmed; pass the same raw \code{pdata} you handed to \code{etwfe()}.
 \dontrun{
   sim <- simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5,
                                eff_size = 2),
-                      N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+                      N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
   res <- etwfeWithSimulatedData(sim)
   broom::augment(res, data = sim$pdata)
 }

--- a/man/augment.fetwfe.Rd
+++ b/man/augment.fetwfe.Rd
@@ -41,7 +41,7 @@ original name.
 \dontrun{
   sim <- simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5,
                                eff_size = 2),
-                      N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+                      N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
   res <- fetwfeWithSimulatedData(sim)
   broom::augment(res, data = sim$pdata)
 }

--- a/man/betwfeWithSimulatedData.Rd
+++ b/man/betwfeWithSimulatedData.Rd
@@ -287,7 +287,7 @@ match their counterparts in \code{betwfe()}.
   coefs <- genCoefs(G = 5, T = 30, d = 12, density = 0.1, eff_size = 2, seed = 123)
 
   # Simulate data using the coefficients
-  sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5)
+  sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5, seed = 123)
 
   result <- betwfeWithSimulatedData(sim_data)
 }

--- a/man/cohortStudy.Rd
+++ b/man/cohortStudy.Rd
@@ -62,7 +62,7 @@ fetwfe 1.11.0) that intercepts pre-1.11.0 Title-Case column names
 \examples{
 \dontrun{
   coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-  dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+  dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
   res <- fetwfeWithSimulatedData(dat)
   cs <- cohortStudy(res)
   cs

--- a/man/etwfeWithSimulatedData.Rd
+++ b/man/etwfeWithSimulatedData.Rd
@@ -198,7 +198,7 @@ match their counterparts in \code{etwfe()}.
   coefs <- genCoefs(G = 5, T = 30, d = 12, density = 0.1, eff_size = 2, seed = 123)
 
   # Simulate data using the coefficients
-  sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5)
+  sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5, seed = 123)
 
   result <- etwfeWithSimulatedData(sim_data)
 }

--- a/man/eventStudy.Rd
+++ b/man/eventStudy.Rd
@@ -77,7 +77,7 @@ regardless of \code{se_type} (two-sample regime, Theorem (b)).
 \examples{
 \dontrun{
   coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-  dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+  dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
   res <- fetwfeWithSimulatedData(dat)
   eventStudy(res)
 }

--- a/man/fetwfeWithSimulatedData.Rd
+++ b/man/fetwfeWithSimulatedData.Rd
@@ -263,7 +263,7 @@ match their counterparts in \code{fetwfe()}.
   coefs <- genCoefs(G = 5, T = 30, d = 12, density = 0.1, eff_size = 2, seed = 123)
 
   # Simulate data using the coefficients
-  sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5)
+  sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5, seed = 123)
 
   result <- fetwfeWithSimulatedData(sim_data)
 }

--- a/man/genCoefs.Rd
+++ b/man/genCoefs.Rd
@@ -203,7 +203,7 @@ Eq. \code{att.estimator.weighted} (line 837).
   coefs <- genCoefs(G = 5, T = 30, d = 12, density = 0.1, eff_size = 2, seed = 123)
 
   # Simulate data using the coefficients
-  sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5)
+  sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5, seed = 123)
 
   # Event-study-sparse truth: treatment effects that share the same time
   # since treatment are fused across cohorts (the simulation-side companion
@@ -219,7 +219,7 @@ Eq. \code{att.estimator.weighted} (line 837).
     assignment_type = "multinomial", assignment_strength = 1.0,
     seed = 123
   )
-  sim_mn <- simulateData(coefs_mn, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5)
+  sim_mn <- simulateData(coefs_mn, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5, seed = 123)
 
   # Covariate-dependent cohort assignment with nonlinear propensity
   # (multinomial-logit + a single x1*x2 interaction term in the propensity

--- a/man/glance.betwfe.Rd
+++ b/man/glance.betwfe.Rd
@@ -21,7 +21,7 @@ Same schema as \code{\link[=glance.fetwfe]{glance.fetwfe()}} (BETWFE also has re
 \dontrun{
   res <- betwfeWithSimulatedData(
     simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2),
-                 N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+                 N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
   )
   broom::glance(res)
 }

--- a/man/glance.etwfe.Rd
+++ b/man/glance.etwfe.Rd
@@ -22,7 +22,7 @@ Like \code{\link[=glance.fetwfe]{glance.fetwfe()}} but omits the \code{lambda_st
 \dontrun{
   res <- etwfeWithSimulatedData(
     simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2),
-                 N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+                 N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
   )
   broom::glance(res)
 }

--- a/man/glance.fetwfe.Rd
+++ b/man/glance.fetwfe.Rd
@@ -26,7 +26,7 @@ scalars: panel-shape counts (\code{nobs}, \code{n_units}, \code{n_periods},
 \dontrun{
   res <- fetwfeWithSimulatedData(
     simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2),
-                 N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+                 N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
   )
   broom::glance(res)
 }

--- a/man/plot.betwfe.Rd
+++ b/man/plot.betwfe.Rd
@@ -48,7 +48,7 @@ selection mechanism, so \code{selected} is encoded the same way (TRUE
 \examples{
 \dontrun{
   coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-  dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+  dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
   res <- betwfeWithSimulatedData(dat)
   if (requireNamespace("ggplot2", quietly = TRUE)) {
     plot(res)

--- a/man/plot.etwfe.Rd
+++ b/man/plot.etwfe.Rd
@@ -47,7 +47,7 @@ points are uniformly styled (no \code{selected = TRUE / FALSE} encoding).
 \examples{
 \dontrun{
   coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-  dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+  dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
   res <- etwfeWithSimulatedData(dat)
   if (requireNamespace("ggplot2", quietly = TRUE)) {
     plot(res)

--- a/man/plot.fetwfe.Rd
+++ b/man/plot.fetwfe.Rd
@@ -59,7 +59,7 @@ all points are uniformly styled.
 \examples{
 \dontrun{
   coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-  dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+  dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
   res <- fetwfeWithSimulatedData(dat)
   if (requireNamespace("ggplot2", quietly = TRUE)) {
     plot(res)                          # default: event-study coefficients

--- a/man/simulateData.Rd
+++ b/man/simulateData.Rd
@@ -10,7 +10,8 @@ simulateData(
   sig_eps_sq,
   sig_eps_c_sq,
   distribution = "gaussian",
-  guarantee_rank_condition = FALSE
+  guarantee_rank_condition = FALSE,
+  seed = NULL
 )
 }
 \arguments{
@@ -33,6 +34,14 @@ from \eqn{[-\sqrt{3}, \sqrt{3}]}.}
 data set is guaranteed to have at least \code{d + 1} units per cohort, which is
 necessary for the final design matrix to have full column rank. Default is
 FALSE, in which case no such condition is enforced.}
+
+\item{seed}{(Optional) Controls the random-number generator for the simulated
+panel. As of fetwfe 1.24.0 the default is \code{NULL}, which draws from the
+ambient random-number generator (respecting any preceding \code{set.seed()})
+and emits a warning; pass an integer for a reproducible panel, or \code{NA}
+to draw from the ambient generator silently. \code{simulateData()} no longer
+reuses \code{coefs_obj$seed} (the seed \code{genCoefs()} used to build the
+coefficients). Default \code{NULL}.}
 }
 \value{
 An object of class \code{"FETWFE_simulated"}, which is a list containing:
@@ -84,12 +93,15 @@ along with additional simulation parameters, to the internal function \code{simu
 It validates that all necessary components are returned and assigns the S3 class
 \code{"FETWFE_simulated"} to the output.
 
-The simulated panel is fully determined by \code{coefs_obj$seed} (the seed
-passed to \code{genCoefs()}): \code{simulateData()} re-seeds from it on every
-call, so re-calling \code{simulateData()} on the same \code{coefs_obj}
-returns the identical panel. To vary the panel across Monte Carlo
-replications, vary the \code{seed} passed to \code{genCoefs()} (re-calling
-\code{simulateData()} alone does not).
+The random draw is controlled by the \code{seed} argument, not by
+\code{coefs_obj$seed}. By default (\code{seed = NULL}) \code{simulateData()}
+draws from the ambient random-number generator (so a preceding
+\code{set.seed()} is respected and repeated calls return different panels) and
+emits a warning noting that this default changed in fetwfe 1.24.0. Pass an
+integer \code{seed} for a reproducible panel (the same integer always yields
+the same panel), or \code{seed = NA} to use the ambient generator without the
+warning. To vary the panel across Monte Carlo replications, pass a different
+\code{seed} each replication.
 
 The argument \code{distribution} controls the generation of covariates. For
 \code{"gaussian"}, covariates are drawn from \code{rnorm}; for \code{"uniform"},

--- a/man/simultaneousCIs.Rd
+++ b/man/simultaneousCIs.Rd
@@ -142,7 +142,7 @@ and downstream RNG-using code observes no perturbation.
 \examples{
 \donttest{
   coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-  sim <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+  sim <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
   fit <- fetwfeWithSimulatedData(sim)
   sci <- simultaneousCIs(fit, family = "event_study", alpha = 0.05)
   print(sci)

--- a/man/tidy.betwfe.Rd
+++ b/man/tidy.betwfe.Rd
@@ -29,7 +29,7 @@ column reflecting BETWFE's bridge-penalized selection.
 \dontrun{
   res <- betwfeWithSimulatedData(
     simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2),
-                 N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+                 N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
   )
   broom::tidy(res)
 }

--- a/man/tidy.cohortStudy.Rd
+++ b/man/tidy.cohortStudy.Rd
@@ -39,7 +39,7 @@ minimum-surprise behavior.
 \dontrun{
   res <- fetwfeWithSimulatedData(
     simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2),
-                 N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+                 N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
   )
   broom::tidy(cohortStudy(res))
 }

--- a/man/tidy.etwfe.Rd
+++ b/man/tidy.etwfe.Rd
@@ -29,7 +29,7 @@ Like \code{\link[=tidy.fetwfe]{tidy.fetwfe()}} but for an ETWFE fit. Has no \cod
 \dontrun{
   res <- etwfeWithSimulatedData(
     simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2),
-                 N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+                 N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
   )
   broom::tidy(res)
 }

--- a/man/tidy.eventStudy.Rd
+++ b/man/tidy.eventStudy.Rd
@@ -48,7 +48,7 @@ carry \code{NA} bounds under both \code{ci_type} settings.)
 \dontrun{
   res <- fetwfeWithSimulatedData(
     simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2),
-                 N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+                 N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
   )
   broom::tidy(eventStudy(res))
 }

--- a/man/tidy.fetwfe.Rd
+++ b/man/tidy.fetwfe.Rd
@@ -50,7 +50,7 @@ single effect).
 \dontrun{
   res <- fetwfeWithSimulatedData(
     simulateData(genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2),
-                 N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+                 N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 123)
   )
   broom::tidy(res)
 }

--- a/man/twfeCovsWithSimulatedData.Rd
+++ b/man/twfeCovsWithSimulatedData.Rd
@@ -191,7 +191,7 @@ match their counterparts in \code{twfeCovs()}.
   coefs <- genCoefs(G = 5, T = 30, d = 12, density = 0.1, eff_size = 2, seed = 123)
 
   # Simulate data using the coefficients
-  sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5)
+  sim_data <- simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5, seed = 123)
 
   result <- twfeCovsWithSimulatedData(sim_data)
 }

--- a/tests/testthat/test-2x2-support-251.R
+++ b/tests/testthat/test-2x2-support-251.R
@@ -330,7 +330,13 @@ test_that("genCoefs and simulateData round-trip at T = 2", {
 	# Overall ATT equals the lone cohort's single-period effect.
 	expect_equal(tes$att_true, tes$actual_cohort_tes[1])
 
-	sim <- simulateData(coefs, N = 400, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	sim <- simulateData(
+		coefs,
+		N = 400,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 251
+	)
 	expect_equal(sim$G, 1)
 	expect_equal(sim$T, 2)
 	expect_s3_class(sim$pdata, "data.frame")

--- a/tests/testthat/test-assemble-cluster-sandwich-78.R
+++ b/tests/testthat/test-assemble-cluster-sandwich-78.R
@@ -166,7 +166,8 @@ test_that(".assemble_cluster_robust_sandwich integration parity: betwfe cluster-
 		coefs,
 		N = 60,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 42
 	)
 	fit <- betwfeWithSimulatedData(sim, se_type = "cluster")
 

--- a/tests/testthat/test-augment-treatment-parity.R
+++ b/tests/testthat/test-augment-treatment-parity.R
@@ -33,7 +33,8 @@ if (!requireNamespace("broom", quietly = TRUE)) {
 		coefs,
 		N = 120,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = seed
 	)
 	pdata <- sim$pdata
 

--- a/tests/testthat/test-betwfe-add-ridge-basis.R
+++ b/tests/testthat/test-betwfe-add-ridge-basis.R
@@ -232,7 +232,8 @@ test_that("betwfe(add_ridge = TRUE) numerical regression: att_hat matches post-f
 		coefs,
 		N = 60,
 		sig_eps_sq = 16,
-		sig_eps_c_sq = 8
+		sig_eps_c_sq = 8,
+		seed = 42
 	)
 	# Pin to BIC because the recorded reference value below was generated
 	# under the BIC selection path (v1.12.0 and earlier). The v1.13.0+

--- a/tests/testthat/test-betwfe-se-fix.R
+++ b/tests/testthat/test-betwfe-se-fix.R
@@ -57,9 +57,9 @@ test_that("BETWFE SE/SD ratio is ~1 under partial selection (MC)", {
 	# `density = 0.5` controls the sparsity in genCoefs internally; the
 	# `eff_size = 4` and `sig_eps_sq = 1` combination gives a clear SNR.
 	#
-	# Critical: simulateData(coefs_obj) reads coefs_obj$seed and calls
-	# set.seed() internally. Wrapping the loop in set.seed(i) does NOT
-	# vary noise across reps. Must mutate coefs_obj$seed.
+	# Critical: as of #250 the panel RNG is controlled by the `seed`
+	# argument to simulateData(), not by coefs_obj$seed. Pass a distinct
+	# `seed = 8000L + i` per rep to vary the noise across replications.
 	coefs_template <- genCoefs(
 		G = 2,
 		T = 5,
@@ -76,13 +76,12 @@ test_that("BETWFE SE/SD ratio is ~1 under partial selection (MC)", {
 	att_se <- numeric(n_reps)
 
 	for (i in seq_len(n_reps)) {
-		coefs_i <- coefs_template
-		coefs_i$seed <- 8000L + i
 		sim <- simulateData(
-			coefs_i,
+			coefs_template,
 			N = 300,
 			sig_eps_sq = 1,
-			sig_eps_c_sq = 1
+			sig_eps_c_sq = 1,
+			seed = 8000L + i
 		)
 		res <- betwfeWithSimulatedData(sim)
 		catt_hat_1[i] <- res$catt_df[["estimate"]][1]

--- a/tests/testthat/test-betwfe.R
+++ b/tests/testthat/test-betwfe.R
@@ -921,7 +921,8 @@ test_that("tibbles work as input to fewtfe", {
 		coefs,
 		N = 120,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 1
+		sig_eps_c_sq = 1,
+		seed = 20260510
 	)
 	betwfeWithSimulatedData(sim)
 }
@@ -999,11 +1000,13 @@ test_that("print.betwfe show_internal = TRUE reads top-level fields", {
 test_that("betwfe surfaces p_value and selected in catt_df", {
 	set.seed(2026)
 	sim <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
 	dat <- simulateData(
 		sim,
 		N = 120,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = NA
 	)
 	res <- betwfeWithSimulatedData(dat, verbose = FALSE)
 
@@ -1036,11 +1039,13 @@ test_that("betwfe surfaces p_value and selected in catt_df", {
 test_that("betwfe produces at least one selected-out cohort in a sparse simulation", {
 	set.seed(2026)
 	sim <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
 	dat <- simulateData(
 		sim,
 		N = 120,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = NA
 	)
 	# Pin to BIC: this test asserts a stronger-selection property of the
 	# BIC path. The v1.13.0+ CV default is less likely to select out, by
@@ -1060,11 +1065,13 @@ test_that("betwfe produces at least one selected-out cohort in a sparse simulati
 test_that("order_by = 'pvalue' sorts CATT by ascending p_value with NAs last", {
 	set.seed(2026)
 	sim <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
 	dat <- simulateData(
 		sim,
 		N = 120,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = NA
 	)
 	res <- betwfeWithSimulatedData(dat, verbose = FALSE)
 
@@ -1164,17 +1171,26 @@ test_that("betwfe errors cleanly when no-never-treated truncation would yield < 
 make_se_type_panel <- function(seed = 2026, N = 120) {
 	set.seed(seed)
 	sim_coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-	simulateData(sim_coefs, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
+	simulateData(
+		sim_coefs,
+		N = N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = NA
+	)
 }
 
 make_ar1_panel <- function(seed = 7, N = 150, rho = 0.85, sd_e = 1) {
 	set.seed(seed)
 	sim_coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
 	sim <- simulateData(
 		sim_coefs,
 		N = N,
 		sig_eps_sq = 0.5,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = NA
 	)
 	pdata <- sim$pdata
 	pdata <- pdata[order(pdata$unit, pdata$time), ]

--- a/tests/testthat/test-broom-methods.R
+++ b/tests/testthat/test-broom-methods.R
@@ -30,7 +30,8 @@ if (!requireNamespace("broom", quietly = TRUE)) {
 		coefs,
 		N = 120,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = seed
 	)
 	list(coefs = coefs, sim = sim)
 }

--- a/tests/testthat/test-catt_df-helpful-errors.R
+++ b/tests/testthat/test-catt_df-helpful-errors.R
@@ -316,7 +316,14 @@ test_that("print(catt_df) dispatches to print.data.frame and includes the snake_
 test_that("fetwfe()$catt_df carries class catt_df and the snake_case columns", {
 	set.seed(2026)
 	coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-	sim <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
+	sim <- simulateData(
+		coefs,
+		N = 120,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = NA
+	)
 	res <- fetwfeWithSimulatedData(sim, verbose = FALSE)
 	expect_s3_class(res$catt_df, "catt_df")
 	expect_s3_class(res$catt_df, "data.frame")
@@ -337,7 +344,14 @@ test_that("fetwfe()$catt_df carries class catt_df and the snake_case columns", {
 test_that("etwfe()$catt_df carries class catt_df and the snake_case columns (no `selected`)", {
 	set.seed(2026)
 	coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-	sim <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
+	sim <- simulateData(
+		coefs,
+		N = 120,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = NA
+	)
 	res <- etwfeWithSimulatedData(sim, verbose = FALSE)
 	expect_s3_class(res$catt_df, "catt_df")
 	expect_s3_class(res$catt_df, "data.frame")

--- a/tests/testthat/test-ci-type-197.R
+++ b/tests/testthat/test-ci-type-197.R
@@ -26,7 +26,7 @@ make_ci_panel <- function(
 		eff_size = eff_size,
 		seed = seed
 	)
-	simulateData(coefs, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	simulateData(coefs, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = seed)
 }
 
 # Scattered / short-overlap panel whose LAST event time is degenerate
@@ -65,7 +65,14 @@ make_scattered_degenerate_panel <- function(n_per = 40, T = 7, seed = 909) {
 make_ci_ar1_panel <- function(seed = 7, N = 150, rho = 0.85, sd_e = 1) {
 	set.seed(seed)
 	sim_coefs <- genCoefs(G = 4, T = 6, d = 2, density = 0.5, eff_size = 2)
-	sim <- simulateData(sim_coefs, N = N, sig_eps_sq = 0.5, sig_eps_c_sq = 0.5)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
+	sim <- simulateData(
+		sim_coefs,
+		N = N,
+		sig_eps_sq = 0.5,
+		sig_eps_c_sq = 0.5,
+		seed = NA
+	)
 	pdata <- sim$pdata
 	pdata <- pdata[order(pdata$unit, pdata$time), ]
 	units <- unique(pdata$unit)

--- a/tests/testthat/test-class-helpers.R
+++ b/tests/testthat/test-class-helpers.R
@@ -39,7 +39,14 @@
 .make_minimal_obj <- function(klass) {
 	set.seed(2026)
 	coefs <- genCoefs(G = 5, T = 7, d = 0, density = 0.5, eff_size = 1)
-	sim <- simulateData(coefs, N = 80, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
+	sim <- simulateData(
+		coefs,
+		N = 80,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = NA
+	)
 	obj <- switch(
 		klass,
 		fetwfe = fetwfeWithSimulatedData(sim, q = 0.5),

--- a/tests/testthat/test-class-validators.R
+++ b/tests/testthat/test-class-validators.R
@@ -23,7 +23,8 @@
 		genCoefs(G = 2, T = 3, d = 2, density = 0.5, eff_size = 1, seed = seed),
 		N = 80,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = seed
 	)
 	list(
 		sim = sim,
@@ -76,7 +77,8 @@ test_that("validators accept well-formed all-zero-theta fallback objects", {
 		),
 		N = 30,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 42
 	)
 	res <- suppressWarnings(fetwfeWithSimulatedData(sim_small, q = 0.5))
 	# Confirm this IS the all-zero-theta path (skip if seed picked a

--- a/tests/testthat/test-cluster_floor.R
+++ b/tests/testthat/test-cluster_floor.R
@@ -234,7 +234,8 @@ test_that("cluster-SE fit on well-conditioned data does not trigger the diagnost
 		coefs,
 		N = 80,
 		sig_eps_sq = 0.5,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 2026
 	)
 	# Run the fit; assert no warning at all surfaces with the message
 	# pattern from `.floor_cluster_quad()`. (Other unrelated warnings are

--- a/tests/testthat/test-cohort-g-rename-41.R
+++ b/tests/testthat/test-cohort-g-rename-41.R
@@ -133,7 +133,13 @@ test_that("$G equals $R on genCoefs / simulateData / getTes objects", {
 	expect_equal(cf$G, cf$R)
 	expect_equal(cf$G, 3)
 
-	sim <- simulateData(cf, N = 80, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	sim <- simulateData(
+		cf,
+		N = 80,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 1
+	)
 	expect_equal(sim$G, sim$R)
 	expect_equal(sim$G, 3)
 
@@ -144,7 +150,13 @@ test_that("$G equals $R on genCoefs / simulateData / getTes objects", {
 
 test_that("$G equals $R on a fit from each of the four estimators", {
 	cf <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 1, seed = 1)
-	sim <- simulateData(cf, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	sim <- simulateData(
+		cf,
+		N = 120,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 1
+	)
 
 	fit_fetwfe <- fetwfeWithSimulatedData(sim)
 	expect_equal(fit_fetwfe$G, fit_fetwfe$R)
@@ -161,7 +173,13 @@ test_that("$G equals $R on a fit from each of the four estimators", {
 
 test_that("ci_type = 'simultaneous' fit exposes $G == $R (cross-feature with #199)", {
 	cf <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 1, seed = 1)
-	sim <- simulateData(cf, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	sim <- simulateData(
+		cf,
+		N = 120,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 1
+	)
 	fit <- fetwfeWithSimulatedData(sim, ci_type = "simultaneous")
 	expect_equal(fit$G, fit$R)
 	expect_equal(fit$ci_type, "simultaneous")
@@ -187,7 +205,13 @@ test_that("a representative pipeline emits no deprecation warning", {
 				eff_size = 1,
 				seed = 1
 			)
-			sim <- simulateData(cf, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+			sim <- simulateData(
+				cf,
+				N = 120,
+				sig_eps_sq = 1,
+				sig_eps_c_sq = 0.5,
+				seed = 1
+			)
 			fit <- fetwfeWithSimulatedData(sim)
 			invisible(capture.output({
 				print(fit)

--- a/tests/testthat/test-cohort_study.R
+++ b/tests/testthat/test-cohort_study.R
@@ -28,7 +28,8 @@ library(fetwfe)
 		coefs,
 		N = 120,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = seed
 	)
 	list(coefs = coefs, sim = sim)
 }

--- a/tests/testthat/test-conservative-band-se-225.R
+++ b/tests/testthat/test-conservative-band-se-225.R
@@ -21,7 +21,7 @@ library(fetwfe)
 # second variance component Sigma_2 (hence v2) is strictly positive there.
 .cs_sim_225 <- local({
 	sc <- genCoefs(G = 4, T = 6, d = 2, density = 0.5, eff_size = 1.5, seed = 7)
-	simulateData(sc, N = 120, sig_eps_sq = 2, sig_eps_c_sq = 1)
+	simulateData(sc, N = 120, sig_eps_sq = 2, sig_eps_c_sq = 1, seed = 7)
 })
 
 .cs_fit_225 <- function(se_type) {

--- a/tests/testthat/test-degenerate-jacobian-225.R
+++ b/tests/testthat/test-degenerate-jacobian-225.R
@@ -32,7 +32,7 @@ library(fetwfe)
 # ---------------------------------------------------------------------------
 .deg_sim_225 <- local({
 	sc <- genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = 0, seed = 1)
-	simulateData(sc, N = 60, sig_eps_sq = 5, sig_eps_c_sq = 1)
+	simulateData(sc, N = 60, sig_eps_sq = 5, sig_eps_c_sq = 1, seed = 1)
 })
 
 .deg_fit_225 <- suppressMessages(fetwfe(
@@ -106,7 +106,7 @@ test_that("simultaneousCIs() K=0 degenerate branch returns collapsed point bands
 # ---------------------------------------------------------------------------
 .var2_sim_225 <- local({
 	sc <- genCoefs(G = 3, T = 5, d = 2, density = 0.6, eff_size = 2, seed = 11)
-	simulateData(sc, N = 150, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	simulateData(sc, N = 150, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 11)
 })
 
 .var2_fit_225 <- suppressMessages(etwfe(

--- a/tests/testthat/test-doc-slot-parity.R
+++ b/tests/testthat/test-doc-slot-parity.R
@@ -119,7 +119,8 @@ test_that("public estimator @return blocks match live names()", {
 		coefs,
 		N = 120,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 20260517
 	)
 
 	cases <- list(
@@ -437,7 +438,8 @@ test_that("eventStudy() @return matches live names() across estimator classes (#
 		coefs,
 		N = 120,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 20260517
 	)
 
 	fits <- list(
@@ -500,7 +502,8 @@ test_that("tidy.eventStudy() schema is locked across conf.int branches (#84 item
 		coefs,
 		N = 120,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 20260517
 	)
 
 	fits <- list(

--- a/tests/testthat/test-est-omega-sqrt-inv.R
+++ b/tests/testthat/test-est-omega-sqrt-inv.R
@@ -32,7 +32,8 @@ test_that("estOmegaSqrtInv recovers sig_eps_sq and sig_eps_c_sq via REML", {
 		coefs,
 		N = 200,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 2
+		sig_eps_c_sq = 2,
+		seed = 20260515
 	)
 
 	# Call estOmegaSqrtInv() directly on the simulator's design matrix.
@@ -71,7 +72,8 @@ test_that("fetwfe() invokes the REML estimator when sig values are NA", {
 		coefs,
 		N = 200,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 2
+		sig_eps_c_sq = 2,
+		seed = 20260516
 	)
 	res <- fetwfe(
 		pdata = sim$pdata,
@@ -181,7 +183,8 @@ test_that("end-to-end fetwfe outputs unchanged with closed-form Omega^(-1/2)", {
 		coefs,
 		N = 60,
 		sig_eps_sq = 1.0,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 20260519
 	)
 
 	# Call .estimate_variance_and_gls() with known sig values to exercise

--- a/tests/testthat/test-etwfe.R
+++ b/tests/testthat/test-etwfe.R
@@ -824,7 +824,8 @@ test_that("etwfeWithSimulatedData end-to-end unchanged after processCovs rewrite
 		coefs,
 		N = 60,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 20260519
 	)
 	res <- etwfeWithSimulatedData(sim)
 	# Smoke check: the rewrite doesn't introduce NaN/Inf on the standard
@@ -1169,11 +1170,13 @@ test_that("etwfe throws error when a cohort contains fewer than d + 1 units", {
 test_that("etwfe surfaces p_value but not selected in catt_df", {
 	set.seed(2026)
 	sim <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
 	dat <- simulateData(
 		sim,
 		N = 120,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = NA
 	)
 	res <- etwfeWithSimulatedData(dat, verbose = FALSE)
 
@@ -1286,17 +1289,26 @@ test_that("etwfe errors cleanly when no-never-treated truncation would yield < 2
 make_se_type_panel <- function(seed = 2026, N = 120) {
 	set.seed(seed)
 	sim_coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-	simulateData(sim_coefs, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
+	simulateData(
+		sim_coefs,
+		N = N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = NA
+	)
 }
 
 make_ar1_panel <- function(seed = 7, N = 150, rho = 0.85, sd_e = 1) {
 	set.seed(seed)
 	sim_coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
 	sim <- simulateData(
 		sim_coefs,
 		N = N,
 		sig_eps_sq = 0.5,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = NA
 	)
 	pdata <- sim$pdata
 	pdata <- pdata[order(pdata$unit, pdata$time), ]

--- a/tests/testthat/test-event-study-fusion-40.R
+++ b/tests/testthat/test-event-study-fusion-40.R
@@ -171,7 +171,8 @@ test_that("event_study recovers event-time-structured truth better than default 
 				coefs,
 				N = 300,
 				sig_eps_sq = 1,
-				sig_eps_c_sq = 0.5
+				sig_eps_c_sq = 0.5,
+				seed = sd
 			)
 			fit_d <- suppressWarnings(fetwfeWithSimulatedData(
 				sim,
@@ -204,7 +205,8 @@ test_that("event_study composes with d=0 / cluster / add_ridge; default is byte-
 		genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = 2, seed = 11),
 		N = 150,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 11
 	)
 	# Byte-identity guard: fusion_structure = "cohort" == omitting it.
 	f_omit <- suppressWarnings(fetwfeWithSimulatedData(
@@ -224,7 +226,8 @@ test_that("event_study composes with d=0 / cluster / add_ridge; default is byte-
 		genCoefs(G = 3, T = 5, d = 0, density = 0.5, eff_size = 2, seed = 12),
 		N = 150,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 12
 	)
 	f0 <- suppressWarnings(fetwfeWithSimulatedData(
 		sim0,
@@ -263,7 +266,8 @@ test_that("event_study fit produces well-formed accessor output (#40)", {
 		genCoefs(G = 2L, T = 4L, d = 1L, density = 0.5, eff_size = 2, seed = 7),
 		N = 150,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 7
 	)
 	fit <- suppressWarnings(fetwfeWithSimulatedData(
 		sim,

--- a/tests/testthat/test-event-study-in-display-138.R
+++ b/tests/testthat/test-event-study-in-display-138.R
@@ -13,7 +13,8 @@ library(fetwfe)
 .es_display_setup <- function() {
 	set.seed(2026)
 	coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-	simulateData(coefs, N = 60, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
+	simulateData(coefs, N = 60, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = NA)
 }
 
 # ----------------------------------------------------------------------

--- a/tests/testthat/test-event-study-no-silent-swallow-174.R
+++ b/tests/testthat/test-event-study-no-silent-swallow-174.R
@@ -25,7 +25,9 @@ library(fetwfe)
 .no_swallow_setup <- function() {
 	set.seed(2026)
 	coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-	simulateData(coefs, N = 60, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	# coefs built without a seed: continue the ambient RNG stream seeded by
+	# the set.seed(2026) above (seed = NA is silent ambient draw, #250).
+	simulateData(coefs, N = 60, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = NA)
 }
 
 # Failure mode: blank-out the cohort_probs_overall slot. The

--- a/tests/testthat/test-event-study-present-in-print-summary-174.R
+++ b/tests/testthat/test-event-study-present-in-print-summary-174.R
@@ -37,7 +37,14 @@ library(fetwfe)
 test_that("print(res) and summary(res) render an Event Study section on consecutive-cohort synthetic fits", {
 	set.seed(2026)
 	coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-	sim <- simulateData(coefs, N = 60, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
+	sim <- simulateData(
+		coefs,
+		N = 60,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = NA
+	)
 	for (res in list(
 		fetwfeWithSimulatedData(sim, q = 0.5),
 		etwfeWithSimulatedData(sim),

--- a/tests/testthat/test-event_study.R
+++ b/tests/testthat/test-event_study.R
@@ -21,7 +21,7 @@ make_es_panel <- function(
 		eff_size = eff_size,
 		seed = seed
 	)
-	simulateData(coefs, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	simulateData(coefs, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = seed)
 }
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-fetwfe-var2-fix.R
+++ b/tests/testthat/test-fetwfe-var2-fix.R
@@ -30,7 +30,13 @@ library(fetwfe)
 		eff_size = 2,
 		seed = 31
 	)
-	sim <- simulateData(coefs, N = 300, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	sim <- simulateData(
+		coefs,
+		N = 300,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 31
+	)
 	res <- fetwfeWithSimulatedData(sim, q = 0.5)
 
 	R_val <- res$G

--- a/tests/testthat/test-fetwfe.R
+++ b/tests/testthat/test-fetwfe.R
@@ -921,11 +921,13 @@ test_that("tibbles work as input to fewtfe", {
 test_that("fetwfe surfaces p_value and selected in catt_df", {
 	set.seed(2026)
 	sim <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
 	dat <- simulateData(
 		sim,
 		N = 120,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = NA
 	)
 	res <- fetwfeWithSimulatedData(dat, verbose = FALSE)
 
@@ -961,11 +963,13 @@ test_that("fetwfe surfaces p_value and selected in catt_df", {
 test_that("fetwfe produces at least one selected-out cohort in a sparse simulation", {
 	set.seed(2026)
 	sim <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
 	dat <- simulateData(
 		sim,
 		N = 120,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = NA
 	)
 	res <- fetwfeWithSimulatedData(dat, verbose = FALSE)
 
@@ -981,11 +985,13 @@ test_that("order_by = 'pvalue' sorts CATT by ascending p_value with NAs last", {
 	# ascending sort AND the NA-last placement, not just one or the other.
 	set.seed(2026)
 	sim <- genCoefs(G = 4, T = 6, d = 2, density = 0.3, eff_size = 2)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
 	dat <- simulateData(
 		sim,
 		N = 120,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = NA
 	)
 	res <- fetwfeWithSimulatedData(dat, verbose = FALSE)
 
@@ -1117,17 +1123,26 @@ test_that("fetwfe errors cleanly when no-never-treated truncation would yield 0 
 make_se_type_panel <- function(seed = 2026, N = 120) {
 	set.seed(seed)
 	sim_coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-	simulateData(sim_coefs, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
+	simulateData(
+		sim_coefs,
+		N = N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = NA
+	)
 }
 
 make_ar1_panel <- function(seed = 7, N = 150, rho = 0.85, sd_e = 1) {
 	set.seed(seed)
 	sim_coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
 	sim <- simulateData(
 		sim_coefs,
 		N = N,
 		sig_eps_sq = 0.5,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = NA
 	)
 	pdata <- sim$pdata
 	pdata <- pdata[order(pdata$unit, pdata$time), ]
@@ -1211,7 +1226,8 @@ test_that("fetwfe runs end-to-end with REML estimation + cluster SE", {
 		sim_coefs,
 		N = 150,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 20260519
 	)
 
 	# Crucially: leave sig_eps_sq / sig_eps_c_sq at NA so REML runs.
@@ -1283,7 +1299,8 @@ test_that("fetwfe runs and gives sensible output with zero covariates", {
 		sim_coefs,
 		N = 120,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 2026
 	)
 
 	res <- fetwfeWithSimulatedData(sim_data)

--- a/tests/testthat/test-formula-interface-covs-28.R
+++ b/tests/testthat/test-formula-interface-covs-28.R
@@ -102,7 +102,14 @@ test_that("non-character, non-formula input is rejected with class info", {
 .covs_setup <- function() {
 	set.seed(2026)
 	coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-	dat <- simulateData(coefs, N = 60, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
+	dat <- simulateData(
+		coefs,
+		N = 60,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = NA
+	)
 	# simulateData() produces pdata with covariate columns named "X1", "X2".
 	# Extract for direct fits.
 	dat

--- a/tests/testthat/test-genCoefs.R
+++ b/tests/testthat/test-genCoefs.R
@@ -100,11 +100,14 @@ test_that("beta from genCoefs is a valid input for simulateData", {
 	sig_eps_c_sq <- 5
 
 	# Use res_coefs$beta as the beta argument for simulateData().
+	# coefs built without a seed: draw from the ambient RNG (seed = NA, #250);
+	# this test only checks structure/dimensions, not values.
 	sim_data <- res_coefs |>
 		simulateData(
 			N = N,
 			sig_eps_sq = sig_eps_sq,
-			sig_eps_c_sq = sig_eps_c_sq
+			sig_eps_c_sq = sig_eps_c_sq,
+			seed = NA
 		)
 
 	expect_type(sim_data, "list")
@@ -151,6 +154,7 @@ test_that("simulateData and fetwfe work when d = 0", {
 			N = N,
 			sig_eps_sq = sig_eps_sq,
 			sig_eps_c_sq = sig_eps_c_sq,
+			seed = 123
 		)
 
 	# Check that cov_names is empty since d = 0.

--- a/tests/testthat/test-gencoefs-fusion-structure-237.R
+++ b/tests/testthat/test-gencoefs-fusion-structure-237.R
@@ -285,7 +285,13 @@ test_that("event_study recovers native event-study truth better than cohort (#23
 	true_te <- co$beta[treat_inds]
 	expect_true(any(true_te != 0)) # non-degenerate treatment block
 
-	sim <- simulateData(co, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	sim <- simulateData(
+		co,
+		N = N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 10
+	)
 	fit_cohort <- suppressWarnings(fetwfeWithSimulatedData(
 		sim,
 		lambda_selection = "bic"

--- a/tests/testthat/test-internal-slot-parity.R
+++ b/tests/testthat/test-internal-slot-parity.R
@@ -11,11 +11,13 @@ library(fetwfe)
 .parity_setup <- function() {
 	set.seed(2026)
 	coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
 	dat <- simulateData(
 		coefs,
 		N = 60,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = NA
 	)
 	dat
 }

--- a/tests/testthat/test-lambda-selection-164.R
+++ b/tests/testthat/test-lambda-selection-164.R
@@ -44,7 +44,13 @@ library(fetwfe)
 		eff_size = 2,
 		seed = seed
 	)
-	simulateData(sim_coefs, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	simulateData(
+		sim_coefs,
+		N = N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = seed
+	)
 }
 
 # ------------------------------------------------------------------------------
@@ -345,14 +351,16 @@ test_that("CV path has |bias| < 0.10 on a representative DGP (smoke test)", {
 
 	n_reps <- 10L
 	biases <- numeric(n_reps)
+	# As of #250 the panel RNG is controlled by the `seed` argument to
+	# simulateData() (it no longer reuses coefs$seed); pass a distinct
+	# `seed = 13000L + i` per rep to vary the noise across replications.
 	for (i in seq_len(n_reps)) {
-		coefs <- template
-		coefs$seed <- 13000L + i
 		sim <- simulateData(
-			coefs,
+			template,
 			N = 200,
 			sig_eps_sq = 1,
-			sig_eps_c_sq = 0.5
+			sig_eps_c_sq = 0.5,
+			seed = 13000L + i
 		)
 		# True ATT = sum(actual_cohort_tes * pi_cond) where pi_cond is
 		# the in-sample treated proportions (excluding never-treated).

--- a/tests/testthat/test-logit-dgp.R
+++ b/tests/testthat/test-logit-dgp.R
@@ -53,7 +53,13 @@ test_that("marginal DGP: byte-identical to v1.13.x at default assignment_type", 
 	expect_identical(coefs$assignment_type, "marginal")
 	expect_null(coefs$assignment_coefs)
 
-	sim <- simulateData(coefs, N = 100, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	sim <- simulateData(
+		coefs,
+		N = 100,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 42
+	)
 	expect_equal(nrow(sim$pdata), 100 * 5)
 	expect_identical(sim$assignments, c(31L, 29L, 18L, 22L))
 	expect_identical(sim$indep_counts, c(24L, 30L, 19L, 27L))
@@ -81,7 +87,13 @@ test_that("multinomial DGP: empirical cohort proportions converge to MC expectat
 		assignment_strength = 1.0,
 		seed = 42
 	)
-	sim <- simulateData(coefs, N = 10000, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	sim <- simulateData(
+		coefs,
+		N = 10000,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 42
+	)
 	empirical_probs <- sim$assignments / sum(sim$assignments)
 	expected_probs <- fetwfe:::.expected_cohort_probs(
 		coefs$assignment_coefs,
@@ -116,7 +128,13 @@ test_that("ordered DGP: empirical cohort proportions match cutpoint structure", 
 		assignment_strength = 1.0,
 		seed = 42
 	)
-	sim <- simulateData(coefs, N = 10000, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	sim <- simulateData(
+		coefs,
+		N = 10000,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 42
+	)
 	empirical_probs <- sim$assignments / sum(sim$assignments)
 	expect_equal(
 		as.numeric(empirical_probs),
@@ -147,7 +165,8 @@ test_that("FETWFE smoke test: fits run cleanly on multinomial and ordered DGPs",
 			coefs,
 			N = 200,
 			sig_eps_sq = 1,
-			sig_eps_c_sq = 0.5
+			sig_eps_c_sq = 0.5,
+			seed = 42
 		)
 		fit <- suppressWarnings(fetwfe(
 			pdata = sim$pdata,
@@ -275,7 +294,8 @@ test_that("interactions-augmented multinomial DGP injects propensity nonlinearit
 		coefs,
 		N = 5000,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 42
 	))
 	# Per-unit cohort labels (first observation per unit; treatment is an
 	# absorbing state, so the unit's cohort is encoded in the panel's
@@ -409,7 +429,8 @@ test_that("ordered DGP with interactions preserves marginal uniformity + baselin
 		coefs,
 		N = 10000,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 42
 	))
 	empirical_probs <- sim_ord$assignments / sum(sim_ord$assignments)
 	max_dev <- max(abs(as.numeric(empirical_probs) - 1 / 4))
@@ -432,7 +453,8 @@ test_that("ordered DGP with interactions preserves marginal uniformity + baselin
 		coefs_baseline,
 		N = 10000,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 42
 	))
 	diff_means <- mean(abs(
 		as.numeric(sim_ord$assignments) -
@@ -594,7 +616,8 @@ test_that("v1.14.0 FETWFE_coefs round-trips through simulateData + getTes (#191)
 			mock,
 			N = 100,
 			sig_eps_sq = 1,
-			sig_eps_c_sq = 0.5
+			sig_eps_c_sq = 0.5,
+			seed = 42L
 		))
 	)
 	tes <- expect_no_error(getTes(mock))

--- a/tests/testthat/test-maxt-pvalues-200.R
+++ b/tests/testthat/test-maxt-pvalues-200.R
@@ -94,7 +94,7 @@ test_that(".maxt_adjusted_p_nd scatters NA into degenerate slots", {
 # ---------------------------------------------------------------------------
 make_maxt_fit <- function(se_type = "default") {
 	sc <- genCoefs(G = 4, T = 6, d = 2, density = 0.5, eff_size = 1.5, seed = 7)
-	sim <- simulateData(sc, N = 120, sig_eps_sq = 2, sig_eps_c_sq = 1)
+	sim <- simulateData(sc, N = 120, sig_eps_sq = 2, sig_eps_c_sq = 1, seed = 7)
 	fetwfe(
 		pdata = sim$pdata,
 		time_var = sim$time_var,

--- a/tests/testthat/test-method-preconditions.R
+++ b/tests/testthat/test-method-preconditions.R
@@ -16,7 +16,8 @@
 		genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2, seed = seed),
 		N = 120,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = seed
 	)
 	list(
 		sim = sim,
@@ -165,7 +166,8 @@ test_that("eventStudy respects calc_ses under se_type='cluster' × q=1", {
 		genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2, seed = 1),
 		N = 200,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 1
 	)
 	res <- suppressWarnings(
 		fetwfeWithSimulatedData(sim, q = 1, se_type = "cluster")

--- a/tests/testthat/test-native-es-recovery-238.R
+++ b/tests/testthat/test-native-es-recovery-238.R
@@ -44,7 +44,13 @@ library(fetwfe)
 			if (all(tb == 0)) {
 				return(NA_real_)
 			}
-			sim <- simulateData(co, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+			sim <- simulateData(
+				co,
+				N = N,
+				sig_eps_sq = 1,
+				sig_eps_c_sq = 0.5,
+				seed = sd
+			)
 			fd <- suppressWarnings(fetwfeWithSimulatedData(
 				sim,
 				lambda_selection = "bic"
@@ -94,7 +100,13 @@ test_that("event_study fit recovers native ES truth on both transform paths (#23
 			seed = sd,
 			fusion_structure = "event_study"
 		)
-		sim <- simulateData(co, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+		sim <- simulateData(
+			co,
+			N = N,
+			sig_eps_sq = 1,
+			sig_eps_c_sq = 0.5,
+			seed = sd
+		)
 		fe <- suppressWarnings(fetwfeWithSimulatedData(
 			sim,
 			lambda_selection = "bic",
@@ -152,7 +164,13 @@ test_that("accessors recover and cover native ES truth (#238)", {
 		numeric(1)
 	)
 
-	sim <- simulateData(co, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	sim <- simulateData(
+		co,
+		N = N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 10
+	)
 	fit <- suppressWarnings(fetwfeWithSimulatedData(
 		sim,
 		lambda_selection = "bic",

--- a/tests/testthat/test-plot-methods-29.R
+++ b/tests/testthat/test-plot-methods-29.R
@@ -12,7 +12,8 @@ library(fetwfe)
 .plot_setup <- function() {
 	set.seed(2026)
 	coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-	simulateData(coefs, N = 60, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
+	simulateData(coefs, N = 60, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = NA)
 }
 
 # ----------------------------------------------------------------------

--- a/tests/testthat/test-simulate-data-seed-250.R
+++ b/tests/testthat/test-simulate-data-seed-250.R
@@ -1,0 +1,189 @@
+library(testthat)
+library(fetwfe)
+
+# ------------------------------------------------------------------------------
+# Issue #250: simulateData()'s `seed` argument and the flipped default.
+#
+# As of fetwfe 1.24.0 simulateData() no longer reuses coefs_obj$seed. The new
+# contract:
+#   - seed = NULL (default): draw from the ambient RNG AND emit a warning whose
+#     text contains "ambient".
+#   - seed = NA: draw from the ambient RNG silently (caller-controlled RNG).
+#   - seed = <numeric scalar>: set.seed(seed) -> reproducible panel.
+#   - anything else: stop("seed must be ...").
+#
+# These default-path calls (the bare simulateData(coefs, ...) without an
+# explicit seed) are the ONLY live simulateData() calls in the suite permitted
+# to omit a seed; every other live call is pinned for byte-exactness. The
+# mutation check on R/gen_data.R (the default flip + the warning) is owned by
+# the parent; this file just locks the observable contract green.
+# ------------------------------------------------------------------------------
+
+# Small, fast fixture reused across the tests below.
+.seed250_coefs <- function() {
+	genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = 2, seed = 123)
+}
+.SEED250_N <- 60L
+
+# ------------------------------------------------------------------------------
+# 1) Default (seed = NULL) flips to the ambient RNG and warns.
+# ------------------------------------------------------------------------------
+test_that("simulateData default draws from the ambient RNG and warns (#250)", {
+	coefs <- .seed250_coefs()
+
+	# The default path emits a warning mentioning the ambient generator.
+	expect_warning(
+		simulateData(
+			coefs,
+			N = .SEED250_N,
+			sig_eps_sq = 1,
+			sig_eps_c_sq = 0.5
+		),
+		"ambient"
+	)
+
+	# Two default draws use the ambient generator, so consecutive panels differ
+	# (the removed reuse behavior would have made them byte-identical). This is
+	# the mutation-bearing assertion: reverting the default flip makes it FAIL.
+	a <- suppressWarnings(simulateData(
+		coefs,
+		N = .SEED250_N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5
+	))
+	b <- suppressWarnings(simulateData(
+		coefs,
+		N = .SEED250_N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5
+	))
+	expect_false(identical(a$y, b$y))
+})
+
+# ------------------------------------------------------------------------------
+# 2) seed = NA is silent and honors the caller's RNG state.
+# ------------------------------------------------------------------------------
+test_that("simulateData seed = NA is silent and respects the ambient RNG (#250)", {
+	coefs <- .seed250_coefs()
+
+	# No warning when the ambient generator is opted into explicitly.
+	expect_warning(
+		simulateData(
+			coefs,
+			N = .SEED250_N,
+			sig_eps_sq = 1,
+			sig_eps_c_sq = 0.5,
+			seed = NA
+		),
+		NA
+	)
+
+	# Same outer set.seed() -> identical panel (caller controls the RNG).
+	set.seed(20250250L)
+	a <- simulateData(
+		coefs,
+		N = .SEED250_N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = NA
+	)
+	set.seed(20250250L)
+	b <- simulateData(
+		coefs,
+		N = .SEED250_N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = NA
+	)
+	expect_identical(a$y, b$y)
+
+	# A different outer seed -> a different panel.
+	set.seed(99999L)
+	c <- simulateData(
+		coefs,
+		N = .SEED250_N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = NA
+	)
+	expect_false(identical(a$y, c$y))
+})
+
+# ------------------------------------------------------------------------------
+# 3) A numeric seed is silent and reproducible.
+# ------------------------------------------------------------------------------
+test_that("simulateData seed = <int> is silent and reproducible (#250)", {
+	coefs <- .seed250_coefs()
+
+	# No warning when an explicit integer seed is supplied.
+	expect_warning(
+		simulateData(
+			coefs,
+			N = .SEED250_N,
+			sig_eps_sq = 1,
+			sig_eps_c_sq = 0.5,
+			seed = 456
+		),
+		NA
+	)
+
+	# The same integer seed always yields the same panel, independent of the
+	# ambient RNG state.
+	set.seed(1L)
+	a <- simulateData(
+		coefs,
+		N = .SEED250_N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 456
+	)
+	set.seed(2L)
+	b <- simulateData(
+		coefs,
+		N = .SEED250_N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 456
+	)
+	expect_identical(a$y, b$y)
+	expect_identical(a$X, b$X)
+	expect_identical(a$assignments, b$assignments)
+
+	# A different integer seed yields a different panel.
+	d <- simulateData(
+		coefs,
+		N = .SEED250_N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 789
+	)
+	expect_false(identical(a$y, d$y))
+})
+
+# ------------------------------------------------------------------------------
+# 4) Validation: non-numeric / non-scalar seeds error.
+# ------------------------------------------------------------------------------
+test_that("simulateData rejects invalid seed values (#250)", {
+	coefs <- .seed250_coefs()
+
+	expect_error(
+		simulateData(
+			coefs,
+			N = .SEED250_N,
+			sig_eps_sq = 1,
+			sig_eps_c_sq = 0.5,
+			seed = "x"
+		),
+		"seed must be"
+	)
+	expect_error(
+		simulateData(
+			coefs,
+			N = .SEED250_N,
+			sig_eps_sq = 1,
+			sig_eps_c_sq = 0.5,
+			seed = c(1, 2)
+		),
+		"seed must be"
+	)
+})

--- a/tests/testthat/test-simulateData.R
+++ b/tests/testthat/test-simulateData.R
@@ -38,7 +38,8 @@ test_that("simulateData (with interactions) returns expected output", {
 		simulateData(
 			N = N,
 			sig_eps_sq = sig_eps_sq,
-			sig_eps_c_sq = sig_eps_c_sq
+			sig_eps_c_sq = sig_eps_c_sq,
+			seed = 843
 		)
 
 	# Check list names (X now instead of X_int)
@@ -98,13 +99,15 @@ test_that("simulateData is reproducible with same seed", {
 		simulateData(
 			N = N,
 			sig_eps_sq = sig_eps_sq,
-			sig_eps_c_sq = sig_eps_c_sq
+			sig_eps_c_sq = sig_eps_c_sq,
+			seed = 456
 		)
 	res2 <- coefs_obj |>
 		simulateData(
 			N = N,
 			sig_eps_sq = sig_eps_sq,
-			sig_eps_c_sq = sig_eps_c_sq
+			sig_eps_c_sq = sig_eps_c_sq,
+			seed = 456
 		)
 
 	expect_equal(res1$X, res2$X)
@@ -143,7 +146,8 @@ test_that("simulateData errors when beta has wrong length", {
 			coefs_obj = bad_coefs,
 			N = N,
 			sig_eps_sq = sig_eps_sq,
-			sig_eps_c_sq = sig_eps_c_sq
+			sig_eps_c_sq = sig_eps_c_sq,
+			seed = 123
 		),
 		"length\\(beta\\)"
 	)
@@ -163,7 +167,7 @@ test_that("Output from simulateData can be piped into fetwfeWithSimulatedData", 
 		seed = 123
 	)
 	sim_data <- coefs_obj |>
-		simulateData(N = 30, sig_eps_sq = 5, sig_eps_c_sq = 5)
+		simulateData(N = 30, sig_eps_sq = 5, sig_eps_c_sq = 5, seed = 123)
 	result <- sim_data |> fetwfeWithSimulatedData()
 	expect_type(result, "list")
 	expect_true("att_hat" %in% names(result))
@@ -183,7 +187,7 @@ test_that("Output from simulateData can be piped into fetwfeWithSimulatedData", 
 		seed = 123
 	)
 	sim_data <- coefs_obj |>
-		simulateData(N = 30, sig_eps_sq = 5, sig_eps_c_sq = 5)
+		simulateData(N = 30, sig_eps_sq = 5, sig_eps_c_sq = 5, seed = 123)
 	result <- sim_data |> fetwfeWithSimulatedData()
 	expect_type(result, "list")
 	expect_true("att_hat" %in% names(result))
@@ -217,7 +221,8 @@ test_that("Covariates are uniformly bounded when distribution = 'uniform'", {
 			N = N,
 			sig_eps_sq = sig_eps_sq,
 			sig_eps_c_sq = sig_eps_c_sq,
-			distribution = "uniform"
+			distribution = "uniform",
+			seed = 123
 		)
 
 	# In the no-interactions case, the design matrix X is built as:
@@ -259,7 +264,8 @@ test_that("Covariates are constant over time within each unit", {
 			N = N,
 			sig_eps_sq = sig_eps_sq,
 			sig_eps_c_sq = sig_eps_c_sq,
-			distribution = "gaussian"
+			distribution = "gaussian",
+			seed = 456
 		)
 
 	# The design matrix X = [cohort_fe, time_fe, X_long, treat_mat_long].
@@ -304,7 +310,13 @@ test_that("simulateData errors when R >= T", {
 	class(obj) <- "FETWFE_coefs"
 
 	expect_error(
-		simulateData(coefs_obj = obj, N = N, sig_eps_sq = 5, sig_eps_c_sq = 2),
+		simulateData(
+			coefs_obj = obj,
+			N = N,
+			sig_eps_sq = 5,
+			sig_eps_c_sq = 2,
+			seed = 123
+		),
 		regexp = "G <= T - 1" # Expect an error message indicating G must be <= T-1
 	)
 })
@@ -330,7 +342,8 @@ test_that("simulateData accepts T = 2 (2x2) and errors only when T < 2", {
 		coefs_obj = obj,
 		N = N,
 		sig_eps_sq = 5,
-		sig_eps_c_sq = 2
+		sig_eps_c_sq = 2,
+		seed = 123
 	)
 	expect_equal(sim$T, 2)
 	expect_equal(sim$G, 1)
@@ -340,7 +353,13 @@ test_that("simulateData accepts T = 2 (2x2) and errors only when T < 2", {
 	obj1 <- obj
 	obj1$T <- 1
 	expect_error(
-		simulateData(coefs_obj = obj1, N = N, sig_eps_sq = 5, sig_eps_c_sq = 2)
+		simulateData(
+			coefs_obj = obj1,
+			N = N,
+			sig_eps_sq = 5,
+			sig_eps_c_sq = 2,
+			seed = 123
+		)
 	)
 })
 
@@ -361,7 +380,13 @@ test_that("simulateData errors when N < R", {
 	class(obj) <- "FETWFE_coefs"
 
 	expect_error(
-		simulateData(coefs_obj = obj, N = N, sig_eps_sq = 5, sig_eps_c_sq = 2),
+		simulateData(
+			coefs_obj = obj,
+			N = N,
+			sig_eps_sq = 5,
+			sig_eps_c_sq = 2,
+			seed = 123
+		),
 		regexp = "N >= G" # Expect an error message indicating N must be at least G
 	)
 })
@@ -380,7 +405,13 @@ test_that("print.FETWFE_simulated summarizes instead of dumping (#84 item 13)", 
 		eff_size = 4,
 		seed = 42
 	)
-	sim <- simulateData(coefs, N = 20, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	sim <- simulateData(
+		coefs,
+		N = 20,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 42
+	)
 	expect_s3_class(sim, "FETWFE_simulated")
 
 	out <- capture.output(print(sim))
@@ -423,7 +454,13 @@ test_that("simulateData accepts sig_eps_c_sq = 0 (#109 Case 2)", {
 		seed = 109
 	)
 	# Pre-fix: this call errored with "sig_eps_c_sq must be a positive numeric value".
-	sim <- simulateData(coefs, N = 40, sig_eps_sq = 1, sig_eps_c_sq = 0)
+	sim <- simulateData(
+		coefs,
+		N = 40,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0,
+		seed = 109
+	)
 	expect_s3_class(sim, "FETWFE_simulated")
 	expect_equal(sim$sig_eps_c_sq, 0)
 	# rnorm(N, sd = 0) returns rep(0, N) — unit residuals are exactly zero.
@@ -441,7 +478,13 @@ test_that("simulateData still rejects negative sig_eps_c_sq (#109 Case 2)", {
 		seed = 109
 	)
 	expect_error(
-		simulateData(coefs, N = 40, sig_eps_sq = 1, sig_eps_c_sq = -0.1),
+		simulateData(
+			coefs,
+			N = 40,
+			sig_eps_sq = 1,
+			sig_eps_c_sq = -0.1,
+			seed = 109
+		),
 		"non-negative"
 	)
 })

--- a/tests/testthat/test-simultaneous-cis.R
+++ b/tests/testthat/test-simultaneous-cis.R
@@ -8,9 +8,9 @@ library(fetwfe)
 # returned by `make_es_panel()` in test-event_study.R. The divergence is
 # intentional and load-bearing: Test 3 needs the `coefs` object for two
 # purposes:
-#   (1) per-rep seed override (`coefs_i <- coefs_master; coefs_i$seed <- s`)
-#       because `simulateData()` reads `coefs$seed`, ignoring the global RNG
-#       state;
+#   (1) per-rep panel variation: each replication passes a distinct
+#       `seed = seeds[i]` to `simulateData()` (as of #250 the panel RNG is
+#       controlled by the `seed` argument, not by `coefs$seed`);
 #   (2) truth-extraction via `coefs$beta[getTreatInds(...)]` for the event-time
 #       truth vector (`getTes()` returns no `tes_actual` slot; per-cell TEs come
 #       from `coefs$beta` directly).
@@ -34,7 +34,13 @@ make_simul_cis_panel <- function(
 	)
 	list(
 		coefs = coefs,
-		sim = simulateData(coefs, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+		sim = simulateData(
+			coefs,
+			N = N,
+			sig_eps_sq = 1,
+			sig_eps_c_sq = 0.5,
+			seed = seed
+		)
 	)
 }
 
@@ -114,8 +120,9 @@ test_that("simultaneousCIs critical value: pointwise < simultaneous < Bonferroni
 # ------------------------------------------------------------------------------
 # Test 3: simultaneous coverage ~ nominal at 500 MC reps (skip_on_cran).
 # Recalibrated to 500 reps (from 200) for 3.1-sigma headroom around 0.95.
-# Pinned seed sequence; per-rep variation via coefs$seed override (simulateData
-# ignores the global RNG state). Truth extracted from coefs$beta directly.
+# Pinned seed sequence; per-rep variation via the `seed` argument to
+# simulateData() (as of #250 the panel RNG is controlled by that argument).
+# Truth extracted from coefs$beta directly.
 # load-bearing: matches PLANS.md #5 ("test fails before, passes after");
 # calibrated to 3-sigma per round-1 B3.
 #
@@ -157,13 +164,12 @@ test_that("simultaneousCIs achieves ~nominal simultaneous coverage", {
 	covered <- logical(length(seeds))
 
 	for (i in seq_along(seeds)) {
-		coefs_i <- coefs_master
-		coefs_i$seed <- seeds[i]
 		sim_i <- simulateData(
-			coefs_i,
+			coefs_master,
 			N = N_,
 			sig_eps_sq = 1,
-			sig_eps_c_sq = 0.5
+			sig_eps_c_sq = 0.5,
+			seed = seeds[i]
 		)
 		fit_i <- fetwfeWithSimulatedData(sim_i)
 		sci_i <- simultaneousCIs(fit_i, family = "event_study", alpha = 0.05)

--- a/tests/testthat/test-single-cohort-112.R
+++ b/tests/testthat/test-single-cohort-112.R
@@ -68,7 +68,13 @@
 		seed = seed
 	)
 	tes <- getTes(coefs)
-	sim <- simulateData(coefs, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	sim <- simulateData(
+		coefs,
+		N = N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = seed
+	)
 	list(sim = sim, att_true = tes$att_true)
 }
 
@@ -504,7 +510,13 @@ test_that("genCoefs and simulateData round-trip at G = 1", {
 	# Overall ATT equals the lone cohort's effect.
 	expect_equal(tes$att_true, tes$actual_cohort_tes[1])
 
-	sim <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	sim <- simulateData(
+		coefs,
+		N = 120,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 4242
+	)
 	expect_equal(sim$G, 1)
 	expect_s3_class(sim$pdata, "data.frame")
 	# One treated cohort -> exactly one unique post-adoption start time among

--- a/tests/testthat/test-tight-gaussian-variance-141-146.R
+++ b/tests/testthat/test-tight-gaussian-variance-141-146.R
@@ -41,7 +41,8 @@ test_that("default `att_se` is the tight Gaussian variance sqrt(V1 + V2)", {
 		sim_coefs,
 		N = 80,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 141
 	)
 
 	res <- fetwfe(
@@ -84,7 +85,8 @@ test_that("se_type = 'conservative' recovers the Cauchy-Schwarz bound (pre-v1.12
 		sim_coefs,
 		N = 80,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 141
 	)
 
 	common_args <- list(
@@ -138,7 +140,8 @@ test_that("variance_components block exposes paper-notation V_1, V_2, and tilde_
 		sim_coefs,
 		N = 80,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 141
 	)
 
 	res <- fetwfe(
@@ -221,7 +224,8 @@ test_that("variance_components block: conservative se_type swaps the headline ti
 		sim_coefs,
 		N = 80,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 141
 	)
 
 	res_def <- fetwfe(
@@ -288,7 +292,8 @@ test_that("variance_components block: indep_counts path uses tight formula regar
 		sim_coefs,
 		N = 80,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 141
 	)
 
 	# fetwfeWithSimulatedData passes indep_counts (from the simulator).
@@ -331,7 +336,8 @@ test_that("variance_components block: q >= 1 path returns NA-filled slots", {
 		sim_coefs,
 		N = 80,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 141
 	)
 
 	res <- fetwfeWithSimulatedData(sim, q = 2)
@@ -367,7 +373,8 @@ test_that("etwfe, betwfe, twfeCovs all expose the variance_components block", {
 		sim_coefs,
 		N = 80,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 141
 	)
 
 	fits <- list(
@@ -451,7 +458,8 @@ test_that("tight Gaussian default delivers near-nominal 95% CI coverage on simul
 			coefs,
 			N = N_per,
 			sig_eps_sq = 1,
-			sig_eps_c_sq = 0.5
+			sig_eps_c_sq = 0.5,
+			seed = seed_i
 		)
 
 		# Population ATT is `cohort_tes %*% pi_cond`, with `pi_cond` the
@@ -560,7 +568,13 @@ test_that("tight-Gaussian default works when variance components are REML-estima
 		eff_size = 2,
 		seed = 141
 	)
-	sim <- simulateData(sim_coefs, N = 80, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	sim <- simulateData(
+		sim_coefs,
+		N = 80,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 141
+	)
 
 	res <- suppressWarnings(fetwfe(
 		pdata = sim$pdata,

--- a/tests/testthat/test-twfeCovs.R
+++ b/tests/testthat/test-twfeCovs.R
@@ -873,11 +873,13 @@ test_that("twfeCovs throws error when a cohort contains fewer than d + 1 units",
 test_that("twfeCovs surfaces p_value but not selected in catt_df", {
 	set.seed(2026)
 	sim <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
 	dat <- simulateData(
 		sim,
 		N = 120,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = NA
 	)
 	res <- twfeCovsWithSimulatedData(dat, verbose = FALSE)
 
@@ -990,17 +992,26 @@ test_that("twfeCovs errors cleanly when no-never-treated truncation would yield 
 make_se_type_panel <- function(seed = 2026, N = 120) {
 	set.seed(seed)
 	sim_coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-	simulateData(sim_coefs, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
+	simulateData(
+		sim_coefs,
+		N = N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = NA
+	)
 }
 
 make_ar1_panel <- function(seed = 7, N = 150, rho = 0.85, sd_e = 1) {
 	set.seed(seed)
 	sim_coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
+	# coefs built without a seed: continue the ambient RNG (seed = NA, #250).
 	sim <- simulateData(
 		sim_coefs,
 		N = N,
 		sig_eps_sq = 0.5,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = NA
 	)
 	pdata <- sim$pdata
 	pdata <- pdata[order(pdata$unit, pdata$time), ]
@@ -1080,7 +1091,8 @@ test_that("twfeCovs returns a classed object with working print + coef methods (
 		genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2, seed = 42),
 		N = 60,
 		sig_eps_sq = 1,
-		sig_eps_c_sq = 0.5
+		sig_eps_c_sq = 0.5,
+		seed = 42
 	)
 	fit <- twfeCovsWithSimulatedData(sim)
 	expect_s3_class(fit, "twfeCovs")

--- a/tests/testthat/test-user-fusion-matrix-236.R
+++ b/tests/testthat/test-user-fusion-matrix-236.R
@@ -33,7 +33,10 @@ library(fetwfe)
 		seed = 1
 	)
 	set.seed(101)
-	simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5)
+	# Byte-exact pin (#250): the previous simulateData() reused coefs$seed,
+	# i.e. drew with set.seed(1), so the preceding set.seed(101) never
+	# governed this panel. Pin seed = 1 to reproduce the original draw.
+	simulateData(coefs, N = 120, sig_eps_sq = 5, sig_eps_c_sq = 5, seed = 1)
 }
 
 .fm236_fit <- function(sim, ...) {

--- a/vignettes/etwfe_betwfe_vignette.Rmd
+++ b/vignettes/etwfe_betwfe_vignette.Rmd
@@ -55,7 +55,8 @@ sim_data <- simulateData(
   sim_coefs,
   N            = 120,
   sig_eps_sq   = 1,
-  sig_eps_c_sq = 1
+  sig_eps_c_sq = 1,
+  seed         = 20260510
 )
 
 # True treatment effects (we'll compare estimator output to these):
@@ -122,7 +123,8 @@ sim_data_d0 <- simulateData(
   sim_coefs_d0,
   N            = 120,
   sig_eps_sq   = 1,
-  sig_eps_c_sq = 1
+  sig_eps_c_sq = 1,
+  seed         = 20260510
 )
 
 true_tes_d0 <- getTes(sim_coefs_d0)

--- a/vignettes/fusion_structure_vignette.Rmd
+++ b/vignettes/fusion_structure_vignette.Rmd
@@ -146,7 +146,7 @@ event_time <- unlist(lapply(n_k, function(nk) 0:(nk - 1)))
 # The true per-cell treatment effects, generated natively (not hand-built).
 true_te <- coefs$beta[treat_inds]
 
-sim <- simulateData(coefs, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+sim <- simulateData(coefs, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 10)
 ```
 
 Now fit the same simulated panel under each fusion structure:

--- a/vignettes/inference_vignette.Rmd
+++ b/vignettes/inference_vignette.Rmd
@@ -147,11 +147,14 @@ A worked comparison on a clean F1-conforming panel:
 ```{r}
 set.seed(2026)
 sim_coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
+# sim_coefs was built without a seed, so draw from the ambient generator
+# (seeded just above); seed = NA selects the ambient generator silently.
 sim_data  <- simulateData(
   sim_coefs,
   N = 120,
   sig_eps_sq = 1,
-  sig_eps_c_sq = 0.5
+  sig_eps_c_sq = 0.5,
+  seed = NA
 )
 
 res_default <- fetwfe(
@@ -344,7 +347,7 @@ The cleanest way to see the implicit test is on simulated data where the truth i
 coefs <- genCoefs(G = 3, T = 6, d = 2, density = 0.2, eff_size = 2, seed = 3)
 getTes(coefs)$actual_cohort_tes
 
-dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+dat <- simulateData(coefs, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 3)
 res <- fetwfeWithSimulatedData(dat, verbose = FALSE)
 
 # The implicit test: the `selected` and `p_value` columns of catt_df.

--- a/vignettes/simulation_vignette.Rmd
+++ b/vignettes/simulation_vignette.Rmd
@@ -92,7 +92,8 @@ sim_data <- simulateData(
   N = 60,
   sig_eps_sq = 1,
   sig_eps_c_sq = 1,
-  distribution = "gaussian"
+  distribution = "gaussian",
+  seed = 101
   )
 ```
 
@@ -148,7 +149,7 @@ You can also chain the simulation functions together with the pipe operator. The
 coefs <- genCoefs(G = 3, T = 4, d = 2, density = 0.1, eff_size = 2, seed = 2025)
 
 result_piped <- coefs |>
-  simulateData(N = 60, sig_eps_sq = 1, sig_eps_c_sq = 1) |>
+  simulateData(N = 60, sig_eps_sq = 1, sig_eps_c_sq = 1, seed = 2025) |>
   fetwfeWithSimulatedData()
 
 cat("Estimated Overall ATT from piped workflow:", result_piped$att_hat, "\n")
@@ -212,7 +213,8 @@ sim_mn <- simulateData(
   sim_coefs_mn,
   N            = 200,
   sig_eps_sq   = 1,
-  sig_eps_c_sq = 1
+  sig_eps_c_sq = 1,
+  seed         = 101
 )
 cat("Empirical cohort proportions:\n")
 print(round(sim_mn$assignments / sum(sim_mn$assignments), 3))
@@ -253,7 +255,8 @@ sim_ord <- simulateData(
   sim_coefs_ord,
   N            = 200,
   sig_eps_sq   = 1,
-  sig_eps_c_sq = 1
+  sig_eps_c_sq = 1,
+  seed         = 101
 )
 cat("Empirical cohort proportions (ordered):\n")
 print(round(sim_ord$assignments / sum(sim_ord$assignments), 3))
@@ -279,7 +282,8 @@ for (s in c(0.0, 1.0, 5.0)) {
     coefs_s,
     N            = 200,
     sig_eps_sq   = 1,
-    sig_eps_c_sq = 1
+    sig_eps_c_sq = 1,
+    seed         = 101
   )
   cat(sprintf(
     "strength = %.1f -> proportions: %s\n",

--- a/vignettes/vignette.Rmd
+++ b/vignettes/vignette.Rmd
@@ -246,7 +246,9 @@ For `fetwfe()`, the `selected` flag carries something stronger than the usual CI
 ```{r zero-effect-demo, message = FALSE}
 set.seed(2026)
 sim <- genCoefs(G = 3, T = 6, d = 2, density = 0.5, eff_size = 2)
-dat <- simulateData(sim, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5)
+# sim was built without a seed, so draw from the ambient generator (seeded
+# just above); seed = NA selects the ambient generator silently.
+dat <- simulateData(sim, N = 120, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = NA)
 res_demo <- fetwfeWithSimulatedData(dat, verbose = FALSE)
 res_demo$catt_df
 ```


### PR DESCRIPTION
Refs #250.

## What changed (behavior flip)
`simulateData()` previously called `set.seed(coefs_obj$seed)` internally on every
call. Two consequences users routinely tripped over: repeated calls on one
`FETWFE_coefs` object returned **byte-identical** panels, and a preceding
`set.seed()` was **silently ignored**. The only way to vary the panel across Monte
Carlo replications was to mutate `coefs_obj$seed` (a private slot) between calls.

This PR adds an explicit `seed` argument and **flips the default to the ambient
RNG**:

- `seed = NULL` (default): draw from the ambient random-number generator
  (respecting any preceding `set.seed()`) **and emit a warning** that the
  default changed in 1.24.0 (fires on every default call, not once per session).
- `seed = NA`: draw from the ambient generator **silently** (explicit opt-in to
  caller-controlled RNG).
- `seed = <integer>`: `set.seed(seed)` then draw — a reproducible panel (the same
  integer always yields the same panel).
- anything else: a clear `stop("seed must be NULL, NA, or a single numeric value")`.

`simulateData()` **no longer reads `coefs_obj$seed`**. `simulateDataCore()`,
`genCoefs()`, and `getTes()` are unchanged.

## Why a loud warning
The change is deliberately noisy so existing scripts don't silently start
producing different numbers: a `warning()` whose text names the ambient generator
fires whenever `seed` is unspecified, plus a flagged **Breaking changes** entry in
NEWS and a version bump. Users restore the old reproducibility by passing
`seed = <integer>`, or silence the warning with `seed = NA` if they want the
caller-controlled stream.

## Byte-exact internal pinning (the bulk of the diff)
To keep today's simulated output **byte-for-byte identical**, every internal
`simulateData()` call (tests + vignettes) is pinned to the seed its feeding coefs
object was built with, following the rule:

- feeding coefs built **with** `seed = S` (so `coefs$seed == S`) -> pin `seed = S`;
- feeding coefs built **without** a seed (incl. the
  `set.seed(K); genCoefs(...no seed...); simulateData(...)` ambient-continuation
  pattern) -> pin **`seed = NA`** (pinning `K` would re-seed and yield a *different*
  panel — empirically confirmed).

Counts: **109 pre-existing test calls** pinned (all of them), **11 vignette
calls** pinned, **29 `seed = NA`** ambient-continuation sites (27 tests + 2
vignettes). The full `devtools::test()` run is the proof: **FAIL 0** means each
pin reproduced the original draw — a wrong literal-vs-NA pin would have broken a
value/coverage assertion (e.g. test-logit-dgp.R's value-locked
`sim$pdata$y[1:3]` / `assignments` / `indep_counts` byte-identity test, which
passed).

## The 3 Monte-Carlo-loop conversions
Three tests used to mutate the private slot per replication
(`coefs_i <- template; coefs_i$seed <- V; simulateData(coefs_i, ...)`). These are
converted to the supported arg (`simulateData(template, ..., seed = V)`),
byte-identical, with their now-stale comments updated:
- test-betwfe-se-fix.R (`V = 8000L + i`)
- test-simultaneous-cis.R (`V = seeds[i]`; also threaded `seed = seed` into the
  `make_simul_cis_panel` helper)
- test-lambda-selection-164.R (`V = 13000L + i`)

`grep 'coefs.*$seed <-'` over the suite is now empty (was 3).

## New test
`tests/testthat/test-simulate-data-seed-250.R` locks the new contract: default
flips to ambient + warns (and two default draws differ — mutation-bearing);
`seed = NA` is silent and honors the caller's `set.seed()`; `seed = <int>` is
silent and reproducible; invalid seeds error. These default-path calls are the
only live `simulateData()` calls in the suite permitted to omit a seed.

## Docs
- `@param seed` + rewritten `@details` on `simulateData()` (regenerated
  `man/simulateData.Rd`).
- Every `simulateData()` example across `R/` now passes `seed = 123` to model the
  reproducible pattern (all examples are in `\dontrun`/`\donttest`).
- NEWS.md: **Breaking changes** entry under the new 1.24.0 section.
- `inst/WORDLIST`: `RNG`, `reproducibility`.

## Gate results
- `air format .`: applied (reflows committed).
- `devtools::document()`: `man/simulateData.Rd` regenerated from the new roxygen;
  22 other `.Rd` files updated only with the example `seed = 123` additions; no
  other drift.
- `devtools::test()`: **FAIL 0 | WARN 0 | SKIP 0 | PASS 3309** (skip_on_cran tests
  ran under `devtools::test()`).
- Zero unpinned live calls outside the new test file's 3 intentional default
  calls; zero "ambient" warning leakage in captured test output.
- `spelling::spell_check_package()`: clean. `devtools::check_man()`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
