### PR TITLE
fix: getTes() no longer perturbs the caller's RNG; harmonize seed = NA across the data-gen API (#254)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,34 @@ paper_arxiv.tex     Source for the methodology paper (R-build-ignored).
 - **No compiled code.** The package is pure R. Don't add C/C++ unless the user
   explicitly asks — it would change the CRAN submission profile.
 
+## RNG / random-seed conventions
+
+The package has two seed conventions, split by a function's role. Pick the one
+that matches the role; do not mix them.
+
+- **Convention A — estimator nuisance (fixed seed, restore the caller's RNG).**
+  A function that consumes randomness as an internal nuisance of an analysis
+  (so its output should be deterministic given its inputs, but it must not
+  perturb the caller's random stream) seeds a fixed value and wraps the draw in
+  `.with_preserved_rng(seed, expr)`, which saves and restores the caller's
+  `.Random.seed` via `on.exit()`. This covers the cross-validation fold
+  assignment in `getBetaCV()`, the `mvtnorm` quasi-Monte-Carlo integration in
+  `.simultaneous_cis_impl()`, and the expected-cohort-probability truth
+  integration in `getTes()`. **Rule: analysis and truth functions (anything
+  that computes an estimate, a standard error, or a population truth such as
+  `getTes()`) follow Convention A** — they never advance the caller's RNG.
+- **Convention B — data generation (ambient; advance the caller's stream).**
+  A data-generating function treats randomness as its product. An explicit
+  numeric `seed` calls `set.seed()` and deliberately leaves the global RNG
+  advanced (reproducible-yet-varying simulation); `seed = NA` (or `NULL`) draws
+  from the ambient stream without calling `set.seed()`. This covers
+  `simulateData()` / `simulateDataCore()` and `genCoefs()` / `genCoefsCore()`.
+
+The shared seed primitive is `.apply_seed(seed)` in `R/utility.R`: `NULL` or a
+scalar `NA` mean "ambient" (no `set.seed()`), a single numeric value is passed
+to `set.seed()`, and anything else errors. Both the data-generation functions
+and `.with_preserved_rng()` route through it.
+
 ## Domain terminology cheat sheet
 
 - **N, T, R, d, p**: units, time periods, treated cohorts, covariates,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.24.0
+Version: 1.25.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,27 @@
 # NEWS
 
+## Version 1.25.0
+
+### Bug fixes
+
+- `getTes()` no longer perturbs the caller's random-number generator. Under a
+  covariate-dependent (`"multinomial"` / `"ordered"`) assignment DGP it
+  integrates the expected cohort propensities by Monte Carlo, and that draw
+  previously advanced the caller's `.Random.seed` as a side effect. `getTes()`
+  is an analysis/truth function, so the integration now runs under a restored
+  RNG (the per-cohort truth is unchanged): the caller's `.Random.seed` is saved
+  and restored, leaving the user's stream untouched (#254).
+
+### New features
+
+- `genCoefs()`, `genCoefsCore()`, and `simulateDataCore()` now accept
+  `seed = NA` to draw from the ambient random-number generator silently (no
+  `set.seed()` call), matching the behavior already available on
+  `simulateData()`. As before, an explicit numeric `seed` calls `set.seed()`
+  (reproducible draw, global RNG left advanced) and `seed = NULL` draws from the
+  ambient stream; an invalid `seed` now reports a single canonical message
+  (`"seed must be NULL, NA, or a single numeric value"`) (#254).
+
 ## Version 1.24.0
 
 ### Breaking changes

--- a/R/cohort_assignment.R
+++ b/R/cohort_assignment.R
@@ -88,7 +88,9 @@
 #'   Scales the Gaussian draws of the interaction coefficients
 #'   independently of `strength`. Defaults to `NULL`, which falls
 #'   through to `strength`. New in 1.14.1.
-#' @param seed Optional integer for reproducibility.
+#' @param seed Optional integer for reproducibility. `NA` (or `NULL`) means
+#'   "draw from the ambient random-number generator" --- no `set.seed()` is
+#'   called.
 #'
 #' @return A list with elements `type`, `strength`, `coefs`, `interactions`,
 #'   `delta`, `interaction_strength`, and (for `"ordered"`) `cutpoints`.
@@ -141,9 +143,7 @@
 	interaction_strength = NULL,
 	seed = NULL
 ) {
-	if (!is.null(seed)) {
-		set.seed(seed)
-	}
+	.apply_seed(seed)
 	.validate_strength_arg(strength, "assignment_strength")
 	if (!(type %in% c("multinomial", "ordered"))) {
 		stop(sprintf(
@@ -434,7 +434,8 @@
 #'   ~0.5% standard error on each component.
 #' @param seed Optional integer for reproducibility. Per the
 #'   seed-offset convention in `.gen_assignment_coefs()`, this is
-#'   typically `coefs_obj$seed + 2L`.
+#'   typically `coefs_obj$seed + 2L`. `NA` (or `NULL`) means "draw from the
+#'   ambient random-number generator" --- no `set.seed()` is called.
 #'
 #' @return Numeric vector of length `G + 1`, sums to 1.
 #'
@@ -447,9 +448,7 @@
 	M = 10000L,
 	seed = NULL
 ) {
-	if (!is.null(seed)) {
-		set.seed(seed)
-	}
+	.apply_seed(seed)
 	X_mc <- if (distribution == "gaussian") {
 		matrix(rnorm(M * d), nrow = M, ncol = d)
 	} else if (distribution == "uniform") {

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -94,6 +94,9 @@
 #'   deterministic offsets share this seed: the main coefficient draw uses
 #'   \code{seed}; the assignment coefficients use \code{seed + 1L}; the
 #'   Monte Carlo integration in \code{getTes()} uses \code{seed + 2L}.
+#'   \code{NA} (or \code{NULL}) means "draw from the ambient random-number
+#'   generator" --- no \code{set.seed()} is called, so any preceding
+#'   \code{set.seed()} is respected and the result varies across calls.
 #' @param verbose Logical. If \code{TRUE}, emit a \code{message()} when
 #'   \code{assignment_interactions} canonicalization removes duplicate or
 #'   unordered pairs (e.g., when the user passes both \code{c(1, 2)} and
@@ -166,6 +169,15 @@
 #' canonical parametric propensity-score models named in Faletto (2025)
 #' line 1016; the propensity-weighted population-truth aggregation matches
 #' Eq. \code{att.estimator.weighted} (line 837).
+#'
+#' Note on the random-number generator: passing an explicit numeric
+#' \code{seed} calls \code{set.seed(seed)} internally and \strong{leaves the
+#' global RNG advanced} after the call returns. This is deliberate --- it
+#' makes a simulation both reproducible (the same \code{seed} always yields
+#' the same coefficients) and varying (drawing data afterwards consumes the
+#' advanced stream). To draw from / preserve the ambient random stream
+#' instead --- without calling \code{set.seed()} --- pass \code{seed = NA}
+#' (or \code{seed = NULL}).
 #'
 #' @references
 #' Faletto, G (2025). Fused Extended Two-Way Fixed Effects for
@@ -575,12 +587,21 @@ getTes <- function(coefs_obj) {
 		} else {
 			coefs_obj$seed + 2L
 		}
-		expected_probs <- .expected_cohort_probs(
-			assignment_coefs = coefs_obj$assignment_coefs,
-			d = d,
-			distribution = "gaussian",
-			M = 10000L,
-			seed = mc_seed
+		# Convention A (#254): getTes() is an analysis/truth function, so compute
+		# the expected cohort probabilities under the fixed seed `mc_seed` but
+		# RESTORE the caller's RNG -- it must not perturb the user's stream. When
+		# `mc_seed` is NULL/NA (coefs built without a seed, or with seed = NA) the
+		# draw is from the ambient RNG (non-deterministic truth, as before) and is
+		# still restored.
+		expected_probs <- .with_preserved_rng(
+			mc_seed,
+			.expected_cohort_probs(
+				assignment_coefs = coefs_obj$assignment_coefs,
+				d = d,
+				distribution = "gaussian",
+				M = 10000L,
+				seed = NULL
+			)
 		)
 		# expected_probs is length (G + 1); index 1 is never-treated,
 		# indices 2..R+1 are treated cohorts.
@@ -640,7 +661,9 @@ getTes <- function(coefs_obj) {
 #' effects are sparse. \code{"cohort"} is byte-identical to previous behavior;
 #' \code{"event_study"} fuses effects at the same time since treatment across
 #' cohorts. See \code{genCoefs()} for details.
-#' @param seed (Optional) Integer. Seed for reproducibility.
+#' @param seed (Optional) Integer. Seed for reproducibility. \code{NA} (or
+#' \code{NULL}) means "draw from the ambient random-number generator" --- no
+#' \code{set.seed()} is called.
 #' @param R Deprecated. The former name for \code{G}; still accepted with a
 #' deprecation warning, and will be removed in a future release. Use \code{G}.
 #'
@@ -724,9 +747,7 @@ genCoefsCore <- function(
 
 	fusion_structure <- match.arg(fusion_structure)
 
-	if (!is.null(seed)) {
-		set.seed(seed)
-	}
+	.apply_seed(seed)
 
 	# Check that T is a numeric scalar and at least 2.
 	if (!is.numeric(T) || length(T) != 1 || T < 2) {

--- a/R/gen_data.R
+++ b/R/gen_data.R
@@ -84,6 +84,14 @@
 #' warning. To vary the panel across Monte Carlo replications, pass a different
 #' \code{seed} each replication.
 #'
+#' Passing an explicit numeric \code{seed} calls \code{set.seed(seed)}
+#' internally and \strong{leaves the global RNG advanced} after the call
+#' returns. This is deliberate --- it makes a simulation both reproducible
+#' (the same \code{seed} always yields the same panel) and varying (subsequent
+#' draws consume the advanced stream). Use \code{seed = NA} (or the default
+#' \code{seed = NULL}) to draw from / preserve the ambient stream without
+#' calling \code{set.seed()}.
+#'
 #' The argument \code{distribution} controls the generation of covariates. For
 #' \code{"gaussian"}, covariates are drawn from \code{rnorm}; for \code{"uniform"},
 #' they are drawn from \code{runif} on the interval \eqn{[-\sqrt{3}, \sqrt{3}]} (which ensures that
@@ -390,9 +398,7 @@ simulateDataCore <- function(
 	# directly.
 	G <- .resolve_cohort_count_arg(G, R, "simulateDataCore")
 
-	if (!is.null(seed)) {
-		set.seed(seed)
-	}
+	.apply_seed(seed)
 
 	# Normalize assignment_type defensively (backward-compat for callers
 	# that pass NULL directly).

--- a/R/utility.R
+++ b/R/utility.R
@@ -1254,16 +1254,44 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 	)
 }
 
+# .apply_seed
+#' @title Apply a seed argument: `set.seed()`, draw from the ambient RNG, or error
+#' @description The canonical seed-to-RNG mapping shared by the data-generation
+#'   functions and `.with_preserved_rng()`. `NULL` or a scalar `NA` mean "use the
+#'   ambient random-number generator" (no `set.seed()`); a single numeric value is
+#'   passed to `set.seed()`; anything else is an error. (#254)
+#' @param seed `NULL`, a scalar `NA`, or a single numeric value.
+#' @return Invisibly `NULL`; called for its `set.seed()` side effect (or none).
+#' @keywords internal
+#' @noRd
+.apply_seed <- function(seed) {
+	if (is.null(seed)) {
+		return(invisible(NULL))
+	}
+	if (length(seed) == 1L && is.na(seed)) {
+		return(invisible(NULL))
+	}
+	if (is.numeric(seed) && length(seed) == 1L) {
+		set.seed(seed)
+		return(invisible(NULL))
+	}
+	stop("seed must be NULL, NA, or a single numeric value")
+}
+
 # .with_preserved_rng
 #' @title Evaluate RNG-consuming code under a fixed seed, preserving caller state
-#' @description Runs `expr` after `set.seed(seed)` so the result is deterministic
-#'   in its inputs, while saving and restoring the caller's `.Random.seed` (via
-#'   `on.exit()`) so the call does not perturb the caller's random stream. Both
-#'   the "caller had a seed at entry" and "caller had none" cases are handled.
+#' @description Runs `expr` after applying `seed` via `.apply_seed()` (a single
+#'   numeric `seed` reseeds for determinism; `NULL` or `NA` draw from the ambient
+#'   stream), while saving and restoring the caller's `.Random.seed` (via
+#'   `on.exit()`) so the call never perturbs the caller's random stream. Both the
+#'   "caller had a seed at entry" and "caller had none" cases are handled.
 #'   Consolidates the idiom shared by `getBetaCV()` (#181, the CV-fold
-#'   assignment) and `.simultaneous_cis_impl()` (#192 / #200, the `mvtnorm`
-#'   Genz-Bretz quasi-Monte-Carlo integration). (#195)
-#' @param seed Integer seed passed to `set.seed()` immediately before `expr`.
+#'   assignment), `.simultaneous_cis_impl()` (#192 / #200, the `mvtnorm`
+#'   Genz-Bretz quasi-Monte-Carlo integration), and `getTes()` (#254, the
+#'   expected-cohort-probability truth computation). (#195)
+#' @param seed A single numeric seed (passed to `set.seed()` before `expr`), or
+#'   `NULL` / `NA` to draw from the ambient RNG without reseeding. Either way the
+#'   caller's `.Random.seed` is saved and restored.
 #' @param expr Expression to evaluate (lazily -- it runs after the caller's seed
 #'   is saved and `set.seed(seed)` is applied). Its value is returned.
 #' @return The value of `expr`.
@@ -1291,7 +1319,7 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 		},
 		add = TRUE
 	)
-	set.seed(seed)
+	.apply_seed(seed)
 	force(expr)
 }
 

--- a/man/genCoefs.Rd
+++ b/man/genCoefs.Rd
@@ -105,7 +105,10 @@ angle). Ignored when \code{assignment_interactions = NULL}. New in
 \item{seed}{(Optional) Integer. Seed for reproducibility. Three
 deterministic offsets share this seed: the main coefficient draw uses
 \code{seed}; the assignment coefficients use \code{seed + 1L}; the
-Monte Carlo integration in \code{getTes()} uses \code{seed + 2L}.}
+Monte Carlo integration in \code{getTes()} uses \code{seed + 2L}.
+\code{NA} (or \code{NULL}) means "draw from the ambient random-number
+generator" --- no \code{set.seed()} is called, so any preceding
+\code{set.seed()} is respected and the result varies across calls.}
 
 \item{verbose}{Logical. If \code{TRUE}, emit a \code{message()} when
 \code{assignment_interactions} canonicalization removes duplicate or
@@ -196,6 +199,15 @@ The multinomial-logit and proportional-odds reference DGPs are the
 canonical parametric propensity-score models named in Faletto (2025)
 line 1016; the propensity-weighted population-truth aggregation matches
 Eq. \code{att.estimator.weighted} (line 837).
+
+Note on the random-number generator: passing an explicit numeric
+\code{seed} calls \code{set.seed(seed)} internally and \strong{leaves the
+global RNG advanced} after the call returns. This is deliberate --- it
+makes a simulation both reproducible (the same \code{seed} always yields
+the same coefficients) and varying (drawing data afterwards consumes the
+advanced stream). To draw from / preserve the ambient random stream
+instead --- without calling \code{set.seed()} --- pass \code{seed = NA}
+(or \code{seed = NULL}).
 }
 \examples{
 \dontrun{

--- a/man/genCoefsCore.Rd
+++ b/man/genCoefsCore.Rd
@@ -39,7 +39,9 @@ effects are sparse. \code{"cohort"} is byte-identical to previous behavior;
 \code{"event_study"} fuses effects at the same time since treatment across
 cohorts. See \code{genCoefs()} for details.}
 
-\item{seed}{(Optional) Integer. Seed for reproducibility.}
+\item{seed}{(Optional) Integer. Seed for reproducibility. \code{NA} (or
+\code{NULL}) means "draw from the ambient random-number generator" --- no
+\code{set.seed()} is called.}
 
 \item{R}{Deprecated. The former name for \code{G}; still accepted with a
 deprecation warning, and will be removed in a future release. Use \code{G}.}

--- a/man/simulateData.Rd
+++ b/man/simulateData.Rd
@@ -103,6 +103,14 @@ the same panel), or \code{seed = NA} to use the ambient generator without the
 warning. To vary the panel across Monte Carlo replications, pass a different
 \code{seed} each replication.
 
+Passing an explicit numeric \code{seed} calls \code{set.seed(seed)}
+internally and \strong{leaves the global RNG advanced} after the call
+returns. This is deliberate --- it makes a simulation both reproducible
+(the same \code{seed} always yields the same panel) and varying (subsequent
+draws consume the advanced stream). Use \code{seed = NA} (or the default
+\code{seed = NULL}) to draw from / preserve the ambient stream without
+calling \code{set.seed()}.
+
 The argument \code{distribution} controls the generation of covariates. For
 \code{"gaussian"}, covariates are drawn from \code{rnorm}; for \code{"uniform"},
 they are drawn from \code{runif} on the interval \eqn{[-\sqrt{3}, \sqrt{3}]} (which ensures that

--- a/tests/testthat/test-seed-conventions-254.R
+++ b/tests/testthat/test-seed-conventions-254.R
@@ -1,0 +1,280 @@
+library(testthat)
+library(fetwfe)
+
+# ==============================================================================
+# Seed / RNG conventions (#254).
+#
+# Two roles, two conventions:
+#   A (estimator nuisance): fixed seed + restore the caller's RNG via
+#     .with_preserved_rng() -- getTes()'s truth integration follows this.
+#   B (data generation): ambient / advance the caller's stream --
+#     genCoefs()/genCoefsCore()/simulateDataCore() follow this, and `seed = NA`
+#     is a silent-ambient value (harmonized with simulateData()).
+#
+# All getTes() coverage uses a NON-MARGINAL (multinomial) DGP so the call
+# routes through .expected_cohort_probs() (the formerly-perturbing path); a
+# marginal coefs object would be vacuous here.
+# ==============================================================================
+
+# Shared non-marginal fixture (multinomial => non-marginal => routes through
+# .expected_cohort_probs()). seed = 42 makes the truth deterministic.
+coefs_nm <- genCoefs(
+	G = 3,
+	T = 5,
+	d = 2,
+	density = 0.5,
+	eff_size = 2,
+	assignment_type = "multinomial",
+	seed = 42
+)
+
+# ------------------------------------------------------------------------------
+# (3a) BYTE-EXACT: the non-marginal att_true is pinned. tolerance = 1e-6 catches
+# RNG-ordering drift (even a 1-draw shift moves att_true by ~2.5e-4, far above
+# 1e-6; a larger reseed change moves it more) while staying robust to platform
+# floating-point. The exact value is 1.822751376679849.
+# ------------------------------------------------------------------------------
+test_that("getTes() att_true is byte-exact on the non-marginal fixture", {
+	expect_equal(getTes(coefs_nm)$att_true, 1.822751, tolerance = 1e-6)
+})
+
+# ------------------------------------------------------------------------------
+# (3b) NON-PERTURBATION (seeded caller): getTes() must not advance the caller's
+# .Random.seed (Convention A). This is the core bug-fix regression.
+# ------------------------------------------------------------------------------
+test_that("getTes() does not perturb the caller's RNG (seeded caller)", {
+	set.seed(1)
+	before <- .Random.seed
+	invisible(getTes(coefs_nm))
+	expect_identical(.Random.seed, before)
+})
+
+# ------------------------------------------------------------------------------
+# (3c) NA-seed coefs: the cross-item blocker regression. A coefs object whose
+# $seed is NA must let getTes() run (mc_seed becomes NA -> .with_preserved_rng
+# -> .apply_seed treats NA as ambient) AND leave .Random.seed unchanged. Because
+# genCoefs(seed = NA) is now legal (item 2b), the freshly-built variant must run
+# too.
+# ------------------------------------------------------------------------------
+test_that("getTes() runs on an NA-seed coefs object and preserves the RNG", {
+	coefs_na <- coefs_nm
+	coefs_na$seed <- NA
+
+	expect_no_error(getTes(coefs_na))
+
+	set.seed(7)
+	before <- .Random.seed
+	invisible(getTes(coefs_na))
+	expect_identical(.Random.seed, before)
+})
+
+test_that("getTes() runs on a freshly genCoefs(seed = NA) non-marginal coefs", {
+	expect_no_error(
+		getTes(genCoefs(
+			G = 3,
+			T = 5,
+			d = 2,
+			density = 0.5,
+			eff_size = 2,
+			assignment_type = "multinomial",
+			seed = NA
+		))
+	)
+})
+
+# ------------------------------------------------------------------------------
+# (3d) NULL-seed coefs: getTes() runs and leaves .Random.seed unchanged. No
+# att_true pin -- the truth is drawn from the ambient stream (non-deterministic).
+# ------------------------------------------------------------------------------
+test_that("getTes() runs on a NULL-seed coefs object and preserves the RNG", {
+	coefs_null <- coefs_nm
+	coefs_null$seed <- NULL
+
+	expect_no_error(getTes(coefs_null))
+
+	set.seed(3)
+	before <- .Random.seed
+	invisible(getTes(coefs_null))
+	expect_identical(.Random.seed, before)
+})
+
+# ------------------------------------------------------------------------------
+# Item 2: `seed = NA` is a silent-ambient value across the data-gen API, and
+# honors an outer set.seed() (Convention B: ambient draw advances the caller's
+# stream). genCoefs / genCoefsCore / simulateDataCore must run without error and
+# be reproducible under the same outer seed.
+# ------------------------------------------------------------------------------
+test_that("genCoefs(seed = NA) runs silently and honors an outer set.seed()", {
+	expect_no_error(
+		genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = 2, seed = NA)
+	)
+
+	set.seed(99)
+	a <- genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = 2, seed = NA)
+	set.seed(99)
+	b <- genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = 2, seed = NA)
+	expect_identical(a$beta, b$beta)
+	expect_identical(a$theta, b$theta)
+})
+
+test_that("genCoefsCore(seed = NA) runs silently and honors an outer set.seed()", {
+	expect_no_error(
+		genCoefsCore(
+			G = 3,
+			T = 5,
+			d = 2,
+			density = 0.5,
+			eff_size = 2,
+			seed = NA
+		)
+	)
+
+	set.seed(123)
+	a <- genCoefsCore(
+		G = 3,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		seed = NA
+	)
+	set.seed(123)
+	b <- genCoefsCore(
+		G = 3,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		seed = NA
+	)
+	expect_identical(a$beta, b$beta)
+	expect_identical(a$theta, b$theta)
+})
+
+test_that("simulateDataCore(seed = NA) runs silently and honors an outer set.seed()", {
+	beta <- genCoefsCore(
+		G = 3,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		seed = 1
+	)$beta
+
+	expect_no_error(
+		simulateDataCore(
+			N = 30,
+			T = 5,
+			G = 3,
+			d = 2,
+			sig_eps_sq = 1,
+			sig_eps_c_sq = 1,
+			beta = beta,
+			seed = NA
+		)
+	)
+
+	set.seed(55)
+	a <- simulateDataCore(
+		N = 30,
+		T = 5,
+		G = 3,
+		d = 2,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 1,
+		beta = beta,
+		seed = NA
+	)
+	set.seed(55)
+	b <- simulateDataCore(
+		N = 30,
+		T = 5,
+		G = 3,
+		d = 2,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 1,
+		beta = beta,
+		seed = NA
+	)
+	expect_identical(a$y, b$y)
+	expect_identical(a$X, b$X)
+})
+
+# ------------------------------------------------------------------------------
+# Item 2: invalid seeds (non-numeric, length > 1) error with the canonical
+# message from .apply_seed().
+# ------------------------------------------------------------------------------
+test_that("the data-gen functions reject invalid seeds with the canonical message", {
+	expect_error(
+		genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = 2, seed = "x"),
+		regexp = "seed must be"
+	)
+	expect_error(
+		genCoefs(
+			G = 3,
+			T = 5,
+			d = 2,
+			density = 0.5,
+			eff_size = 2,
+			seed = c(1, 2)
+		),
+		regexp = "seed must be"
+	)
+	expect_error(
+		genCoefsCore(
+			G = 3,
+			T = 5,
+			d = 2,
+			density = 0.5,
+			eff_size = 2,
+			seed = "x"
+		),
+		regexp = "seed must be"
+	)
+	expect_error(
+		genCoefsCore(
+			G = 3,
+			T = 5,
+			d = 2,
+			density = 0.5,
+			eff_size = 2,
+			seed = c(1, 2)
+		),
+		regexp = "seed must be"
+	)
+
+	beta <- genCoefsCore(
+		G = 3,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		seed = 1
+	)$beta
+	expect_error(
+		simulateDataCore(
+			N = 30,
+			T = 5,
+			G = 3,
+			d = 2,
+			sig_eps_sq = 1,
+			sig_eps_c_sq = 1,
+			beta = beta,
+			seed = "x"
+		),
+		regexp = "seed must be"
+	)
+	expect_error(
+		simulateDataCore(
+			N = 30,
+			T = 5,
+			G = 3,
+			d = 2,
+			sig_eps_sq = 1,
+			sig_eps_c_sq = 1,
+			beta = beta,
+			seed = c(1, 2)
+		),
+		regexp = "seed must be"
+	)
+})


### PR DESCRIPTION

Refs #254 (follow-up to #250).

## The two seed conventions

The package has two *correct* RNG-seed conventions, split by a function's role:

- **Convention A — estimator nuisance.** A function that consumes randomness as
  an internal nuisance of an analysis seeds a fixed value and wraps the draw in
  `.with_preserved_rng()`, which saves and restores the caller's `.Random.seed`
  via `on.exit()`. Output is deterministic given its inputs, and the caller's
  random stream is never perturbed. This covers the CV-fold assignment in
  `getBetaCV()`, the `mvtnorm` quasi-Monte-Carlo integration in
  `.simultaneous_cis_impl()`, and — now — the truth integration in `getTes()`.
- **Convention B — data generation.** A data-generating function treats
  randomness as its product: an explicit numeric `seed` calls `set.seed()` and
  deliberately leaves the global RNG advanced; `seed = NA` (or `NULL`) draws
  from the ambient stream. This covers `simulateData()` / `simulateDataCore()`
  and `genCoefs()` / `genCoefsCore()`.

This PR aligns the two outliers without changing either convention.

## The `getTes()` bug fix

`getTes()` is an analysis/truth function (Convention A), but under a
covariate-dependent (`"multinomial"` / `"ordered"`) assignment DGP it integrates
the expected cohort propensities by Monte Carlo, and that draw previously
advanced the caller's `.Random.seed` as a side effect. The integration now runs
under `.with_preserved_rng(mc_seed, .expected_cohort_probs(..., seed = NULL))`,
so the caller's stream is saved and restored. The per-cohort truth is unchanged.

A new shared seed primitive, `.apply_seed(seed)` (`R/utility.R`), is the
canonical seed-to-RNG mapping (`NULL`/`NA` → ambient; single numeric →
`set.seed()`; else → a single canonical error). Both `.with_preserved_rng()` and
the four data-generation functions now route through it.

## The `seed = NA` harmonization

`genCoefs()`, `genCoefsCore()`, and `simulateDataCore()` now accept `seed = NA`
to draw from the ambient RNG silently (no `set.seed()` call), matching the
behavior already available on `simulateData()` (#250). The four data-gen sites
that read `if (!is.null(seed)) set.seed(seed)` were replaced by a single
`.apply_seed(seed)` call. This also resolves a cross-item blocker: a
`FETWFE_coefs` object built with `seed = NA` (now legal) flows into `getTes()`
as `mc_seed = NA`, which `.with_preserved_rng()` → `.apply_seed()` treats as an
ambient draw rather than erroring on `set.seed(NA)`.

The docs for `genCoefs` / `simulateData` gained an `@details` note that an
explicit numeric `seed` deliberately leaves the global RNG advanced (reproducible
yet varying), and that `seed = NA` draws from / preserves the ambient stream. A
present-tense "RNG / random-seed conventions" subsection documents A vs B in
`AGENTS.md`.

## Byte-exactness

The wrapped non-marginal draw is byte-identical to the previous behavior: the
same `set.seed(mc_seed)` is followed by the *immediate* `rnorm`/`runif` with
nothing consuming RNG in between, so only the *perturbation* is removed, not the
result. A new regression test pins the non-marginal `att_true` at
`1.822751376679849` (`expect_equal(..., tolerance = 1e-6)`); the tolerance
catches RNG-ordering drift (even a 1-draw shift moves `att_true` by ~2.5e-4, far
above 1e-6) while staying robust to platform floating-point. The full suite
(`FAIL 0`) proves non-breakage.

For the existing NULL/numeric seeds the four `.apply_seed()` swaps are
byte-identical; `NA` is the only newly-accepted value.

## Bookkeeping

Version 1.24.0 → 1.25.0, with a `NEWS.md` "Bug fixes" entry (`getTes()` RNG
non-perturbation) and a "New features" entry (`seed = NA` on
`genCoefs`/`genCoefsCore`/`simulateDataCore`). No `inst/CITATION` change.

## Gate results

- `air format .` — clean (reformatted only the new test file; R/ sources and
  `AGENTS.md` were already air-clean).
- `devtools::document()` — regenerated only `man/genCoefs.Rd`,
  `man/genCoefsCore.Rd`, `man/simulateData.Rd` (the two cohort helpers are
  `@noRd`); no unexpected drift.
- `devtools::test()` — `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 3331 ]`.
- `spelling::spell_check_package()` — "No spelling errors found."

(R CMD check is run by the parent.)

- `R CMD check --as-cran` (parent) — **0 errors | 0 warnings | 0 notes** (Status OK), fetwfe 1.25.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
