### PR TITLE
docs: clarify twfeCovs estimand wording and add 'Optional' to genCoefs @param G

### DIFF
--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -19,7 +19,7 @@
 #' byte-identically. See \code{vignette("simulation_vignette", package = "fetwfe")}
 #' for worked examples.
 #'
-#' @param G Integer. The number of treated cohorts (treatment is assumed to start in periods 2 to
+#' @param G Optional integer. The number of treated cohorts (treatment is assumed to start in periods 2 to
 #'   \code{G + 1}). Defaults to \code{NULL}; supply either \code{G} or the
 #'   deprecated alias \code{R} (described below).
 #' @param T Integer. The total number of time periods.

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -1,9 +1,9 @@
-#' @title Two-way fixed effects with covariates and separate treatment effects
-#' for each cohort
+#' @title Two-way fixed effects with covariates and a single pooled treatment
+#' effect per cohort
 #'
 #' @description **WARNING: This function should NOT be used for estimation. It
 #' is a biased estimator of treatment effects.** Implementation of two-way fixed
-#' effects with covariates and separate treatment effects for each cohort.
+#' effects with covariates and a single pooled treatment effect per cohort.
 #' Estimates overall ATT as well as CATT (cohort average treatment effects on
 #' the treated units). It is implemented only for the sake of the simulation
 #' studies in Faletto (2025). This estimator is only unbiased under the

--- a/man/genCoefs.Rd
+++ b/man/genCoefs.Rd
@@ -21,7 +21,7 @@ genCoefs(
 )
 }
 \arguments{
-\item{G}{Integer. The number of treated cohorts (treatment is assumed to start in periods 2 to
+\item{G}{Optional integer. The number of treated cohorts (treatment is assumed to start in periods 2 to
 \code{G + 1}). Defaults to \code{NULL}; supply either \code{G} or the
 deprecated alias \code{R} (described below).}
 

--- a/man/twfeCovs.Rd
+++ b/man/twfeCovs.Rd
@@ -2,8 +2,8 @@
 % Please edit documentation in R/twfeCovs.R
 \name{twfeCovs}
 \alias{twfeCovs}
-\title{Two-way fixed effects with covariates and separate treatment effects
-for each cohort}
+\title{Two-way fixed effects with covariates and a single pooled treatment
+effect per cohort}
 \usage{
 twfeCovs(
   pdata,
@@ -254,7 +254,7 @@ the labels are integer-coercible. New in v1.13.3 (issue #174).}
 \description{
 \strong{WARNING: This function should NOT be used for estimation. It
 is a biased estimator of treatment effects.} Implementation of two-way fixed
-effects with covariates and separate treatment effects for each cohort.
+effects with covariates and a single pooled treatment effect per cohort.
 Estimates overall ATT as well as CATT (cohort average treatment effects on
 the treated units). It is implemented only for the sake of the simulation
 studies in Faletto (2025). This estimator is only unbiased under the


### PR DESCRIPTION
## Summary

This PR addresses two documentation clarity issues identified in issue #257:

### 1. `twfeCovs()` estimand wording

The `@title` and `@description` of `twfeCovs()` incorrectly stated "separate treatment effects for each cohort." The function actually estimates a **single pooled effect per cohort** (pooled across all post-treatment periods, no cohort-time interactions). This contradicted the correct body text at lines 495 and 613.

**Fix:** Reworded to "single pooled treatment effect per cohort" to match the (correct) body text.

### 2. `genCoefs()` `@param G` missing "Optional" qualifier

The `@param G` description lacked the leading "Optional" qualifier that sibling params carry.

**Fix:** Added "Optional" to harmonize the tone.

## Changes

- `R/twfeCovs.R`: Updated `@title` and `@description` for `twfeCovs()`
- `R/gen_coefs.R`: Updated `@param G` description
- `man/twfeCovs.Rd`: Regenerated
- `man/genCoefs.Rd`: Regenerated

## Testing

- Ran `devtools::document()` to regenerate documentation
- Ran `devtools::test(filter="doc-slot-parity")` — all 140 tests pass
- No functional changes; documentation-only fix

## Related

Fixes #257