### PR TITLE
docs: guard fetwfe()/betwfe() bacondecomp examples with requireNamespace (#260)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.26.0
+Version: 1.26.1
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # NEWS
 
+## Version 1.26.1
+
+### Documentation
+
+- `fetwfe()` and `betwfe()` runnable `@examples` now guard their
+  `library(bacondecomp)` / `data(castle)` usage behind
+  `if (requireNamespace("bacondecomp", quietly = TRUE)) { ... }`. `bacondecomp`
+  is a Suggests-only dependency, so previously `example(fetwfe)` / `example(betwfe)`
+  errored for users without it installed (#260).
+- Clarified `twfeCovs()`'s title/description: it estimates a single pooled
+  treatment effect per cohort (not per-(cohort, time)), matching the body text;
+  added the "Optional" qualifier to `genCoefs()`'s `@param G` (#257).
+
 ## Version 1.26.0
 
 ### New features

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -319,49 +319,53 @@
 #' Pinheiro, J. C., & Bates, D. M. (2000). \emph{Mixed-Effects Models in
 #' S and S-PLUS}. Springer.
 #' @examples
-#' library(bacondecomp)
+#' # `bacondecomp` (which supplies the `castle` data) is a Suggests-only
+#' # dependency, so guard the example on its availability.
+#' if (requireNamespace("bacondecomp", quietly = TRUE)) {
+#'   library(bacondecomp)
 #'
-#' data(castle)
+#'   data(castle)
 #'
-#' # Response: the log homicide rate. Treatment: `cdl` records the share of
-#' # the year the castle-doctrine law was in effect, so `cdl > 0` gives the
-#' # absorbing 0/1 treatment indicator. No `covs`: castle's smallest
-#' # adoption cohorts contain a single state, so the design is
-#' # rank-deficient once any covariate is added.
-#' castle$l_homicide <- log(castle$homicide)
-#' castle$treated <- as.integer(castle$cdl > 0)
+#'   # Response: the log homicide rate. Treatment: `cdl` records the share of
+#'   # the year the castle-doctrine law was in effect, so `cdl > 0` gives the
+#'   # absorbing 0/1 treatment indicator. No `covs`: castle's smallest
+#'   # adoption cohorts contain a single state, so the design is
+#'   # rank-deficient once any covariate is added.
+#'   castle$l_homicide <- log(castle$homicide)
+#'   castle$treated <- as.integer(castle$cdl > 0)
 #'
-#' # On this panel betwfe's bridge penalty selects every cohort out, so the
-#' # estimated ATT and cohort effects below are all zero.
-#' res <- betwfe(
-#'     pdata = castle,
-#'     time_var = "year",
-#'     unit_var = "state",
-#'     treatment = "treated",
-#'     response = "l_homicide",
-#'     verbose = TRUE)
+#'   # On this panel betwfe's bridge penalty selects every cohort out, so the
+#'   # estimated ATT and cohort effects below are all zero.
+#'   res <- betwfe(
+#'       pdata = castle,
+#'       time_var = "year",
+#'       unit_var = "state",
+#'       treatment = "treated",
+#'       response = "l_homicide",
+#'       verbose = TRUE)
 #'
-#' # Average treatment effect on the treated units (in percentage point
-#' # units)
-#' 100 * res$att_hat
+#'   # Average treatment effect on the treated units (in percentage point
+#'   # units)
+#'   100 * res$att_hat
 #'
-#' # Conservative 95% confidence interval for ATT (in percentage point units)
+#'   # Conservative 95% confidence interval for ATT (in percentage point units)
 #'
-#' low_att <- 100 * (res$att_hat - qnorm(1 - 0.05 / 2) * res$att_se)
-#' high_att <- 100 * (res$att_hat + qnorm(1 - 0.05 / 2) * res$att_se)
+#'   low_att <- 100 * (res$att_hat - qnorm(1 - 0.05 / 2) * res$att_se)
+#'   high_att <- 100 * (res$att_hat + qnorm(1 - 0.05 / 2) * res$att_se)
 #'
-#' c(low_att, high_att)
+#'   c(low_att, high_att)
 #'
-#' # Cohort average treatment effects and confidence intervals (in percentage
-#' # point units)
+#'   # Cohort average treatment effects and confidence intervals (in percentage
+#'   # point units)
 #'
-#' catt_df_pct <- res$catt_df
-#' catt_df_pct[["estimate"]] <- 100 * catt_df_pct[["estimate"]]
-#' catt_df_pct[["se"]] <- 100 * catt_df_pct[["se"]]
-#' catt_df_pct[["ci_low"]] <- 100 * catt_df_pct[["ci_low"]]
-#' catt_df_pct[["ci_high"]] <- 100 * catt_df_pct[["ci_high"]]
+#'   catt_df_pct <- res$catt_df
+#'   catt_df_pct[["estimate"]] <- 100 * catt_df_pct[["estimate"]]
+#'   catt_df_pct[["se"]] <- 100 * catt_df_pct[["se"]]
+#'   catt_df_pct[["ci_low"]] <- 100 * catt_df_pct[["ci_low"]]
+#'   catt_df_pct[["ci_high"]] <- 100 * catt_df_pct[["ci_high"]]
 #'
-#' catt_df_pct
+#'   catt_df_pct
+#' }
 #' @export
 betwfe <- function(
 	pdata,

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -294,39 +294,43 @@
 #' Pinheiro, J. C., & Bates, D. M. (2000). \emph{Mixed-Effects Models in
 #' S and S-PLUS}. Springer.
 #' @examples
-#' library(bacondecomp)
+#' # `bacondecomp` (which supplies the `castle` data) is a Suggests-only
+#' # dependency, so guard the example on its availability.
+#' if (requireNamespace("bacondecomp", quietly = TRUE)) {
+#'   library(bacondecomp)
 #'
-#' data(castle)
+#'   data(castle)
 #'
-#' # Response: the log homicide rate. Treatment: `cdl` records the share of
-#' # the year the castle-doctrine law was in effect, so `cdl > 0` gives the
-#' # absorbing 0/1 treatment indicator `fetwfe()` requires.
-#' castle$l_homicide <- log(castle$homicide)
-#' castle$treated <- as.integer(castle$cdl > 0)
+#'   # Response: the log homicide rate. Treatment: `cdl` records the share of
+#'   # the year the castle-doctrine law was in effect, so `cdl > 0` gives the
+#'   # absorbing 0/1 treatment indicator `fetwfe()` requires.
+#'   castle$l_homicide <- log(castle$homicide)
+#'   castle$treated <- as.integer(castle$cdl > 0)
 #'
-#' # No `covs` here: castle's smallest adoption cohorts contain a single
-#' # state, so the design is rank-deficient once any covariate is added.
-#' # The v1.13.0+ default lambda_selection is "cv" (10-fold CV).
-#' res <- fetwfe(
-#'     pdata = castle,
-#'     time_var = "year",
-#'     unit_var = "state",
-#'     treatment = "treated",
-#'     response = "l_homicide",
-#'     verbose = TRUE)
+#'   # No `covs` here: castle's smallest adoption cohorts contain a single
+#'   # state, so the design is rank-deficient once any covariate is added.
+#'   # The v1.13.0+ default lambda_selection is "cv" (10-fold CV).
+#'   res <- fetwfe(
+#'       pdata = castle,
+#'       time_var = "year",
+#'       unit_var = "state",
+#'       treatment = "treated",
+#'       response = "l_homicide",
+#'       verbose = TRUE)
 #'
-#' # Print results with internal details
-#' print(res, max_cohorts = Inf)
+#'   # Print results with internal details
+#'   print(res, max_cohorts = Inf)
 #'
-#' # To recover the prior BIC behavior (e.g., for reproducing analyses
-#' # run against v1.12.0 or earlier), pass lambda_selection = "bic":
-#' res_bic <- fetwfe(
-#'     pdata = castle,
-#'     time_var = "year",
-#'     unit_var = "state",
-#'     treatment = "treated",
-#'     response = "l_homicide",
-#'     lambda_selection = "bic")
+#'   # To recover the prior BIC behavior (e.g., for reproducing analyses
+#'   # run against v1.12.0 or earlier), pass lambda_selection = "bic":
+#'   res_bic <- fetwfe(
+#'       pdata = castle,
+#'       time_var = "year",
+#'       unit_var = "state",
+#'       treatment = "treated",
+#'       response = "l_homicide",
+#'       lambda_selection = "bic")
+#' }
 #'
 #' @export
 fetwfe <- function(

--- a/man/betwfe.Rd
+++ b/man/betwfe.Rd
@@ -357,49 +357,53 @@ penalty. Estimates overall ATT as well as CATT (cohort average treatment
 effects on the treated units).
 }
 \examples{
-library(bacondecomp)
+# `bacondecomp` (which supplies the `castle` data) is a Suggests-only
+# dependency, so guard the example on its availability.
+if (requireNamespace("bacondecomp", quietly = TRUE)) {
+  library(bacondecomp)
 
-data(castle)
+  data(castle)
 
-# Response: the log homicide rate. Treatment: `cdl` records the share of
-# the year the castle-doctrine law was in effect, so `cdl > 0` gives the
-# absorbing 0/1 treatment indicator. No `covs`: castle's smallest
-# adoption cohorts contain a single state, so the design is
-# rank-deficient once any covariate is added.
-castle$l_homicide <- log(castle$homicide)
-castle$treated <- as.integer(castle$cdl > 0)
+  # Response: the log homicide rate. Treatment: `cdl` records the share of
+  # the year the castle-doctrine law was in effect, so `cdl > 0` gives the
+  # absorbing 0/1 treatment indicator. No `covs`: castle's smallest
+  # adoption cohorts contain a single state, so the design is
+  # rank-deficient once any covariate is added.
+  castle$l_homicide <- log(castle$homicide)
+  castle$treated <- as.integer(castle$cdl > 0)
 
-# On this panel betwfe's bridge penalty selects every cohort out, so the
-# estimated ATT and cohort effects below are all zero.
-res <- betwfe(
-    pdata = castle,
-    time_var = "year",
-    unit_var = "state",
-    treatment = "treated",
-    response = "l_homicide",
-    verbose = TRUE)
+  # On this panel betwfe's bridge penalty selects every cohort out, so the
+  # estimated ATT and cohort effects below are all zero.
+  res <- betwfe(
+      pdata = castle,
+      time_var = "year",
+      unit_var = "state",
+      treatment = "treated",
+      response = "l_homicide",
+      verbose = TRUE)
 
-# Average treatment effect on the treated units (in percentage point
-# units)
-100 * res$att_hat
+  # Average treatment effect on the treated units (in percentage point
+  # units)
+  100 * res$att_hat
 
-# Conservative 95\% confidence interval for ATT (in percentage point units)
+  # Conservative 95\% confidence interval for ATT (in percentage point units)
 
-low_att <- 100 * (res$att_hat - qnorm(1 - 0.05 / 2) * res$att_se)
-high_att <- 100 * (res$att_hat + qnorm(1 - 0.05 / 2) * res$att_se)
+  low_att <- 100 * (res$att_hat - qnorm(1 - 0.05 / 2) * res$att_se)
+  high_att <- 100 * (res$att_hat + qnorm(1 - 0.05 / 2) * res$att_se)
 
-c(low_att, high_att)
+  c(low_att, high_att)
 
-# Cohort average treatment effects and confidence intervals (in percentage
-# point units)
+  # Cohort average treatment effects and confidence intervals (in percentage
+  # point units)
 
-catt_df_pct <- res$catt_df
-catt_df_pct[["estimate"]] <- 100 * catt_df_pct[["estimate"]]
-catt_df_pct[["se"]] <- 100 * catt_df_pct[["se"]]
-catt_df_pct[["ci_low"]] <- 100 * catt_df_pct[["ci_low"]]
-catt_df_pct[["ci_high"]] <- 100 * catt_df_pct[["ci_high"]]
+  catt_df_pct <- res$catt_df
+  catt_df_pct[["estimate"]] <- 100 * catt_df_pct[["estimate"]]
+  catt_df_pct[["se"]] <- 100 * catt_df_pct[["se"]]
+  catt_df_pct[["ci_low"]] <- 100 * catt_df_pct[["ci_low"]]
+  catt_df_pct[["ci_high"]] <- 100 * catt_df_pct[["ci_high"]]
 
-catt_df_pct
+  catt_df_pct
+}
 }
 \references{
 Faletto, G (2025). Fused Extended Two-Way Fixed Effects for

--- a/man/fetwfe.Rd
+++ b/man/fetwfe.Rd
@@ -332,39 +332,43 @@ Estimates overall ATT as well as CATT (cohort average treatment effects on
 the treated units).
 }
 \examples{
-library(bacondecomp)
+# `bacondecomp` (which supplies the `castle` data) is a Suggests-only
+# dependency, so guard the example on its availability.
+if (requireNamespace("bacondecomp", quietly = TRUE)) {
+  library(bacondecomp)
 
-data(castle)
+  data(castle)
 
-# Response: the log homicide rate. Treatment: `cdl` records the share of
-# the year the castle-doctrine law was in effect, so `cdl > 0` gives the
-# absorbing 0/1 treatment indicator `fetwfe()` requires.
-castle$l_homicide <- log(castle$homicide)
-castle$treated <- as.integer(castle$cdl > 0)
+  # Response: the log homicide rate. Treatment: `cdl` records the share of
+  # the year the castle-doctrine law was in effect, so `cdl > 0` gives the
+  # absorbing 0/1 treatment indicator `fetwfe()` requires.
+  castle$l_homicide <- log(castle$homicide)
+  castle$treated <- as.integer(castle$cdl > 0)
 
-# No `covs` here: castle's smallest adoption cohorts contain a single
-# state, so the design is rank-deficient once any covariate is added.
-# The v1.13.0+ default lambda_selection is "cv" (10-fold CV).
-res <- fetwfe(
-    pdata = castle,
-    time_var = "year",
-    unit_var = "state",
-    treatment = "treated",
-    response = "l_homicide",
-    verbose = TRUE)
+  # No `covs` here: castle's smallest adoption cohorts contain a single
+  # state, so the design is rank-deficient once any covariate is added.
+  # The v1.13.0+ default lambda_selection is "cv" (10-fold CV).
+  res <- fetwfe(
+      pdata = castle,
+      time_var = "year",
+      unit_var = "state",
+      treatment = "treated",
+      response = "l_homicide",
+      verbose = TRUE)
 
-# Print results with internal details
-print(res, max_cohorts = Inf)
+  # Print results with internal details
+  print(res, max_cohorts = Inf)
 
-# To recover the prior BIC behavior (e.g., for reproducing analyses
-# run against v1.12.0 or earlier), pass lambda_selection = "bic":
-res_bic <- fetwfe(
-    pdata = castle,
-    time_var = "year",
-    unit_var = "state",
-    treatment = "treated",
-    response = "l_homicide",
-    lambda_selection = "bic")
+  # To recover the prior BIC behavior (e.g., for reproducing analyses
+  # run against v1.12.0 or earlier), pass lambda_selection = "bic":
+  res_bic <- fetwfe(
+      pdata = castle,
+      time_var = "year",
+      unit_var = "state",
+      treatment = "treated",
+      response = "l_homicide",
+      lambda_selection = "bic")
+}
 
 }
 \references{


### PR DESCRIPTION
Refs #260.

`fetwfe()` and `betwfe()`'s primary runnable `@examples` opened with a bare
`library(bacondecomp)` + `data(castle)`. `bacondecomp` is a **Suggests-only**
dependency, so `example(fetwfe)` / `example(betwfe)` errored with
`there is no package called 'bacondecomp'` for any user without it installed.
(`R CMD check --as-cran` installs `Suggests`, so the check itself was always clean —
this only bit interactive `example()` use.)

## Fix
Wrap each of the two affected example bodies in
`if (requireNamespace("bacondecomp", quietly = TRUE)) { ... }`. With `bacondecomp`
present (including under `R CMD check`) the example runs exactly as before; without
it, the example is silently skipped instead of erroring.

## Scope — deliberately just two examples
Only `fetwfe()` and `betwfe()` have **un-guarded, runnable** bacondecomp examples.
The other estimator examples are intentionally left untouched:
- `etwfe()`'s bacondecomp example is already inside `\dontrun{}` (never runs → no
  problem).
- `fetwfeWithSimulatedData()` / `etwfeWithSimulatedData()` /
  `betwfeWithSimulatedData()` use `genCoefs()` / `simulateData()` and **do not use
  `bacondecomp` at all**, so they must NOT be gated on it.

(This is the narrowly-correct implementation of #260. The open drive-by PR #262
applied the `bacondecomp` guard to all six examples — including the three
`simulateData`-based ones that don't use `bacondecomp` — which is incorrect; this
PR supersedes it.)

## Bookkeeping
- Version 1.26.0 → 1.26.1. The `NEWS.md` 1.26.1 section also documents the #257
  doc-clarity fix (twfeCovs estimand wording + `genCoefs()` `@param G` "Optional"),
  which merged via #259 without a NEWS entry.

## Gate results
- `air format .`: clean.
- `devtools::document()`: regenerated only `man/fetwfe.Rd` + `man/betwfe.Rd`; no drift.
- `devtools::test()`: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 3351 ]`.
- `R CMD check --as-cran`: **0 errors | 0 warnings | 0 notes** (Status OK), fetwfe 1.26.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
