### PR TITLE
fix: label FETWFE_tes cohorts by adoption time consistently across print/summary/tidy (#261)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.26.1
+Version: 1.26.2
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # NEWS
 
+## Version 1.26.2
+
+### Bug fixes
+
+- `print()` and `summary()` for the `FETWFE_tes` object returned by `getTes()`
+  now label cohorts by calendar adoption time (cohort `g` adopts at time `g + 1`),
+  matching `tidy.FETWFE_tes()` and the fitted estimators' `catt_df$cohort`.
+  Previously they used the 1-based loop index, so the same cohort showed as e.g.
+  "Cohort 1" under `print()` / `summary()` but "Cohort 2" under `tidy()`. The
+  convention now lives in one shared helper (#261).
+
 ## Version 1.26.1
 
 ### Documentation

--- a/R/broom_methods.R
+++ b/R/broom_methods.R
@@ -686,13 +686,9 @@ tidy.cohortStudy <- function(x, ...) {
 tidy.FETWFE_tes <- function(x, conf.int = TRUE, conf.level = 0.95, ...) {
 	stopifnot(conf.level > 0, conf.level < 1)
 	G <- length(x$actual_cohort_tes)
-	cohort_times <- if (!is.null(x$cohort_times)) {
-		x$cohort_times
-	} else {
-		# Fallback for pre-1.9.0 dev objects without the slot: use the
-		# simulator's convention that cohort g adopts at calendar time g + 1.
-		as.integer(seq_len(G) + 1L)
-	}
+	# Cohorts are labeled by calendar adoption time (#261), shared with
+	# print/summary.FETWFE_tes via .resolve_tes_cohort_times().
+	cohort_times <- .resolve_tes_cohort_times(x)
 	terms <- c("ATT_true", paste0("Cohort ", cohort_times))
 	estimates <- c(x$att_true, x$actual_cohort_tes)
 	out <- data.frame(

--- a/R/getTes_class.R
+++ b/R/getTes_class.R
@@ -27,6 +27,18 @@ NULL
 	invisible(NULL)
 }
 
+# Resolve cohort labels for a FETWFE_tes (or summary.FETWFE_tes) object by
+# calendar adoption time (cohort g adopts at time g + 1), matching
+# tidy.FETWFE_tes() and the fitted estimators' catt_df$cohort (#261). Falls back
+# to the simulator convention for pre-1.9.0 objects lacking the slot.
+.resolve_tes_cohort_times <- function(x) {
+	if (!is.null(x$cohort_times)) {
+		x$cohort_times
+	} else {
+		as.integer(seq_along(x$actual_cohort_tes) + 1L)
+	}
+}
+
 #' @export
 print.FETWFE_tes <- function(x, ...) {
 	cat(
@@ -35,9 +47,14 @@ print.FETWFE_tes <- function(x, ...) {
 		sep = ""
 	)
 	cat(sprintf("Overall true ATT: %.4f\n\n", x$att_true))
+	cohort_times <- .resolve_tes_cohort_times(x)
 	cat("Cohort effects:\n")
 	for (g in seq_along(x$actual_cohort_tes)) {
-		cat(sprintf("  Cohort %d: %.4f\n", g, x$actual_cohort_tes[g]))
+		cat(sprintf(
+			"  Cohort %d: %.4f\n",
+			cohort_times[g],
+			x$actual_cohort_tes[g]
+		))
 	}
 	cat("\n")
 	.cat_tes_assignment_dgp(x)
@@ -67,6 +84,7 @@ summary.FETWFE_tes <- function(object, ...) {
 		d = object$d,
 		seed = object$seed,
 		cohort_weights = object$cohort_weights,
+		cohort_times = object$cohort_times,
 		assignment_type = object$assignment_type,
 		assignment_strength = object$assignment_strength,
 		cohort_te_stats = c(
@@ -87,9 +105,14 @@ print.summary.FETWFE_tes <- function(x, ...) {
 		sep = ""
 	)
 	cat(sprintf("Overall true ATT: %.4f\n\n", x$att_true))
+	cohort_times <- .resolve_tes_cohort_times(x)
 	cat("Cohort effects:\n")
 	for (g in seq_along(x$actual_cohort_tes)) {
-		cat(sprintf("  Cohort %d: %.4f\n", g, x$actual_cohort_tes[g]))
+		cat(sprintf(
+			"  Cohort %d: %.4f\n",
+			cohort_times[g],
+			x$actual_cohort_tes[g]
+		))
 	}
 	cat("\n")
 	cat("Cohort effect dispersion:\n")

--- a/tests/testthat/test-getTes.R
+++ b/tests/testthat/test-getTes.R
@@ -169,13 +169,49 @@ test_that("print.FETWFE_tes writes the expected sections", {
 	out <- capture.output(print(getTes(coefs)))
 	joined <- paste(out, collapse = "\n")
 	expect_match(joined, "Overall true ATT")
-	expect_match(joined, "Cohort 1")
+	# Cohorts are labeled by calendar adoption time (g + 1), so for G = 3 the
+	# labels are Cohort 2/3/4, not the 1-based index (#261).
 	expect_match(joined, "Cohort 2")
 	expect_match(joined, "Cohort 3")
+	expect_match(joined, "Cohort 4")
 	expect_match(joined, "Cohorts \\(G\\)")
 	expect_match(joined, "Time periods \\(T\\)")
 	expect_match(joined, "Covariates \\(d\\)")
 	expect_match(joined, "Seed")
+})
+
+# ------------------------------------------------------------------------------
+# #261: print / summary / tidy.FETWFE_tes must label cohorts identically, by
+# calendar adoption time (cohort g adopts at time g + 1), matching the fitted
+# estimators' catt_df$cohort -- never the 1-based loop index.
+# ------------------------------------------------------------------------------
+test_that("FETWFE_tes cohort labels agree across print/summary/tidy (adoption time, #261)", {
+	coefs <- genCoefs(
+		G = 3,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 1,
+		seed = 1
+	)
+	tes <- getTes(coefs)
+	expect_equal(tes$cohort_times, as.integer(c(2, 3, 4)))
+
+	p <- paste(capture.output(print(tes)), collapse = "\n")
+	s <- paste(capture.output(print(summary(tes))), collapse = "\n")
+	td <- broom::tidy(tes)
+
+	# All three label cohorts by adoption time (2, 3, 4).
+	for (lab in c("Cohort 2:", "Cohort 3:", "Cohort 4:")) {
+		expect_match(p, lab, fixed = TRUE)
+		expect_match(s, lab, fixed = TRUE)
+	}
+	expect_setequal(td$term, c("ATT_true", "Cohort 2", "Cohort 3", "Cohort 4"))
+
+	# The old 1-based index labeling is gone (cohort 1 is now "Cohort 2").
+	expect_no_match(p, "Cohort 1:", fixed = TRUE)
+	expect_no_match(s, "Cohort 1:", fixed = TRUE)
+	expect_false("Cohort 1" %in% td$term)
 })
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Refs #261.

For the `FETWFE_tes` object returned by `getTes()`, the three accessors labeled
cohorts two different ways: `print.FETWFE_tes` / `summary.FETWFE_tes` used the
1-based loop index (`Cohort 1, 2, …`), while `tidy.FETWFE_tes` used the calendar
adoption time (`cohort_times = g + 1`, i.e. `Cohort 2, 3, …`). So the *same* cohort
read as "Cohort 1" under `print()` but "Cohort 2" under `tidy()`.

## Fix
`print` and `summary` now label cohorts by **adoption time** too, matching `tidy`
and the fitted estimators' `catt_df$cohort`. The convention is centralized in one
internal helper, `.resolve_tes_cohort_times()` — used by all three accessors, with
the existing fallback for pre-1.9.0 objects lacking the `cohort_times` slot — so it
can't drift apart again. The per-cohort effect *values* are unchanged; only the
labels.

## Behavior change (user-visible)
`print(getTes(coefs))` / `summary(...)` now show e.g. `Cohort 2/3/4` (for G = 3)
instead of `Cohort 1/2/3`. (`tidy()` already used adoption time, so it is unchanged.)

## Tests
- Updated the existing `print.FETWFE_tes` section test for the new labels (it
  already carried a "relabeling requires updating this test" note).
- New test pinning label consistency across `print` / `summary` / `tidy` (all show
  the adoption-time labels; the 1-based label is absent). **Mutation-checked:**
  reverting the helper to the index makes it FAIL (the "Cohort 4" assertions bite).

## Bookkeeping
- Version 1.26.1 → 1.26.2; `NEWS.md` "Bug fixes" entry.

## Gate results
- `air format .`: clean.
- `devtools::document()`: no drift (no roxygen changed; function bodies + an
  internal helper only).
- `devtools::test()`: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 3362 ]`.
- `R CMD check --as-cran`: **0 errors | 0 warnings | 0 notes** (Status OK), fetwfe 1.26.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
