### PR TITLE
docs: document the cohort row-order invariant for the simultaneous-CI band (#258)

### DIFF
--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -881,6 +881,10 @@ simultaneousCIs.twfeCovs <- function(
 
 	if (family == "cohort") {
 		# Effect g = cohort g's ATT = mean(tes over cohort g's block).
+		# ORDER-INVARIANT (#258): rows are built in g = 1:G order, matching
+		# getCohortATTsFinal()'s catt_df row order, so
+		# .apply_simultaneous_catt_band() can positionally row-bind the resulting
+		# band to catt_df. Do NOT reorder without making that binding label-based.
 		psi_tes <- matrix(0, nrow = G, ncol = num_treats)
 		for (g in 1:G) {
 			block <- .cohort_block_inds(g, G, first_inds, num_treats)

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -1538,7 +1538,11 @@ getCohortATTsFinal <- function(
 
 	psi_mat <- matrix(0, length(sel_treat_inds_shifted), G)
 
-	# loop over cohorts
+	# Loop over cohorts in g = 1:G order. ORDER-INVARIANT (#258): this defines the
+	# row order of the returned `catt_df`, which `.apply_simultaneous_catt_band()`
+	# positionally row-binds against `.build_psi_tes_for_family(family = "cohort")`
+	# (also g = 1:G). Do NOT reorder these rows without making that binding
+	# label-based.
 	for (g in 1:G) {
 		# Get indices corresponding to marginal treatment effects for rth cohort.
 		# Endpoint-preservation form: downstream `getPsiGFused()` takes


### PR DESCRIPTION
Refs #258.

#258 tracked two residual test-robustness nits from the 2026-06-03 review.

## Item 1 — already resolved (no action)
The event-study + cluster widening assertion is **no longer** conditionally
skipped. `tests/testthat/test-ci-type-197.R:677-684` already does
`expect_gte(sum(es_fin), 2L)` (the AR(1) fixture is guaranteed to keep >= 2
finite-SE event times) followed by an **unconditional** `simultaneous > pointwise`
widening check, with a comment explaining why it asserts rather than silently
skips. (Landed with the #242 sweep; verified against current code.)

## Item 2 — this PR (comment-only)
Added an explicit **ORDER-INVARIANT** comment to the two source functions whose
`g = 1:G` iteration order `.apply_simultaneous_catt_band()` relies on for
positional row-binding:
- `getCohortATTsFinal()` (`R/variance_machinery.R`) — defines the `catt_df` row
  order.
- `.build_psi_tes_for_family(family = "cohort")` (`R/simultaneous_cis.R`) — builds
  the band rows in the same order.

The *consumer* (`.apply_simultaneous_catt_band()`) already documented this
dependency; now the two *sources* do too, so someone editing either is warned not
to reorder without making the binding label-based.

Comment-only: no logic, test, or doc change → **no version bump, no NEWS**
(`man/` / `NAMESPACE` unchanged).

## Gate results
- `air format .`: clean.
- `devtools::document()`: no drift (comments don't affect roxygen/man).
- `devtools::test()`: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 3362 ]`.
- `R CMD check --as-cran`: **0 errors | 0 warnings | 0 notes** (Status OK), fetwfe
  1.26.2 (unchanged — comment-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
