### PR TITLE
fix: warn when only one of sig_eps_sq/sig_eps_c_sq is supplied (it was silently discarded) (#266)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.26.2
+Version: 1.26.3
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # NEWS
 
+## Version 1.26.3
+
+### Bug fixes
+
+- The estimators (`fetwfe()` / `etwfe()` / `betwfe()` / `twfeCovs()`) now emit a
+  warning when exactly one of `sig_eps_sq` / `sig_eps_c_sq` is supplied and the
+  other is left `NA`. The two noise variances are estimated jointly by REML, so
+  supplying only one silently discarded it (re-estimating both); the warning
+  names the ignored value and notes that they must be supplied together or both
+  omitted (#266).
+
 ## Version 1.26.2
 
 ### Bug fixes

--- a/R/gls_machinery.R
+++ b/R/gls_machinery.R
@@ -5,7 +5,9 @@
 
 #' @title Estimate variance components and apply GLS whitening
 #' @description If `sig_eps_sq` or `sig_eps_c_sq` is NA, estimate both via
-#'   `estOmegaSqrtInv()` (REML on `y ~ X + (1 | unit)`). Then build
+#'   `estOmegaSqrtInv()` (REML on `y ~ X + (1 | unit)`) -- warning when exactly
+#'   one was supplied, since REML estimates them jointly so the supplied value is
+#'   discarded (#266). Then build
 #'   `Omega = sig_eps_sq * I_T + sig_eps_c_sq * J_T`, take its
 #'   matrix square root inverse, and apply the kronecker-product GLS
 #'   transform to `y` and `X_mod`.
@@ -37,6 +39,23 @@
 	}
 
 	if (is.na(sig_eps_sq) | is.na(sig_eps_c_sq)) {
+		# Both noise variances are estimated jointly by REML, so supplying only
+		# ONE of them silently discards it. Warn when exactly one is given (#266).
+		if (xor(is.na(sig_eps_sq), is.na(sig_eps_c_sq))) {
+			supplied <- if (is.na(sig_eps_sq)) {
+				sprintf("sig_eps_c_sq = %g", sig_eps_c_sq)
+			} else {
+				sprintf("sig_eps_sq = %g", sig_eps_sq)
+			}
+			warning(
+				"Only one of `sig_eps_sq` / `sig_eps_c_sq` was supplied (",
+				supplied,
+				"); the two noise variances are estimated jointly (REML), so the ",
+				"supplied value is ignored and both are re-estimated. Supply both ",
+				"(or neither) to control the noise variances.",
+				call. = FALSE
+			)
+		}
 		omega_res <- estOmegaSqrtInv(
 			y,
 			X_ints,

--- a/tests/testthat/test-partial-variance-warning-266.R
+++ b/tests/testthat/test-partial-variance-warning-266.R
@@ -1,0 +1,69 @@
+library(testthat)
+library(fetwfe)
+
+# ------------------------------------------------------------------------------
+# #266: supplying exactly ONE of sig_eps_sq / sig_eps_c_sq used to silently
+# discard it -- REML re-estimates BOTH noise variances jointly, so the supplied
+# value was overwritten with no signal. .estimate_variance_and_gls() now warns
+# when exactly one is supplied. The guard is shared by all four estimators; etwfe
+# (pure OLS) is the fastest path through it.
+# ------------------------------------------------------------------------------
+test_that("supplying exactly one noise variance warns; both/neither is silent (#266)", {
+	skip_if_not_installed("lme4") # the NA path estimates via REML (estOmegaSqrtInv)
+
+	coefs <- genCoefs(
+		G = 3,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 1,
+		seed = 1
+	)
+	sim <- simulateData(
+		coefs,
+		N = 120,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 1
+	)
+	base <- list(
+		pdata = sim$pdata,
+		time_var = sim$time_var,
+		unit_var = sim$unit_var,
+		treatment = sim$treatment,
+		response = sim$response,
+		covs = sim$covs
+	)
+	warns_of <- function(extra) {
+		w <- character(0)
+		withCallingHandlers(
+			suppressMessages(do.call(etwfe, c(base, extra))),
+			warning = function(c) {
+				w <<- c(w, conditionMessage(c))
+				invokeRestart("muffleWarning")
+			}
+		)
+		w
+	}
+
+	# Partial provision (either direction) -> warns and names the discarded value.
+	w_sq <- warns_of(list(sig_eps_sq = 1, sig_eps_c_sq = NA))
+	expect_true(any(grepl("Only one of", w_sq, fixed = TRUE)))
+	expect_true(any(grepl("sig_eps_sq = 1", w_sq, fixed = TRUE)))
+
+	w_c <- warns_of(list(sig_eps_sq = NA, sig_eps_c_sq = 0.5))
+	expect_true(any(grepl("Only one of", w_c, fixed = TRUE)))
+	expect_true(any(grepl("sig_eps_c_sq = 0.5", w_c, fixed = TRUE)))
+
+	# Both supplied OR both omitted -> NO partial-provision warning.
+	expect_false(any(grepl(
+		"Only one of",
+		warns_of(list(sig_eps_sq = 1, sig_eps_c_sq = 0.5)),
+		fixed = TRUE
+	)))
+	expect_false(any(grepl(
+		"Only one of",
+		warns_of(list(sig_eps_sq = NA, sig_eps_c_sq = NA)),
+		fixed = TRUE
+	)))
+})


### PR DESCRIPTION
Refs #266.

`.estimate_variance_and_gls()` (`R/gls_machinery.R:39`) re-estimates **both** noise
variances via REML whenever **either** `sig_eps_sq` or `sig_eps_c_sq` is `NA` — REML
estimates them jointly. So a user who supplied a *known* `sig_eps_sq` with
`sig_eps_c_sq = NA` had their value **silently discarded** and both re-estimated,
with no warning and measurably wrong SEs (`Omega^(-1/2)` scales with
`sqrt(sig_eps_sq)` — ~6× SE distortion in the review's repro). Input validation
didn't enforce both-or-neither, and the entry-point roxygen documents each variance
independently, inviting partial provision. (Confirmed in the 2026-06-06 review, B1.)

## Fix
Emit a `warning()` when exactly one component is `NA` and the other is supplied,
naming the ignored value and telling the user to supply both or neither. The guard
lives in the shared `.estimate_variance_and_gls()`, so all four estimators
(fetwfe/etwfe/betwfe/twfeCovs) get it. Behavior is otherwise unchanged — the value
was already being re-estimated; now it's loud, not silent.

Not attempted: honoring the supplied component and estimating only the other — REML
estimates them jointly, which would need a profiled/conditional estimator (out of
scope, per the issue).

## Scope note on the docs
The synthesis flagged the entry-point `@param` blocks as "inviting partial
provision." Each `@param`'s "can be omitted" is individually *accurate* (you may omit
either), and the runtime warning now catches the joint-provision case loudly — so I
left the variance `@param` text as-is rather than edit it, since it's duplicated
byte-for-byte across each estimator and its `*WithSimulatedData` wrapper (that
duplication is itself tracked in the OLS-refactor issue #270). Happy to add a
joint-requirement note there if you'd prefer.

## Tests
New `test-partial-variance-warning-266.R`: warns (and names the discarded value) on
both partial-provision directions; silent when both supplied or both omitted.
**Mutation-checked:** disabling the warning condition FAILs the partial-provision
assertions.

## Bookkeeping
Version 1.26.2 → 1.26.3; `NEWS.md` "Bug fixes".

## Gate results
- `air format .`: clean.
- `devtools::document()`: no drift (the warning is code; the internal `@noRd`
  description note generates no man page).
- `devtools::test()`: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 3368 ]`.
- `R CMD check --as-cran`: **0 errors | 0 warnings | 0 notes** (Status OK), fetwfe 1.26.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
