### PR TITLE
fix: print.twfeCovs(max_event_times=) parity + out_names contract validation (#267, #268)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.26.4
+Version: 1.26.5
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # NEWS
 
+## Version 1.26.5
+
+### Bug fixes
+
+- `print.twfeCovs()` now accepts a `max_event_times` argument, for parity with the
+  other estimators' print methods, instead of erroring with "argument matched by
+  multiple actual arguments" when one was supplied. The argument is a no-op for
+  `twfeCovs` (its output has no event-study section) (#267).
+- `attgtToFetwfeDf()` / `etwfeToFetwfeDf()` now validate the `out_names` argument
+  (it must be a list containing the four keys `time`, `unit`, `treatment`, and
+  `response`) and raise a clear error naming that contract, instead of failing later
+  with a cryptic internal message — including the case of a named character vector,
+  which carries the right names but is indexed with `$` downstream (#268).
+
 ## Version 1.26.4
 
 ### Improvements

--- a/R/convert_dfs.R
+++ b/R/convert_dfs.R
@@ -281,6 +281,20 @@ etwfeToFetwfeDf <- function(
 	verbose = FALSE
 ) {
 	stopifnot(is.data.frame(data))
+	# Validate the `out_names` contract (#268): it must be a *list* (the assembly
+	# below uses `out_names$time` etc., so a named character vector would crash at
+	# `$` with "$ operator is invalid for atomic vectors") containing the four
+	# required keys. Without this, a missing or mistyped key surfaces only as a
+	# cryptic internal error ("select less than one element") that never mentions
+	# `out_names`.
+	out_names_required <- c("time", "unit", "treatment", "response")
+	if (!is.list(out_names) || !all(out_names_required %in% names(out_names))) {
+		stop(
+			"`out_names` must be a list containing the four names `time`, `unit`, ",
+			"`treatment`, and `response`.",
+			call. = FALSE
+		)
+	}
 	required <- unlist(vars, use.names = FALSE)
 	missing <- setdiff(c(required, covars), names(data))
 	if (length(missing)) {

--- a/R/twfeCovs_class.R
+++ b/R/twfeCovs_class.R
@@ -32,6 +32,7 @@ print.twfeCovs <- function(
 	max_cohorts = getOption("twfeCovs.max_cohorts", 10),
 	order_by = c("cohort", "estimate", "abs_estimate", "pvalue", "none"),
 	show_internal = FALSE,
+	max_event_times = getOption("twfeCovs.max_event_times", 10),
 	...
 ) {
 	.print_estimator_output(
@@ -45,7 +46,7 @@ print.twfeCovs <- function(
 		max_cohorts = max_cohorts,
 		order_by = match.arg(order_by),
 		show_internal = show_internal,
-		max_event_times = 10L,
+		max_event_times = max_event_times,
 		include_event_study = FALSE,
 		...
 	)

--- a/tests/testthat/test-out-names-validation-268.R
+++ b/tests/testthat/test-out-names-validation-268.R
@@ -1,0 +1,65 @@
+library(testthat)
+library(fetwfe)
+
+# ------------------------------------------------------------------------------
+# #268: malformed `out_names` (passed through attgtToFetwfeDf()/etwfeToFetwfeDf()
+# to .fetwfe_df_core()) must error with the documented four-name contract, not a
+# cryptic internal error ("attempt to select less than one element", "$ operator is
+# invalid for atomic vectors"). The named-character-vector case is the subtle one:
+# it carries the four names yet the assembly indexes with `$`, invalid for an atomic
+# vector -- so the guard must require a *list*, not merely the right names.
+# ------------------------------------------------------------------------------
+test_that("malformed out_names errors with the four-name contract message (#268)", {
+	df <- data.frame(
+		county = rep(1:3, each = 3),
+		year = rep(2000:2002, times = 3),
+		first.treat = rep(c(0L, 0L, 2001L), each = 3),
+		lemp = as.numeric(1:9)
+	)
+	call_with <- function(on) {
+		etwfeToFetwfeDf(
+			data = df,
+			yvar = "lemp",
+			tvar = "year",
+			idvar = "county",
+			gvar = "first.treat",
+			out_names = on
+		)
+	}
+	msg <- "must be a list containing the four names"
+
+	# Missing a required key.
+	expect_error(
+		call_with(list(time = "t", unit = "u", treatment = "tr")),
+		msg,
+		fixed = TRUE
+	)
+	# Mistyped key (`treat` instead of `treatment`).
+	expect_error(
+		call_with(list(time = "t", unit = "u", treat = "tr", response = "r")),
+		msg,
+		fixed = TRUE
+	)
+	# Named character VECTOR: carries all four names but is not a list.
+	expect_error(
+		call_with(c(time = "t", unit = "u", treatment = "tr", response = "r")),
+		msg,
+		fixed = TRUE
+	)
+
+	# A well-formed list must NOT raise the contract error (any later error -- e.g.
+	# from the tiny panel -- is unrelated to out_names validation).
+	good_err <- tryCatch(
+		{
+			call_with(list(
+				time = "time_var",
+				unit = "unit_var",
+				treatment = "treatment",
+				response = "response"
+			))
+			NA_character_
+		},
+		error = function(e) conditionMessage(e)
+	)
+	expect_false(isTRUE(grepl(msg, good_err, fixed = TRUE)))
+})

--- a/tests/testthat/test-print-twfecovs-max-event-times-267.R
+++ b/tests/testthat/test-print-twfecovs-max-event-times-267.R
@@ -1,0 +1,36 @@
+library(testthat)
+library(fetwfe)
+
+# Panel-data fixture helpers (generate_panel_data, ...) live in
+# tests/testthat/helper-panel-fixture.R and are sourced by testthat first (#91).
+
+# ------------------------------------------------------------------------------
+# #267: print.twfeCovs() must accept `max_event_times` like its three sibling print
+# methods, instead of erroring via a formals/body mismatch. The body forwarded a
+# literal `max_event_times = 10L` AND `...`, so a user-supplied value double-bound
+# into .print_estimator_output() ("matched by multiple actual arguments"). The arg
+# is a documented no-op for twfeCovs (no event-study section), so the correct
+# behavior is "accepted and ignored", not an error.
+# ------------------------------------------------------------------------------
+test_that("print.twfeCovs() accepts max_event_times without erroring (#267)", {
+	df <- generate_panel_data(N = 30, T = 5, R = 2, seed = 123)
+	tc <- twfeCovs(
+		pdata = df,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		covs = c("cov1", "cov2"),
+		response = "y",
+		verbose = FALSE
+	)
+
+	# The formal now exists, matching the three sibling print methods.
+	expect_true(
+		"max_event_times" %in% names(formals(getS3method("print", "twfeCovs")))
+	)
+	# A user-supplied value no longer double-binds into .print_estimator_output().
+	expect_no_error(invisible(capture.output(print(tc, max_event_times = 5))))
+	# Sibling args and the plain call still work.
+	expect_no_error(invisible(capture.output(print(tc, max_cohorts = 2))))
+	expect_no_error(invisible(capture.output(print(tc))))
+})


### PR DESCRIPTION
Refs #267, #268. Two small input-validation fixes from the 2026-06-06 periodic review (findings B2, B3).

## #267 — `print.twfeCovs(max_event_times=)` double-binding
`print.twfeCovs`'s formals lacked `max_event_times`, yet the body forwarded a literal
`max_event_times = 10L` **and** `...` into `.print_estimator_output()`. A user-supplied
`max_event_times` landed in `...` and double-bound:

```
print(tc, max_event_times = 5)
#> Error: formal argument "max_event_times" matched by multiple actual arguments
```

The three sibling print methods all declare the argument. Fix: add
`max_event_times = getOption("twfeCovs.max_event_times", 10)` to the formals and
forward the bound value instead of the literal `10L`. The argument is a documented
no-op for `twfeCovs` (its output has no event-study section), so it is accepted and
ignored — restoring the sibling parity the class doc (#58) promises.

## #268 — `out_names` contract not validated
`.fetwfe_df_core()` (reachable via `attgtToFetwfeDf()` / `etwfeToFetwfeDf()`)
documents that `out_names` "must contain exactly these four names" but never checked
it, so a missing or mistyped key produced a cryptic internal error ("attempt to
select less than one element"). Added a guard that requires a **list** containing the
four keys (`time`, `unit`, `treatment`, `response`) and `stop()`s with the contract
message. Requiring a list (rather than "list *or* character") is deliberate — a named
character vector carries the four names but the assembly indexes with `$`, which is
invalid for atomic vectors, so it must be rejected too (the refinement the review's
verifier flagged).

## Tests
- `test-print-twfecovs-max-event-times-267.R`: the formal exists and
  `print(tc, max_event_times = 5)` no longer errors (siblings + plain `print` still
  work). Mutation-checked (removing the formal → FAIL).
- `test-out-names-validation-268.R`: missing key, mistyped key, and named-character-
  vector all error with the contract message; a well-formed list does not.
  Mutation-checked (disabling the guard → FAIL).

## Bookkeeping
Version 1.26.4 → 1.26.5; `NEWS.md` "Bug fixes". No behavior change beyond the two
error paths; no man-page drift.

## Gate
- `air format .`: clean. `devtools::document()`: no drift.
- `devtools::test()`: full suite green (2 new regression tests, both mutation-checked).
- `R CMD check --as-cran`: **0 errors | 0 warnings | 0 notes** (Status OK), fetwfe 1.26.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
