### PR TITLE
docs: switch real-data example to divorce; repair fusion_structure + simulation vignette builds

### DIFF
--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -294,42 +294,45 @@
 #' Pinheiro, J. C., & Bates, D. M. (2000). \emph{Mixed-Effects Models in
 #' S and S-PLUS}. Springer.
 #' @examples
-#' # `bacondecomp` (which supplies the `castle` data) is a Suggests-only
-#' # dependency, so guard the example on its availability.
+#' # `bacondecomp` (which supplies the `divorce` data) is a Suggests-only
+#' # dependency, so guard the example on its availability. The fit is wrapped in
+#' # \donttest{} because it is slower than a toy example.
+#' \donttest{
 #' if (requireNamespace("bacondecomp", quietly = TRUE)) {
 #'   library(bacondecomp)
 #'
-#'   data(castle)
+#'   data(divorce)
 #'
-#'   # Response: the log homicide rate. Treatment: `cdl` records the share of
-#'   # the year the castle-doctrine law was in effect, so `cdl > 0` gives the
-#'   # absorbing 0/1 treatment indicator `fetwfe()` requires.
-#'   castle$l_homicide <- log(castle$homicide)
-#'   castle$treated <- as.integer(castle$cdl > 0)
+#'   # Stevenson & Wolfers (2006): the effect of unilateral ("no-fault") divorce
+#'   # reforms on female suicide rates. Restrict to the female subset
+#'   # (`sex == 2`); `changed` is already the absorbing 0/1 reform indicator, and
+#'   # the elasticity-scaled female suicide rate is the response.
+#'   divorce_f <- divorce[divorce$sex == 2, ]
 #'
-#'   # No `covs` here: castle's smallest adoption cohorts contain a single
-#'   # state, so the design is rank-deficient once any covariate is added.
-#'   # The v1.13.0+ default lambda_selection is "cv" (10-fold CV).
+#'   # Reproduces the empirical application in Faletto (2025, Sec. 8.2). The 9
+#'   # states already treated by 1964 are auto-dropped as first-period-treated,
+#'   # and `murderrate` is auto-dropped (missing in 1964 for one state); both are
+#'   # reported as (expected) warnings. The noise variances are supplied
+#'   # (precomputed by REML) to keep the example fast and reproducible; the
+#'   # default lambda_selection is "cv" (10-fold cross-validation).
 #'   res <- fetwfe(
-#'       pdata = castle,
+#'       pdata = divorce_f,
 #'       time_var = "year",
-#'       unit_var = "state",
-#'       treatment = "treated",
-#'       response = "l_homicide",
-#'       verbose = TRUE)
+#'       unit_var = "st",
+#'       treatment = "changed",
+#'       covs = c("murderrate", "lnpersinc", "afdcrolls"),
+#'       response = "suiciderate_elast_jag",
+#'       sig_eps_sq = 0.0344,
+#'       sig_eps_c_sq = 0.1507,
+#'       add_ridge = TRUE,
+#'       q = 0.5)
 #'
-#'   # Print results with internal details
+#'   # FETWFE estimates an overall ATT of roughly -6% on the elasticity-scaled
+#'   # female suicide rate, with a 95% confidence interval that excludes zero.
+#'   # The selection step retains heterogeneous cohort effects (several cohorts
+#'   # are pruned to exactly zero), rather than fusing to a single common effect.
 #'   print(res, max_cohorts = Inf)
-#'
-#'   # To recover the prior BIC behavior (e.g., for reproducing analyses
-#'   # run against v1.12.0 or earlier), pass lambda_selection = "bic":
-#'   res_bic <- fetwfe(
-#'       pdata = castle,
-#'       time_var = "year",
-#'       unit_var = "state",
-#'       treatment = "treated",
-#'       response = "l_homicide",
-#'       lambda_selection = "bic")
+#' }
 #' }
 #'
 #' @export

--- a/README.md
+++ b/README.md
@@ -21,28 +21,36 @@ You can also install the latest development version by using
 remotes::install_github("gregfaletto/fetwfePackage")
 ```
 
-The primary function in the `{fetwfe}` is `fetwfe()`, which implements fused extended two-way fixed effects. Here's some example code applying `fetwfe()` to the `castle` data set from the `bacondecomp` package:
+The primary function in the `{fetwfe}` is `fetwfe()`, which implements fused extended two-way fixed effects. Here's some example code applying `fetwfe()` to the `divorce` data set from the `bacondecomp` package -- the unilateral ("no-fault") divorce / female-suicide panel of Stevenson and Wolfers (2006):
 
 ```R
 library(fetwfe)
 library(bacondecomp)
 
-data(castle)
+data(divorce)
 
-# Response: the log homicide rate. Treatment: `cdl` records the share of
-# the year the castle-doctrine law was in effect, so `cdl > 0` gives the
-# absorbing 0/1 treatment indicator `fetwfe()` requires.
-castle$l_homicide <- log(castle$homicide)
-castle$treated <- as.integer(castle$cdl > 0)
+# Restrict to the female subset (`sex == 2`). `changed` is already the absorbing
+# 0/1 divorce-reform indicator, and the response is the elasticity-scaled female
+# suicide rate. This reproduces the empirical application in Faletto (2025,
+# Sec. 8.2): the three covariates are passed as controls (one, `murderrate`, is
+# auto-dropped because it is missing in 1964, leaving two), and the noise
+# variances are supplied (precomputed by REML) to keep the call fast.
+divorce_f <- divorce[divorce$sex == 2, ]
 
 res <- fetwfe(
-    pdata = castle,
+    pdata = divorce_f,
     time_var = "year",
-    unit_var = "state",
-    treatment = "treated",
-    response = "l_homicide",
-    verbose = TRUE)
+    unit_var = "st",
+    treatment = "changed",
+    covs = c("murderrate", "lnpersinc", "afdcrolls"),
+    response = "suiciderate_elast_jag",
+    sig_eps_sq = 0.0344,
+    sig_eps_c_sq = 0.1507,
+    add_ridge = TRUE,
+    q = 0.5)
 
+# Overall ATT is about -6% on the elasticity-scaled female suicide rate, with a
+# 95% CI that excludes zero; FETWFE retains heterogeneous cohort effects here.
 summary(res)
 ```
 

--- a/man/fetwfe.Rd
+++ b/man/fetwfe.Rd
@@ -332,42 +332,45 @@ Estimates overall ATT as well as CATT (cohort average treatment effects on
 the treated units).
 }
 \examples{
-# `bacondecomp` (which supplies the `castle` data) is a Suggests-only
-# dependency, so guard the example on its availability.
+# `bacondecomp` (which supplies the `divorce` data) is a Suggests-only
+# dependency, so guard the example on its availability. The fit is wrapped in
+# \donttest{} because it is slower than a toy example.
+\donttest{
 if (requireNamespace("bacondecomp", quietly = TRUE)) {
   library(bacondecomp)
 
-  data(castle)
+  data(divorce)
 
-  # Response: the log homicide rate. Treatment: `cdl` records the share of
-  # the year the castle-doctrine law was in effect, so `cdl > 0` gives the
-  # absorbing 0/1 treatment indicator `fetwfe()` requires.
-  castle$l_homicide <- log(castle$homicide)
-  castle$treated <- as.integer(castle$cdl > 0)
+  # Stevenson & Wolfers (2006): the effect of unilateral ("no-fault") divorce
+  # reforms on female suicide rates. Restrict to the female subset
+  # (`sex == 2`); `changed` is already the absorbing 0/1 reform indicator, and
+  # the elasticity-scaled female suicide rate is the response.
+  divorce_f <- divorce[divorce$sex == 2, ]
 
-  # No `covs` here: castle's smallest adoption cohorts contain a single
-  # state, so the design is rank-deficient once any covariate is added.
-  # The v1.13.0+ default lambda_selection is "cv" (10-fold CV).
+  # Reproduces the empirical application in Faletto (2025, Sec. 8.2). The 9
+  # states already treated by 1964 are auto-dropped as first-period-treated,
+  # and `murderrate` is auto-dropped (missing in 1964 for one state); both are
+  # reported as (expected) warnings. The noise variances are supplied
+  # (precomputed by REML) to keep the example fast and reproducible; the
+  # default lambda_selection is "cv" (10-fold cross-validation).
   res <- fetwfe(
-      pdata = castle,
+      pdata = divorce_f,
       time_var = "year",
-      unit_var = "state",
-      treatment = "treated",
-      response = "l_homicide",
-      verbose = TRUE)
+      unit_var = "st",
+      treatment = "changed",
+      covs = c("murderrate", "lnpersinc", "afdcrolls"),
+      response = "suiciderate_elast_jag",
+      sig_eps_sq = 0.0344,
+      sig_eps_c_sq = 0.1507,
+      add_ridge = TRUE,
+      q = 0.5)
 
-  # Print results with internal details
+  # FETWFE estimates an overall ATT of roughly -6\% on the elasticity-scaled
+  # female suicide rate, with a 95\% confidence interval that excludes zero.
+  # The selection step retains heterogeneous cohort effects (several cohorts
+  # are pruned to exactly zero), rather than fusing to a single common effect.
   print(res, max_cohorts = Inf)
-
-  # To recover the prior BIC behavior (e.g., for reproducing analyses
-  # run against v1.12.0 or earlier), pass lambda_selection = "bic":
-  res_bic <- fetwfe(
-      pdata = castle,
-      time_var = "year",
-      unit_var = "state",
-      treatment = "treated",
-      response = "l_homicide",
-      lambda_selection = "bic")
+}
 }
 
 }

--- a/vignettes/fusion_structure_vignette.Rmd
+++ b/vignettes/fusion_structure_vignette.Rmd
@@ -138,7 +138,11 @@ cohort_times <- getTes(coefs)$cohort_times # each cohort's first treated period
 n_k <- T - cohort_times + 1 # number of post-treatment effects per cohort
 num_treats <- sum(n_k)
 base_cols <- G + (T - 1) + d + d * G + d * (T - 1) # fixed effects + covariate terms
-treat_inds <- base_cols + seq_len(num_treats) # the tau block
+# `fetwfe()` reports these positions as an integer vector, so build `treat_inds`
+# as an integer too (the `base_cols` arithmetic above is double-typed) -- this
+# keeps the `identical()` cross-check below exact rather than tripping on storage
+# mode.
+treat_inds <- as.integer(base_cols + seq_len(num_treats)) # the tau block
 
 # Event time (time since treatment) of each tau, in the same order.
 event_time <- unlist(lapply(n_k, function(nk) 0:(nk - 1)))

--- a/vignettes/simulation_vignette.Rmd
+++ b/vignettes/simulation_vignette.Rmd
@@ -8,7 +8,7 @@ output:
     math_method: "mathml"
     output_file: "FETWFE_Simulation_Vignette.html"
 vignette: >
-  %\VignetteIndexEntry{FETWFE Simulation Vignette}
+  %\VignetteIndexEntry{Simulation Vignette for FETWFE: From Coefficients to True Treatment Effects}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/vignette.Rmd
+++ b/vignettes/vignette.Rmd
@@ -178,43 +178,43 @@ When you run this code, the function internally performs all the necessary data 
 
 ## A "Real Data" Example
 
-Next I illustrate FETWFE in an empirical context. I'll use the `castle` data set from the `bacondecomp` package, which comes from the study by Cheng and Hoekstra (2013) of castle-doctrine ("stand-your-ground") laws and homicide. It is a balanced state-year panel covering all 50 states over 2000-2010, with the laws adopted in a staggered fashion across states from 2005 to 2009.
+Next I illustrate FETWFE in an empirical context. I'll use the `divorce` data set from the `bacondecomp` package, which comes from the study by Stevenson and Wolfers (2006) of unilateral ("no-fault") divorce laws and female suicide rates. It is a balanced state-year panel covering 51 states over 1964-1996, with the reforms adopted in a staggered, scattered fashion across states. This is the empirical application in Section 8.2 of Faletto (2025).
 
 ```{r}
 library(bacondecomp)  # for the example data
 
-# Load the example data
-data(castle)
+# Load the data and restrict to the female subset (`sex == 2`), the sample
+# analyzed by Stevenson and Wolfers (2006).
+data(divorce)
+divorce_f <- divorce[divorce$sex == 2, ]
 
-# Response: the log homicide rate, so the ATT reads roughly as a
-# percentage change in the homicide rate.
-castle$l_homicide <- log(castle$homicide)
-
-# Treatment indicator. `cdl` records the share of the year the
-# castle-doctrine law was in effect; a state is treated from the year its
-# law took effect, so we binarize with `cdl > 0`. `fetwfe()` requires the
-# treatment column to be an integer 0/1 absorbing indicator.
-castle$treated <- as.integer(castle$cdl > 0)
-
-# Call the estimator. Here
-# - 'year' is the time period variable (an integer),
-# - 'state' is the unit identifier,
-# - 'treated' is the absorbing treatment indicator.
-res <- fetwfe(
-    pdata = castle,
+# - 'year' is the time period, 'st' is the unit (state) identifier;
+# - 'changed' is already an absorbing 0/1 divorce-reform indicator;
+# - 'suiciderate_elast_jag' is the elasticity-scaled female suicide rate.
+# Three covariates enter as controls. fetwfe() automatically drops the 9 states
+# already treated by 1964 (first-period-treated) and `murderrate` (missing in
+# 1964 for one state); both are reported as warnings, suppressed here for
+# brevity. The noise variances are supplied (precomputed by REML) to keep the
+# call fast.
+res <- suppressWarnings(fetwfe(
+    pdata = divorce_f,
     time_var = "year",
-    unit_var = "state",
-    treatment = "treated",
-    response = "l_homicide"
-    )
+    unit_var = "st",
+    treatment = "changed",
+    covs = c("murderrate", "lnpersinc", "afdcrolls"),
+    response = "suiciderate_elast_jag",
+    sig_eps_sq = 0.0344,
+    sig_eps_c_sq = 0.1507,
+    add_ridge = TRUE,
+    q = 0.5
+    ))
 
 summary(res)
 
-# Average treatment effect on the treated units (in percentage point
-# units)
+# Average treatment effect on the treated units (in percentage point units)
 100 * res$att_hat
 
-# Conservative 95% confidence interval for ATT (in percentage point units)
+# 95% confidence interval for ATT (in percentage point units)
 
 low_att <- 100 * (res$att_hat - qnorm(1 - 0.05 / 2) * res$att_se)
 high_att <- 100 * (res$att_hat + qnorm(1 - 0.05 / 2) * res$att_se)
@@ -222,7 +222,7 @@ high_att <- 100 * (res$att_hat + qnorm(1 - 0.05 / 2) * res$att_se)
 c(low_att, high_att)
 
 # Cohort average treatment effects and confidence intervals (in percentage
-# point units)
+# point units). Several cohorts are pruned to exactly zero by the selection.
 
 catt_df_pct <- res$catt_df
 catt_df_pct[["estimate"]] <- 100 * catt_df_pct[["estimate"]]
@@ -233,9 +233,9 @@ catt_df_pct[["ci_high"]] <- 100 * catt_df_pct[["ci_high"]]
 catt_df_pct
 ```
 
-FETWFE estimates that adopting a castle-doctrine law is associated with roughly a +5.5% change in the homicide rate. The sign and rough magnitude are consistent with Cheng and Hoekstra (2013), who found that these laws increased homicide. FETWFE fused all five adoption cohorts (those adopting in 2005 through 2009) to a single common effect, so each row of `res$catt_df` reports the same estimate.
+FETWFE estimates that adopting a unilateral divorce law is associated with roughly a -6% change in the elasticity-scaled female suicide rate, with a 95% confidence interval that excludes zero. The sign and order of magnitude match Stevenson and Wolfers (2006), who found that these reforms reduced female suicide. Unlike a fully fused fit, FETWFE's selection step retains *heterogeneous* cohort effects here: several adoption cohorts are pruned to exactly zero while the rest carry nonzero, varying estimates, so the rows of `res$catt_df` are no longer all identical.
 
-This example is covariate-free; `castle`'s smallest cohorts contain a single state, so the design cannot support additional covariates. Covariate handling is illustrated in the simulated example above — the `covs` argument is optional.
+Unlike the simulated example above, this fit includes covariates (the `covs` argument). Because FETWFE regularizes the cohort-interacted design through its bridge penalty, it accommodates covariates even on this panel's scattered, single-state adoption cohorts -- a setting in which an unregularized two-way fixed effects fit would be rank-deficient.
 
 ## Testing the zero-effect null
 


### PR DESCRIPTION
Part of the 2.0.0 / CRAN-release prep. Two folded-but-separate changes (one commit each).

## 1. Real-data example: castle → divorce
Switches the headline real-data example from `bacondecomp::castle` to
`bacondecomp::divorce` (Stevenson & Wolfers 2006, unilateral divorce → female
suicide) to match the empirical application in Faletto (2025, Sec. 8.2), now that
FETWFE returns a meaningful non-zero result there. Surfaces: the `fetwfe()`
`@example`, `README.md`, and the vignette's "A Real Data Example" section
(+ `man/fetwfe.Rd` regen).

- Reproduces Sec. 8.2: overall ATT **−6.0%, 95% CI (−9.7%, −2.3%) excludes zero**,
  9/12 cohorts retained (heterogeneous selection, not a single fused effect).
- Full paper spec: female subset, `changed`, three covs (`murderrate` auto-dropped,
  missing in 1964), `suiciderate_elast_jag`, precomputed REML variances + `add_ridge`,
  CV. Fit wrapped in `\donttest{}`.
- Dropped the `res_bic` BIC-variant demo (BIC over-shrinks to exactly zero here).
- **etwfe/betwfe/twfeCovs `@examples` intentionally stay on castle** — the OLS family
  is rank-deficient with covariates on divorce's single-treated-unit cohorts, and
  gives weaker/non-significant results there. (A plan-review workflow ran each
  estimator on divorce to establish this; a post-exec review workflow confirmed
  scope + live-fit numbers.)

## 2. Vignette build fixes (pre-existing, exposed by checking WITH vignettes)
The gate had been running `--no-vignettes`, masking two vignette failures that would
have blocked CRAN submission:
- `fusion_structure_vignette.Rmd`: a `stopifnot(identical(treat_inds, ...))` failed on
  storage mode — `fit$treat_inds` is integer (#185), the vignette built it as a
  double; values matched. Now built with `as.integer()`.
- `simulation_vignette.Rmd`: `\VignetteIndexEntry` didn't match the YAML title (check
  warning). Aligned, matching every other vignette.

All 5 vignettes now build clean.

## Process / notes
- Ran through the standard workflow (plan-review + post-exec review workflows).
- No version bump / NEWS here — folds into the 2.0.0 release.
- Recommend making **`R CMD check` with vignettes** a standing part of release prep:
  the `--no-vignettes` habit had been masking vignette health (it caught one blocker
  + one nit here).

## Gate
- `air`: clean. `document()`: `man/fetwfe.Rd` only.
- `R CMD check --as-cran` WITH vignettes: **0 errors | 0 warnings | 0 notes** (all 5 vignettes build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
