### PR TITLE
docs: make R CMD check WITH vignettes the standard gate (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,10 +253,14 @@ root:
 # In R, with devtools / usethis available:
 devtools::document()      # regenerate man/*.Rd and NAMESPACE from roxygen
 devtools::test()          # run testthat suite
-devtools::check()         # full R CMD check
+devtools::check()         # full R CMD check (rebuilds all 5 vignettes)
 devtools::check(args = "--as-cran")   # CRAN-strict check
 devtools::build_vignettes()
 ```
+
+Always let `check()` build the vignettes -- do **not** gate on `--no-vignettes`.
+The five vignettes run real fits and CRAN rebuilds them on submission, so a vignette
+that fails to build is a blocker that a vignette-less check silently hides.
 
 Or from the shell:
 
@@ -281,6 +285,9 @@ generated files will fail `R CMD check`.
 - Uncommitted CRAN-only artifacts (`fetwfe.Rcheck/`, `..Rcheck/`, `Meta/`,
   `doc/`, `paper_arxiv.tex`) leaking into the build — they're already in
   `.Rbuildignore`; keep it that way.
+- A vignette that fails to rebuild — `check()` and CRAN rebuild all five
+  (`vignette`, `etwfe_betwfe`, `fusion_structure`, `inference`, `simulation`),
+  so build with vignettes on, not `--no-vignettes`.
 
 ## Tests
 


### PR DESCRIPTION
Encodes the agreed change: the PR-gating check builds all five vignettes (the `check()` default), and `--no-vignettes` is no longer the gate.

## Why
The routine gate had been `--no-vignettes` for speed, which silently skips the vignette rebuild CRAN runs on submission. That let `fusion_structure_vignette.Rmd` (a `treat_inds` integer-vs-double `identical()` failure) stay broken for many dev versions until the divorce-example work (#276) ran a with-vignettes check for the first time.

## Change (AGENTS.md only, no code)
- Checking section: note that `check()` rebuilds all 5 vignettes and to not gate on `--no-vignettes`.
- "Things that will break a CRAN submission": add "a vignette that fails to rebuild."

No gate needed (AGENTS.md is not part of the package build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)