### PR TITLE
chore: gitignore AGENTS.md (complete the #278 untrack)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,8 @@ TODO_*
 mybib2fin.bib
 
 # Working / local-only docs (don't push to remote)
+# AGENTS.md is local-only agent guidance (it points at the .gitignore'd .workflow/);
+# kept on disk, not tracked. Still viewable in history before this commit.
+AGENTS.md
 Referee reports/
 *.Rcheck/


### PR DESCRIPTION
Follow-up to #278. That PR untracked AGENTS.md (git rm --cached) but the .gitignore entry was never staged, so on main AGENTS.md is untracked-but-not-ignored and a plain git add -A would re-add it. This adds the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)