### PR TITLE
docs: surface fusion-structure options on high-traffic doc surfaces (#282)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.27.0
+Version: 1.27.1
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # NEWS
 
+## Version 1.27.1
+
+### Documentation
+
+- Surfaced the fusion-penalty structure options on high-traffic documentation
+  surfaces (#282). The choice of fusion geometry --- `fusion_structure = "cohort"`
+  (default) vs. `"event_study"`, and the custom `fusion_matrix` override --- is a
+  core differentiator of FETWFE but was previously reachable only through a
+  buried `@param`. It is now named in a new "Penalty and fusion structures"
+  section of the README, cross-linked from the introductory and simulation
+  vignettes to the existing "Choosing a fusion structure" vignette, pulled into
+  `fetwfe()`'s `@description`, and given a `@seealso` on `fetwfe()` and
+  `genCoefs()` (the two functions that expose `fusion_structure`).
+
 ## Version 1.27.0
 
 ### New features

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -7,6 +7,14 @@
 #' Estimates overall ATT as well as CATT (cohort average treatment effects on
 #' the treated units).
 #'
+#' The treatment-effect fusion penalty defaults to a within-/between-cohort
+#' geometry (`fusion_structure = "cohort"`) and also supports an event-study
+#' geometry (`fusion_structure = "event_study"`, fusing effects at the same
+#' time since treatment across cohorts) or a fully custom `fusion_matrix`. See
+#' the `fusion_structure` / `fusion_matrix` arguments below and
+#' \code{vignette("fusion_structure_vignette", package = "fetwfe")} for guidance
+#' on choosing.
+#'
 #' @param pdata Dataframe; the panel data set. Each row should represent an
 #' observation of a unit at a time. Should contain columns as described below.
 #' @param time_var Character; the name of a single column containing a variable
@@ -293,6 +301,9 @@
 #'
 #' Pinheiro, J. C., & Bates, D. M. (2000). \emph{Mixed-Effects Models in
 #' S and S-PLUS}. Springer.
+#' @seealso \code{vignette("fusion_structure_vignette", package = "fetwfe")} for
+#'   guidance on choosing between the cohort (default) and event-study fusion
+#'   penalties and on supplying a custom \code{fusion_matrix}.
 #' @examples
 #' # `bacondecomp` (which supplies the `divorce` data) is a Suggests-only
 #' # dependency, so guard the example on its availability. The fit is wrapped in

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -185,6 +185,13 @@
 #' \emph{arXiv preprint arXiv:2312.05985}.
 #' \url{https://arxiv.org/abs/2312.05985}.
 #'
+#' @seealso \code{\link{fetwfe}}, whose \code{fusion_structure} argument this
+#'   mirrors on the estimation side;
+#'   \code{vignette("fusion_structure_vignette", package = "fetwfe")} for the
+#'   cohort-vs-event-study distinction, and
+#'   \code{vignette("simulation_vignette", package = "fetwfe")} for the full
+#'   simulation pipeline.
+#'
 #' @examples
 #' \dontrun{
 #'   # Generate coefficients

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ summary(res)
 
 For vignettes and full documentation, check out the [page for the `{fetwfe}` package on CRAN](https://CRAN.R-project.org/package=fetwfe).
 
+## Penalty and fusion structures
+
+A core differentiator of FETWFE is the *geometry* of its fusion penalty, chosen via the `fusion_structure` argument of `fetwfe()`:
+
+- **`"cohort"`** (the default) fuses treatment effects within and between cohorts — the two-way fusion structure of Faletto (2025).
+- **`"event_study"`** instead fuses effects at the same time since treatment (event time `e = t - g`) across cohorts — the package realization of the paper's event-study-penalty theory.
+
+For full control, the `fusion_matrix` argument accepts any invertible `num_treats x num_treats` differencing matrix `D_N`, encoding an arbitrary fusion structure beyond the two built-ins. The same `fusion_structure` option is available in `genCoefs()` for simulation studies.
+
+For guidance on which to use, see the vignette *"Choosing a fusion structure: cohort vs. event-study penalties"* — `vignette("fusion_structure_vignette", package = "fetwfe")`, also on the [CRAN page](https://CRAN.R-project.org/package=fetwfe).
+
 ## References
 - Faletto, G (2025). *Fused Extended Two-Way Fixed Effects for Difference-in-Differences with Staggered Adoptions*. [arXiv preprint arXiv:2312.05985](https://arxiv.org/abs/2312.05985).
 

--- a/man/fetwfe.Rd
+++ b/man/fetwfe.Rd
@@ -330,6 +330,14 @@ The object has methods for \code{print()}, \code{summary()}, and \code{coef()}. 
 Implementation of fused extended two-way fixed effects.
 Estimates overall ATT as well as CATT (cohort average treatment effects on
 the treated units).
+
+The treatment-effect fusion penalty defaults to a within-/between-cohort
+geometry (\code{fusion_structure = "cohort"}) and also supports an event-study
+geometry (\code{fusion_structure = "event_study"}, fusing effects at the same
+time since treatment across cohorts) or a fully custom \code{fusion_matrix}. See
+the \code{fusion_structure} / \code{fusion_matrix} arguments below and
+\code{vignette("fusion_structure_vignette", package = "fetwfe")} for guidance
+on choosing.
 }
 \examples{
 # `bacondecomp` (which supplies the `divorce` data) is a Suggests-only
@@ -390,6 +398,11 @@ information when block sizes are unequal. \emph{Biometrika}, 58(3),
 
 Pinheiro, J. C., & Bates, D. M. (2000). \emph{Mixed-Effects Models in
 S and S-PLUS}. Springer.
+}
+\seealso{
+\code{vignette("fusion_structure_vignette", package = "fetwfe")} for
+guidance on choosing between the cohort (default) and event-study fusion
+penalties and on supplying a custom \code{fusion_matrix}.
 }
 \author{
 Gregory Faletto

--- a/man/genCoefs.Rd
+++ b/man/genCoefs.Rd
@@ -252,3 +252,11 @@ Difference-in-Differences with Staggered Adoptions.
 \emph{arXiv preprint arXiv:2312.05985}.
 \url{https://arxiv.org/abs/2312.05985}.
 }
+\seealso{
+\code{\link{fetwfe}}, whose \code{fusion_structure} argument this
+mirrors on the estimation side;
+\code{vignette("fusion_structure_vignette", package = "fetwfe")} for the
+cohort-vs-event-study distinction, and
+\code{vignette("simulation_vignette", package = "fetwfe")} for the full
+simulation pipeline.
+}

--- a/vignettes/simulation_vignette.Rmd
+++ b/vignettes/simulation_vignette.Rmd
@@ -45,7 +45,7 @@ Below is a complete simulation pipeline, step by step.
 
 ## Step 1: Generate Simulation Coefficients
 
-The `genCoefs()` function returns an object of class `"FETWFE_coefs"`, containing both the coefficient vector and its simulation parameters. In this example we set:
+The `genCoefs()` function returns an object of class `"FETWFE_coefs"`, containing both the coefficient vector and its simulation parameters. The `fusion_structure` argument (mirroring `fetwfe()`) additionally controls the *basis* in which the true treatment effects are sparse — `"cohort"` (the default) or `"event_study"`; see the vignette `vignette("fusion_structure_vignette", package = "fetwfe")`. In this example we set:
 
 - **G** (number of treated cohorts) = 3
 - **T** (number of time periods) = 6

--- a/vignettes/vignette.Rmd
+++ b/vignettes/vignette.Rmd
@@ -63,7 +63,7 @@ The package provides a single exported function, `fetwfe()`, which implements th
 - **`treatment`**: A character string specifying the treatment indicator variable (which must be an absorbing binary indicator).
 - **`response`**: A character string specifying the response (outcome) variable.
 - **`covs`**: A character vector of covariate names (typically time-invariant or the pre-treatment values), if applicable.
-- **Additional tuning parameters:** such as the tuning parameter for the bridge penalty (controlled via argument `q`) and options for verbosity, standard error calculation, and so on.
+- **Additional tuning parameters:** such as the tuning parameter for the bridge penalty (controlled via argument `q`), the geometry of the fusion penalty (`fusion_structure`, either the default `"cohort"` or `"event_study"`, or a fully custom `fusion_matrix`), and options for verbosity, standard error calculation, and so on.
 
 The function returns a list containing, for example, the estimated overall average treatment effect, cohort-specific treatment effects, standard errors (when available), and various diagnostic quantities.
 
@@ -175,6 +175,8 @@ summary(result)
 ```
 
 When you run this code, the function internally performs all the necessary data preparation, applies the fusion penalty via a bridge regression (using the `grpreg` package), and returns a list with overall and cohort-specific treatment effect estimates, standard errors (if available), and additional diagnostics.
+
+By default the fusion penalty uses the within-/between-cohort structure, but you can instead fuse treatment effects by event time (time since treatment) with `fusion_structure = "event_study"`, or supply a fully custom fusion matrix. For when to prefer each, see the vignette ["Choosing a fusion structure: cohort vs. event-study penalties"](fusion_structure_vignette.html) (`vignette("fusion_structure_vignette", package = "fetwfe")`).
 
 ## A "Real Data" Example
 


### PR DESCRIPTION
## Summary

Doc-only surfacing of the **fusion-penalty structure** options (`fusion_structure = "cohort"` / `"event_study"`, and the custom `fusion_matrix`) — a core differentiator of FETWFE that was previously reachable only through a buried `@param`. Closes #282.

## Changes

- **README**: new "Penalty and fusion structures" section naming both built-in structures and the custom `fusion_matrix`, with a link to the dedicated vignette.
- **Intro vignette** (`vignette.Rmd`): `fusion_structure` named in the tuning-parameter list + a cross-link to the "Choosing a fusion structure" vignette where the penalty is introduced.
- **Simulation vignette**: one-line mention of `genCoefs(fusion_structure = ...)` with a cross-link.
- **Roxygen**: fusion options pulled into `fetwfe()`'s `@description`; new `@seealso vignette("fusion_structure_vignette", package = "fetwfe")` on `fetwfe()` and `genCoefs()`.

## Note on scope (one correction to the issue)

The issue lists `betwfe()` as a "parallel" to receive the `@seealso`. **It was intentionally skipped**: `betwfe()` penalizes the coefficients directly (bridge regression on the raw coefficients) and has **no** `fusion_structure` / `fusion_matrix` argument (verified — 0 references in `betwfe_core.R`), so pointing it at the fusion vignette would mislead. `fetwfe()` and `genCoefs()` are the only two exported functions that expose `fusion_structure`, and both got the cross-link.

## Gate

- `R CMD check` **with vignettes**: clean (0/0/0) — all five vignettes build, including the new cross-links.
- Doc-only (no R logic touched); patch bump 1.27.0 → 1.27.1 + NEWS under "### Documentation".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
