### PR TITLE
feat: accept density = 1 in genCoefs() (fully non-sparse truth)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.27.1
+Version: 1.27.2
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # NEWS
 
+## Version 1.27.2
+
+### Improvements
+
+- `genCoefs()` and `genCoefsCore()` now accept `density = 1`, which yields a
+  fully dense (non-sparse) coefficient vector — every entry of the initial
+  `theta` is nonzero. Previously `density` had to be *strictly* in `(0, 1)`; the
+  accepted range is now `(0, 1]`. This supports simulating data in which the
+  FETWFE sparsity assumption is maximally violated. `density <= 0` (which would
+  zero every coefficient) and `density > 1` still error (#286).
+
 ## Version 1.27.1
 
 ### Documentation

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -25,8 +25,9 @@
 #' @param T Integer. The total number of time periods.
 #' @param d Integer. The number of time-invariant covariates. If \code{d > 0}, additional terms
 #'   corresponding to covariate main effects and interactions are included in \code{beta}.
-#' @param density Numeric in (0,1). The probability that any given entry in the initial sparse
-#'   coefficient vector \code{theta} is nonzero.
+#' @param density Numeric in (0,1]. The probability that any given entry in the initial
+#'   coefficient vector \code{theta} is nonzero. \code{density = 1} gives a fully dense
+#'   (non-sparse) coefficient vector.
 #' @param eff_size Numeric. The magnitude used to scale nonzero entries in \code{theta}. Each
 #'   nonzero entry is set to \code{eff_size} or \code{-eff_size} (with a 60 percent chance for a
 #'   positive value).
@@ -271,14 +272,14 @@ genCoefs <- function(
 		stop("d must be a non-negative numeric value")
 	}
 
-	# Check that density is a numeric scalar strictly between 0 and 1.
+	# Check that density is a numeric scalar in (0, 1] (1 = fully dense, non-sparse).
 	if (
 		!is.numeric(density) ||
 			length(density) != 1 ||
 			density <= 0 ||
-			density >= 1
+			density > 1
 	) {
-		stop("density must be numeric and strictly between 0 and 1")
+		stop("density must be numeric, greater than 0 and at most 1")
 	}
 
 	# Check that eff_size is numeric.
@@ -657,8 +658,9 @@ getTes <- function(coefs_obj) {
 #' @param T Integer. The total number of time periods.
 #' @param d Integer. The number of time-invariant covariates. If \code{d > 0}, additional terms
 #' corresponding to covariate main effects and interactions are included in \code{beta}.
-#' @param density Numeric in (0,1). The probability that any given entry in the initial sparse
-#' coefficient vector \code{theta} is nonzero.
+#' @param density Numeric in (0,1]. The probability that any given entry in the initial
+#' coefficient vector \code{theta} is nonzero. \code{density = 1} gives a fully dense
+#' (non-sparse) coefficient vector.
 #' @param eff_size Numeric. The magnitude used to scale nonzero entries in \code{theta}. Each
 #' nonzero entry is set to \code{eff_size} or \code{-eff_size} (with a 60 percent chance for a
 #' positive value).
@@ -778,14 +780,14 @@ genCoefsCore <- function(
 		stop("d must be a non-negative numeric value")
 	}
 
-	# Check that density is a numeric scalar strictly between 0 and 1.
+	# Check that density is a numeric scalar in (0, 1] (1 = fully dense, non-sparse).
 	if (
 		!is.numeric(density) ||
 			length(density) != 1 ||
 			density <= 0 ||
-			density >= 1
+			density > 1
 	) {
-		stop("density must be numeric and strictly between 0 and 1")
+		stop("density must be numeric, greater than 0 and at most 1")
 	}
 
 	# Check that eff_size is numeric.

--- a/man/genCoefs.Rd
+++ b/man/genCoefs.Rd
@@ -30,8 +30,9 @@ deprecated alias \code{R} (described below).}
 \item{d}{Integer. The number of time-invariant covariates. If \code{d > 0}, additional terms
 corresponding to covariate main effects and interactions are included in \code{beta}.}
 
-\item{density}{Numeric in (0,1). The probability that any given entry in the initial sparse
-coefficient vector \code{theta} is nonzero.}
+\item{density}{Numeric in (0,1]. The probability that any given entry in the initial
+coefficient vector \code{theta} is nonzero. \code{density = 1} gives a fully dense
+(non-sparse) coefficient vector.}
 
 \item{eff_size}{Numeric. The magnitude used to scale nonzero entries in \code{theta}. Each
 nonzero entry is set to \code{eff_size} or \code{-eff_size} (with a 60 percent chance for a

--- a/man/genCoefsCore.Rd
+++ b/man/genCoefsCore.Rd
@@ -25,8 +25,9 @@ deprecated alias \code{R} (described below).}
 \item{d}{Integer. The number of time-invariant covariates. If \code{d > 0}, additional terms
 corresponding to covariate main effects and interactions are included in \code{beta}.}
 
-\item{density}{Numeric in (0,1). The probability that any given entry in the initial sparse
-coefficient vector \code{theta} is nonzero.}
+\item{density}{Numeric in (0,1]. The probability that any given entry in the initial
+coefficient vector \code{theta} is nonzero. \code{density = 1} gives a fully dense
+(non-sparse) coefficient vector.}
 
 \item{eff_size}{Numeric. The magnitude used to scale nonzero entries in \code{theta}. Each
 nonzero entry is set to \code{eff_size} or \code{-eff_size} (with a 60 percent chance for a

--- a/tests/testthat/test-genCoefs.R
+++ b/tests/testthat/test-genCoefs.R
@@ -228,15 +228,27 @@ test_that("genCoefs errors when d is negative", {
 	)
 })
 
-test_that("genCoefs errors when density is not between 0 and 1", {
+test_that("genCoefs errors when density is outside (0, 1]", {
 	expect_error(
 		genCoefs(G = 5, T = 30, density = -0.1, eff_size = 2, d = 12),
+		regexp = "density must be"
+	)
+	expect_error(
+		genCoefs(G = 5, T = 30, density = 0, eff_size = 2, d = 12),
 		regexp = "density must be"
 	)
 	expect_error(
 		genCoefs(G = 5, T = 30, density = 1.1, eff_size = 2, d = 12),
 		regexp = "density must be"
 	)
+})
+
+test_that("genCoefs accepts density = 1 (fully dense, non-sparse truth)", {
+	expect_no_error(
+		res <- genCoefs(G = 5, T = 30, density = 1, eff_size = 2, d = 12)
+	)
+	# density = 1 means every entry of the initial theta vector is nonzero
+	expect_true(all(res$theta != 0))
 })
 
 test_that("genCoefs errors when eff_size is not numeric", {

--- a/tests/testthat/test-genCoefsCore.R
+++ b/tests/testthat/test-genCoefsCore.R
@@ -233,15 +233,27 @@ test_that("genCoefsCore errors when d is negative", {
 	)
 })
 
-test_that("genCoefsCore errors when density is not between 0 and 1", {
+test_that("genCoefsCore errors when density is outside (0, 1]", {
 	expect_error(
 		genCoefsCore(G = 5, T = 30, density = -0.1, eff_size = 2, d = 12),
+		regexp = "density must be"
+	)
+	expect_error(
+		genCoefsCore(G = 5, T = 30, density = 0, eff_size = 2, d = 12),
 		regexp = "density must be"
 	)
 	expect_error(
 		genCoefsCore(G = 5, T = 30, density = 1.1, eff_size = 2, d = 12),
 		regexp = "density must be"
 	)
+})
+
+test_that("genCoefsCore accepts density = 1 (fully dense, non-sparse truth)", {
+	expect_no_error(
+		res <- genCoefsCore(G = 5, T = 30, density = 1, eff_size = 2, d = 12)
+	)
+	# density = 1 means every entry of the initial theta vector is nonzero
+	expect_true(all(res$theta != 0))
 })
 
 test_that("genCoefsCore errors when eff_size is not numeric", {


### PR DESCRIPTION
## Summary

`genCoefs()` / `genCoefsCore()` now accept **`density = 1`** — a fully dense (non-sparse) coefficient vector with every `theta` entry nonzero. Previously `density` had to be *strictly* in `(0, 1)`; the accepted range is now `(0, 1]`.

`density` is the probability each transformed-coefficient entry is nonzero, so `density = 1` is the genuinely non-sparse case — exactly the simulation needed to test how FETWFE behaves when the sparsity assumption is maximally violated (the methodology paper's referee #11). There's no technical reason to forbid it (nothing divides by `1 - density`); the previous `density >= 1` check conflated the valid probability `1` with the invalid `> 1`.

Closes #286.

## Changes

- `R/gen_coefs.R`: both validation sites `density >= 1` → `density > 1`; updated the two `stop()` messages and the two `@param density` docstrings (`(0,1)` → `(0,1]`, noting `density = 1` gives a fully dense vector). `density <= 0` (which zeroes every coefficient) and `density > 1` still error.
- `tests/testthat/test-genCoefs.R`: added a `density = 1` success test (asserts all `theta` nonzero) and a `density = 0` error case; existing `-0.1` / `1.1` error tests unchanged.
- Regenerated `man/genCoefs.Rd` + `man/genCoefsCore.Rd`; NEWS + version bump to 1.27.2.

## Verification

`devtools::document()` (only the two `.Rd` changed) + `devtools::test(filter="genCoefs")` → genCoefs (62) and genCoefsCore (33) tests pass, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
