### PR TITLE
fix: recover cohort timing for indep_counts fits with late adoption (#288)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.27.2
+Version: 1.27.3
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,25 @@
 # NEWS
 
+## Version 1.27.3
+
+### Bug fixes
+
+- `eventStudy()`, `cohortTimeATTs()`, and `simultaneousCIs()` no longer error on a
+  fit produced with `indep_counts` when the treated cohorts adopt *later* than the
+  earliest panel periods (e.g. cohorts adopting in 2005–2009 within a 2000–2010
+  panel). The accessors previously failed with `first_inds[G] <= n_vars is not TRUE`
+  (`eventStudy()` / `cohortTimeATTs()`) or `subscript out of bounds`
+  (`simultaneousCIs()`). The cause: the `indep_counts` path stored `cohort_probs`
+  unnamed, so the cohort adoption timing could not be recovered and the accessors
+  fell back to the earliest-timing layout, inconsistent with the actual number of
+  treatment effects. `att_hat` / `att_se` / `catt_df` are unchanged by this fix
+  (it only attaches the previously-missing cohort labels) (#288).
+  Older saved `indep_counts` fits also now recover their cohort timing (from
+  `catt_df`) without re-fitting. Note: with `indep_counts` the `eventStudy()`
+  event-time estimates and the overall `att_hat` are (as before) re-weighted by the
+  independent-sample cohort probabilities; the per-cell `cohortTimeATTs()` estimates
+  are unchanged by `indep_counts`.
+
 ## Version 1.27.2
 
 ### Improvements

--- a/R/utility.R
+++ b/R/utility.R
@@ -1140,12 +1140,33 @@ getFirstIndsFromOffsets <- function(cohort_offsets_int, T) {
 #' @keywords internal
 #' @noRd
 .derive_cohort_offsets_from_fit <- function(x) {
+	# Cohort adoption-time labels. Primary source: the names of `cohort_probs`.
+	# On older (pre-#288) saved fits produced with `indep_counts`, `cohort_probs`
+	# is the indep version, which was built unnamed --- fall back to
+	# `catt_df$cohort`, which carries the same adoption-time labels from the
+	# in-sample counts (R/input_prep.R) and is present on every fit, independent
+	# of `indep_counts`. Newly-fitted objects keep the names (via
+	# `.select_att_branch()`, #288), so this fall-back only fires for legacy
+	# objects; on synthetic fixtures `catt_df$cohort` equals the `cohort_probs`
+	# names, so the resolved offsets are unchanged.
 	cohort_probs <- x$cohort_probs
-	if (is.null(cohort_probs) || length(cohort_probs) == 0L) {
-		return(NULL)
-	}
 	cohort_names <- names(cohort_probs)
-	if (is.null(cohort_names) || any(!nzchar(cohort_names))) {
+	if (
+		is.null(cohort_probs) ||
+			length(cohort_probs) == 0L ||
+			is.null(cohort_names) ||
+			any(!nzchar(cohort_names))
+	) {
+		if (is.null(x$catt_df) || is.null(x$catt_df$cohort)) {
+			return(NULL)
+		}
+		cohort_names <- as.character(x$catt_df$cohort)
+	}
+	if (
+		is.null(cohort_names) ||
+			length(cohort_names) == 0L ||
+			any(!nzchar(cohort_names))
+	) {
 		return(NULL)
 	}
 	# Try integer-coerce; suppress the introduced-by-coercion warning so the
@@ -1735,6 +1756,15 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 		att_var_2 <- res$indep_att_var_2
 		cohort_probs <- res$indep_cohort_probs
 		cohort_probs_overall <- res$indep_cohort_probs_overall
+		# Carry over the cohort-year labels from the (named) in-sample vectors
+		# (#288). `indep_counts` describes the SAME cohorts as the in-sample
+		# counts in the same order --- only the probability values differ --- but
+		# the indep vectors are built unnamed from the raw count vector. Without
+		# these names `.derive_cohort_offsets_from_fit()` cannot recover the
+		# adoption timing, so `eventStudy()` / `cohortTimeATTs()` fall back to the
+		# earliest-timing `getFirstInds()` and trip `first_inds[G] <= n_vars`.
+		names(cohort_probs) <- names(res$cohort_probs)
+		names(cohort_probs_overall) <- names(res$cohort_probs_overall)
 	} else {
 		if (uses_bridge) {
 			stopifnot(!is.na(res$in_sample_att_hat))

--- a/tests/testthat/test-indep-counts-late-adoption-288.R
+++ b/tests/testthat/test-indep-counts-late-adoption-288.R
@@ -1,0 +1,190 @@
+# Regression tests for #288: cohortTimeATTs() / eventStudy() / simultaneousCIs()
+# errored ("first_inds[G] <= n_vars is not TRUE", or "subscript out of bounds"
+# for simultaneousCIs) on a fit given `indep_counts` when the treated cohorts
+# adopt LATER than the earliest panel periods.
+#
+# Root cause: the indep_counts path stored cohort_probs/cohort_probs_overall
+# UNNAMED, so .derive_cohort_offsets_from_fit() could not recover the adoption
+# years and the accessors fell back to earliest-timing getFirstInds(), producing
+# a first_inds inconsistent with the actual num_treats. Two layered fixes:
+#   (1) .select_att_branch() now carries the cohort-year names onto the indep
+#       vectors (forward fix for new fits) -- bitten by the name/first_inds
+#       parity assertions below.
+#   (2) .derive_cohort_offsets_from_fit() falls back to catt_df$cohort when
+#       cohort_probs names are absent (rescues legacy/persisted pre-fix objects)
+#       -- bitten by the "legacy object" test below.
+#
+# The fixture is pure base R (no bacondecomp / dplyr) and uses
+# `indep_counts == in-sample counts`, so the cohort probabilities -- and hence
+# all POINT estimates -- are identical with and without indep_counts (only the
+# SE *formula* differs by design, so SEs are not asserted equal). Synthetic
+# genCoefs fixtures do NOT expose the bug: their cohorts adopt consecutively
+# from period 2, where the earliest-timing fallback is already correct.
+
+# A balanced panel whose cohorts adopt at t = 6, 7, 8, 9 in a 1..11 panel
+# (earliest offset 6 > 2 = the trigger), plus never-treated units. d = 0.
+.make_late_adoption_panel <- function() {
+	set.seed(11)
+	cohort_of_unit <- c(
+		rep(0L, 22),
+		rep(6L, 8),
+		rep(7L, 7),
+		rep(8L, 6),
+		rep(9L, 9)
+	) # N = 52
+	N <- length(cohort_of_unit)
+	T <- 11L
+	pdata <- do.call(
+		rbind,
+		lapply(seq_len(N), function(i) {
+			g <- cohort_of_unit[i]
+			treated <- as.integer(g > 0 & (1:T) >= g)
+			data.frame(
+				unit = sprintf("u%02d", i),
+				year = 1:T,
+				treat = treated,
+				y = 0.5 *
+					i /
+					N +
+					0.3 * (1:T) / T +
+					0.8 * treated +
+					rnorm(T, 0, 0.5),
+				stringsAsFactors = FALSE
+			)
+		})
+	)
+	# indep_counts in cohort order c(never, 6, 7, 8, 9); == in-sample counts.
+	ic <- as.integer(table(factor(cohort_of_unit, levels = c(0, 6, 7, 8, 9))))
+	list(pdata = pdata, indep_counts = ic)
+}
+
+.fit_estimator <- function(estimator, pdata, indep_counts = NULL) {
+	fn <- switch(estimator, fetwfe = fetwfe, etwfe = etwfe, betwfe = betwfe)
+	args <- list(
+		pdata = pdata,
+		time_var = "year",
+		unit_var = "unit",
+		treatment = "treat",
+		response = "y",
+		verbose = FALSE
+	)
+	if (!is.null(indep_counts)) {
+		args$indep_counts <- indep_counts
+	}
+	do.call(fn, args)
+}
+
+for (est in c("fetwfe", "etwfe", "betwfe")) {
+	test_that(
+		paste0(
+			"indep_counts + late adoption: accessors succeed and labels match (",
+			est,
+			")"
+		),
+		{
+			panel <- .make_late_adoption_panel()
+			fit_no <- .fit_estimator(est, panel$pdata)
+			fit_ic <- .fit_estimator(est, panel$pdata, panel$indep_counts)
+
+			# (a) Forward-fix smoke test: the three accessors that crashed must now
+			# succeed on the indep_counts fit. These error ("first_inds[G] <=
+			# n_vars" / "subscript out of bounds") only if BOTH fixes are reverted
+			# --- either the names-copy (fix #1) OR the catt_df fallback (fix #2)
+			# rescues them. Fix #1 is isolated by the name/first_inds parity
+			# assertions in (b); fix #2 is isolated by the legacy test below.
+			expect_no_error(eventStudy(fit_ic))
+			expect_no_error(cohortTimeATTs(fit_ic))
+			expect_no_error(simultaneousCIs(fit_ic))
+
+			# (b) The indep path now carries the same cohort-year names + resolves
+			# the same first_inds as the no-indep path (bites the source fix).
+			expect_identical(
+				names(fit_ic$cohort_probs),
+				names(fit_no$cohort_probs)
+			)
+			expect_identical(names(fit_ic$cohort_probs), c("6", "7", "8", "9"))
+			fi_no <- .resolve_event_study_offsets_and_first_inds(
+				fit_no,
+				fit_no$G,
+				fit_no$T
+			)$first_inds
+			fi_ic <- .resolve_event_study_offsets_and_first_inds(
+				fit_ic,
+				fit_ic$G,
+				fit_ic$T
+			)$first_inds
+			expect_identical(as.integer(fi_ic), as.integer(fi_no))
+			expect_identical(as.integer(fi_ic), c(1L, 7L, 12L, 16L))
+
+			# (c) indep_counts == in-sample counts, so all POINT estimates are
+			# identical across paths (indep changes only the SE form, not asserted).
+			expect_equal(fit_ic$att_hat, fit_no$att_hat)
+			expect_equal(
+				eventStudy(fit_ic)$estimate,
+				eventStudy(fit_no)$estimate
+			)
+			expect_equal(
+				cohortTimeATTs(fit_ic)$estimate,
+				cohortTimeATTs(fit_no)$estimate
+			)
+		}
+	)
+}
+
+test_that("legacy indep fit with unnamed cohort_probs is rescued via catt_df", {
+	# Simulate a pre-#288 saved object: the indep_counts fix did not yet attach
+	# names, so cohort_probs / cohort_probs_overall are unnamed. The catt_df
+	# fallback in .derive_cohort_offsets_from_fit() must still recover the
+	# correct adoption timing so the accessors do not crash. (Reverting that
+	# fallback makes this test error with "first_inds[G] <= n_vars".)
+	panel <- .make_late_adoption_panel()
+	legacy <- .fit_estimator("fetwfe", panel$pdata, panel$indep_counts)
+	names(legacy$cohort_probs) <- NULL
+	names(legacy$cohort_probs_overall) <- NULL
+
+	# catt_df$cohort still carries the adoption years -> correct offsets.
+	off <- .derive_cohort_offsets_from_fit(legacy)
+	expect_identical(as.integer(off), c(6L, 7L, 8L, 9L))
+	expect_identical(
+		as.integer(
+			.resolve_event_study_offsets_and_first_inds(
+				legacy,
+				legacy$G,
+				legacy$T
+			)$first_inds
+		),
+		c(1L, 7L, 12L, 16L)
+	)
+	expect_no_error(eventStudy(legacy))
+	expect_no_error(cohortTimeATTs(legacy))
+	expect_no_error(simultaneousCIs(legacy))
+})
+
+test_that("indep_counts re-weights eventStudy / att_hat but not cohortTimeATTs cells", {
+	# Executable guard for the invariance nuance in NEWS: with indep_counts that
+	# DIFFER from the in-sample cohort counts, the overall att_hat and the
+	# eventStudy() event-time estimates are re-weighted by the independent-sample
+	# cohort probabilities, while the per-(cohort, time) cohortTimeATTs() cells are
+	# invariant (each cell is a single coefficient with no cross-cohort weighting).
+	panel <- .make_late_adoption_panel()
+	fit_no <- .fit_estimator("fetwfe", panel$pdata)
+	# Skewed indep_counts: same total (N) and same never-treated count, but the
+	# treated-cohort weights differ from the in-sample c(8, 7, 6, 9).
+	ic_skew <- c(22L, 12L, 3L, 6L, 9L)
+	stopifnot(sum(ic_skew) == sum(panel$indep_counts))
+	fit_sk <- .fit_estimator("fetwfe", panel$pdata, ic_skew)
+
+	# The #288 fix still applies (accessors succeed), and the per-cell estimates
+	# are invariant to the cohort weighting.
+	expect_no_error(eventStudy(fit_sk))
+	expect_equal(
+		cohortTimeATTs(fit_sk)$estimate,
+		cohortTimeATTs(fit_no)$estimate
+	)
+	# ...but the overall ATT and the aggregated event-time estimates re-weight.
+	expect_false(isTRUE(all.equal(fit_sk$att_hat, fit_no$att_hat)))
+	expect_false(isTRUE(all.equal(
+		eventStudy(fit_sk)$estimate,
+		eventStudy(fit_no)$estimate
+	)))
+})


### PR DESCRIPTION
## Summary

Fixes #288: `eventStudy()`, `cohortTimeATTs()`, and `simultaneousCIs()` errored on a fit produced with `indep_counts` when the treated cohorts adopt **later than the earliest panel periods** (e.g. `bacondecomp::castle` — cohorts adopting 2005–2009 in a 2000–2010 panel), with `first_inds[G] <= n_vars is not TRUE` (`eventStudy`/`cohortTimeATTs`) or `subscript out of bounds` (`simultaneousCIs`).

## Root cause (verified; deeper than the issue's framing)

The accessors recover cohort adoption timing from `names(cohort_probs)` via `.derive_cohort_offsets_from_fit()`. On the `indep_counts` path `cohort_probs` / `cohort_probs_overall` are the indep versions, built **unnamed** from the raw count vector. With no names, offset derivation returned `NULL` → the resolver fell back to earliest-timing `getFirstInds()`, producing a `first_inds` inconsistent with the actual `num_treats` → the `stopifnot` in the fusion-transform builder tripped. `first_year` was correct on both paths; only the missing names differed.

## Fix (two layered changes, both `R/utility.R`)

1. **`.select_att_branch()`** — carry the cohort-year names from the (named) in-sample vectors onto the indep vectors. **Single shared site** → fixes fetwfe / betwfe / etwfe / twfeCovs at once. Names-only: `att_hat` / `att_se` / `catt_df` byte-identical.
2. **`.derive_cohort_offsets_from_fit()`** — fall back to `catt_df$cohort` (always named, independent of `indep_counts`) when `cohort_probs` names are absent. **Rescues legacy/persisted pre-fix `indep_counts` fits** without re-fitting; byte-identical on synthetic fixtures.

## Notes

- **`simultaneousCIs()` was a third affected accessor** (the issue named only two) — same resolver, distinct `subscript out of bounds` symptom. Fixed + covered.
- **Invariance nuance:** `cohortTimeATTs()` per-cell estimates are invariant to `indep_counts`; `eventStudy()` event-time estimates and the overall `att_hat` are (as before) re-weighted by the independent-sample cohort probabilities. The new test pins both.

## Tests / verification

- New `tests/testthat/test-indep-counts-late-adoption-288.R`: synthetic late-adoption panel (cohorts t=6–9 in a 1–11 panel; base R, no Suggests deps) × {`eventStudy`, `cohortTimeATTs`, `simultaneousCIs`} × {fetwfe, etwfe, betwfe}; a legacy unnamed-`cohort_probs` rescue test; and a skewed-`indep_counts` guard for the invariance nuance.
- Both fixes **mutation-verified** to bite (revert names-copy → name-parity assertions fail; revert `catt_df` fallback → legacy test fails).
- `R CMD check` **with vignettes**: 0/0/0. Full suite FAIL 0.
- Plan-review + post-exec review (multi-agent): **GO, no blockers**.

Patch bump 1.27.2 → 1.27.3 + NEWS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
