### PR TITLE
feat: extend debiasedATT() to the high-dimensional p >= NT regime (#31)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.28.0
+Version: 1.29.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # NEWS
 
+## Version 1.29.0
+
+### New features
+
+- `debiasedATT()` now also supports **high-dimensional (`p >= NT`)** fits, where
+  the unrestricted ETWFE is infeasible and the fixed-`p` exact-inverse debiasing
+  direction is invalid. In that regime the debiasing direction is instead the
+  **nodewise (desparsified-lasso) relaxed inverse** of the design Gram (paper
+  Theorem 6.6, `debiased.highdim.thm`). It is the *same* estimator and standard
+  error as the fixed-`p` case — only the construction of the debiasing direction
+  `v` changes — so existing `p < NT` results are unchanged (byte-identical). The
+  `p >= NT` error introduced in 1.28.0 is lifted. New arguments `lambda_c`,
+  `riesz_max_iter`, and `riesz_tol` control the nodewise solver (ignored when
+  `p < NT`), and for `p >= NT` fits the returned list gains `feasibility`,
+  `converged`, and `lambda_node` diagnostics. The high-dimensional path is
+  **experimental**: its finite-sample coverage is not yet validated by
+  simulation and the penalty constant `lambda_c` is not yet tuned — inspect the
+  returned diagnostics and treat `lambda_c` as a tunable knob (#31).
+
 ## Version 1.28.0
 
 ### New features
@@ -15,8 +34,9 @@
   rather than a `se_type` option. The standard error has a per-unit-clustered
   regression channel plus a cohort-weight channel that add under marginal cohort
   assignment / (Psi-IF); the assumptions are documented on `?debiasedATT`. Errors
-  cleanly for `q >= 1` (no selection) and for the high-dimensional `p >= NT`
-  regime (a desparsified-lasso construction is follow-up work) (#291).
+  cleanly for `q >= 1` (no selection). (At this version it also errored for the
+  high-dimensional `p >= NT` regime; that regime is supported as of 1.29.0.)
+  (#291).
 
 ## Version 1.27.3
 

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -19,13 +19,20 @@
 #' returns an interval with asymptotically nominal coverage at roughly the
 #' efficiency of unrestricted ETWFE.
 #'
-#' The debiased point estimate **differs** from the fused `fit$att_hat`: by the
-#' OLS identity (paper eq. `debiased.ols.identity`) it equals the unrestricted
-#' ETWFE/OLS estimate in the ATT direction. You therefore get a dual offering ---
-#' `fit$att_hat` / `fit$att_se` (fused, efficient, pointwise) and
+#' The debiased point estimate **differs** from the fused `fit$att_hat`: when
+#' `p < NT`, by the OLS identity (paper eq. `debiased.ols.identity`) it equals the
+#' unrestricted ETWFE/OLS estimate in the ATT direction. You therefore get a dual
+#' offering --- `fit$att_hat` / `fit$att_se` (fused, efficient, pointwise) and
 #' `debiasedATT(fit)` (debiased, ETWFE-efficient, uniformly valid). It is exposed
 #' as a separate accessor (rather than a `se_type` option) precisely because the
 #' debiased SE accompanies a different point estimate than the fused one.
+#'
+#' When `p >= NT` the unrestricted ETWFE is infeasible, so the OLS identity no
+#' longer applies; the accessor instead builds the debiasing direction by a
+#' nodewise (desparsified-lasso) relaxed inverse (paper Theorem
+#' `debiased.highdim.thm`). The point estimate, SE formula, and return value are
+#' otherwise identical --- "one estimator, two regimes." This high-dimensional
+#' branch is **experimental** (see Assumptions).
 #'
 #' @details
 #' The standard error has two channels that **add** under marginal cohort
@@ -59,23 +66,44 @@
 #'   \item **Correctly specified (GLS-whitened) conditional mean** of the
 #'     outcome. Neyman-orthogonality removes first-order sensitivity to the
 #'     selected nuisance coefficients, but not to mean-misspecification.
-#'   \item **Asymptotically negligible ridge,** `lambda = o((NT)^(-1/2))` (the
-#'     theoretical condition; the leading case is the exact inverse `lambda = 0`).
-#'     The implementation does **not** use a vanishing schedule --- it adds a fixed
-#'     numerical stabilizer `1e-6 * mean(diag(Sigma))` to the Gram before solving,
-#'     which (running only at `p < NT`) is negligible and cancels in the
-#'     OLS-identity case.
+#'   \item **(Low-dimensional `p < NT` only) Asymptotically negligible ridge,**
+#'     `lambda = o((NT)^(-1/2))` (the theoretical condition; the leading case is
+#'     the exact inverse `lambda = 0`). The implementation does **not** use a
+#'     vanishing schedule --- it adds a fixed numerical stabilizer
+#'     `1e-6 * mean(diag(Sigma))` to the Gram before solving, which is negligible
+#'     and cancels in the OLS-identity case.
 #'   \item **Growing number of clusters,** `N -> infinity`. The CLT is over the
 #'     `N` independent units, not the `NT` rows. With few treated units the
 #'     cluster approximation is poor; prefer a wild-cluster bootstrap when `N` is
 #'     small.
-#'   \item **Fixed-dimension regularity:** the full design Gram matrix is
-#'     nonsingular with finite fourth covariate moments, and the design is
-#'     low-dimensional, `p < NT`. The high-dimensional regime `p >= NT` (where
-#'     unrestricted ETWFE is infeasible and a desparsified-lasso construction is
-#'     required) is out of scope; the accessor errors in that case (paper Remark
-#'     `debiased.regime.remark`).
+#'   \item **Regularity / two regimes.** When `p < NT` (Theorem
+#'     `debiased.att.thm`) the full design Gram is nonsingular and the debiasing
+#'     direction is the exact inverse; the accessor reduces to debiased ETWFE.
+#'     When `p >= NT` (Theorem `debiased.highdim.thm`) the Gram is singular and the
+#'     direction is the **nodewise (desparsified-lasso) relaxed inverse** of
+#'     equation `debiased.highdim.v` (the same estimate and SE, only `v` differs
+#'     --- "one estimator, two regimes"); it requires sparsity
+#'     (`s_N log(p_N) / sqrt(N) -> 0`), a restricted-eigenvalue condition over
+#'     sparse cones, `||v*||_1 = O(1)`, and a bounded limiting variance
+#'     `a' Sigma_theta^(-1) a`. The high-dimensional branch realizes Theorem
+#'     `debiased.highdim.thm` with the theory-scaled penalty, but its
+#'     finite-sample **coverage is not yet validated by simulation** (the penalty
+#'     constant `lambda_c` is not yet tuned); treat the `p >= NT` path as
+#'     **experimental** and inspect the returned `feasibility` / `converged`
+#'     diagnostics.
 #' }
+#'
+#' The high-dimensional branch reuses the same bridge (`q < 1`) nuisance
+#' `theta_hat` as the fixed-`p` branch rather than the paper's literal `q = 1`
+#' fused lasso (a `q = 1` fit carries no valid SE here, since `calc_ses` is
+#' `FALSE`). For the fixed-`p` branch this substitution is first-order innocuous:
+#' Theorem `debiased.att.thm` needs only *consistency* of the nuisance. In the
+#' high-dimensional regime, however, Theorem `debiased.highdim.thm` controls the
+#' orthogonalization remainder through the nuisance's `l1` *rate*
+#' (`||theta_hat - theta*||_1 = O_p(s_N lambda_theta)`), which the paper
+#' establishes for the `q = 1` fused lasso; the bridge nuisance is `l1`-consistent
+#' and sparse, but its high-dimensional `l1` rate is not established for `q < 1`.
+#' This is a further reason the `p >= NT` path is flagged experimental.
 #'
 #' @param fit A fitted object from [fetwfe()] computed with `q < 1` (so the
 #'   bridge selection produces a valid standard error). [etwfe()] / [betwfe()] /
@@ -83,6 +111,15 @@
 #'   transformed-coefficient space).
 #' @param alpha Numeric in `(0, 1)`; the confidence level is `1 - alpha`.
 #'   Defaults to the `alpha` stored on the fit.
+#' @param lambda_c Numeric `> 0`; the leading constant of the high-dimensional
+#'   (`p >= NT`) nodewise penalty `lambda_node = lambda_c * max(|a|) *
+#'   sqrt(log(p) / N)` (`N` = number of units). Larger values shrink the
+#'   debiasing direction more (more conservative). **Ignored when `p < NT`.**
+#'   Default `1.0`. The coverage-optimal value is regime- and data-dependent and
+#'   not yet established by simulation (see *Assumptions*); treat this as a
+#'   tunable, experimental knob.
+#' @param riesz_max_iter,riesz_tol Integer / numeric; coordinate-descent controls
+#'   for the high-dimensional nodewise solver. **Ignored when `p < NT`.**
 #'
 #' @return A named list with elements:
 #'   \describe{
@@ -102,6 +139,11 @@
 #'   CLT-scale variances `V_1^full` / `V_2` from Theorem `debiased.att.thm`, which
 #'   are larger by a factor on the order of `NT`.
 #'
+#'   For high-dimensional (`p >= NT`) fits the list additionally contains
+#'   `feasibility` (`= ||Sigma v - a||_inf`, the nodewise KKT certificate, which
+#'   should be `<= lambda_node`), `converged` (the coordinate-descent flag), and
+#'   `lambda_node` (the penalty used). These are absent for `p < NT` fits.
+#'
 #' @seealso [fetwfe()] for the fused fit; [cohortTimeATTs()] / [eventStudy()] /
 #'   [cohortStudy()] for the disaggregated fused effects.
 #' @examples
@@ -113,7 +155,13 @@
 #'   debiasedATT(fit) # debiased (uniformly valid)
 #' }
 #' @export
-debiasedATT <- function(fit, alpha = NULL) {
+debiasedATT <- function(
+	fit,
+	alpha = NULL,
+	lambda_c = 1.0,
+	riesz_max_iter = 5000L,
+	riesz_tol = 1e-9
+) {
 	if (!inherits(fit, "fetwfe")) {
 		stop(
 			"debiasedATT() requires a fitted object from fetwfe(). The debiased ",
@@ -137,6 +185,43 @@ debiasedATT <- function(fit, alpha = NULL) {
 	) {
 		stop(
 			"debiasedATT(): `alpha` must be a single number in (0, 1).",
+			call. = FALSE
+		)
+	}
+
+	# High-dimensional nodewise-solver controls. These only affect the p >= NT
+	# path, but validate them unconditionally so a malformed value fails loudly
+	# rather than silently producing a degenerate debiasing direction.
+	if (
+		!is.numeric(lambda_c) ||
+			length(lambda_c) != 1L ||
+			is.na(lambda_c) ||
+			lambda_c <= 0
+	) {
+		stop(
+			"debiasedATT(): `lambda_c` must be a single positive number.",
+			call. = FALSE
+		)
+	}
+	if (
+		!is.numeric(riesz_max_iter) ||
+			length(riesz_max_iter) != 1L ||
+			is.na(riesz_max_iter) ||
+			riesz_max_iter < 1
+	) {
+		stop(
+			"debiasedATT(): `riesz_max_iter` must be a single positive integer.",
+			call. = FALSE
+		)
+	}
+	if (
+		!is.numeric(riesz_tol) ||
+			length(riesz_tol) != 1L ||
+			is.na(riesz_tol) ||
+			riesz_tol <= 0
+	) {
+		stop(
+			"debiasedATT(): `riesz_tol` must be a single positive number.",
 			call. = FALSE
 		)
 	}
@@ -173,23 +258,10 @@ debiasedATT <- function(fit, alpha = NULL) {
 		)
 	}
 
-	# High-dimensional regime: the OLS identity (and the whole leading-order
-	# argument) requires p < NT. When p >= NT the unrestricted estimator is
-	# infeasible and a (cluster-ported) desparsified-lasso construction of `v` is
-	# needed -- out of scope here (paper Remark `debiased.regime.remark`).
-	if (p >= n) {
-		stop(
-			"debiasedATT(): the design is high-dimensional (p >= NT: p = ",
-			p,
-			", NT = ",
-			n,
-			"), where unrestricted ETWFE is infeasible and the OLS identity ",
-			"underlying the debiased estimator no longer holds. The desparsified-",
-			"lasso construction for this regime is follow-up work (paper Remark ",
-			"`debiased.regime.remark`) and is not yet available.",
-			call. = FALSE
-		)
-	}
+	# Regime is detected from `p` vs `NT` below (see the `v` construction): p < NT
+	# uses the exact/ridged inverse; p >= NT uses the nodewise desparsified-lasso
+	# direction of paper Theorem `debiased.highdim.thm`. Both share everything
+	# else (estimate + SE).
 
 	G <- fit$G
 	T <- fit$T
@@ -272,8 +344,66 @@ debiasedATT <- function(fit, alpha = NULL) {
 	}
 
 	# ---- debiased estimate: plug-in functional + orthogonal correction ----
+	# Two regimes, ONE estimator: only the debiasing direction `v` differs (paper
+	# Theorem `debiased.highdim.thm`, "one estimator, two regimes"); everything
+	# downstream (the correction, both SE channels) is identical.
 	Sig <- crossprod(X) / n
-	v <- solve(Sig + (1e-6 * mean(diag(Sig))) * diag(p), a_theta[-1])
+	highdim <- p >= n
+	riesz_diag <- NULL
+	if (!highdim) {
+		# Fixed-p (p < NT): exact / tiny-ridge inverse. Byte-identical to the
+		# validated fixed-p reference; `lambda_c` / `riesz_*` are ignored here.
+		v <- solve(Sig + (1e-6 * mean(diag(Sig))) * diag(p), a_theta[-1])
+	} else {
+		# High-dimensional (p >= NT): nodewise (desparsified-lasso) relaxed inverse.
+		# `Sig` is singular, so the exact inverse is invalid; `v` is the l1-penalized
+		# Riesz representer with theory penalty
+		# lambda_node = lambda_c * max(|a|) * sqrt(log p / N), N = clusters = n / T
+		# (NOT NT). max(|a|) rescales to the units of the KKT constraint.
+		a_th <- a_theta[-1]
+		N_units <- n / T
+		lambda_node <- lambda_node_default(
+			p = p,
+			N = N_units,
+			c = lambda_c,
+			scale = max(abs(a_th))
+		)
+		v <- riesz_lasso(
+			Sig,
+			a_th,
+			lambda_node,
+			max_iter = riesz_max_iter,
+			tol = riesz_tol
+		)
+		feasibility <- attr(v, "feasibility")
+		converged <- attr(v, "converged")
+		# The KKT certificate ||Sig v - a||_inf <= lambda_node is exactly the
+		# relaxed-inverse feasibility the Theorem 6.6 remainder bound needs.
+		if (feasibility > lambda_node * (1 + riesz_tol)) {
+			warning(
+				"debiasedATT(): the high-dimensional nodewise direction did not meet ",
+				"its feasibility constraint (||Sig v - a||_inf = ",
+				signif(feasibility, 3),
+				" > lambda_node = ",
+				signif(lambda_node, 3),
+				"); the standard error may be unreliable. Raise `riesz_max_iter` ",
+				"and/or `lambda_c`.",
+				call. = FALSE
+			)
+		} else if (!converged) {
+			warning(
+				"debiasedATT(): the high-dimensional nodewise solver hit ",
+				"`riesz_max_iter` (the feasibility constraint is met, but more ",
+				"iterations would tighten the direction).",
+				call. = FALSE
+			)
+		}
+		riesz_diag <- list(
+			feasibility = feasibility,
+			converged = converged,
+			lambda_node = lambda_node
+		)
+	}
 	resid <- as.numeric(y - theta_hat[1] - X %*% theta_hat[-1])
 	score <- as.numeric((X %*% v) * resid)
 	att_db <- sum(a_theta * theta_hat) + mean(score)
@@ -289,7 +419,7 @@ debiasedATT <- function(fit, alpha = NULL) {
 
 	se_db <- sqrt(var_reg + var_weight)
 	z <- stats::qnorm(1 - alpha / 2)
-	list(
+	out <- list(
 		att = att_db,
 		se = se_db,
 		ci_low = att_db - z * se_db,
@@ -297,6 +427,14 @@ debiasedATT <- function(fit, alpha = NULL) {
 		var_reg = var_reg,
 		var_weight = var_weight
 	)
+	# High-dimensional fits append the nodewise-direction diagnostics (the fixed-p
+	# return is unchanged).
+	if (highdim) {
+		out$feasibility <- riesz_diag$feasibility
+		out$converged <- riesz_diag$converged
+		out$lambda_node <- riesz_diag$lambda_node
+	}
+	out
 }
 
 #' Run debiasedATT() on simulated data

--- a/R/riesz_lasso.R
+++ b/R/riesz_lasso.R
@@ -1,0 +1,78 @@
+# High-dimensional (p >= NT) debiasing direction for debiasedATT() (#31).
+#
+# The fixed-p debiased path builds the debiasing direction as the exact/ridged
+# inverse v = (Sigma_hat + tiny*I)^{-1} a, which is invalid once p >= NT
+# (Sigma_hat = X'X/n is singular and the tiny ridge yields an unstable v). In the
+# high-dimensional regime v is instead the nodewise (desparsified) Riesz
+# representer of paper Theorem `debiased.highdim.thm`, computed as the
+# l1-penalized solve below. Ported verbatim from the validated reference
+# `simulations/highdim_functions.R::riesz_lasso` in the FETWFE paper repo.
+
+#' Nodewise (desparsified) debiasing direction for the high-dimensional regime
+#'
+#' @description
+#' Solves `v_hat = argmin_v (1/2) v' Sig v - a' v + lambda * ||v||_1` by
+#' coordinate descent. By the KKT conditions the minimizer satisfies
+#' `|| Sig %*% v_hat - a ||_inf <= lambda` --- the relaxed-inverse feasibility the
+#' Theorem `debiased.highdim.thm` remainder bound uses --- and as `lambda -> 0`
+#' with `Sig` nonsingular it returns the exact inverse `Sig^{-1} a` (the fixed-p
+#' boundary). `O(p^2)` per sweep via a rank-1 maintenance of `Sig %*% v`.
+#'
+#' @param Sig Numeric matrix; the (whitened theta-space) Gram `X'X / n`.
+#' @param a Numeric vector; the target direction (length `ncol(Sig)`).
+#' @param lambda Numeric scalar; the nodewise l1 penalty.
+#' @param max_iter Integer; maximum coordinate-descent sweeps.
+#' @param tol Numeric; convergence tolerance on the max coordinate change.
+#' @return `v` with attributes `feasibility` (`= ||Sig v - a||_inf`), `iters`,
+#'   and `converged` (`FALSE` => `lambda` likely too small / more iterations
+#'   needed).
+#' @keywords internal
+#' @noRd
+riesz_lasso <- function(Sig, a, lambda, max_iter = 5000L, tol = 1e-9) {
+	p <- length(a)
+	v <- numeric(p)
+	Sv <- numeric(p) # Sig %*% v, maintained incrementally
+	dgSig <- diag(Sig)
+	it <- 0L
+	converged <- FALSE
+	for (it in seq_len(max_iter)) {
+		max_change <- 0
+		for (j in seq_len(p)) {
+			if (dgSig[j] <= 0) {
+				next # all-zero column: leave v_j = 0
+			}
+			cj <- Sv[j] - dgSig[j] * v[j] # (Sig v)_j without the j-th term
+			rho <- a[j] - cj
+			vj_new <- sign(rho) * max(0, abs(rho) - lambda) / dgSig[j] # soft-threshold
+			dv <- vj_new - v[j]
+			if (dv != 0) {
+				Sv <- Sv + Sig[, j] * dv # rank-1 update of Sig %*% v
+				v[j] <- vj_new
+				adv <- abs(dv)
+				if (adv > max_change) {
+					max_change <- adv
+				}
+			}
+		}
+		if (max_change < tol) {
+			converged <- TRUE
+			break
+		}
+	}
+	attr(v, "feasibility") <- max(abs(Sv - a)) # ||Sig v - a||_inf
+	attr(v, "iters") <- it
+	attr(v, "converged") <- converged # FALSE => lambda likely too small
+	v
+}
+
+#' Theory-scaled nodewise penalty `lambda_node = c * scale * sqrt(log p / N)`
+#'
+#' @description The Theorem `debiased.highdim.thm` rate scale. The effective
+#'   sample size is the number of clusters `N` (units), not `n = NT`. `scale`
+#'   rescales to the units of the constraint `||Sig v - a||_inf` (the accessor
+#'   passes `scale = max(abs(a))`).
+#' @keywords internal
+#' @noRd
+lambda_node_default <- function(p, N, c = 1.0, scale = 1.0) {
+	c * scale * sqrt(log(p) / N)
+}

--- a/man/debiasedATT.Rd
+++ b/man/debiasedATT.Rd
@@ -4,7 +4,13 @@
 \alias{debiasedATT}
 \title{Debiased overall-ATT with a uniformly-valid standard error}
 \usage{
-debiasedATT(fit, alpha = NULL)
+debiasedATT(
+  fit,
+  alpha = NULL,
+  lambda_c = 1,
+  riesz_max_iter = 5000L,
+  riesz_tol = 1e-09
+)
 }
 \arguments{
 \item{fit}{A fitted object from \code{\link[=fetwfe]{fetwfe()}} computed with \code{q < 1} (so the
@@ -14,6 +20,16 @@ transformed-coefficient space).}
 
 \item{alpha}{Numeric in \verb{(0, 1)}; the confidence level is \code{1 - alpha}.
 Defaults to the \code{alpha} stored on the fit.}
+
+\item{lambda_c}{Numeric \verb{> 0}; the leading constant of the high-dimensional
+(\code{p >= NT}) nodewise penalty \verb{lambda_node = lambda_c * max(|a|) * sqrt(log(p) / N)} (\code{N} = number of units). Larger values shrink the
+debiasing direction more (more conservative). \strong{Ignored when \code{p < NT}.}
+Default \code{1.0}. The coverage-optimal value is regime- and data-dependent and
+not yet established by simulation (see \emph{Assumptions}); treat this as a
+tunable, experimental knob.}
+
+\item{riesz_max_iter, riesz_tol}{Integer / numeric; coordinate-descent controls
+for the high-dimensional nodewise solver. \strong{Ignored when \code{p < NT}.}}
 }
 \value{
 A named list with elements:
@@ -33,6 +49,11 @@ carries the correct single- or two-sample (\code{indep_counts}) formula.}
 components, so \code{se = sqrt(var_reg + var_weight)}. They are \emph{not} the paper's
 CLT-scale variances \code{V_1^full} / \code{V_2} from Theorem \code{debiased.att.thm}, which
 are larger by a factor on the order of \code{NT}.
+
+For high-dimensional (\code{p >= NT}) fits the list additionally contains
+\code{feasibility} (\verb{= ||Sigma v - a||_inf}, the nodewise KKT certificate, which
+should be \verb{<= lambda_node}), \code{converged} (the coordinate-descent flag), and
+\code{lambda_node} (the penalty used). These are absent for \code{p < NT} fits.
 }
 \description{
 Computes a \emph{debiased} estimate of the overall average treatment effect on the
@@ -44,13 +65,20 @@ overall ATT (it omits the between-selection term), whereas \code{debiasedATT()}
 returns an interval with asymptotically nominal coverage at roughly the
 efficiency of unrestricted ETWFE.
 
-The debiased point estimate \strong{differs} from the fused \code{fit$att_hat}: by the
-OLS identity (paper eq. \code{debiased.ols.identity}) it equals the unrestricted
-ETWFE/OLS estimate in the ATT direction. You therefore get a dual offering ---
-\code{fit$att_hat} / \code{fit$att_se} (fused, efficient, pointwise) and
+The debiased point estimate \strong{differs} from the fused \code{fit$att_hat}: when
+\code{p < NT}, by the OLS identity (paper eq. \code{debiased.ols.identity}) it equals the
+unrestricted ETWFE/OLS estimate in the ATT direction. You therefore get a dual
+offering --- \code{fit$att_hat} / \code{fit$att_se} (fused, efficient, pointwise) and
 \code{debiasedATT(fit)} (debiased, ETWFE-efficient, uniformly valid). It is exposed
 as a separate accessor (rather than a \code{se_type} option) precisely because the
 debiased SE accompanies a different point estimate than the fused one.
+
+When \code{p >= NT} the unrestricted ETWFE is infeasible, so the OLS identity no
+longer applies; the accessor instead builds the debiasing direction by a
+nodewise (desparsified-lasso) relaxed inverse (paper Theorem
+\code{debiased.highdim.thm}). The point estimate, SE formula, and return value are
+otherwise identical --- "one estimator, two regimes." This high-dimensional
+branch is \strong{experimental} (see Assumptions).
 }
 \details{
 The standard error has two channels that \strong{add} under marginal cohort
@@ -85,23 +113,44 @@ implemented).
 \item \strong{Correctly specified (GLS-whitened) conditional mean} of the
 outcome. Neyman-orthogonality removes first-order sensitivity to the
 selected nuisance coefficients, but not to mean-misspecification.
-\item \strong{Asymptotically negligible ridge,} \code{lambda = o((NT)^(-1/2))} (the
-theoretical condition; the leading case is the exact inverse \code{lambda = 0}).
-The implementation does \strong{not} use a vanishing schedule --- it adds a fixed
-numerical stabilizer \code{1e-6 * mean(diag(Sigma))} to the Gram before solving,
-which (running only at \code{p < NT}) is negligible and cancels in the
-OLS-identity case.
+\item \strong{(Low-dimensional \code{p < NT} only) Asymptotically negligible ridge,}
+\code{lambda = o((NT)^(-1/2))} (the theoretical condition; the leading case is
+the exact inverse \code{lambda = 0}). The implementation does \strong{not} use a
+vanishing schedule --- it adds a fixed numerical stabilizer
+\code{1e-6 * mean(diag(Sigma))} to the Gram before solving, which is negligible
+and cancels in the OLS-identity case.
 \item \strong{Growing number of clusters,} \code{N -> infinity}. The CLT is over the
 \code{N} independent units, not the \code{NT} rows. With few treated units the
 cluster approximation is poor; prefer a wild-cluster bootstrap when \code{N} is
 small.
-\item \strong{Fixed-dimension regularity:} the full design Gram matrix is
-nonsingular with finite fourth covariate moments, and the design is
-low-dimensional, \code{p < NT}. The high-dimensional regime \code{p >= NT} (where
-unrestricted ETWFE is infeasible and a desparsified-lasso construction is
-required) is out of scope; the accessor errors in that case (paper Remark
-\code{debiased.regime.remark}).
+\item \strong{Regularity / two regimes.} When \code{p < NT} (Theorem
+\code{debiased.att.thm}) the full design Gram is nonsingular and the debiasing
+direction is the exact inverse; the accessor reduces to debiased ETWFE.
+When \code{p >= NT} (Theorem \code{debiased.highdim.thm}) the Gram is singular and the
+direction is the \strong{nodewise (desparsified-lasso) relaxed inverse} of
+equation \code{debiased.highdim.v} (the same estimate and SE, only \code{v} differs
+--- "one estimator, two regimes"); it requires sparsity
+(\verb{s_N log(p_N) / sqrt(N) -> 0}), a restricted-eigenvalue condition over
+sparse cones, \verb{||v*||_1 = O(1)}, and a bounded limiting variance
+\verb{a' Sigma_theta^(-1) a}. The high-dimensional branch realizes Theorem
+\code{debiased.highdim.thm} with the theory-scaled penalty, but its
+finite-sample \strong{coverage is not yet validated by simulation} (the penalty
+constant \code{lambda_c} is not yet tuned); treat the \code{p >= NT} path as
+\strong{experimental} and inspect the returned \code{feasibility} / \code{converged}
+diagnostics.
 }
+
+The high-dimensional branch reuses the same bridge (\code{q < 1}) nuisance
+\code{theta_hat} as the fixed-\code{p} branch rather than the paper's literal \code{q = 1}
+fused lasso (a \code{q = 1} fit carries no valid SE here, since \code{calc_ses} is
+\code{FALSE}). For the fixed-\code{p} branch this substitution is first-order innocuous:
+Theorem \code{debiased.att.thm} needs only \emph{consistency} of the nuisance. In the
+high-dimensional regime, however, Theorem \code{debiased.highdim.thm} controls the
+orthogonalization remainder through the nuisance's \code{l1} \emph{rate}
+(\verb{||theta_hat - theta*||_1 = O_p(s_N lambda_theta)}), which the paper
+establishes for the \code{q = 1} fused lasso; the bridge nuisance is \code{l1}-consistent
+and sparse, but its high-dimensional \code{l1} rate is not established for \code{q < 1}.
+This is a further reason the \code{p >= NT} path is flagged experimental.
 }
 
 \examples{

--- a/tests/testthat/test-debiased-att-highdim.R
+++ b/tests/testthat/test-debiased-att-highdim.R
@@ -1,0 +1,318 @@
+# Tests for the high-dimensional (p >= NT) regime of debiasedATT() (#31).
+#
+# The fixed-p path builds the debiasing direction by the exact/ridged inverse
+# v = (Sig + tiny*I)^{-1} a, which is invalid once p >= NT (Sig = X'X/n is
+# singular). The high-dim path instead uses the nodewise (desparsified-lasso)
+# Riesz representer `riesz_lasso()` of paper Theorem `debiased.highdim.thm`.
+# These tests pin (a) the nodewise solver's fidelity and KKT/boundary behavior
+# and (b) the accessor end-to-end on a genuine p >= NT fit.
+
+# ---- An independent, naive reference for riesz_lasso ------------------------
+# Same coordinate-descent minimizer of (1/2) v'Sig v - a'v + lambda||v||_1, but
+# WITHOUT the package's O(p^2) rank-1 maintenance of `Sig %*% v`: it recomputes
+# (Sig v)_j by a full inner product each coordinate. The two must agree to
+# machine precision (the problem is strictly convex when Sig is nonsingular, so
+# the minimizer is unique) -- this validates exactly the rank-1 update, the one
+# optimization that could harbor a bug.
+.ref_riesz_naive <- function(Sig, a, lambda, max_iter = 5000L, tol = 1e-12) {
+	p <- length(a)
+	v <- numeric(p)
+	dg <- diag(Sig)
+	conv <- FALSE
+	for (it in seq_len(max_iter)) {
+		mc <- 0
+		for (j in seq_len(p)) {
+			if (dg[j] <= 0) {
+				next
+			}
+			Sv_j <- sum(Sig[j, ] * v) # full recompute of (Sig v)_j
+			cj <- Sv_j - dg[j] * v[j]
+			rho <- a[j] - cj
+			vj <- sign(rho) * max(0, abs(rho) - lambda) / dg[j]
+			dv <- vj - v[j]
+			if (dv != 0) {
+				v[j] <- vj
+				ad <- abs(dv)
+				if (ad > mc) {
+					mc <- ad
+				}
+			}
+		}
+		if (mc < tol) {
+			conv <- TRUE
+			break
+		}
+	}
+	v
+}
+
+# A reasonably-conditioned nonsingular Gram for the solver-level tests.
+.psd_gram <- function(p = 40L, n = 200L, seed = 11L) {
+	set.seed(seed)
+	M <- matrix(stats::rnorm(n * p), n, p)
+	crossprod(M) / n
+}
+
+# ---- A genuine p >= NT fetwfe fit (the simulator cannot make one: it enforces
+# N >= (G+1)(d+1), so build the raw panel directly and supply the noise
+# variances to bypass REML). N=20, T=8, d=12 => p = 376 >> NT = 160. -----------
+.make_highdim_fit <- function() {
+	set.seed(3)
+	N <- 20L
+	T <- 8L
+	d <- 12L
+	cohort_of_unit <- c(rep(0L, 8), rep(2L, 4), rep(3L, 4), rep(4L, 4))
+	eff <- c(`2` = 0.5, `3` = 1.75, `4` = 3.0)
+	covs <- matrix(stats::rnorm(N * d), N, d)
+	rows <- do.call(
+		rbind,
+		lapply(seq_len(N), function(i) {
+			g <- cohort_of_unit[i]
+			df <- data.frame(
+				unit = sprintf("u%02d", i),
+				year = 1:T,
+				treat = as.integer(g > 0 & (1:T) >= g)
+			)
+			for (j in 1:d) {
+				df[[paste0("x", j)]] <- covs[i, j]
+			}
+			te <- if (g > 0) eff[[as.character(g)]] else 0
+			df$y <- 0.3 *
+				(1:T) /
+				T +
+				te * df$treat +
+				0.2 * covs[i, 1] +
+				stats::rnorm(T, 0, 0.4)
+			df
+		})
+	)
+	fetwfe(
+		pdata = rows,
+		time_var = "year",
+		unit_var = "unit",
+		treatment = "treat",
+		covs = paste0("x", 1:d),
+		response = "y",
+		q = 0.5,
+		verbose = FALSE,
+		sig_eps_sq = 0.16,
+		sig_eps_c_sq = 0.1
+	)
+}
+
+# Build the high-dim fit once (the fit is the slow part); reuse across tests.
+hd_fix <- .make_highdim_fit()
+
+# ============================ solver-level tests =============================
+
+test_that("riesz_lasso matches an independent naive implementation (machine precision)", {
+	Sig <- .psd_gram(p = 40L)
+	set.seed(101)
+	a <- stats::rnorm(40) * 0.5
+	lam <- 0.05
+	v_pkg <- riesz_lasso(Sig, a, lam, max_iter = 5000L, tol = 1e-12)
+	v_nai <- .ref_riesz_naive(Sig, a, lam, max_iter = 5000L, tol = 1e-12)
+	expect_lt(max(abs(v_pkg - v_nai)), 1e-12)
+	expect_true(attr(v_pkg, "converged"))
+})
+
+test_that("riesz_lasso reduces to the exact inverse as lambda -> 0 (fixed-p boundary)", {
+	Sig <- .psd_gram(p = 40L)
+	set.seed(102)
+	a <- stats::rnorm(40) * 0.5
+	v <- riesz_lasso(Sig, a, 1e-10, max_iter = 2e5L, tol = 1e-12)
+	expect_lt(max(abs(v - solve(Sig, a))), 1e-7)
+	expect_true(attr(v, "converged"))
+})
+
+test_that("riesz_lasso satisfies its KKT feasibility certificate when converged", {
+	Sig <- .psd_gram(p = 30L, seed = 7L)
+	set.seed(103)
+	a <- stats::rnorm(30)
+	lam <- 0.1
+	v <- riesz_lasso(Sig, a, lam, max_iter = 5000L, tol = 1e-12)
+	# KKT for the l1-penalized objective: ||Sig v - a||_inf <= lambda.
+	expect_true(attr(v, "converged"))
+	expect_lte(attr(v, "feasibility"), lam * (1 + 1e-9))
+	# attr matches a direct recomputation of the residual sup-norm.
+	expect_equal(attr(v, "feasibility"), max(abs(Sig %*% v - a)))
+})
+
+test_that("riesz_lasso leaves all-zero (dead) columns at zero without NaNs", {
+	Sig <- .psd_gram(p = 20L, seed = 5L)
+	Sig[5, ] <- 0
+	Sig[, 5] <- 0
+	set.seed(104)
+	a <- stats::rnorm(20)
+	v <- riesz_lasso(Sig, a, 0.05)
+	expect_identical(v[5], 0)
+	expect_true(all(is.finite(v)))
+})
+
+test_that("riesz_lasso is deterministic", {
+	Sig <- .psd_gram(p = 25L, seed = 9L)
+	set.seed(105)
+	a <- stats::rnorm(25)
+	v1 <- riesz_lasso(Sig, a, 0.07)
+	v2 <- riesz_lasso(Sig, a, 0.07)
+	expect_identical(as.numeric(v1), as.numeric(v2))
+	expect_identical(attr(v1, "feasibility"), attr(v2, "feasibility"))
+})
+
+test_that("lambda_node_default is the theory-scaled rate c * scale * sqrt(log p / N)", {
+	expect_equal(lambda_node_default(p = 100, N = 25), sqrt(log(100) / 25))
+	expect_equal(
+		lambda_node_default(p = 376, N = 20, c = 2, scale = 3),
+		2 * 3 * sqrt(log(376) / 20)
+	)
+})
+
+# ====================== accessor end-to-end (p >= NT) ========================
+
+test_that("the high-dim fixture really is p >= NT and fits with q < 1", {
+	X <- hd_fix$internal$X_final
+	expect_gte(ncol(X), nrow(X)) # p >= NT
+	expect_true(isTRUE(hd_fix$internal$calc_ses))
+})
+
+test_that("debiasedATT runs in the p >= NT regime and returns nodewise diagnostics", {
+	db <- debiasedATT(hd_fix)
+	# the 6 fixed-p elements PLUS the 3 high-dim diagnostics
+	expect_identical(
+		names(db),
+		c(
+			"att",
+			"se",
+			"ci_low",
+			"ci_high",
+			"var_reg",
+			"var_weight",
+			"feasibility",
+			"converged",
+			"lambda_node"
+		)
+	)
+	expect_true(is.finite(db$att))
+	expect_gt(db$se, 0)
+	expect_true(is.finite(db$se))
+	expect_gt(db$var_reg, 0)
+	expect_gt(db$var_weight, 0)
+	expect_equal(db$se, sqrt(db$var_reg + db$var_weight))
+	# Wald interval ordering.
+	expect_lt(db$ci_low, db$att)
+	expect_lt(db$att, db$ci_high)
+	# Debiased estimate differs from the fused plug-in (it is a different
+	# estimator, not a re-report of att_hat).
+	expect_false(isTRUE(all.equal(db$att, hd_fix$att_hat)))
+})
+
+test_that("the nodewise direction meets its feasibility certificate end-to-end", {
+	db <- debiasedATT(hd_fix)
+	expect_true(db$converged)
+	# KKT: ||Sig v - a||_inf <= lambda_node (the relaxed-inverse bound Theorem
+	# `debiased.highdim.thm` uses). With converged == TRUE this must hold.
+	expect_lte(db$feasibility, db$lambda_node * (1 + 1e-9))
+	expect_gt(db$lambda_node, 0)
+})
+
+test_that("the high-dim branch is load-bearing: the fixed-p inverse explodes on the singular Gram", {
+	# Reconstruct Sig and the theta-space target a exactly as the accessor does,
+	# then compare the nodewise direction against the WRONG fixed-p formula
+	# solve(Sig + tiny*I, a). On the singular high-dim Gram the latter blows up;
+	# the nodewise direction stays O(1). This is why the regime branch exists.
+	X <- hd_fix$internal$X_final
+	n <- nrow(X)
+	p <- ncol(X)
+	Sig <- crossprod(X) / n
+	G <- hd_fix$G
+	Tt <- hd_fix$T
+	dd <- hd_fix$d
+	ti <- hd_fix$treat_inds
+	cp <- hd_fix$cohort_probs
+	num_treats <- length(ti)
+	fi <- getFirstInds(G = G, T = Tt)
+	cot <- rep(seq_len(G), times = (Tt - 1):(Tt - G))
+	a_beta <- numeric(p)
+	for (g in seq_len(G)) {
+		idx <- ti[cot == g]
+		a_beta[idx] <- cp[g] / length(idx)
+	}
+	A <- genFullInvFusionTransformMat(
+		first_inds = fi,
+		T = Tt,
+		G = G,
+		d = dd,
+		num_treats = num_treats,
+		fusion_structure = hd_fix$fusion_structure,
+		d_inv_treat = hd_fix$internal$d_inv_treat
+	)
+	a_th <- as.numeric(crossprod(A, a_beta))
+
+	lam_node <- lambda_node_default(
+		p = p,
+		N = n / Tt,
+		c = 1.0,
+		scale = max(abs(a_th))
+	)
+	v_node <- riesz_lasso(Sig, a_th, lam_node)
+	v_fixedp <- solve(Sig + (1e-6 * mean(diag(Sig))) * diag(p), a_th)
+
+	expect_lt(max(abs(v_node)), 50) # nodewise: O(1)
+	expect_gt(max(abs(v_fixedp)), 1e4) # fixed-p inverse: blows up
+	expect_gt(max(abs(v_fixedp)) / max(abs(v_node)), 100)
+
+	# End-to-end pin: the accessor's lambda_node and debiased att must equal an
+	# independent reconstruction from the same a_th / v_node above (the high-dim
+	# analog of the fixed-p reference test). This pins the scale = max(|a|), the
+	# N = clusters scaling, and the score/correction formula through the accessor.
+	th <- hd_fix$internal$theta_hat
+	resid <- as.numeric(hd_fix$internal$y_final - th[1] - X %*% th[-1])
+	att_recompute <- sum(c(0, a_th) * th) + mean((X %*% v_node) * resid)
+	db <- debiasedATT(hd_fix)
+	expect_equal(db$lambda_node, lam_node)
+	expect_equal(db$att, att_recompute)
+})
+
+test_that("lambda_c scales the nodewise penalty and shrinks the debiasing direction", {
+	db1 <- debiasedATT(hd_fix, lambda_c = 1)
+	db2 <- debiasedATT(hd_fix, lambda_c = 2)
+	# lambda_node is exactly linear in lambda_c (everything else held fixed).
+	expect_equal(db2$lambda_node, 2 * db1$lambda_node)
+	# At lambda_c = 2 the penalty lambda_node exceeds ||a||_inf (= 1 here), so
+	# v = 0 is optimal and the debiased estimate collapses to the fused plug-in
+	# att_hat; at the default lambda_c = 1 the correction is active (att != att_hat).
+	expect_equal(db2$att, hd_fix$att_hat)
+	expect_false(isTRUE(all.equal(db1$att, hd_fix$att_hat)))
+})
+
+test_that("debiasedATT warns when the nodewise solver does not fully resolve", {
+	# Tiny penalty + capped iterations => the KKT feasibility constraint cannot be
+	# met within the budget => the feasibility warning fires.
+	expect_warning(
+		debiasedATT(hd_fix, lambda_c = 1e-6, riesz_max_iter = 200L),
+		"feasibility"
+	)
+	# A single sweep is feasible (loose penalty) but not converged => the softer
+	# "more iterations" warning fires instead.
+	expect_warning(
+		debiasedATT(hd_fix, riesz_max_iter = 1L),
+		"more iterations"
+	)
+})
+
+test_that("debiasedATT is deterministic in the high-dim regime", {
+	a <- debiasedATT(hd_fix)
+	b <- debiasedATT(hd_fix)
+	expect_identical(a$att, b$att)
+	expect_identical(a$se, b$se)
+	expect_identical(a$lambda_node, b$lambda_node)
+})
+
+test_that("debiasedATT validates the high-dim solver arguments", {
+	expect_error(debiasedATT(hd_fix, lambda_c = 0), "lambda_c")
+	expect_error(debiasedATT(hd_fix, lambda_c = -1), "lambda_c")
+	expect_error(debiasedATT(hd_fix, lambda_c = c(1, 2)), "lambda_c")
+	expect_error(debiasedATT(hd_fix, riesz_max_iter = 0), "riesz_max_iter")
+	expect_error(debiasedATT(hd_fix, riesz_tol = 0), "riesz_tol")
+	expect_error(debiasedATT(hd_fix, riesz_tol = -1e-9), "riesz_tol")
+})

--- a/tests/testthat/test-debiased-att.R
+++ b/tests/testthat/test-debiased-att.R
@@ -286,17 +286,4 @@ test_that("debiasedATT input guards", {
 	# alpha out of (0, 1)
 	expect_error(debiasedATT(f$fit, alpha = 1.5), "alpha")
 	expect_error(debiasedATT(f$fit, alpha = 0), "alpha")
-
-	# p >= NT high-dimensional regime (synthetic: shrink BOTH X_final and y_final
-	# to fewer rows than columns so the p >= NT guard fires -- keeping their row
-	# counts equal so the add_ridge guard does not pre-empt it)
-	bad <- f$fit
-	pcols <- ncol(bad$internal$X_final)
-	bad$internal$X_final <- bad$internal$X_final[
-		seq_len(pcols - 1L),
-		,
-		drop = FALSE
-	]
-	bad$internal$y_final <- bad$internal$y_final[seq_len(pcols - 1L)]
-	expect_error(debiasedATT(bad), "high-dimensional")
 })


### PR DESCRIPTION
## Summary

Extends `debiasedATT()` from the fixed-dimension regime (`p < NT`) to the **high-dimensional regime `p >= NT`**, realizing paper **Theorem 6.6** (`debiased.highdim.thm`). When `p >= NT` the design Gram `X'X/n` is singular and the fixed-`p` exact/ridged inverse debiasing direction is invalid, so the direction `v` is instead the **nodewise (desparsified-lasso) relaxed inverse** of eq `debiased.highdim.v`:

```
v_hat = argmin_v  v' Sig v   s.t.  || Sig v - a ||_inf <= lambda_node
```

The point estimate, both SE channels, and the return value are **otherwise identical** to the fixed-`p` path — *"one estimator, two regimes."* `p < NT` results are **byte-identical** to before; the `p >= NT` error added in 1.28.0 is lifted (Closes #31).

## What changed

- **`R/riesz_lasso.R`** (new, internal): `riesz_lasso()` + `lambda_node_default()`, ported verbatim from the validated paper-repo reference `simulations/highdim_functions.R`. The theory-scaled penalty is `lambda_node = lambda_c * max(|a|) * sqrt(log p / N)`, where **`N` is the number of clusters (units), not `NT`**.
- **`R/debiased_att.R`**: a hard regime branch on the single line that builds `v` (`highdim <- p >= n`). New args `lambda_c` / `riesz_max_iter` / `riesz_tol` (solver controls, validated; no computational effect when `p < NT`). For `p >= NT` fits the returned list gains `feasibility`, `converged`, and `lambda_node` diagnostics. The OLS-identity guard and both SE channels are unchanged and shared across regimes.
- **NEWS / DESCRIPTION**: `1.28.0 -> 1.29.0`.

## ⚠️ Experimental

The `p >= NT` path is flagged **experimental** in `?debiasedATT` and NEWS: its finite-sample coverage is **not yet validated by simulation** and `lambda_c` is **not yet tuned**. Unlike the fixed-`p` case (Thm 6.5, which needs only nuisance *consistency*), Theorem 6.6 controls the orthogonalization remainder through the nuisance's **ℓ1 rate** (`O_p(s_N λ_θ)`, established for the `q = 1` fused lasso); the accessor reuses the bridge (`q < 1`) nuisance for which the high-dim ℓ1 rate is not established — a further reason for the caveat. Users should inspect the returned `feasibility` / `converged` diagnostics.

## Testing

`tests/testthat/test-debiased-att-highdim.R` (new):
- **Solver fidelity** vs an *independent* naive (no rank-1 maintenance) re-implementation — agree to machine precision (`4e-15`).
- **Boundary**: `riesz_lasso(λ→0) == solve(Sig, a)` (`< 1e-7`) — reduces to the exact inverse.
- **KKT feasibility** certificate; **dead-column** robustness; **determinism**.
- **The regime branch is load-bearing**: on the singular high-dim Gram the fixed-`p` inverse explodes ~`5e5×` while the nodewise direction stays `O(1)`.
- **End-to-end** on a genuine `p >= NT` fixture (`N=20, T=8, d=12 ⇒ p=376 > NT=160`; the simulator cannot build one, so the raw panel is constructed directly with supplied noise variances), with an **independent reconstruction** of `att` and `lambda_node`.
- `lambda_c` scaling, **both warning paths**, and **arg validation**.

Mutation-checked that the new tests bite: forcing `highdim <- FALSE`, breaking the soft-threshold, and `N_units <- n` (instead of `n/T`) each fail 3–4 tests; all reverted.

- Full suite: **FAIL 0 | WARN 0 | PASS 3635**.
- `R CMD check` **with vignettes**: **Status: 1 NOTE** (only a stray untracked top-level file, not part of this PR); vignettes re-build OK.

## Review

Ran a 3-reviewer post-implementation pass (correctness/paper-fidelity, test-quality, docs/API). No blockers. Addressed: a docs overclaim about the `q<1` nuisance (tightened against the Thm 6.6 proof), input validation for the new args, untested warning/`lambda_c` paths, and NEWS wording. **Deliberately deferred** (genuine nice-to-haves): a second denser-`v` fixture and the high-dim `indep_counts` two-sample path (regime-independent, already covered for `p < NT`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
