### PR TITLE
feat: let simulateData() generate high-dimensional (p > NT) panels (#293)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.29.0
+Version: 1.30.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # NEWS
 
+## Version 1.30.0
+
+### Improvements
+
+- `simulateData()` / `simulateDataCore()` can now generate **high-dimensional
+  (`p > NT`) panels**. Previously `genCohortTimeFE()` enforced
+  `N >= (G + 1) * (d + 1)` **unconditionally** (every cohort needed at least
+  `d + 1` units), which structurally confined the generator to the `p < NT`
+  regime. That stricter bound is now gated behind `guarantee_rank_condition`
+  (consistent with every other rank guard in the generator); with the default
+  `guarantee_rank_condition = FALSE` only `>= 1` unit per cohort is required, so
+  small cohorts -- and therefore `p > NT` designs -- are reachable. This lets the
+  high-dimensional `debiasedATT()` path (added in 1.29.0) be exercised on
+  synthetic `p > NT` data with a known data-generating coefficient vector (for
+  coverage studies of the method; recovering the truth requires an adequate
+  number of units). Generation with
+  `N >= (G + 1) * (d + 1)` is unchanged, and `guarantee_rank_condition = TRUE`
+  still enforces the full-rank bound (#293).
+
 ## Version 1.29.0
 
 ### New features

--- a/R/gen_data.R
+++ b/R/gen_data.R
@@ -29,7 +29,11 @@
 #' @param guarantee_rank_condition (Optional). Logical. If TRUE, the returned
 #' data set is guaranteed to have at least `d + 1` units per cohort, which is
 #' necessary for the final design matrix to have full column rank. Default is
-#' FALSE, in which case no such condition is enforced.
+#' FALSE, in which case only `>= 1` unit per cohort is required -- this permits
+#' small cohorts and therefore high-dimensional (`p > NT`) panels, which
+#' `fetwfe()` fits in its regularized regime (and on which the high-dimensional
+#' `debiasedATT()` path can be exercised, using the known data-generating
+#' coefficient vector; recovering the truth requires an adequate number of units).
 #' @param seed (Optional) Controls the random-number generator for the simulated
 #'   panel. As of fetwfe 1.24.0 the default is \code{NULL}, which draws from the
 #'   ambient random-number generator (respecting any preceding \code{set.seed()})
@@ -276,7 +280,11 @@ simulateData <- function(
 #' @param guarantee_rank_condition (Optional). Logical. If TRUE, the returned
 #' data set is guaranteed to have at least `d + 1` units per cohort, which is
 #' necessary for the final design matrix to have full column rank. Default is
-#' FALSE, in which case no such condition is enforced.
+#' FALSE, in which case only `>= 1` unit per cohort is required -- this permits
+#' small cohorts and therefore high-dimensional (`p > NT`) panels, which
+#' `fetwfe()` fits in its regularized regime (and on which the high-dimensional
+#' `debiasedATT()` path can be exercised, using the known data-generating
+#' coefficient vector; recovering the truth requires an adequate number of units).
 #' @param assignment_type Character. One of \code{"marginal"} (default),
 #'   \code{"multinomial"}, or \code{"ordered"}. Selects the cohort-assignment
 #'   DGP. \code{"marginal"} preserves the pre-1.14.0 behavior. The

--- a/R/sim_helpers.R
+++ b/R/sim_helpers.R
@@ -217,7 +217,8 @@ generateBaseEffects <- function(
 #' @param guarantee_rank_condition (Optional). Logical. If TRUE, the returned
 #' data set is guaranteed to have at least `d + 1` units per cohort, which is
 #' necessary for the final design matrix to have full column rank. Default is
-#' FALSE, in which case no such condition is enforced.
+#' FALSE, in which case only `>= 1` unit per cohort is required (permitting small
+#' cohorts and therefore rank-deficient, high-dimensional `p > NT` designs).
 #'
 #' @return A list containing:
 #'   \item{cohort_fe}{An NT x G matrix of cohort dummy variables. The g-th column is 1
@@ -239,10 +240,18 @@ genCohortTimeFE <- function(N, T, G, d, guarantee_rank_condition = FALSE) {
 	# the observations from untreated units, then the next N_PER_COHORT*T
 	# rows contain the observations from the first cohort, and so on.
 
-	# Each cohort, as well as the untreated group, will have at least d + 1
-	# units. The remaining units will be allocated to each of these G + 1
-	# groups uniformly at random.
-	stopifnot(N >= (G + 1) * (d + 1))
+	# Each of the G + 1 groups (G treated cohorts + the never-treated) needs at
+	# least one unit so its fixed effect is defined; the remaining units are
+	# allocated to the groups uniformly at random. Only when
+	# guarantee_rank_condition = TRUE do we additionally require >= d + 1 units
+	# per group (the OLS full-column-rank condition). Gating the stricter bound
+	# behind the flag -- consistent with every other rank guard, e.g.
+	# .generateBaseEffectsCovariate() and genAssignments() -- is what lets the
+	# generator reach the regularized high-dimensional (p > NT) regime (#293).
+	stopifnot(N >= (G + 1))
+	if (guarantee_rank_condition) {
+		stopifnot(N >= (G + 1) * (d + 1))
+	}
 
 	# Generate cohort assignments
 	assignments <- genAssignments(

--- a/man/simulateData.Rd
+++ b/man/simulateData.Rd
@@ -33,7 +33,11 @@ from \eqn{[-\sqrt{3}, \sqrt{3}]}.}
 \item{guarantee_rank_condition}{(Optional). Logical. If TRUE, the returned
 data set is guaranteed to have at least \code{d + 1} units per cohort, which is
 necessary for the final design matrix to have full column rank. Default is
-FALSE, in which case no such condition is enforced.}
+FALSE, in which case only \verb{>= 1} unit per cohort is required -- this permits
+small cohorts and therefore high-dimensional (\code{p > NT}) panels, which
+\code{fetwfe()} fits in its regularized regime (and on which the high-dimensional
+\code{debiasedATT()} path can be exercised, using the known data-generating
+coefficient vector; recovering the truth requires an adequate number of units).}
 
 \item{seed}{(Optional) Controls the random-number generator for the simulated
 panel. As of fetwfe 1.24.0 the default is \code{NULL}, which draws from the

--- a/man/simulateDataCore.Rd
+++ b/man/simulateDataCore.Rd
@@ -60,7 +60,11 @@ from \eqn{[-\sqrt{3}, \sqrt{3}]}.}
 \item{guarantee_rank_condition}{(Optional). Logical. If TRUE, the returned
 data set is guaranteed to have at least \code{d + 1} units per cohort, which is
 necessary for the final design matrix to have full column rank. Default is
-FALSE, in which case no such condition is enforced.}
+FALSE, in which case only \verb{>= 1} unit per cohort is required -- this permits
+small cohorts and therefore high-dimensional (\code{p > NT}) panels, which
+\code{fetwfe()} fits in its regularized regime (and on which the high-dimensional
+\code{debiasedATT()} path can be exercised, using the known data-generating
+coefficient vector; recovering the truth requires an adequate number of units).}
 
 \item{assignment_type}{Character. One of \code{"marginal"} (default),
 \code{"multinomial"}, or \code{"ordered"}. Selects the cohort-assignment

--- a/tests/testthat/test-simulate-data-highdim-293.R
+++ b/tests/testthat/test-simulate-data-highdim-293.R
@@ -1,0 +1,153 @@
+# Tests for high-dimensional (p > NT) data generation (#293).
+#
+# Before #293, genCohortTimeFE() carried an UNCONDITIONAL guard
+# `stopifnot(N >= (G + 1) * (d + 1))` (R/sim_helpers.R), so every group needed
+# >= d + 1 units and the generator structurally lived in the p < NT regime --
+# the high-dimensional debiasedATT() path (#31) could not be exercised on
+# synthetic p > NT data with a known data-generating coefficient vector. The fix gates that stricter bound
+# behind `guarantee_rank_condition` (consistent with every other rank guard), so
+# `guarantee_rank_condition = FALSE` (the default) only needs >= 1 unit per
+# group and small cohorts -> p > NT become reachable.
+
+# A small-N, large-d config that lands the design well into p > NT.
+.HD <- list(G = 3L, T = 5L, d = 22L, N = 8L) # N >= G+1 = 4
+
+.make_hd_coefs <- function() {
+	genCoefs(
+		G = .HD$G,
+		T = .HD$T,
+		d = .HD$d,
+		density = 0.5,
+		eff_size = 2,
+		seed = 1
+	)
+}
+
+test_that("simulateData() reaches p > NT at small N with the default (rank condition off)", {
+	coefs <- .make_hd_coefs()
+	# Previously errored at the unconditional (G+1)(d+1) guard; now succeeds.
+	dat <- simulateData(
+		coefs,
+		N = .HD$N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 1
+	)
+	expect_s3_class(dat, "FETWFE_simulated")
+	pd <- dat$pdata
+	expect_equal(length(unique(pd[[dat$unit_var]])), .HD$N)
+	# The generated design is genuinely high-dimensional.
+	expect_gt(dat$p, .HD$N * .HD$T)
+	# Ground truth is carried on the object (the point of #293: synthetic data
+	# with known coefficients for validating the p > NT method).
+	expect_false(is.null(dat$coefs))
+})
+
+test_that("the p > NT simulated panel fits and debiasedATT() runs its high-dim path", {
+	coefs <- .make_hd_coefs()
+	dat <- simulateData(
+		coefs,
+		N = .HD$N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 1
+	)
+	# REML cannot estimate the variances at p > NT, so supply them.
+	fit <- fetwfe(
+		pdata = dat$pdata,
+		time_var = dat$time_var,
+		unit_var = dat$unit_var,
+		treatment = dat$treatment,
+		response = dat$response,
+		covs = dat$covs,
+		q = 0.5,
+		verbose = FALSE,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5
+	)
+	X <- fit$internal$X_final
+	expect_gt(ncol(X), nrow(X)) # p > NT
+	db <- debiasedATT(fit)
+	expect_true(db$converged)
+	expect_lte(db$feasibility, db$lambda_node * (1 + 1e-9))
+	expect_true(is.finite(db$att))
+	expect_gt(db$se, 0)
+})
+
+test_that("guarantee_rank_condition = TRUE still enforces N >= (G+1)(d+1)", {
+	coefs <- .make_hd_coefs()
+	# The strict (full-rank) path is preserved: small N still errors.
+	expect_error(
+		simulateData(
+			coefs,
+			N = .HD$N,
+			sig_eps_sq = 1,
+			sig_eps_c_sq = 0.5,
+			seed = 1,
+			guarantee_rank_condition = TRUE
+		),
+		"d \\+ 1"
+	)
+})
+
+test_that("genCohortTimeFE() gates the rank bound on guarantee_rank_condition", {
+	G <- .HD$G
+	T <- .HD$T
+	d <- .HD$d
+	# Minimum feasible N (one unit per group) succeeds with the rank condition off
+	# and yields a valid, fully-allocated set of small cohorts.
+	set.seed(1)
+	res <- genCohortTimeFE(N = G + 1L, T = T, G = G, d = d)
+	expect_equal(sum(res$assignments), G + 1L)
+	expect_true(all(res$assignments >= 1L)) # >= 1 unit per group, < d + 1
+	expect_true(any(res$assignments < d + 1L))
+	expect_equal(ncol(res$cohort_fe), G)
+	expect_equal(nrow(res$cohort_fe), (G + 1L) * T)
+	# With the rank condition on, the same small N errors.
+	expect_error(
+		genCohortTimeFE(
+			N = G + 1L,
+			T = T,
+			G = G,
+			d = d,
+			guarantee_rank_condition = TRUE
+		),
+		"d \\+ 1"
+	)
+})
+
+test_that("an all-singleton (N = G+1) high-dim panel generates and fits without erroring", {
+	coefs <- .make_hd_coefs()
+	# The extreme corner: exactly one unit per group (every treated cohort AND
+	# the never-treated group is a singleton). Within-cohort covariate centering
+	# then makes the treatment x covariate interaction columns exactly zero (no
+	# NaN -- my_scale() guards zero-variance columns), so generation and a
+	# regularized fit must still run to completion. The debiased SE may collapse
+	# to 0 at this near-zero residual-d.o.f. corner; that is honest, not an error.
+	# Reaching these lines without an error/NaN IS the assertion.
+	dat <- simulateData(
+		coefs,
+		N = .HD$G + 1L,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 1
+	)
+	expect_equal(length(unique(dat$pdata[[dat$unit_var]])), .HD$G + 1L)
+	fit <- fetwfe(
+		pdata = dat$pdata,
+		time_var = dat$time_var,
+		unit_var = dat$unit_var,
+		treatment = dat$treatment,
+		response = dat$response,
+		covs = dat$covs,
+		q = 0.5,
+		verbose = FALSE,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5
+	)
+	expect_gt(ncol(fit$internal$X_final), nrow(fit$internal$X_final)) # p > NT
+	db <- debiasedATT(fit)
+	expect_true(is.finite(db$att))
+	expect_false(is.na(db$se))
+	expect_gte(db$se, 0) # may be 0 at this degenerate corner; must not be NaN
+})


### PR DESCRIPTION
## Summary

Lets `simulateData()` / `simulateDataCore()` generate **high-dimensional (`p > NT`) panels**, so the high-dim `debiasedATT()` path shipped in #31 (paper Theorem 6.6) can be exercised on synthetic data. Closes #293.

## Root cause

`genCohortTimeFE()` (`R/sim_helpers.R`) had an **unconditional** guard `stopifnot(N >= (G + 1) * (d + 1))` — every one of the `G + 1` groups needed `>= d + 1` units. That forces `N >= (G+1)(d+1)`, and a grid scan finds no config with `p > NT`: the generator structurally lived in `p < NT`. Meanwhile **every other rank guard** in the generator already gates that stricter bound behind `guarantee_rank_condition` (`.generateBaseEffectsCovariate` at 142–144, `genAssignments`, `cohort_assignment.R:576`). Line 245 was the lone inconsistency.

## Fix

Gate the base-effects guard behind `guarantee_rank_condition`, exactly like the others. With the default `FALSE`, only `>= 1` unit per cohort is required, so small cohorts — and `p > NT` — are reachable (e.g. `G=3, T=5, d=22, N=8 => p=390 > NT=40`).

- `guarantee_rank_condition = FALSE` (default): `>= 1` unit/cohort. Previously-erroring small-N calls now succeed; `N >= (G+1)(d+1)` generation is **byte-identical** (the `stopifnot` consumes no RNG).
- `guarantee_rank_condition = TRUE`: unchanged — still enforces the full-rank bound everywhere.

**Singleton cohorts are safe:** within-cohort covariate centering makes a singleton's interaction columns exactly zero (no NaN — `my_scale()` guards zero-variance columns), and the true overall ATT doesn't depend on the within-cohort-centered interaction coefficients, so ground truth stays well-defined (recovering it still needs adequate `N`).

## Tests (`test-simulate-data-highdim-293.R`)

`p > NT` reachable at small N with the default; the panel fits and `debiasedATT()` runs its high-dim path; the `guarantee_rank_condition = TRUE` strict path is preserved; a `genCohortTimeFE()` gating unit test; and an all-singleton (`N = G+1`) corner that must generate + fit without erroring. **Mutation-checked**: restoring the unconditional guard fails the enablement tests.

- Full suite: **FAIL 0 | PASS 3667**.
- `R CMD check` **with vignettes**: 0 errors / 0 warnings / 2 NOTEs (both non-code: an environmental "unable to verify current time", and a stray untracked top-level file not in this PR).

## Review

Post-implementation review (full gen-call-graph trace + singleton end-to-end + back-compat byte-check). No blockers. Addressed: softened a "known ground truth" over-claim (the data carries a known coefficient vector, but recovery needs adequate N), added the all-singleton corner test, and clarified the internal `genCohortTimeFE` doc.

Unblocks the coverage-validation work in #295 (retiring the high-dim `debiasedATT()` experimental flag).

Version 1.29.0 -> 1.30.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
