### PR TITLE
feat: multiplier-bootstrap method for simultaneousCIs() (#142, Phase 1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.30.0
+Version: 1.31.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,28 @@
 # NEWS
 
+## Version 1.31.0
+
+### New features
+
+- `simultaneousCIs()` gains a **multiplier-bootstrap** method
+  (`method = "bootstrap"`), the Chernozhukov-Chetverikov-Kato (2013) sup-t
+  bootstrap, as an alternative to the default analytic `mvtnorm::qmvnorm()`
+  critical value (`method = "analytic"`, unchanged and still the default). It
+  perturbs the per-unit influence functions with random multipliers
+  (`multiplier = "rademacher"` or `"mammen"`, `B` replicates, optional `seed`)
+  and reads the simultaneous critical value off the bootstrap distribution. The
+  two methods are asymptotically equivalent; the bootstrap scales better to
+  large effect families (where `qmvnorm` strains) and is
+  heteroskedasticity/cluster-robust by construction. The per-unit influence
+  matrix `F` reproduces the cluster-robust joint covariance (`crossprod(F) /
+  (NT)^2` equals it up to the `N/(N-1)` finite-sample factor), so on a
+  `se_type = "cluster"` fit the bootstrap per-effect standard errors match the
+  analytic ones exactly. This
+  release covers `family = "cohort"`, `"all_post_treatment"`, and `"custom"`;
+  `"event_study"` (whose cohort-probability variance term needs a per-unit
+  propensity influence function) and the high-dimensional `p >= NT` regime are
+  planned follow-ups (#142).
+
 ## Version 1.30.0
 
 ### Improvements

--- a/R/simultaneous_bootstrap.R
+++ b/R/simultaneous_bootstrap.R
@@ -1,0 +1,274 @@
+# Multiplier-bootstrap simultaneous bands for simultaneousCIs() (#142, Phase 1).
+#
+# An alternative to the analytic `mvtnorm::qmvnorm()` critical value: perturb the
+# per-unit influence-function (IF) matrix `F` (N_units x K) with random
+# multipliers and read the sup-t critical value off the bootstrap distribution
+# (Chernozhukov-Chetverikov-Kato 2013). Asymptotically equivalent to the analytic
+# band under the paper's tight-Gaussianity, with three practical edges: it scales
+# to large families (where `qmvnorm` strains), it is heteroskedasticity/cluster
+# robust by construction (the empirical per-unit IF), and it is the path that
+# generalizes to the high-dimensional regime (Phase 2, where the analytic Gram
+# inverse does not exist).
+#
+# Phase 1 covers the regression-channel families (`cohort`,
+# `all_post_treatment`, `custom`), where the cohort-probability variance term
+# `Sigma_2` is zero, so `F = F_reg`. The `event_study` family (which needs the
+# per-unit propensity IF `F_pi`) and the high-dimensional regime are Phase 2.
+
+#' Draw multiplier-bootstrap weights
+#'
+#' @description `N x B` matrix of mean-zero, unit-variance multipliers, one column
+#'   per bootstrap replicate. `"rademacher"` draws `+/-1` with probability 1/2;
+#'   `"mammen"` draws the two-point distribution of Mammen (1993) (mean 0,
+#'   variance 1, third moment 1).
+#' @keywords internal
+#' @noRd
+.draw_multipliers <- function(N, B, type = c("rademacher", "mammen")) {
+	type <- match.arg(type)
+	if (type == "rademacher") {
+		matrix(
+			sample(c(-1, 1), size = N * B, replace = TRUE),
+			nrow = N,
+			ncol = B
+		)
+	} else {
+		# Mammen two-point: values a1 < 0 < a2 with P(a1) = p1.
+		phi <- (1 + sqrt(5)) / 2
+		a1 <- 1 - phi # = -(sqrt(5)-1)/2
+		a2 <- phi # = (sqrt(5)+1)/2
+		p1 <- (sqrt(5) + 1) / (2 * sqrt(5))
+		draws <- ifelse(
+			matrix(stats::runif(N * B), nrow = N, ncol = B) < p1,
+			a1,
+			a2
+		)
+		matrix(draws, nrow = N, ncol = B)
+	}
+}
+
+#' Per-unit regression influence-function matrix `F_reg` (N_units x K)
+#'
+#' @description
+#' For each effect `k` in the family, the per-unit regression IF is
+#' `F_reg[i, k] = sum_{t} (x_{it}' v_k) * resid_{it}`, where `v_k` is the
+#' debiasing direction for effect `k` and `resid` are the OLS-refit residuals on
+#' the selected support (the same residuals the cluster-robust sandwich uses).
+#' Vectorized as `F_reg = XEps %*% V`, with `XEps = rowsum(X_sel_c * resid, unit)`
+#' (the per-unit aggregated score, `N x p_sel`) and `V` the `p_sel x K` matrix of
+#' debiasing directions. This is `debiasedATT()`'s `(X %*% v) * resid` per-unit
+#' score generalized to `K` columns, in `getGramInv()`'s centered / `n = NT`
+#' convention. By construction `crossprod(F_reg) / (N*T)^2` equals the
+#' cluster-robust `Sigma_1` divided by the finite-sample adjustment `N/(N-1)`.
+#'
+#' @param X_sel Numeric `NT x p_sel`; the SELECTED-support design (uncentered).
+#' @param y Numeric; the (post-GLS) response, length `>= NT`.
+#' @param N,T Integers; units and periods.
+#' @param Psi_full Numeric `p_sel x K`; effect contrasts mapped to the selected
+#'   support and zero-padded over nuisance columns (column `k` is effect `k`'s
+#'   direction in selected coefficient space).
+#' @return `F_reg`, an `N x K` matrix.
+#' @keywords internal
+#' @noRd
+.build_regression_if <- function(X_sel, y, N, T, Psi_full) {
+	n <- N * T
+	X_sel_c <- scale(X_sel, center = TRUE, scale = FALSE)
+	# OLS-refit residuals on the selected support (matches
+	# .compute_cluster_robust_sandwich; the intercept is absorbed by centering).
+	resid <- stats::lm.fit(cbind(1, X_sel), y[seq_len(n)])$residuals
+	unit <- rep(seq_len(N), each = T)
+	XEps <- rowsum(X_sel_c * resid, group = unit, reorder = FALSE) # N x p_sel
+	Sig <- crossprod(X_sel_c) / n
+	K <- ncol(Psi_full)
+	V <- matrix(0, ncol(X_sel_c), K)
+	for (k in seq_len(K)) {
+		V[, k] <- solve(Sig, Psi_full[, k])
+	}
+	XEps %*% V
+}
+
+#' Studentized sup-t multiplier-bootstrap critical value
+#'
+#' @description
+#' Given the per-unit IF matrix `F` (`N x K`), draws `B` multiplier-bootstrap
+#' replicates of the studentized max-statistic
+#' `T_b = max_k |sum_i xi_i F[i,k]| / sd_k` (`sd_k = sqrt(crossprod(F)[k,k])`) and
+#' returns the `(1 - alpha)` quantile as the simultaneous critical value, along
+#' with the per-effect empirical standard errors `se_k = sd_k / (N*T)` (the
+#' cluster-robust SEs implied by `F`). Degenerate (zero-variance) effects are
+#' excluded from the max (they would divide by ~0); their CIs collapse to the
+#' point estimate.
+#'
+#' @return A list with `crit` (scalar), `ses` (length-K), and `nondeg`
+#'   (logical length-K).
+#' @keywords internal
+#' @noRd
+.simultaneous_bootstrap_crit <- function(
+	F_mat,
+	n,
+	alpha,
+	B,
+	multiplier = c("rademacher", "mammen"),
+	seed = NULL
+) {
+	multiplier <- match.arg(multiplier)
+	N <- nrow(F_mat)
+	K <- ncol(F_mat)
+	n_obs_sq <- n^2 # (N*T)^2
+	col_ss <- colSums(F_mat^2) # crossprod diagonal = sd_k^2
+	var_tol <- .Machine$double.eps^0.5 * max(col_ss, 1)
+	nondeg <- col_ss > var_tol
+	sd_k <- sqrt(col_ss)
+	# Per-effect cluster-robust SE: crossprod(F)/n^2 = cluster Sigma / cadjust, so
+	# the matching SE restores the finite-sample factor cadjust = N/(N-1). (It
+	# cancels in the studentized `crit` below, so it only scales band widths.)
+	cadjust <- N / (N - 1)
+	ses <- sqrt(cadjust * col_ss / n_obs_sq)
+
+	draw_boot <- function() {
+		Xi <- .draw_multipliers(N, B, multiplier) # N x B
+		G <- crossprod(F_mat[, nondeg, drop = FALSE], Xi) # K_nd x B
+		apply(abs(G) / sd_k[nondeg], 2, max) # length-B sup-t sample T_b
+	}
+	# With 0 or 1 non-degenerate effect the sup-t statistic reduces to the
+	# pointwise |Z|/sd, whose 1-alpha quantile is exactly qnorm(1 - alpha/2); use
+	# it directly rather than the Monte-Carlo estimate (which can dip below the
+	# pointwise value and make a K=1 band anti-conservative) -- and skip the draw
+	# entirely (drawing would also take max() over an empty set when every effect
+	# is degenerate). `boot_max = NULL` signals this branch to the caller.
+	if (sum(nondeg) <= 1L) {
+		crit <- stats::qnorm(1 - alpha / 2)
+		boot_max <- NULL
+	} else {
+		# Conv A: a non-NULL seed gives reproducible draws and is restored
+		# afterward; a NULL seed draws from the ambient RNG (do NOT wrap -- that
+		# would re-seed).
+		boot_max <- if (is.null(seed)) {
+			draw_boot()
+		} else {
+			.with_preserved_rng(seed, draw_boot())
+		}
+		crit <- stats::quantile(
+			boot_max,
+			probs = 1 - alpha,
+			names = FALSE,
+			type = 7
+		)
+	}
+
+	list(crit = crit, ses = ses, nondeg = nondeg, boot_max = boot_max)
+}
+
+#' Bootstrap path for `simultaneousCIs()` (Phase 1: regression-channel families)
+#'
+#' @description
+#' Called by `.simultaneous_cis_impl()` when `method = "bootstrap"`. Builds the
+#' per-unit IF matrix from the already-resolved selected support + effect
+#' contrasts, runs the multiplier bootstrap, and returns the same
+#' `"simultaneous_cis"` S3 object the analytic path returns, plus `method` / `B`
+#' / `seed` / `multiplier` fields. Phase 1 supports `cohort` /
+#' `all_post_treatment` / `custom` (the cohort-probability variance term is zero,
+#' so `F = F_reg`); `event_study` needs the per-unit propensity IF and is a
+#' follow-up.
+#' @keywords internal
+#' @noRd
+.simultaneous_cis_bootstrap <- function(
+	family,
+	alpha,
+	B,
+	seed,
+	multiplier,
+	X_final,
+	y_final,
+	N,
+	T,
+	treat_inds,
+	sel_feat_inds,
+	sel_treat_inds_shifted,
+	Psi,
+	K,
+	estimates,
+	effect_labels,
+	pointwise_crit,
+	bonferroni_crit
+) {
+	if (identical(family, "event_study")) {
+		stop(
+			"simultaneousCIs(): method = 'bootstrap' does not yet support ",
+			"family = 'event_study' (its cohort-probability variance channel ",
+			"needs a per-unit propensity influence function, planned as a ",
+			"follow-up). Use method = 'analytic' for event_study, or method = ",
+			"'bootstrap' with family = 'cohort', 'all_post_treatment', or ",
+			"'custom'.",
+			call. = FALSE
+		)
+	}
+	n <- N * T
+
+	# X_sel + zero-padded Psi_full over the selected support. FETWFE/BETWFE select
+	# a subset (`sel_feat_inds`); etwfe/twfeCovs use the full design.
+	if (any(!is.na(sel_feat_inds))) {
+		X_sel <- X_final[, sel_feat_inds, drop = FALSE]
+		Psi_full <- matrix(0, length(sel_feat_inds), K)
+		treat_pos <- match(treat_inds[sel_treat_inds_shifted], sel_feat_inds)
+		Psi_full[treat_pos, ] <- Psi
+	} else {
+		X_sel <- X_final
+		Psi_full <- matrix(0, ncol(X_final), K)
+		Psi_full[treat_inds[sel_treat_inds_shifted], ] <- Psi
+	}
+
+	F_mat <- .build_regression_if(X_sel, y_final, N, T, Psi_full)
+	bc <- .simultaneous_bootstrap_crit(
+		F_mat,
+		n = n,
+		alpha = alpha,
+		B = B,
+		multiplier = multiplier,
+		seed = seed
+	)
+	crit <- bc$crit
+	ses <- bc$ses
+
+	# Single-step max-T adjusted p-values, the exact dual of the band. With > 1
+	# non-degenerate effect: from the bootstrap sup-t distribution,
+	# p_k = mean_b{ T_b >= |estimate_k| / se_k }. With a single non-degenerate
+	# effect `boot_max` is NULL and the band uses the exact qnorm crit, so the
+	# matching dual is the two-sided normal p-value 2 * pnorm(-|z|) (mirrors the
+	# analytic K = 1 path; keeps "outside band iff adjusted p < alpha" exact).
+	t_stat <- ifelse(bc$nondeg & ses > 0, abs(estimates) / ses, NA_real_)
+	adjusted_p_values <- if (is.null(bc$boot_max)) {
+		2 * stats::pnorm(-abs(t_stat))
+	} else {
+		vapply(
+			t_stat,
+			function(t) if (is.na(t)) NA_real_ else mean(bc$boot_max >= t),
+			numeric(1)
+		)
+	}
+
+	ci <- data.frame(
+		effect = effect_labels,
+		estimate = estimates,
+		simultaneous_ci_low = estimates - crit * ses,
+		simultaneous_ci_high = estimates + crit * ses,
+		pointwise_ci_low = estimates - pointwise_crit * ses,
+		pointwise_ci_high = estimates + pointwise_crit * ses,
+		stringsAsFactors = FALSE
+	)
+	out <- list(
+		ci = ci,
+		adjusted_p_values = adjusted_p_values,
+		critical_value = crit,
+		pointwise_critical_value = pointwise_crit,
+		bonferroni_critical_value = bonferroni_crit,
+		family = family,
+		alpha = alpha,
+		K = K,
+		method = "bootstrap",
+		B = B,
+		seed = seed,
+		multiplier = multiplier
+	)
+	class(out) <- "simultaneous_cis"
+	out
+}

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -65,6 +65,27 @@ utils::globalVariables(c(
 #'   that pools across cohorts in a probability-weighted way is
 #'   anti-conservative (its band can under-cover); use `family = "cohort"` for
 #'   cohort-pooled effects.
+#' @param method Character; how the simultaneous critical value is computed.
+#'   `"analytic"` (default) uses the exact multivariate-normal sup-t quantile via
+#'   `mvtnorm::qmvnorm()`. `"bootstrap"` uses the multiplier bootstrap of
+#'   Chernozhukov, Chetverikov & Kato (2013): it perturbs the per-unit influence
+#'   functions and reads the sup-t critical value off the bootstrap
+#'   distribution. The two are asymptotically equivalent; the bootstrap scales
+#'   better to large effect families and is heteroskedasticity/cluster-robust by
+#'   construction (it always reports cluster-robust per-unit standard errors,
+#'   regardless of the fit's `se_type`). **Currently `method = "bootstrap"`
+#'   supports `family = "cohort"`, `"all_post_treatment"`, and `"custom"`;**
+#'   `"event_study"` (whose cohort-probability variance term needs a per-unit
+#'   propensity influence function) is analytic-only for now.
+#' @param B Integer; number of multiplier-bootstrap replicates
+#'   (`method = "bootstrap"` only). Default `1000`.
+#' @param seed Optional integer; if supplied, the bootstrap draws are
+#'   reproducible (the ambient random-number stream is saved and restored around
+#'   them). If `NULL` (default), the draws come from the ambient generator, so
+#'   results vary run to run. Ignored when `method = "analytic"`.
+#' @param multiplier Character; the multiplier-weight distribution for the
+#'   bootstrap: `"rademacher"` (default, `+/-1`) or `"mammen"` (the Mammen 1993
+#'   two-point distribution). Ignored when `method = "analytic"`.
 #' @return An object of S3 class `"simultaneous_cis"`: a list with
 #'   \describe{
 #'     \item{ci}{A data frame with columns `effect`, `estimate`,
@@ -87,6 +108,11 @@ utils::globalVariables(c(
 #'     \item{alpha}{The significance level used.}
 #'     \item{K}{The number of effects in the family (integer).}
 #'   }
+#'   For `method = "bootstrap"` the list additionally carries `method`, `B`,
+#'   `seed`, and `multiplier`; the `critical_value` is the bootstrap sup-t
+#'   quantile and the standard errors backing `ci` are the cluster-robust
+#'   per-unit ones (so for a non-`cluster` fit the bootstrap band may differ
+#'   from the analytic homoskedastic band).
 #' @details
 #' **Family resolution and `K`.** `"event_study"` resolves to one effect per
 #' post-treatment event time `e = 0, ..., T - 2` (`K = T - 1`); `"cohort"` to
@@ -171,7 +197,11 @@ simultaneousCIs <- function(
 	result,
 	family = c("event_study", "cohort", "all_post_treatment", "custom"),
 	alpha = 0.05,
-	contrasts = NULL
+	contrasts = NULL,
+	method = c("analytic", "bootstrap"),
+	B = 1000L,
+	seed = NULL,
+	multiplier = c("rademacher", "mammen")
 ) {
 	UseMethod("simultaneousCIs")
 }
@@ -181,7 +211,11 @@ simultaneousCIs.fetwfe <- function(
 	result,
 	family = c("event_study", "cohort", "all_post_treatment", "custom"),
 	alpha = 0.05,
-	contrasts = NULL
+	contrasts = NULL,
+	method = c("analytic", "bootstrap"),
+	B = 1000L,
+	seed = NULL,
+	multiplier = c("rademacher", "mammen")
 ) {
 	contract <- .check_for_simultaneous_cis(result)
 	family <- match.arg(family)
@@ -190,7 +224,11 @@ simultaneousCIs.fetwfe <- function(
 		family = family,
 		alpha = alpha,
 		contrasts = contrasts,
-		has_valid_ses = contract$has_valid_ses
+		has_valid_ses = contract$has_valid_ses,
+		method = match.arg(method),
+		B = B,
+		seed = seed,
+		multiplier = match.arg(multiplier)
 	)
 }
 
@@ -199,7 +237,11 @@ simultaneousCIs.etwfe <- function(
 	result,
 	family = c("event_study", "cohort", "all_post_treatment", "custom"),
 	alpha = 0.05,
-	contrasts = NULL
+	contrasts = NULL,
+	method = c("analytic", "bootstrap"),
+	B = 1000L,
+	seed = NULL,
+	multiplier = c("rademacher", "mammen")
 ) {
 	contract <- .check_for_simultaneous_cis(result)
 	family <- match.arg(family)
@@ -208,7 +250,11 @@ simultaneousCIs.etwfe <- function(
 		family = family,
 		alpha = alpha,
 		contrasts = contrasts,
-		has_valid_ses = contract$has_valid_ses
+		has_valid_ses = contract$has_valid_ses,
+		method = match.arg(method),
+		B = B,
+		seed = seed,
+		multiplier = match.arg(multiplier)
 	)
 }
 
@@ -217,7 +263,11 @@ simultaneousCIs.betwfe <- function(
 	result,
 	family = c("event_study", "cohort", "all_post_treatment", "custom"),
 	alpha = 0.05,
-	contrasts = NULL
+	contrasts = NULL,
+	method = c("analytic", "bootstrap"),
+	B = 1000L,
+	seed = NULL,
+	multiplier = c("rademacher", "mammen")
 ) {
 	contract <- .check_for_simultaneous_cis(result)
 	family <- match.arg(family)
@@ -226,7 +276,11 @@ simultaneousCIs.betwfe <- function(
 		family = family,
 		alpha = alpha,
 		contrasts = contrasts,
-		has_valid_ses = contract$has_valid_ses
+		has_valid_ses = contract$has_valid_ses,
+		method = match.arg(method),
+		B = B,
+		seed = seed,
+		multiplier = match.arg(multiplier)
 	)
 }
 
@@ -244,7 +298,11 @@ simultaneousCIs.twfeCovs <- function(
 	result,
 	family = c("event_study", "cohort", "all_post_treatment", "custom"),
 	alpha = 0.05,
-	contrasts = NULL
+	contrasts = NULL,
+	method = c("analytic", "bootstrap"),
+	B = 1000L,
+	seed = NULL,
+	multiplier = c("rademacher", "mammen")
 ) {
 	contract <- .check_for_simultaneous_cis(result)
 	family <- match.arg(family)
@@ -253,7 +311,11 @@ simultaneousCIs.twfeCovs <- function(
 		family = family,
 		alpha = alpha,
 		contrasts = contrasts,
-		has_valid_ses = contract$has_valid_ses
+		has_valid_ses = contract$has_valid_ses,
+		method = match.arg(method),
+		B = B,
+		seed = seed,
+		multiplier = match.arg(multiplier)
 	)
 }
 
@@ -277,10 +339,39 @@ simultaneousCIs.twfeCovs <- function(
 	family,
 	alpha,
 	contrasts,
-	has_valid_ses
+	has_valid_ses,
+	method = "analytic",
+	B = 1000L,
+	seed = NULL,
+	multiplier = "rademacher"
 ) {
 	# --- 1. Argument validation (mvtnorm guard deferred to step 11). ---
 	stopifnot(is.numeric(alpha), length(alpha) == 1L, alpha > 0, alpha < 1)
+	method <- match.arg(method, c("analytic", "bootstrap"))
+	if (method == "bootstrap") {
+		if (
+			!is.numeric(B) ||
+				length(B) != 1L ||
+				is.na(B) ||
+				B < 1 ||
+				B != round(B)
+		) {
+			stop(
+				"simultaneousCIs(): `B` must be a single positive integer.",
+				call. = FALSE
+			)
+		}
+		B <- as.integer(B)
+		if (
+			!is.null(seed) &&
+				(!is.numeric(seed) || length(seed) != 1L || is.na(seed))
+		) {
+			stop(
+				"simultaneousCIs(): `seed` must be NULL or a single number.",
+				call. = FALSE
+			)
+		}
+	}
 
 	# --- 2. Read fit slots via class-aware shims. ---
 	is_fetwfe <- inherits(x, "fetwfe")
@@ -484,6 +575,32 @@ simultaneousCIs.twfeCovs <- function(
 	#        per-cell contrast into the selected support (theta-space for
 	#        FETWFE, beta-space for the OLS family). ---
 	Psi <- t(psi_tes_mat %*% d_inv_treat_sel)
+
+	# --- Bootstrap method (#142): perturb the per-unit IF matrix instead of the
+	#     analytic qmvnorm critical value. Reuses the selected support + Psi
+	#     above; returns early with the same S3 shape (+ method/B/seed fields). ---
+	if (identical(method, "bootstrap")) {
+		return(.simultaneous_cis_bootstrap(
+			family = family,
+			alpha = alpha,
+			B = B,
+			seed = seed,
+			multiplier = multiplier,
+			X_final = X_final,
+			y_final = y_final,
+			N = N,
+			T = T_,
+			treat_inds = treat_inds,
+			sel_feat_inds = sel_feat_inds,
+			sel_treat_inds_shifted = sel_treat_inds_shifted,
+			Psi = Psi,
+			K = K,
+			estimates = estimates,
+			effect_labels = effect_labels,
+			pointwise_crit = pointwise_crit,
+			bonferroni_crit = bonferroni_crit
+		))
+	}
 
 	Sigma_1 <- .assemble_joint_cov_var1(
 		Psi = Psi,

--- a/man/simultaneousCIs.Rd
+++ b/man/simultaneousCIs.Rd
@@ -9,7 +9,11 @@ simultaneousCIs(
   result,
   family = c("event_study", "cohort", "all_post_treatment", "custom"),
   alpha = 0.05,
-  contrasts = NULL
+  contrasts = NULL,
+  method = c("analytic", "bootstrap"),
+  B = 1000L,
+  seed = NULL,
+  multiplier = c("rademacher", "mammen")
 )
 }
 \arguments{
@@ -31,6 +35,31 @@ cohort-probability variance term (\code{Sigma_2 = 0}), so a custom contrast
 that pools across cohorts in a probability-weighted way is
 anti-conservative (its band can under-cover); use \code{family = "cohort"} for
 cohort-pooled effects.}
+
+\item{method}{Character; how the simultaneous critical value is computed.
+\code{"analytic"} (default) uses the exact multivariate-normal sup-t quantile via
+\code{mvtnorm::qmvnorm()}. \code{"bootstrap"} uses the multiplier bootstrap of
+Chernozhukov, Chetverikov & Kato (2013): it perturbs the per-unit influence
+functions and reads the sup-t critical value off the bootstrap
+distribution. The two are asymptotically equivalent; the bootstrap scales
+better to large effect families and is heteroskedasticity/cluster-robust by
+construction (it always reports cluster-robust per-unit standard errors,
+regardless of the fit's \code{se_type}). \strong{Currently \code{method = "bootstrap"}
+supports \code{family = "cohort"}, \code{"all_post_treatment"}, and \code{"custom"};}
+\code{"event_study"} (whose cohort-probability variance term needs a per-unit
+propensity influence function) is analytic-only for now.}
+
+\item{B}{Integer; number of multiplier-bootstrap replicates
+(\code{method = "bootstrap"} only). Default \code{1000}.}
+
+\item{seed}{Optional integer; if supplied, the bootstrap draws are
+reproducible (the ambient random-number stream is saved and restored around
+them). If \code{NULL} (default), the draws come from the ambient generator, so
+results vary run to run. Ignored when \code{method = "analytic"}.}
+
+\item{multiplier}{Character; the multiplier-weight distribution for the
+bootstrap: \code{"rademacher"} (default, \verb{+/-1}) or \code{"mammen"} (the Mammen 1993
+two-point distribution). Ignored when \code{method = "analytic"}.}
 }
 \value{
 An object of S3 class \code{"simultaneous_cis"}: a list with
@@ -55,6 +84,11 @@ effects. (#200)}
 \item{alpha}{The significance level used.}
 \item{K}{The number of effects in the family (integer).}
 }
+For \code{method = "bootstrap"} the list additionally carries \code{method}, \code{B},
+\code{seed}, and \code{multiplier}; the \code{critical_value} is the bootstrap sup-t
+quantile and the standard errors backing \code{ci} are the cluster-robust
+per-unit ones (so for a non-\code{cluster} fit the bootstrap band may differ
+from the analytic homoskedastic band).
 }
 \description{
 Computes simultaneous (family-wise) confidence intervals for a user-

--- a/tests/testthat/test-simultaneous-bootstrap-142.R
+++ b/tests/testthat/test-simultaneous-bootstrap-142.R
@@ -1,0 +1,364 @@
+# Tests for the multiplier-bootstrap method of simultaneousCIs() (#142, Phase 1).
+#
+# The bootstrap perturbs the per-unit influence-function matrix F (N x K) instead
+# of computing the analytic mvtnorm::qmvnorm() critical value. Phase 1 covers the
+# regression-channel families (cohort / all_post_treatment / custom), where the
+# cohort-probability variance term is zero. The correctness anchor: F is built so
+# that crossprod(F)/(NT)^2 equals the cluster-robust Sigma, hence on a
+# se_type = "cluster" fit the bootstrap per-effect SEs equal the analytic
+# per-effect SEs to machine precision; and the bootstrap critical value matches
+# the analytic qmvnorm one up to Monte-Carlo error.
+
+.boot_fit <- function(
+	se_type = "cluster",
+	G = 3,
+	T = 5,
+	d = 2,
+	N = 150,
+	seed = 1
+) {
+	coefs <- genCoefs(
+		G = G,
+		T = T,
+		d = d,
+		density = 0.6,
+		eff_size = 1.5,
+		seed = seed
+	)
+	dat <- simulateData(
+		coefs,
+		N = N,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = seed
+	)
+	dat$indep_counts <- NA
+	fetwfeWithSimulatedData(dat, q = 0.5, se_type = se_type)
+}
+
+.se_from <- function(sc) {
+	# per-effect SE backed out of the pointwise band
+	(sc$ci$pointwise_ci_high - sc$ci$estimate) / sc$pointwise_critical_value
+}
+
+test_that("bootstrap per-effect SEs match the analytic cluster SEs to machine precision (the anchor)", {
+	fit <- .boot_fit(se_type = "cluster")
+	an <- simultaneousCIs(fit, family = "cohort", method = "analytic")
+	bo <- simultaneousCIs(
+		fit,
+		family = "cohort",
+		method = "bootstrap",
+		B = 500,
+		seed = 1
+	)
+	# crossprod(F)/n^2 == cluster Sigma / cadjust, and the bootstrap SE restores
+	# cadjust, so the per-effect SEs coincide with the analytic cluster SEs. The
+	# SEs do NOT depend on the random multipliers, so this is exact.
+	expect_equal(.se_from(bo), .se_from(an), tolerance = 1e-9)
+})
+
+test_that("bootstrap critical value matches the analytic qmvnorm one up to Monte-Carlo error", {
+	fit <- .boot_fit(se_type = "cluster")
+	for (fam in c("cohort", "all_post_treatment")) {
+		an <- simultaneousCIs(fit, family = fam, method = "analytic")
+		bo <- simultaneousCIs(
+			fit,
+			family = fam,
+			method = "bootstrap",
+			B = 5000,
+			seed = 1
+		)
+		expect_lt(abs(bo$critical_value - an$critical_value), 0.12)
+	}
+})
+
+test_that("bootstrap critical value sits in [pointwise, Bonferroni]", {
+	fit <- .boot_fit(se_type = "cluster")
+	bo <- simultaneousCIs(
+		fit,
+		family = "all_post_treatment",
+		method = "bootstrap",
+		B = 4000,
+		seed = 7
+	)
+	expect_gte(bo$critical_value, bo$pointwise_critical_value - 1e-8)
+	expect_lte(bo$critical_value, bo$bonferroni_critical_value + 1e-8)
+	# strictly tighter than Bonferroni when K > 1 and effects are correlated
+	expect_lt(bo$critical_value, bo$bonferroni_critical_value)
+})
+
+test_that("a single non-degenerate effect uses the exact pointwise critical value", {
+	fit <- .boot_fit(se_type = "cluster")
+	ctr <- matrix(c(1, rep(0, length(fit$treat_inds) - 1L)), nrow = 1)
+	bo <- simultaneousCIs(
+		fit,
+		family = "custom",
+		contrasts = ctr,
+		method = "bootstrap",
+		B = 1000,
+		seed = 1
+	)
+	expect_equal(bo$K, 1L)
+	expect_equal(bo$critical_value, stats::qnorm(1 - 0.05 / 2))
+})
+
+test_that("bootstrap is deterministic given a seed, and varies without one", {
+	fit <- .boot_fit(se_type = "cluster")
+	a <- simultaneousCIs(
+		fit,
+		family = "all_post_treatment",
+		method = "bootstrap",
+		B = 1000,
+		seed = 42
+	)
+	b <- simultaneousCIs(
+		fit,
+		family = "all_post_treatment",
+		method = "bootstrap",
+		B = 1000,
+		seed = 42
+	)
+	expect_identical(a$critical_value, b$critical_value)
+	c2 <- simultaneousCIs(
+		fit,
+		family = "all_post_treatment",
+		method = "bootstrap",
+		B = 1000,
+		seed = 99
+	)
+	expect_false(isTRUE(all.equal(a$critical_value, c2$critical_value)))
+})
+
+test_that("seed is restored: a seeded bootstrap does not perturb the ambient RNG stream", {
+	fit <- .boot_fit(se_type = "cluster")
+	set.seed(123)
+	before <- stats::runif(1)
+	set.seed(123)
+	invisible(simultaneousCIs(
+		fit,
+		family = "cohort",
+		method = "bootstrap",
+		B = 500,
+		seed = 7
+	))
+	after <- stats::runif(1)
+	expect_identical(before, after)
+})
+
+test_that("mammen multipliers also produce an in-range critical value", {
+	fit <- .boot_fit(se_type = "cluster")
+	bo <- simultaneousCIs(
+		fit,
+		family = "all_post_treatment",
+		method = "bootstrap",
+		B = 4000,
+		seed = 1,
+		multiplier = "mammen"
+	)
+	expect_gte(bo$critical_value, bo$pointwise_critical_value - 1e-8)
+	expect_lte(bo$critical_value, bo$bonferroni_critical_value + 1e-8)
+})
+
+test_that("method = 'analytic' is the default and byte-identical to omitting it", {
+	fit <- .boot_fit(se_type = "cluster")
+	expect_equal(
+		simultaneousCIs(fit, family = "cohort"),
+		simultaneousCIs(fit, family = "cohort", method = "analytic")
+	)
+	# the bootstrap return adds method/B/seed/multiplier and is otherwise the
+	# same S3 shape
+	bo <- simultaneousCIs(
+		fit,
+		family = "cohort",
+		method = "bootstrap",
+		B = 500,
+		seed = 1
+	)
+	expect_s3_class(bo, "simultaneous_cis")
+	expect_true(all(c("method", "B", "seed", "multiplier") %in% names(bo)))
+	expect_identical(bo$method, "bootstrap")
+})
+
+test_that("event_study is rejected for the bootstrap method (Phase 1)", {
+	fit <- .boot_fit(se_type = "cluster")
+	expect_error(
+		simultaneousCIs(fit, family = "event_study", method = "bootstrap"),
+		"event_study"
+	)
+	# but still works analytically
+	expect_s3_class(
+		simultaneousCIs(fit, family = "event_study", method = "analytic"),
+		"simultaneous_cis"
+	)
+})
+
+test_that("bootstrap validates B and seed", {
+	fit <- .boot_fit(se_type = "cluster")
+	expect_error(
+		simultaneousCIs(fit, family = "cohort", method = "bootstrap", B = 0),
+		"B"
+	)
+	expect_error(
+		simultaneousCIs(
+			fit,
+			family = "cohort",
+			method = "bootstrap",
+			seed = c(1, 2)
+		),
+		"seed"
+	)
+})
+
+test_that("adjusted p-values are the dual of the simultaneous band (both sides)", {
+	# Weak-/sparse-effect DGP so the all_post_treatment family contains BOTH
+	# rejected and non-rejected cells, exercising both directions of the iff
+	# (a strong-effect DGP rejects every cell and never bites the non-reject side).
+	coefs <- genCoefs(
+		G = 3,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 0.4,
+		seed = 2
+	)
+	dat <- simulateData(
+		coefs,
+		N = 150,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 2
+	)
+	dat$indep_counts <- NA
+	fit <- fetwfeWithSimulatedData(dat, q = 0.5, se_type = "cluster")
+	bo <- simultaneousCIs(
+		fit,
+		family = "all_post_treatment",
+		method = "bootstrap",
+		B = 4000,
+		seed = 3
+	)
+	excludes_zero <- bo$ci$simultaneous_ci_low > 0 |
+		bo$ci$simultaneous_ci_high < 0
+	nd <- !is.na(bo$adjusted_p_values)
+	# outside band iff adjusted p < alpha -- over all non-degenerate effects, so
+	# both the reject and non-reject sides bite whenever the family has each.
+	expect_equal(excludes_zero[nd], (bo$adjusted_p_values < bo$alpha)[nd])
+})
+
+test_that("the bootstrap method works for the non-FETWFE estimators (etwfe, betwfe)", {
+	coefs <- genCoefs(
+		G = 3,
+		T = 5,
+		d = 2,
+		density = 0.6,
+		eff_size = 1.5,
+		seed = 1
+	)
+	dat <- simulateData(
+		coefs,
+		N = 150,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 1
+	)
+	dat$indep_counts <- NA
+	# etwfe: full design, no selection (sel_feat_inds = NA path);
+	# betwfe: beta-space selected support.
+	for (fit in list(
+		etwfeWithSimulatedData(dat),
+		betwfeWithSimulatedData(dat)
+	)) {
+		bo <- simultaneousCIs(
+			fit,
+			family = "cohort",
+			method = "bootstrap",
+			B = 1000,
+			seed = 1
+		)
+		expect_s3_class(bo, "simultaneous_cis")
+		expect_true(all(is.finite(bo$ci$simultaneous_ci_low)))
+		expect_gte(bo$critical_value, bo$pointwise_critical_value - 1e-8)
+		expect_lte(bo$critical_value, bo$bonferroni_critical_value + 1e-8)
+	}
+})
+
+test_that(".simultaneous_bootstrap_crit handles degenerate / single-effect F without warnings", {
+	# All-degenerate F (zero-variance columns): no draw, no max()-over-empty
+	# warning, crit falls back to the exact pointwise quantile.
+	F0 <- matrix(0, 60, 3)
+	expect_no_warning(
+		r0 <- .simultaneous_bootstrap_crit(
+			F0,
+			n = 240,
+			alpha = 0.05,
+			B = 100,
+			multiplier = "rademacher",
+			seed = 1
+		)
+	)
+	expect_equal(r0$crit, stats::qnorm(1 - 0.05 / 2))
+	expect_null(r0$boot_max)
+	# Exactly one non-degenerate effect: same fallback, no warning.
+	set.seed(1)
+	F1 <- cbind(stats::rnorm(60), 0, 0)
+	expect_no_warning(
+		r1 <- .simultaneous_bootstrap_crit(F1, n = 240, alpha = 0.05, B = 100)
+	)
+	expect_equal(r1$crit, stats::qnorm(1 - 0.05 / 2))
+})
+
+test_that("bootstrap simultaneous bands attain near-nominal family-wise coverage", {
+	skip_on_cran()
+	# A small but honest family-wise coverage check for the cohort family: in what
+	# fraction of simulated panels does the simultaneous band cover ALL true cohort
+	# ATTs jointly? Nominal is 0.95; the lower bound is generous to absorb the
+	# modest nsim and finite N (this is a sanity floor, not a precise estimate).
+	G <- 2L
+	T <- 4L
+	nsim <- 40L
+	coefs <- genCoefs(
+		G = G,
+		T = T,
+		d = 1,
+		density = 0.8,
+		eff_size = 1.5,
+		seed = 1
+	)
+	num_treats <- getNumTreats(G = G, T = T)
+	true_catt <- getActualCohortTes(
+		G = G,
+		first_inds = getFirstInds(G = G, T = T),
+		treat_inds = getTreatInds(
+			G = G,
+			T = T,
+			d = 1L,
+			num_treats = num_treats
+		),
+		coefs = coefs$beta,
+		num_treats = num_treats
+	)
+	covered <- logical(nsim)
+	for (s in seq_len(nsim)) {
+		dat <- simulateData(
+			coefs,
+			N = 100,
+			sig_eps_sq = 1,
+			sig_eps_c_sq = 0.5,
+			seed = 100L + s
+		)
+		dat$indep_counts <- NA
+		fit <- fetwfeWithSimulatedData(dat, q = 0.5, se_type = "cluster")
+		bo <- simultaneousCIs(
+			fit,
+			family = "cohort",
+			method = "bootstrap",
+			B = 400,
+			seed = 1
+		)
+		covered[s] <- all(
+			true_catt >= bo$ci$simultaneous_ci_low &
+				true_catt <= bo$ci$simultaneous_ci_high
+		)
+	}
+	expect_gt(mean(covered), 0.80)
+})

--- a/vignettes/inference_vignette.Rmd
+++ b/vignettes/inference_vignette.Rmd
@@ -292,7 +292,24 @@ The critical value is computed via `mvtnorm::qmvnorm(..., algorithm = mvtnorm::G
 
 As of version 1.16.0 the `mvtnorm` package is an `Imports` dependency (it ships with the package), because simultaneous bands are now computed by default at fit time --- see the `ci_type` subsection below. (In versions 1.15.x `mvtnorm` was in `Suggests` and only loaded when `simultaneousCIs()` was called.) The `plot.simultaneous_cis` method additionally requires `ggplot2`, which is in `Suggests`; install it with `install.packages("ggplot2")` if you have not already.
 
-The pattern matches `did::aggte(cband = TRUE)` from the Callaway-Sant'Anna `did` package, which computes simultaneous bands via the CCK (2013) multiplier bootstrap. Asymptotically the two critical values are identical under fixed-dim Gaussianity; the parametric `simultaneousCIs()` path here is deterministic and sub-second, whereas the multiplier-bootstrap path is stochastic and resampling-based.
+The default analytic path matches `did::aggte(cband = TRUE)` from the Callaway-Sant'Anna `did` package, which computes simultaneous bands via the CCK (2013) multiplier bootstrap. Asymptotically the two critical values are identical under fixed-dim Gaussianity; the analytic `simultaneousCIs()` path is deterministic and sub-second, whereas a multiplier bootstrap is stochastic and resampling-based.
+
+## The multiplier-bootstrap method: `method = "bootstrap"`
+
+`simultaneousCIs(..., method = "bootstrap")` computes the same sup-t critical value by the CCK (2013) multiplier bootstrap directly --- the procedure `did` uses. It perturbs the per-unit influence functions $\hat f_i^{(k)}$ with random multipliers $\xi_i$ (`multiplier = "rademacher"` or `"mammen"`), forms $T^{(b)} = \max_k |\frac{1}{N}\sum_i \xi_i \hat f_i^{(k)}| / \widehat{\mathrm{sd}}_k$ over $B$ replicates, and takes the $(1-\alpha)$ quantile. The analytic and bootstrap critical values agree up to Monte-Carlo error, and both sit between the pointwise and Bonferroni values:
+
+```{r}
+sci_boot <- simultaneousCIs(res_default, family = "all_post_treatment",
+                            method = "bootstrap", B = 1000, seed = 1)
+c(pointwise  = sci_boot$pointwise_critical_value,
+  analytic   = simultaneousCIs(res_default, family = "all_post_treatment")$critical_value,
+  bootstrap  = sci_boot$critical_value,
+  bonferroni = sci_boot$bonferroni_critical_value)
+```
+
+Two reasons to prefer the bootstrap. First, it **scales to large effect families**: `qmvnorm` integration strains at hundreds of effects (e.g. simultaneous bands over the full disaggregated cohort $\times$ event-time grid), whereas the bootstrap stays stable and linear in $B \cdot K$. Second, it is **heteroskedasticity/cluster-robust by construction** --- its per-unit influence matrix $F$ reproduces the cluster-robust joint covariance ($\mathrm{crossprod}(F)/(NT)^2$ equals it up to the $N/(N-1)$ finite-sample factor), so on a `se_type = "cluster"` fit the bootstrap per-effect standard errors equal the analytic ones exactly (and on a default fit the bootstrap reports the cluster-robust band regardless). Pass an integer `seed` for reproducible draws; with `seed = NULL` the draws come from the ambient RNG.
+
+Phase 1 (this release) supports `method = "bootstrap"` for `family = "cohort"`, `"all_post_treatment"`, and `"custom"`. The `"event_study"` family --- whose pooling across cohorts introduces a cohort-probability variance term needing a per-unit propensity influence function --- and the high-dimensional `p \ge NT` regime (where the analytic Gram inverse does not exist, so the bootstrap is the *only* route to simultaneous bands) are planned follow-ups; use `method = "analytic"` for `event_study` in the meantime.
 
 ## Simultaneous bands are the default: the `ci_type` argument
 


### PR DESCRIPTION
## Summary

Adds `method = "bootstrap"` to `simultaneousCIs()` — the Chernozhukov–Chetverikov–Kato (2013) sup-t **multiplier bootstrap** — as an alternative to the default analytic `mvtnorm::qmvnorm()` critical value. `method = "analytic"` is unchanged and remains the default (existing calls are byte-identical). Refs #142 — Phase 1; `event_study` and the high-dimensional `p ≥ NT` regime are follow-ups.

## How it works

It perturbs a per-unit influence-function matrix `F` (N×K) with random multipliers (`rademacher`/`mammen`, `B` reps, optional `seed`) and reads the simultaneous critical value off the bootstrap distribution. `F` is `debiasedATT()`'s `(X v_k)·resid` per-unit score generalized to the K effects of the family, in `getGramInv()`'s centered / `n = NT` convention:

```
F_reg = XEps %*% V,   V[,k] = solve(Sig, Psi_full[,k]),   Sig = X_sel_c'X_sel_c / n
```

with `resid` the OLS-refit residuals on the selected support. By construction `crossprod(F)/(NT)²` reproduces the cluster-robust joint covariance (up to the `N/(N-1)` factor), so on a `se_type = "cluster"` fit the bootstrap per-effect SEs **match the analytic ones to machine precision** (verified, 2e-16), and the studentized sup-t critical value matches the analytic `qmvnorm` one up to Monte-Carlo error and lies in `[pointwise, Bonferroni]`.

## Why the bootstrap

- **Scales to large families** where `qmvnorm` strains (e.g. the full disaggregated `(g,t)` grid).
- **Heteroskedasticity/cluster-robust** by construction (the empirical per-unit IF).
- It is the **only route to simultaneous bands in the high-dimensional `p ≥ NT` regime** (where the analytic Gram inverse does not exist) — the planned Phase 2.

## Scope (Phase 1)

`family = "cohort"`, `"all_post_treatment"`, and `"custom"` (the cohort-probability variance term is zero, so `F = F_reg`). `event_study` (which needs a per-unit propensity influence function) and the high-dimensional regime are follow-ups; `event_study` cleanly errors under `method = "bootstrap"` and still works analytically.

## Testing

`tests/testthat/test-simultaneous-bootstrap-142.R` (36 tests): the machine-precision SE anchor, crit ≈ `qmvnorm`, crit ∈ `[pointwise, Bonferroni]`, the single-effect → exact pointwise crit, determinism + seed restore, `mammen`, arg validation, `event_study` rejection, the adjusted-p ↔ band dual (both sides), the **non-FETWFE estimator path** (etwfe + betwfe), **degenerate-family** handling (no `max()`-over-empty warnings), and a **family-wise coverage** check. Mutation-checked (Sig scaling; studentization).

- Full suite: **FAIL 0 | PASS 3694+**.
- `R CMD check` **with vignettes**: 0 errors / 0 warnings; NOTEs only for stray untracked working docs and the environmental "unable to verify current time".

## Process

Full workflow: a plan-review caught (and I fixed) a load-bearing `F`-scaling error before any code was written; a multi-agent post-exec review (3 dimensions × adversarial verification) returned **0 blockers** — its confirmed SHOULD-FIXes (degenerate-family warnings, the missing coverage test, the untested non-FETWFE path) and key NITs (the K=1 adjusted-p dual, a dead `se_type` parameter, fractional `B`, an imprecise "= cluster covariance" claim) are all addressed here.

Version `1.30.0 → 1.31.0`. NEWS entry + a worked `inference_vignette.Rmd` subsection included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
