### PR TITLE
feat: q=1 fused-lasso nuisance for the high-dim debiased construction (#303)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.34.0
+Version: 1.35.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,26 @@
 # NEWS
 
+## Version 1.35.0
+
+### Changes
+
+- The high-dimensional (`p >= NT`) **debiased nuisance** is now an internally-fit
+  **`q = 1` fused lasso** (`grpreg::cv.grpreg(penalty = "gBridge", gamma = 1)`,
+  CV-selected `lambda`) -- the Theorem 6.6 nuisance -- rather than the reused
+  `q < 1` FETWFE bridge `theta_hat` (#303). The `q < 1` bridge is
+  super-efficient / non-uniform (the wrong rate for a uniformly-valid CI); only
+  its `l1` *rate*, which the paper establishes for the `q = 1` fused lasso,
+  controls the orthogonalization remainder. This changes the debiased **point
+  estimate** (and, through the nuisance residuals, its regression-channel
+  standard error / band width) returned by `debiasedATT()` and the
+  high-dimensional band centers of `simultaneousCIs(method = "bootstrap")` (both
+  move to the `q = 1` nuisance consistently, so they remain equal for the
+  matching contrast). The *input* fit
+  stays `q < 1` (the cohort-weight variance channel `att_var_2` and the
+  `calc_ses` gate are unchanged); fixed-`p` (`p < NT`) behavior is unchanged. The
+  `p >= NT` path remains **experimental** (coverage not yet simulation-validated;
+  `lambda_c` not yet tuned, #295).
+
 ## Version 1.34.0
 
 ### New features

--- a/R/bridge_selection.R
+++ b/R/bridge_selection.R
@@ -293,3 +293,75 @@ getBetaCV <- function(
 		cv_seed = cv_seed
 	)
 }
+
+# .fit_q1_nuisance
+#' @title Fit the high-dimensional debiased nuisance as a `q = 1` fused lasso
+#' @description The high-dimensional (`p >= NT`) debiased construction --- shared
+#'   by `debiasedATT()` and the `simultaneousCIs(method = "bootstrap")` band
+#'   center --- needs a nuisance `theta_hat` whose `l1` *rate* controls the
+#'   Neyman-orthogonal remainder (paper Theorem `debiased.highdim.thm`). The paper
+#'   establishes that rate for a **`q = 1` fused lasso** (the convex case,
+#'   standard under the restricted-eigenvalue condition); the `q < 1` FETWFE
+#'   bridge is super-efficient / non-uniform --- the wrong nuisance for a
+#'   uniformly-valid CI (#303). This fits that nuisance on the SAME whitened,
+#'   fusion-transformed design the bridge used, via `grpreg::cv.grpreg(penalty =
+#'   "gBridge", gamma = 1)` (the group-bridge penalty at `gamma = 1` over
+#'   singleton groups is the lasso), CV-selecting `lambda` --- the package's "CV
+#'   on the raw lambda" convention (cf. `getBetaCV()`).
+#'
+#'   **Determinism contract.** `debiasedATT()` and `.simultaneous_cis_bootstrap()`
+#'   must obtain the *identical* nuisance so the high-dim band center equals
+#'   `debiasedATT()$att` to machine precision. The seed is derived from the data
+#'   (`as.integer(N * T)`, `getBetaCV()`'s default), NOT the fit's `cv_seed`
+#'   (which is `NA` for BIC-selected fits); both call sites pass the same
+#'   `X_final` / `y_final` / `N` / `T` from the same fit, and
+#'   `.with_preserved_rng()` leaves the caller's RNG untouched (#177).
+#' @param X_final Numeric matrix; the `NT x p` unscaled, fusion + GLS-transformed
+#'   design (`fit$internal$X_final`).
+#' @param y_final Numeric vector of length `NT`; the GLS-transformed response
+#'   (callers pass the `NT`-truncated `y_final`, matching the `add_ridge` design).
+#' @param N,T Integer; the number of units and time periods.
+#' @param cv_folds Integer; CV folds (fixed by the call sites for determinism).
+#' @return Numeric vector of length `p + 1`: the `q = 1` nuisance coefficients
+#'   (intercept at position 1) on the original-data scale.
+#' @keywords internal
+#' @noRd
+.fit_q1_nuisance <- function(X_final, y_final, N, T, cv_folds = 10L) {
+	p <- ncol(X_final)
+	X_scaled <- my_scale(X_final)
+	scale_center <- attr(X_scaled, "scaled:center")
+	scale_scale <- attr(X_scaled, "scaled:scale")
+	# Deterministic seed from the data only (NOT fit$cv_seed, which is NA for
+	# BIC-selected fits). as.integer(N * T) is getBetaCV()'s default-seed
+	# convention; identical at both call sites since N, T come from the same fit.
+	nt_double <- as.numeric(N) * as.numeric(T)
+	cv_seed <- if (nt_double > .Machine$integer.max) {
+		.Machine$integer.max
+	} else {
+		as.integer(nt_double)
+	}
+	cv_fit <- .with_preserved_rng(cv_seed, {
+		grpreg::cv.grpreg(
+			X = X_scaled,
+			y = y_final,
+			penalty = "gBridge",
+			gamma = 1,
+			nfolds = cv_folds
+		)
+	})
+	lambda_star <- cv_fit$lambda.min
+	lam_idx <- which(cv_fit$fit$lambda == lambda_star)
+	if (length(lam_idx) != 1L) {
+		# Fall back to nearest match in case of floating-point comparison drift.
+		lam_idx <- which.min(abs(cv_fit$fit$lambda - lambda_star))
+	}
+	stopifnot(length(lam_idx) == 1L, nrow(cv_fit$fit$beta) == p + 1L)
+	theta_scaled <- cv_fit$fit$beta[, lam_idx]
+	stopifnot(length(theta_scaled) == p + 1L, all(!is.na(theta_scaled)))
+	.untransform_scaled_theta(
+		theta_hat_scaled = theta_scaled,
+		p = p,
+		scale_center = scale_center,
+		scale_scale = scale_scale
+	)
+}

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -107,6 +107,10 @@
 #' the wrong nuisance for a uniformly-valid CI (#303). The
 #' *input* fit must still be `q < 1` (it supplies the cohort-weight variance
 #' channel `att_var_2`); only the high-dimensional debiasing nuisance is `q = 1`.
+#' That nuisance's cross-validation uses a fixed, data-derived seed, so it is
+#' deterministic across calls (`debiasedATT()` and the high-dimensional
+#' [simultaneousCIs()] band center agree exactly) --- but it is not tunable via
+#' the fit's `cv_seed`.
 #'
 #' @param fit A fitted object from [fetwfe()] computed with `q < 1` (so the
 #'   bridge selection produces a valid standard error). [etwfe()] / [betwfe()] /
@@ -273,14 +277,20 @@ debiasedATT <- function(
 	num_treats <- length(treat_inds)
 	cohort_probs <- fit$cohort_probs
 
-	# The cohort-weight SE channel is exactly the package's plug-in propensity
-	# variance `att_var_2` (the weight channel concerns the estimated cohort
-	# weights, not the theta-selection, so it is identical for the fused and
-	# debiased estimators). Reuse it rather than recomputing
-	# `(1/N_T) sum_g pi_g (catt_g - att)^2`: it is byte-identical on single-sample
-	# fits and, crucially, already carries the correct two-sample formula for
-	# `indep_counts` fits (the same `att_var_2` that `fit$att_se` uses). Single
-	# source of truth (#291 review).
+	# The cohort-weight SE channel is the package's plug-in propensity variance
+	# `att_var_2` = `(1/N_T) sum_g pi_g (catt_g - att)^2` -- the variance from
+	# estimating the cohort weights pi_hat_g. Reuse the fit's stored value rather
+	# than recomputing: it is the same `att_var_2` `fit$att_se` uses, byte-identical
+	# on single-sample fits and already carrying the correct two-sample formula for
+	# `indep_counts` fits (single source of truth, #291 review).
+	#
+	# CAVEAT (#303 review, second-order, deferred -> #295): this channel plugs in
+	# the BRIDGE `catt_g` / `att_hat`, while the high-dim center is now the q=1
+	# debiased estimate -- the same center(q=1)/variance-channel(bridge) mismatch as
+	# the event_study propensity channel `F_pi` (#309), here for the overall-ATT V2.
+	# It is second-order (the bridge and q=1 `catt_g` are both consistent for the
+	# true cohort effects), so the additive SE stays asymptotically correct; the
+	# finite-sample effect is part of the #295 high-dim coverage validation.
 	var_weight <- fit$internal$variance_components$att_var_2
 	if (
 		is.null(var_weight) ||

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -93,17 +93,20 @@
 #'     diagnostics.
 #' }
 #'
-#' The high-dimensional branch reuses the same bridge (`q < 1`) nuisance
-#' `theta_hat` as the fixed-`p` branch rather than the paper's literal `q = 1`
-#' fused lasso (a `q = 1` fit carries no valid SE here, since `calc_ses` is
-#' `FALSE`). For the fixed-`p` branch this substitution is first-order innocuous:
-#' Theorem `debiased.att.thm` needs only *consistency* of the nuisance. In the
-#' high-dimensional regime, however, Theorem `debiased.highdim.thm` controls the
+#' The two regimes use different nuisances. The **fixed-`p`** branch uses the
+#' fit's bridge (`q < 1`) `theta_hat`: Theorem `debiased.att.thm` needs only
+#' *consistency* of the nuisance, and with the exact inverse this is the OLS
+#' identity. The **high-dimensional** branch instead fits an internal `q = 1`
+#' fused lasso (`grpreg::cv.grpreg(penalty = "gBridge", gamma = 1)`, CV-selected
+#' `lambda`) as the nuisance, because Theorem `debiased.highdim.thm` controls the
 #' orthogonalization remainder through the nuisance's `l1` *rate*
-#' (`||theta_hat - theta*||_1 = O_p(s_N lambda_theta)`), which the paper
-#' establishes for the `q = 1` fused lasso; the bridge nuisance is `l1`-consistent
-#' and sparse, but its high-dimensional `l1` rate is not established for `q < 1`.
-#' This is a further reason the `p >= NT` path is flagged experimental.
+#' (`||theta_hat - theta*||_1 = O_p(s_N lambda_theta)`) --- the rate the `q = 1`
+#' fused lasso enjoys under a restricted-eigenvalue condition (the standard
+#' desparsified-lasso rate; cf. Negahban et al. 2012), the `p >= NT` extension
+#' the paper points to; the `q < 1` bridge is super-efficient / non-uniform ---
+#' the wrong nuisance for a uniformly-valid CI (#303). The
+#' *input* fit must still be `q < 1` (it supplies the cohort-weight variance
+#' channel `att_var_2`); only the high-dimensional debiasing nuisance is `q = 1`.
 #'
 #' @param fit A fitted object from [fetwfe()] computed with `q < 1` (so the
 #'   bridge selection produces a valid standard error). [etwfe()] / [betwfe()] /
@@ -354,6 +357,10 @@ debiasedATT <- function(
 		# Fixed-p (p < NT): exact / tiny-ridge inverse. Byte-identical to the
 		# validated fixed-p reference; `lambda_c` / `riesz_*` are ignored here.
 		v <- solve(Sig + (1e-6 * mean(diag(Sig))) * diag(p), a_theta[-1])
+		# Fixed-p nuisance: the bridge theta_hat. Theorem `debiased.att.thm` needs
+		# only nuisance *consistency*, and with the exact inverse this reduces to
+		# the OLS identity. Byte-unchanged.
+		theta_nuis <- theta_hat
 	} else {
 		# High-dimensional (p >= NT): nodewise (desparsified-lasso) relaxed inverse.
 		# `Sig` is singular, so the exact inverse is invalid; `v` is the l1-penalized
@@ -403,10 +410,20 @@ debiasedATT <- function(
 			converged = converged,
 			lambda_node = lambda_node
 		)
+		# High-dim nuisance (#303): an internal q=1 fused lasso, NOT the reused
+		# q<1 bridge theta_hat. Its l1 rate is what Theorem `debiased.highdim.thm`
+		# controls the orthogonalization remainder through (the q<1 bridge is
+		# super-efficient / non-uniform -- the wrong nuisance for a uniform CI).
+		# Deterministic (fixed seed) so the simultaneousCIs() high-dim band center
+		# matches debiasedATT()$att exactly.
+		theta_nuis <- .fit_q1_nuisance(X, y, N_units, T)
 	}
-	resid <- as.numeric(y - theta_hat[1] - X %*% theta_hat[-1])
+	# Nuisance: the q=1 fused lasso in high-dim (theta_nuis set above), the bridge
+	# theta_hat in fixed-p. The plug-in functional and the residuals use it; the
+	# debiasing direction `v` and the `a_theta` identity check (above) do not.
+	resid <- as.numeric(y - theta_nuis[1] - X %*% theta_nuis[-1])
 	score <- as.numeric((X %*% v) * resid)
-	att_db <- sum(a_theta * theta_hat) + mean(score)
+	att_db <- sum(a_theta * theta_nuis) + mean(score)
 
 	# ---- channel 1: regression (outcome) variance, per-unit clustered ----
 	unit <- rep(seq_len(n / T), each = T)

--- a/R/simultaneous_bootstrap.R
+++ b/R/simultaneous_bootstrap.R
@@ -15,7 +15,8 @@
 # `Sigma_2` is zero, so `F = F_reg`. Phase 2 added the `event_study` family (the
 # per-unit propensity IF `F_pi`) and the high-dimensional (`p >= NT`) regime --
 # including their combination (high-dim `event_study` uses BOTH channels), and
-# the high-dim band center is debiased (Theorem 6.6) rather than the raw bridge.
+# the high-dim band center is debiased (Theorem 6.6) on an internal q=1
+# fused-lasso nuisance (#303), not the raw q<1 bridge.
 
 #' Draw multiplier-bootstrap weights
 #'
@@ -104,8 +105,9 @@
 #' * sqrt(log p / N)`.
 #'
 #' @param X Numeric `NT x p`; the FULL (uncentered) design.
-#' @param resid Numeric length `NT`; bridge residuals
-#'   `y - theta_hat[1] - X theta_hat[-1]`.
+#' @param resid Numeric length `NT`; the nuisance residuals
+#'   `y - theta[1] - X theta[-1]` (the high-dim center uses the q=1 fused-lasso
+#'   nuisance, #303). This helper is residual-agnostic.
 #' @param N,T Integers.
 #' @param targets Numeric `p x K`; per-effect full theta-space directions.
 #' @param lambda_c,riesz_max_iter,riesz_tol Nodewise-solver controls.
@@ -420,7 +422,6 @@
 	effect_labels,
 	pointwise_crit,
 	bonferroni_crit,
-	theta_hat_full = NULL,
 	targets = NULL,
 	J_list = NULL,
 	theta_sel = NULL,
@@ -435,15 +436,19 @@
 	# generalized to K effects -- uniformly valid, NOT post-selection). Otherwise
 	# the fixed-p selected-support construction (Phase 1).
 	if (!is.null(targets)) {
-		# Bridge residuals (debiasedATT convention) over the FULL design.
-		resid_bridge <- as.numeric(
-			y_final[seq_len(n)] -
-				theta_hat_full[1] -
-				X_final %*% theta_hat_full[-1]
+		# High-dim nuisance (#303): an internal q=1 fused lasso (NOT the q<1 bridge
+		# theta_hat), the SAME nuisance debiasedATT() uses -- its l1 rate is what
+		# Theorem `debiased.highdim.thm` controls the orthogonalization remainder
+		# through, and the fixed seed makes it byte-identical to debiasedATT()'s
+		# nuisance so the debiased center below matches debiasedATT()$att exactly.
+		theta_q1 <- .fit_q1_nuisance(X_final, y_final[seq_len(n)], N, T)
+		# q=1 residuals over the FULL design (debiasedATT convention).
+		resid_q1 <- as.numeric(
+			y_final[seq_len(n)] - theta_q1[1] - X_final %*% theta_q1[-1]
 		)
 		F_mat <- .build_regression_if_highdim(
 			X_final,
-			resid_bridge,
+			resid_q1,
 			N,
 			T,
 			targets,
@@ -451,15 +456,16 @@
 			riesz_max_iter = riesz_max_iter,
 			riesz_tol = riesz_tol
 		)
-		# Debias the band center (Theorem 6.6). In the high-dim regime the bridge
-		# (post-selection) estimate is biased; the per-effect desparsified
-		# correction `colSums(F_mat)/(N*T)` is exactly `debiasedATT()`'s
-		# `mean(score)` (the per-effect generalization of `att_db = sum(a*theta) +
-		# mean(score)`), so `estimates_used` here equals `debiasedATT()$att` for the
-		# matching overall-ATT contrast. Centering the band on the bridge estimate
-		# instead would carry the post-selection bias (variance -> 0 with N, bias
-		# does not) and undercover.
-		estimates_used <- estimates + colSums(F_mat) / (N * T)
+		# Debias the band center (Theorem 6.6): the q=1 plug-in plus the per-effect
+		# desparsified correction `colSums(F_mat)/(N*T)` (exactly `debiasedATT()`'s
+		# `mean(score)`, the per-effect generalization of `att_db = sum(a*theta) +
+		# mean(score)`), so `estimates_used` equals `debiasedATT()$att` for the
+		# matching overall-ATT contrast. The q=1 plug-in `crossprod(targets,
+		# theta_q1[-1])` is the per-effect generalization of `sum(a_theta * theta)`.
+		# Centering on the post-selection bridge estimate instead would carry the
+		# selection bias (variance -> 0 with N, bias does not) and undercover.
+		estimates_q1 <- as.numeric(crossprod(targets, theta_q1[-1]))
+		estimates_used <- estimates_q1 + colSums(F_mat) / (N * T)
 	} else {
 		# Fixed-p: selected support + zero-padded Psi_full. FETWFE/BETWFE select a
 		# subset (`sel_feat_inds`); etwfe/twfeCovs use the full design.

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -687,7 +687,6 @@ simultaneousCIs.twfeCovs <- function(
 			effect_labels = effect_labels,
 			pointwise_crit = pointwise_crit,
 			bonferroni_crit = bonferroni_crit,
-			theta_hat_full = theta_hat_full,
 			targets = targets,
 			J_list = J_list,
 			theta_sel = theta_sel,

--- a/man/debiasedATT.Rd
+++ b/man/debiasedATT.Rd
@@ -140,17 +140,20 @@ constant \code{lambda_c} is not yet tuned); treat the \code{p >= NT} path as
 diagnostics.
 }
 
-The high-dimensional branch reuses the same bridge (\code{q < 1}) nuisance
-\code{theta_hat} as the fixed-\code{p} branch rather than the paper's literal \code{q = 1}
-fused lasso (a \code{q = 1} fit carries no valid SE here, since \code{calc_ses} is
-\code{FALSE}). For the fixed-\code{p} branch this substitution is first-order innocuous:
-Theorem \code{debiased.att.thm} needs only \emph{consistency} of the nuisance. In the
-high-dimensional regime, however, Theorem \code{debiased.highdim.thm} controls the
+The two regimes use different nuisances. The \strong{fixed-\code{p}} branch uses the
+fit's bridge (\code{q < 1}) \code{theta_hat}: Theorem \code{debiased.att.thm} needs only
+\emph{consistency} of the nuisance, and with the exact inverse this is the OLS
+identity. The \strong{high-dimensional} branch instead fits an internal \code{q = 1}
+fused lasso (\code{grpreg::cv.grpreg(penalty = "gBridge", gamma = 1)}, CV-selected
+\code{lambda}) as the nuisance, because Theorem \code{debiased.highdim.thm} controls the
 orthogonalization remainder through the nuisance's \code{l1} \emph{rate}
-(\verb{||theta_hat - theta*||_1 = O_p(s_N lambda_theta)}), which the paper
-establishes for the \code{q = 1} fused lasso; the bridge nuisance is \code{l1}-consistent
-and sparse, but its high-dimensional \code{l1} rate is not established for \code{q < 1}.
-This is a further reason the \code{p >= NT} path is flagged experimental.
+(\verb{||theta_hat - theta*||_1 = O_p(s_N lambda_theta)}) --- the rate the \code{q = 1}
+fused lasso enjoys under a restricted-eigenvalue condition (the standard
+desparsified-lasso rate; cf. Negahban et al. 2012), the \code{p >= NT} extension
+the paper points to; the \code{q < 1} bridge is super-efficient / non-uniform ---
+the wrong nuisance for a uniformly-valid CI (#303). The
+\emph{input} fit must still be \code{q < 1} (it supplies the cohort-weight variance
+channel \code{att_var_2}); only the high-dimensional debiasing nuisance is \code{q = 1}.
 }
 
 \examples{

--- a/man/debiasedATT.Rd
+++ b/man/debiasedATT.Rd
@@ -154,6 +154,10 @@ the paper points to; the \code{q < 1} bridge is super-efficient / non-uniform --
 the wrong nuisance for a uniformly-valid CI (#303). The
 \emph{input} fit must still be \code{q < 1} (it supplies the cohort-weight variance
 channel \code{att_var_2}); only the high-dimensional debiasing nuisance is \code{q = 1}.
+That nuisance's cross-validation uses a fixed, data-derived seed, so it is
+deterministic across calls (\code{debiasedATT()} and the high-dimensional
+\code{\link[=simultaneousCIs]{simultaneousCIs()}} band center agree exactly) --- but it is not tunable via
+the fit's \code{cv_seed}.
 }
 
 \examples{

--- a/tests/testthat/test-debiased-att-highdim.R
+++ b/tests/testthat/test-debiased-att-highdim.R
@@ -265,9 +265,18 @@ test_that("the high-dim branch is load-bearing: the fixed-p inverse explodes on 
 	# independent reconstruction from the same a_th / v_node above (the high-dim
 	# analog of the fixed-p reference test). This pins the scale = max(|a|), the
 	# N = clusters scaling, and the score/correction formula through the accessor.
-	th <- hd_fix$internal$theta_hat
-	resid <- as.numeric(hd_fix$internal$y_final - th[1] - X %*% th[-1])
-	att_recompute <- sum(c(0, a_th) * th) + mean((X %*% v_node) * resid)
+	# The high-dim nuisance is the internal q=1 fused lasso (#303), NOT the bridge
+	# theta_hat -- reconstruct it the same way the accessor does (n / Tt units), so
+	# this stays an INDEPENDENT reconstruction (the deterministic seed gives the
+	# identical nuisance => exact match), not a tautology.
+	th_q1 <- fetwfe:::.fit_q1_nuisance(
+		X,
+		as.numeric(hd_fix$internal$y_final),
+		n / Tt,
+		Tt
+	)
+	resid <- as.numeric(hd_fix$internal$y_final - th_q1[1] - X %*% th_q1[-1])
+	att_recompute <- sum(c(0, a_th) * th_q1) + mean((X %*% v_node) * resid)
 	db <- debiasedATT(hd_fix)
 	expect_equal(db$lambda_node, lam_node)
 	expect_equal(db$att, att_recompute)
@@ -278,10 +287,15 @@ test_that("lambda_c scales the nodewise penalty and shrinks the debiasing direct
 	db2 <- debiasedATT(hd_fix, lambda_c = 2)
 	# lambda_node is exactly linear in lambda_c (everything else held fixed).
 	expect_equal(db2$lambda_node, 2 * db1$lambda_node)
-	# At lambda_c = 2 the penalty lambda_node exceeds ||a||_inf (= 1 here), so
-	# v = 0 is optimal and the debiased estimate collapses to the fused plug-in
-	# att_hat; at the default lambda_c = 1 the correction is active (att != att_hat).
-	expect_equal(db2$att, hd_fix$att_hat)
+	# At lambda_c = 2 the penalty lambda_node exceeds ||a||_inf, so v = 0 is optimal
+	# and the debiased estimate collapses to the *q = 1 plug-in* (#303) -- NOT
+	# att_hat (the bridge plug-in). A much larger lambda_c gives the same v = 0, so
+	# both collapse to the identical q = 1 plug-in; and that plug-in differs from
+	# the bridge att_hat -- the mutation signal that the nuisance actually moved.
+	expect_equal(db2$att, debiasedATT(hd_fix, lambda_c = 100)$att)
+	expect_false(isTRUE(all.equal(db2$att, hd_fix$att_hat)))
+	# At the default lambda_c = 1 the correction is active (att != the plug-in).
+	expect_false(isTRUE(all.equal(db1$att, db2$att)))
 	expect_false(isTRUE(all.equal(db1$att, hd_fix$att_hat)))
 })
 

--- a/tests/testthat/test-simultaneous-bootstrap-highdim-142.R
+++ b/tests/testthat/test-simultaneous-bootstrap-highdim-142.R
@@ -207,6 +207,65 @@ test_that("high-dim debiased band center equals debiasedATT()$att for the overal
 })
 
 # ------------------------------------------------------------------------------
+# Per-effect q=1 plug-in pin (#303, post-exec review). The cross-check above pins
+# ONE direction (via debiasedATT). This pins a MULTI-effect (K = 2) custom family
+# against a fully INDEPENDENT reconstruction: the q=1 nuisance plug-in
+# `sum(a_theta * theta_q1)` plus the manual nodewise correction
+# `mean((X v) resid_q1)` -- built here with `riesz_lasso` + a hand-rolled score,
+# NOT the implementation's `.build_regression_if_highdim`. Mutation-checkable:
+# reverting the high-dim band center from the q=1 plug-in (`estimates_q1`) to the
+# bridge `estimates` shifts these per-effect centers and fails the match.
+# ------------------------------------------------------------------------------
+test_that("high-dim custom per-effect centers match an independent q=1 reconstruction (#303)", {
+	X <- hd_fit$internal$X_final
+	y <- as.numeric(hd_fit$internal$y_final)
+	n <- nrow(X)
+	p <- ncol(X)
+	Tt <- hd_fit$T
+	G <- hd_fit$G
+	ti <- hd_fit$treat_inds
+	nt <- length(ti)
+	A <- genFullInvFusionTransformMat(
+		first_inds = getFirstInds(G = G, T = Tt),
+		T = Tt,
+		G = G,
+		d = hd_fit$d,
+		num_treats = nt,
+		fusion_structure = hd_fit$fusion_structure,
+		d_inv_treat = hd_fit$internal$d_inv_treat
+	)
+	theta_q1 <- fetwfe:::.fit_q1_nuisance(X, y, n / Tt, Tt)
+	resid <- as.numeric(y - theta_q1[1] - X %*% theta_q1[-1])
+	Sig <- crossprod(X) / n
+	# two distinct multi-effect contrasts (K = 2): first and last treatment cell.
+	C <- rbind(c(1, rep(0, nt - 1)), c(rep(0, nt - 1), 1))
+	recon <- apply(C, 1, function(cc) {
+		ab <- numeric(p)
+		ab[ti] <- cc
+		ath <- as.numeric(crossprod(A, ab))
+		ln <- lambda_node_default(
+			p = p,
+			N = n / Tt,
+			c = 1.0,
+			scale = max(abs(ath))
+		)
+		v <- riesz_lasso(Sig, ath, ln)
+		sum(ath * theta_q1[-1]) + mean((X %*% v) * resid)
+	})
+	sc <- simultaneousCIs(
+		hd_fit,
+		family = "custom",
+		contrasts = C,
+		method = "bootstrap",
+		B = 100,
+		seed = 1
+	)
+	expect_identical(sc$regime, "high-dimensional")
+	# centers are B/seed-independent (plug-in + deterministic correction).
+	expect_equal(sc$ci$estimate, recon, tolerance = 1e-9)
+})
+
+# ------------------------------------------------------------------------------
 # Band / adjusted-p duality under debiasing (#299, plan-review item 1). The
 # adjusted-p `t_stat` MUST use the debiased center `estimates_used`, not the bridge
 # `estimates`, or the band and its adjusted p-values disagree on a bridge-zeroed


### PR DESCRIPTION
Closes #303.

Switches the high-dimensional (`p >= NT`) **debiased nuisance** from the reused `q < 1` FETWFE bridge `theta_hat` to an internally-fit **`q = 1` fused lasso** (the paper's Theorem 6.6 nuisance). The `q < 1` bridge is super-efficient / non-uniform — the wrong rate for a uniformly-valid CI; only the `q = 1` fused lasso's `l1` rate controls the orthogonalization remainder (the package↔paper mismatch flagged at `gregfaletto/fetwfe#75`).

## What changed

Applied consistently to **both** high-dim call sites of the shared debiased construction (decided in chat — keep them on the same nuisance so the cross-check holds and the band centers stay correct):

1. **`debiasedATT()`** (`R/debiased_att.R`) — the residuals and the plug-in use the q=1 nuisance; the `a_theta` identity check stays on the bridge `theta_hat` (it verifies `a_theta`, not the estimate); fixed-`p` (`p < NT`) is byte-unchanged.
2. **`simultaneousCIs(method = "bootstrap")`'s high-dim band center** (`R/simultaneous_bootstrap.R`) — the per-effect q=1 plug-in `crossprod(targets, theta_q1[-1])` + the desparsified correction.

New shared helper **`.fit_q1_nuisance()`** (`R/bridge_selection.R`): `grpreg::cv.grpreg(penalty = "gBridge", gamma = 1)` (the group-bridge penalty at γ=1 over singleton groups is the lasso) on the same whitened design, CV-selecting λ. **Deterministic** (fixed seed `N*T` via `.with_preserved_rng`) so both sites get the byte-identical nuisance — the high-dim band center equals `debiasedATT()$att` to machine precision (`|diff| = 0`).

## Scope (as decided)

- The **input fit stays `q < 1`** (the cohort-weight channel `var_weight = att_var_2` and the `calc_ses` gate are unchanged) — **not** decoupled.
- Doc trimmed to drop the now-resolved "q<1 rate not established" experimental reason (the RE-condition / `lambda_c` / coverage reasons remain).
- The `p >= NT` path stays **experimental** (#295). The `event_study` propensity channel `F_pi` is **out of scope** — that's #309 (the in-code caveat says so; a q=1 lasso still *selects*, so it doesn't un-zero a cohort in `F_pi`).
- Removed the now-dead `theta_hat_full` bootstrap-worker param.

## Verification

- **Cross-check** `simultaneousCIs` high-dim center == `debiasedATT()$att` holds at `|diff| = 0` (the determinism contract).
- Re-derived the two value-pinned high-dim debiased assertions against the q=1 nuisance (load-bearing reconstruction; the `lambda_c = 2` collapse — now to the *q=1 plug-in*, not the bridge `att_hat`).
- Added a **multi-effect (K=2) per-effect cross-check** — independent `riesz_lasso` reconstruction (post-exec review request; closes the per-family pin gap).
- Both call-site switches + all changed/new assertions **mutation-checked** (each bites; reverts byte-identical).
- Independent post-exec review: *mergeable as experimental, no blockers* (its one Minor + two doc/NEWS Nits addressed).
- Full suite green (**3816** pass, 0 fail, 0 warn); **`R CMD check --as-cran` clean** (0/0/0, vignettes built); version 1.34.0 → 1.35.0 + NEWS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
