### PR TITLE
feat: gls = FALSE -- Omega-free high-dim cluster-robust SE (#307)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.35.0
+Version: 1.36.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,26 @@
 # NEWS
 
+## Version 1.36.0
+
+### New features
+
+- `fetwfe(gls = FALSE)` skips GLS whitening and variance-component estimation, so
+  high-dimensional (`p >= NT`) fits run **without** supplied `sig_eps_sq` /
+  `sig_eps_c_sq` (previously a hard error from the REML guard `p < N(T - 1)` in
+  `estOmegaSqrtInv()`). Such fits have `calc_ses = FALSE` and un-whitened
+  `internal$X_final` / `internal$y_final`; the default `gls = TRUE` is unchanged
+  (#307).
+- `debiasedATT()` now produces its cluster-robust standard error on these
+  un-whitened high-dimensional fits, so the `p >= NT` path is usable on **real
+  data** (not only supplied-variance simulations). The regression channel
+  `var_reg` is the unit-clustered sandwich (robust to within-unit dependence);
+  the cohort-weight channel `var_weight` falls back to the plug-in
+  `(1/N_tau) sum_g pi_g (catt_g - att)^2` when the fit carries no `att_var_2`
+  (byte-identical to `att_var_2` when present). Whitening buys efficiency, not
+  validity (paper Decision D1). The `p >= NT` path remains **experimental**
+  (coverage / `lambda_c` per #295); small-cluster applications (few treated
+  units) should prefer a wild-cluster bootstrap (a planned follow-up).
+
 ## Version 1.35.0
 
 ### Changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,10 @@
   the cohort-weight channel `var_weight` falls back to the plug-in
   `(1/N_tau) sum_g pi_g (catt_g - att)^2` when the fit carries no `att_var_2`
   (byte-identical to `att_var_2` when present). Whitening buys efficiency, not
-  validity (paper Decision D1). The `p >= NT` path remains **experimental**
+  validity (paper Decision D1). Because the high-dimensional branch re-fits its
+  own nuisance, `debiasedATT()` now accepts **any** `p >= NT` fit regardless of
+  `calc_ses` (a high-dimensional `q >= 1` fit is now accepted; previously an
+  error). The `p >= NT` path remains **experimental**
   (coverage / `lambda_c` per #295); small-cluster applications (few treated
   units) should prefer a wild-cluster bootstrap (a planned follow-up).
 

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -117,7 +117,7 @@
 #'     `N -> infinity` with **no** model for within-unit dependence (so a
 #'     `gls = FALSE` fit, which skips GLS whitening, yields a valid cluster-robust
 #'     SE; #307, paper Decision D1). GLS whitening (`gls = TRUE`) buys
-#'     *efficiency* (a smaller `var_reg`), not validity.
+#'     *efficiency* (an asymptotically smaller `var_reg`), not validity.
 #'   \item **(Low-dimensional `p < NT` only) Asymptotically negligible ridge,**
 #'     `lambda = o((NT)^(-1/2))` (the theoretical condition; the leading case is
 #'     the exact inverse `lambda = 0`). The implementation does **not** use a
@@ -301,7 +301,11 @@ debiasedATT <- function(
 	#  - High-dim (p >= NT): the SE is the desparsified cluster-robust sandwich
 	#    (V1 unit-clustered + V2 plug-in), which needs neither the oracle SE
 	#    machinery nor Omega -- so a `gls = FALSE` fit (`calc_ses = FALSE`, no GLS
-	#    whitening; #307) is the EXPECTED input and is accepted here.
+	#    whitening; #307) is the EXPECTED input and is accepted here. The high-dim
+	#    branch re-fits its OWN q=1 nuisance internally (#303), so it does not rely
+	#    on the input fit's `calc_ses`: ANY p >= NT fit is accepted regardless,
+	#    including a high-dim q >= 1 fit (newly accepted vs prior versions) -- both
+	#    give the same debiased estimate + cluster-robust SE.
 	if (!highdim && !isTRUE(fit$internal$calc_ses)) {
 		stop(
 			"debiasedATT() requires a fit computed with q < 1 (bridge selection) in ",
@@ -494,8 +498,9 @@ debiasedATT <- function(
 	var_reg <- sum(unit_scores^2) / n^2
 
 	# ---- channel 2: cohort-weight variance ----
-	# `var_weight` is the fit's plug-in `att_var_2` (read above): the same
-	# cohort-weight variance, with the correct single- / two-sample formula.
+	# `var_weight` is the fit's stored `att_var_2` or its `.plugin_v2()`
+	# recomputation (read above): the same cohort-weight variance, with the correct
+	# single- / two-sample formula.
 
 	se_db <- sqrt(var_reg + var_weight)
 	z <- stats::qnorm(1 - alpha / 2)

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -302,11 +302,29 @@ debiasedATT <- function(
 	#    (V1 unit-clustered + V2 plug-in), which needs neither the oracle SE
 	#    machinery nor Omega -- so a `gls = FALSE` fit (`calc_ses = FALSE`, no GLS
 	#    whitening; #307) is the EXPECTED input and is accepted here. The high-dim
-	#    branch re-fits its OWN q=1 nuisance internally (#303), so it does not rely
-	#    on the input fit's `calc_ses`: ANY p >= NT fit is accepted regardless,
-	#    including a high-dim q >= 1 fit (newly accepted vs prior versions) -- both
-	#    give the same debiased estimate + cluster-robust SE.
+	#    branch re-fits its OWN q=1 nuisance internally (#303), so it depends on
+	#    neither the input fit's `calc_ses` NOR its `q`: ANY p >= NT fit is accepted,
+	#    and the debiased estimate is IDENTICAL across the input fit's q (verified
+	#    |diff| = 0, q = 1 vs q < 1) -- the high-dim center uses the re-fit q=1
+	#    nuisance, not the input `theta_hat` (which seeds only the `a_theta` identity
+	#    check below). A high-dim q >= 1 fit is newly accepted (vs prior versions).
 	if (!highdim && !isTRUE(fit$internal$calc_ses)) {
+		if (is.na(fit$sig_eps_sq)) {
+			# A `gls = FALSE` (un-whitened) fixed-p fit -- including the boundary band
+			# N(T-1) <= p < NT where REML is infeasible but p < NT. The cluster-robust
+			# sandwich IS valid here, but the fixed-p `debiasedATT()` path is not yet
+			# wired for an un-whitened fit (the p >= NT path is; the fixed-p one is the
+			# #312 follow-up). Name the real cause, not the misleading "requires q < 1".
+			stop(
+				"debiasedATT(): a `gls = FALSE` (un-whitened) fit in the fixed-p ",
+				"(p < NT) regime is not yet supported -- the high-dimensional ",
+				"(p >= NT) cluster-robust path is implemented, but the fixed-p ",
+				"cluster-robust SE is a planned follow-up (#312). Re-fit with ",
+				"`gls = TRUE` (supplying `sig_eps_sq` / `sig_eps_c_sq` if ",
+				"`p >= N(T - 1)`), or use a `p >= NT` design.",
+				call. = FALSE
+			)
+		}
 		stop(
 			"debiasedATT() requires a fit computed with q < 1 (bridge selection) in ",
 			"the fixed-p (p < NT) regime, so a valid debiased standard error exists. ",

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -7,6 +7,53 @@
 # algorithm mirrors the validated simulation reference
 # `simulations/method_functions.R::debiased_fetwfe` in the paper repo.
 
+#' Plug-in cohort-weight variance V2 (the `att_var_2` channel, without Omega)
+#'
+#' @description The debiased SE's cohort-weight channel
+#'   `V2 = (1/N_tau) sum_g pi_hat_g (catt_g - att)^2` (paper eq `debiased.att.se`)
+#'   --- the variance from estimating the cohort sample proportions. It needs only
+#'   the per-cohort effects `catt_g`, the within-treated weights `pi_hat_g`, the
+#'   overall ATT, and the treated-unit count `N_tau` --- NOT the noise variances
+#'   or Omega. This equals the value the oracle SE machinery stores as
+#'   `att_var_2` (verified identical, single-sample, including unequal cohorts);
+#'   `debiasedATT()` recomputes it here when the fit carries no `att_var_2`
+#'   (a `gls = FALSE` high-dimensional fit, #307).
+#' @param fit A fitted `fetwfe` object.
+#' @return Numeric scalar; the plug-in V2.
+#' @keywords internal
+#' @noRd
+.plugin_v2 <- function(fit) {
+	att <- fit$att_hat
+	pi_g <- fit$cohort_probs
+	catt <- fit$catt_df$estimate
+	# N_tau = number of treated units = sum_g N_g, recovered from the overall
+	# cohort proportions (`cohort_probs_overall` sums to the treated fraction).
+	N_tau <- round(sum(fit$cohort_probs_overall) * fit$N)
+	if (
+		!is.numeric(att) ||
+			length(att) != 1L ||
+			is.na(att) ||
+			!is.numeric(pi_g) ||
+			!is.numeric(catt) ||
+			length(pi_g) != length(catt) ||
+			length(pi_g) == 0L ||
+			anyNA(pi_g) ||
+			anyNA(catt) ||
+			!is.numeric(N_tau) ||
+			length(N_tau) != 1L ||
+			is.na(N_tau) ||
+			N_tau <= 0
+	) {
+		stop(
+			"debiasedATT(): could not compute the plug-in cohort-weight variance ",
+			"(V2) from the fit (missing `catt_df` / `cohort_probs` / `att_hat`). ",
+			"Re-fit with a current version of fetwfe().",
+			call. = FALSE
+		)
+	}
+	sum(pi_g * (catt - att)^2) / N_tau
+}
+
 #' Debiased overall-ATT with a uniformly-valid standard error
 #'
 #' @description
@@ -63,9 +110,14 @@
 #'     heterogeneity) the two channels correlate and the additive SE can
 #'     mis-state uncertainty; a combined per-unit score is then required (not yet
 #'     implemented).
-#'   \item **Correctly specified (GLS-whitened) conditional mean** of the
-#'     outcome. Neyman-orthogonality removes first-order sensitivity to the
-#'     selected nuisance coefficients, but not to mean-misspecification.
+#'   \item **Correctly specified conditional mean** of the outcome.
+#'     Neyman-orthogonality removes first-order sensitivity to the selected
+#'     nuisance coefficients, but not to mean-misspecification. The regression
+#'     channel is the unit-clustered sandwich, valid as the number of units
+#'     `N -> infinity` with **no** model for within-unit dependence (so a
+#'     `gls = FALSE` fit, which skips GLS whitening, yields a valid cluster-robust
+#'     SE; #307, paper Decision D1). GLS whitening (`gls = TRUE`) buys
+#'     *efficiency* (a smaller `var_reg`), not validity.
 #'   \item **(Low-dimensional `p < NT` only) Asymptotically negligible ridge,**
 #'     `lambda = o((NT)^(-1/2))` (the theoretical condition; the leading case is
 #'     the exact inverse `lambda = 0`). The implementation does **not** use a
@@ -233,23 +285,32 @@ debiasedATT <- function(
 		)
 	}
 
-	# q >= 1 gate: a valid debiased SE requires the bridge-selection regime
-	# (q < 1), which is exactly when the fit computed standard errors. `q` is not
-	# stored on the object, so detect via the canonical `calc_ses` flag.
-	if (!isTRUE(fit$internal$calc_ses)) {
-		stop(
-			"debiasedATT() requires a fit computed with q < 1 (bridge selection), ",
-			"so a valid debiased standard error exists. This fit has ",
-			"calc_ses = FALSE (q >= 1). Re-fit with q < 1 (e.g. q = 0.5).",
-			call. = FALSE
-		)
-	}
-
 	X <- fit$internal$X_final
 	y <- as.numeric(fit$internal$y_final)
 	theta_hat <- fit$internal$theta_hat
 	n <- nrow(X)
 	p <- ncol(X)
+	# Regime: p < NT (fixed-p, exact/ridged inverse) vs p >= NT (high-dimensional
+	# nodewise desparsified direction, paper Theorem `debiased.highdim.thm`).
+	highdim <- p >= n
+
+	# Standard-error gate, regime-aware.
+	#  - Fixed-p (p < NT): the SE is the OLS-identity construction, which needs the
+	#    bridge-selection regime (q < 1) -- exactly when the fit computed its oracle
+	#    SEs (`calc_ses = TRUE`). A q >= 1 fit has no valid debiased SE here.
+	#  - High-dim (p >= NT): the SE is the desparsified cluster-robust sandwich
+	#    (V1 unit-clustered + V2 plug-in), which needs neither the oracle SE
+	#    machinery nor Omega -- so a `gls = FALSE` fit (`calc_ses = FALSE`, no GLS
+	#    whitening; #307) is the EXPECTED input and is accepted here.
+	if (!highdim && !isTRUE(fit$internal$calc_ses)) {
+		stop(
+			"debiasedATT() requires a fit computed with q < 1 (bridge selection) in ",
+			"the fixed-p (p < NT) regime, so a valid debiased standard error exists. ",
+			"This fit has calc_ses = FALSE (q >= 1). Re-fit with q < 1 (e.g. ",
+			"q = 0.5).",
+			call. = FALSE
+		)
+	}
 
 	# add_ridge = TRUE fits store a ridge-row-augmented `y_final` (length NT + p)
 	# against an unaugmented `X_final` (NT rows), and un-shrink the coefficients
@@ -265,11 +326,6 @@ debiasedATT <- function(
 		)
 	}
 
-	# Regime is detected from `p` vs `NT` below (see the `v` construction): p < NT
-	# uses the exact/ridged inverse; p >= NT uses the nodewise desparsified-lasso
-	# direction of paper Theorem `debiased.highdim.thm`. Both share everything
-	# else (estimate + SE).
-
 	G <- fit$G
 	T <- fit$T
 	d <- fit$d
@@ -277,33 +333,31 @@ debiasedATT <- function(
 	num_treats <- length(treat_inds)
 	cohort_probs <- fit$cohort_probs
 
-	# The cohort-weight SE channel is the package's plug-in propensity variance
-	# `att_var_2` = `(1/N_T) sum_g pi_g (catt_g - att)^2` -- the variance from
-	# estimating the cohort weights pi_hat_g. Reuse the fit's stored value rather
-	# than recomputing: it is the same `att_var_2` `fit$att_se` uses, byte-identical
-	# on single-sample fits and already carrying the correct two-sample formula for
-	# `indep_counts` fits (single source of truth, #291 review).
+	# The cohort-weight SE channel V2 = `(1/N_tau) sum_g pi_g (catt_g - att)^2` --
+	# the variance from estimating the cohort weights pi_hat_g. Prefer the fit's
+	# stored plug-in `att_var_2` when present (the same value `fit$att_se` uses,
+	# byte-identical on single-sample fits and carrying the correct two-sample
+	# formula for `indep_counts` fits; single source of truth, #291 review). It is
+	# ABSENT on a `gls = FALSE` fit (`calc_ses = FALSE`, no oracle SE machinery;
+	# #307) -- there, recompute the identical plug-in directly via `.plugin_v2()`,
+	# which needs only `catt_g` / `att_hat` / the cohort weights, NOT Omega.
 	#
-	# CAVEAT (#303 review, second-order, deferred -> #295): this channel plugs in
-	# the BRIDGE `catt_g` / `att_hat`, while the high-dim center is now the q=1
-	# debiased estimate -- the same center(q=1)/variance-channel(bridge) mismatch as
-	# the event_study propensity channel `F_pi` (#309), here for the overall-ATT V2.
-	# It is second-order (the bridge and q=1 `catt_g` are both consistent for the
-	# true cohort effects), so the additive SE stays asymptotically correct; the
-	# finite-sample effect is part of the #295 high-dim coverage validation.
-	var_weight <- fit$internal$variance_components$att_var_2
-	if (
-		is.null(var_weight) ||
-			!is.numeric(var_weight) ||
-			length(var_weight) != 1L ||
-			is.na(var_weight)
+	# CAVEAT (#303 review, second-order, deferred -> #295): V2 plugs in the BRIDGE
+	# `catt_g` / `att_hat`, while the high-dim center is the q=1 debiased estimate
+	# -- the same center(q=1)/variance-channel(bridge) mismatch as the event_study
+	# `F_pi` (#309), here for the overall-ATT V2. Second-order (bridge and q=1
+	# `catt_g` are both consistent), so the additive SE stays asymptotically
+	# correct; the finite-sample effect is part of the #295 coverage validation.
+	att_var_2 <- fit$internal$variance_components$att_var_2
+	var_weight <- if (
+		is.null(att_var_2) ||
+			!is.numeric(att_var_2) ||
+			length(att_var_2) != 1L ||
+			is.na(att_var_2)
 	) {
-		stop(
-			"debiasedATT(): the fit does not carry a cohort-weight variance ",
-			"component (`internal$variance_components$att_var_2`). Re-fit with a ",
-			"current version of fetwfe() (>= 1.12.0).",
-			call. = FALSE
-		)
+		.plugin_v2(fit)
+	} else {
+		att_var_2
 	}
 
 	# Balanced, unit-major panel is required for the per-unit cluster sums
@@ -361,7 +415,6 @@ debiasedATT <- function(
 	# Theorem `debiased.highdim.thm`, "one estimator, two regimes"); everything
 	# downstream (the correction, both SE channels) is identical.
 	Sig <- crossprod(X) / n
-	highdim <- p >= n
 	riesz_diag <- NULL
 	if (!highdim) {
 		# Fixed-p (p < NT): exact / tiny-ridge inverse. Byte-identical to the

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -191,6 +191,19 @@
 #'   `D_N` still yields a valid point estimator but emits a `warning()` that its
 #'   inverse may be unreliable. Default is `NULL` (use the built-in
 #'   `fusion_structure`).
+#' @param gls (Optional.) Logical; default `TRUE`. When `TRUE`, the design is
+#'   GLS-whitened using REML-estimated (or supplied) variance components --- the
+#'   standard, efficient path. When `FALSE`, `fetwfe()` **skips GLS whitening and
+#'   variance-component estimation entirely**, fitting on the un-whitened
+#'   (fusion-transformed) design. This is the high-dimensional (`p >= NT`) path:
+#'   REML cannot estimate the variance components there (the `p < N(T - 1)` REML
+#'   guard would otherwise stop the fit), and whitening buys efficiency, not
+#'   validity --- the [debiasedATT()] cluster-robust sandwich standard error needs
+#'   no `Omega` (paper Decision D1). A `gls = FALSE` fit has `calc_ses = FALSE`
+#'   (no within-selection oracle standard errors) and un-whitened
+#'   `internal$X_final` / `internal$y_final`; pass it to [debiasedATT()] for a
+#'   valid cluster-robust SE. `add_ridge = TRUE` is not supported, and supplied
+#'   `sig_eps_sq` / `sig_eps_c_sq` are ignored, under `gls = FALSE`.
 #' @param ci_type Character; one of `"simultaneous"` (default) or
 #'   `"pointwise"`. Controls the confidence-interval bounds reported for the
 #'   cohort-specific ATTs (in `catt_df`) and the event-study effects (from
@@ -371,13 +384,41 @@ fetwfe <- function(
 	cv_seed = NULL,
 	ci_type = c("simultaneous", "pointwise"),
 	fusion_structure = c("cohort", "event_study"),
-	fusion_matrix = NULL
+	fusion_matrix = NULL,
+	gls = TRUE
 ) {
 	se_type <- match.arg(
 		se_type,
 		c("default", "conservative", "cluster")
 	)
 	ci_type <- match.arg(ci_type)
+	# #307: `gls = FALSE` skips GLS whitening + variance-component estimation (the
+	# high-dimensional `p >= NT` path, where REML cannot estimate Omega). Validate
+	# it and its interactions before any heavy work.
+	if (!is.logical(gls) || length(gls) != 1L || is.na(gls)) {
+		stop(
+			"fetwfe(): `gls` must be a single logical (TRUE or FALSE).",
+			call. = FALSE
+		)
+	}
+	if (!gls) {
+		if (isTRUE(add_ridge)) {
+			stop(
+				"fetwfe(): `add_ridge = TRUE` is not supported with `gls = FALSE` ",
+				"(the ridge penalty scales with the noise variances, which are not ",
+				"estimated when whitening is skipped). Re-fit with `add_ridge = FALSE`.",
+				call. = FALSE
+			)
+		}
+		if (!is.na(sig_eps_sq) || !is.na(sig_eps_c_sq)) {
+			warning(
+				"fetwfe(): `sig_eps_sq` / `sig_eps_c_sq` are ignored when ",
+				"`gls = FALSE` (no GLS whitening is performed); the fit uses the ",
+				"un-whitened design.",
+				call. = FALSE
+			)
+		}
+	}
 	# Record whether the user explicitly passed `fusion_structure` so we can
 	# emit a one-line override notice when a custom `fusion_matrix` is also
 	# supplied (the matrix wins for the treatment block; #236).
@@ -499,7 +540,8 @@ fetwfe <- function(
 		cv_folds = cv_folds,
 		cv_seed = cv_seed,
 		fusion_structure = fusion_structure,
-		d_inv_treat = d_inv_treat
+		d_inv_treat = d_inv_treat,
+		gls = gls
 	)
 
 	att_branch <- .select_att_branch(
@@ -749,6 +791,19 @@ fetwfe <- function(
 #'   `D_N` still yields a valid point estimator but emits a `warning()` that its
 #'   inverse may be unreliable. Default is `NULL` (use the built-in
 #'   `fusion_structure`).
+#' @param gls (Optional.) Logical; default `TRUE`. When `TRUE`, the design is
+#'   GLS-whitened using REML-estimated (or supplied) variance components --- the
+#'   standard, efficient path. When `FALSE`, `fetwfe()` **skips GLS whitening and
+#'   variance-component estimation entirely**, fitting on the un-whitened
+#'   (fusion-transformed) design. This is the high-dimensional (`p >= NT`) path:
+#'   REML cannot estimate the variance components there (the `p < N(T - 1)` REML
+#'   guard would otherwise stop the fit), and whitening buys efficiency, not
+#'   validity --- the [debiasedATT()] cluster-robust sandwich standard error needs
+#'   no `Omega` (paper Decision D1). A `gls = FALSE` fit has `calc_ses = FALSE`
+#'   (no within-selection oracle standard errors) and un-whitened
+#'   `internal$X_final` / `internal$y_final`; pass it to [debiasedATT()] for a
+#'   valid cluster-robust SE. `add_ridge = TRUE` is not supported, and supplied
+#'   `sig_eps_sq` / `sig_eps_c_sq` are ignored, under `gls = FALSE`.
 #' @param ci_type Character; one of `"simultaneous"` (default) or
 #'   `"pointwise"`. Controls the confidence-interval bounds reported for the
 #'   cohort-specific ATTs (in `catt_df`) and the event-study effects (from
@@ -870,7 +925,8 @@ fetwfeWithSimulatedData <- function(
 	cv_seed = NULL,
 	ci_type = c("simultaneous", "pointwise"),
 	fusion_structure = c("cohort", "event_study"),
-	fusion_matrix = NULL
+	fusion_matrix = NULL,
+	gls = TRUE
 ) {
 	se_type <- match.arg(
 		se_type,
@@ -907,7 +963,8 @@ fetwfeWithSimulatedData <- function(
 		cv_seed = cv_seed,
 		ci_type = ci_type,
 		fusion_structure = fusion_structure,
-		fusion_matrix = fusion_matrix
+		fusion_matrix = fusion_matrix,
+		gls = gls
 	)
 
 	return(res)

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -432,7 +432,8 @@ fetwfe_core <- function(
 	cv_folds = 10L,
 	cv_seed = NULL,
 	fusion_structure = "cohort",
-	d_inv_treat = NULL
+	d_inv_treat = NULL,
+	gls = TRUE
 ) {
 	se_type <- match.arg(
 		se_type,
@@ -507,7 +508,8 @@ fetwfe_core <- function(
 		indep_counts = indep_counts,
 		is_fetwfe = TRUE,
 		fusion_structure = fusion_structure,
-		d_inv_treat = d_inv_treat
+		d_inv_treat = d_inv_treat,
+		gls = gls
 	)
 
 	X_final_scaled <- res$X_final_scaled
@@ -776,7 +778,10 @@ fetwfe_core <- function(
 		N = N,
 		T = T,
 		fused = TRUE,
-		calc_ses = q < 1,
+		# gls = FALSE (#307) skips variance-component estimation, so the oracle SE
+		# machinery cannot run -> no within-selection SEs. The debiasedATT()
+		# cluster-robust sandwich (V1 unit-clustered + V2 plug-in) needs none.
+		calc_ses = (q < 1) && gls,
 		include_selected = TRUE,
 		alpha = alpha,
 		se_type = se_type,

--- a/R/gls_machinery.R
+++ b/R/gls_machinery.R
@@ -426,7 +426,14 @@ getGramInv <- function(
 #' @noRd
 estOmegaSqrtInv <- function(y, X_ints, N, T, p) {
 	if (N * (T - 1) - p <= 0) {
-		stop("Not enough units available to estimate the noise variance.")
+		stop(
+			"Not enough units available to estimate the noise variance (REML needs ",
+			"p < N(T - 1)). For a high-dimensional (p >= NT) fit, either supply ",
+			"`sig_eps_sq` / `sig_eps_c_sq`, or re-fit with `gls = FALSE` to skip ",
+			"variance-component estimation entirely (the debiasedATT() ",
+			"cluster-robust standard error needs no whitening).",
+			call. = FALSE
+		)
 	}
 	stopifnot(N > 1)
 

--- a/R/input_prep.R
+++ b/R/input_prep.R
@@ -122,23 +122,42 @@ prep_for_etwfe_regression <- function(
 	is_fetwfe,
 	is_twfe_covs = FALSE,
 	fusion_structure = "cohort",
-	d_inv_treat = NULL
+	d_inv_treat = NULL,
+	gls = TRUE
 ) {
-	gls <- .estimate_variance_and_gls(
-		y = y,
-		X_ints = X_ints,
-		X_mod = X_mod,
-		sig_eps_sq = sig_eps_sq,
-		sig_eps_c_sq = sig_eps_c_sq,
-		N = N,
-		T = T,
-		p = p,
-		verbose = verbose
-	)
-	y_final <- gls$y_gls
-	X_final <- gls$X_gls
-	sig_eps_sq <- gls$sig_eps_sq
-	sig_eps_c_sq <- gls$sig_eps_c_sq
+	if (gls) {
+		# Default: estimate the variance components (REML when not supplied) and
+		# GLS-whiten the design. This is where `estOmegaSqrtInv()` hard-stops at
+		# `p >= N(T - 1)` (its REML guard) -- the reason `gls = FALSE` exists for the
+		# high-dimensional path.
+		gls_res <- .estimate_variance_and_gls(
+			y = y,
+			X_ints = X_ints,
+			X_mod = X_mod,
+			sig_eps_sq = sig_eps_sq,
+			sig_eps_c_sq = sig_eps_c_sq,
+			N = N,
+			T = T,
+			p = p,
+			verbose = verbose
+		)
+		y_final <- gls_res$y_gls
+		X_final <- gls_res$X_gls
+		sig_eps_sq <- gls_res$sig_eps_sq
+		sig_eps_c_sq <- gls_res$sig_eps_c_sq
+	} else {
+		# gls = FALSE (#307): skip whitening AND variance-component estimation
+		# entirely. The high-dimensional (`p >= NT`) path, where REML cannot estimate
+		# Omega -- and whitening buys efficiency, not validity: the `debiasedATT()`
+		# cluster-robust sandwich SE needs no Omega (paper Decision D1 /
+		# gregfaletto/fetwfe#90). Use the un-whitened (fusion-transformed) design
+		# `X_mod`; leave the variance components NA (`calc_ses` is forced FALSE in
+		# `fetwfe_core()`).
+		y_final <- as.numeric(y)
+		X_final <- X_mod
+		sig_eps_sq <- NA_real_
+		sig_eps_c_sq <- NA_real_
+	}
 
 	if (is_twfe_covs) {
 		coll <- .collapse_design_for_twfe_covs(

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -514,7 +514,9 @@ simultaneousCIs.twfeCovs <- function(
 		stop(
 			"simultaneousCIs(): the fitted object was constructed with ",
 			"calc_ses = FALSE; standard errors are not available. Re-fit ",
-			"with q < 1 (FETWFE/BETWFE) and a satisfied rank condition.",
+			"with q < 1 (FETWFE/BETWFE) and a satisfied rank condition, or -- for ",
+			"a `gls = FALSE` high-dimensional fit -- use `debiasedATT()` for the ",
+			"overall-ATT standard error.",
 			call. = FALSE
 		)
 	}

--- a/man/debiasedATT.Rd
+++ b/man/debiasedATT.Rd
@@ -117,7 +117,7 @@ channel is the unit-clustered sandwich, valid as the number of units
 \code{N -> infinity} with \strong{no} model for within-unit dependence (so a
 \code{gls = FALSE} fit, which skips GLS whitening, yields a valid cluster-robust
 SE; #307, paper Decision D1). GLS whitening (\code{gls = TRUE}) buys
-\emph{efficiency} (a smaller \code{var_reg}), not validity.
+\emph{efficiency} (an asymptotically smaller \code{var_reg}), not validity.
 \item \strong{(Low-dimensional \code{p < NT} only) Asymptotically negligible ridge,}
 \code{lambda = o((NT)^(-1/2))} (the theoretical condition; the leading case is
 the exact inverse \code{lambda = 0}). The implementation does \strong{not} use a

--- a/man/debiasedATT.Rd
+++ b/man/debiasedATT.Rd
@@ -110,9 +110,14 @@ assignment (cohort membership correlated with treatment-effect
 heterogeneity) the two channels correlate and the additive SE can
 mis-state uncertainty; a combined per-unit score is then required (not yet
 implemented).
-\item \strong{Correctly specified (GLS-whitened) conditional mean} of the
-outcome. Neyman-orthogonality removes first-order sensitivity to the
-selected nuisance coefficients, but not to mean-misspecification.
+\item \strong{Correctly specified conditional mean} of the outcome.
+Neyman-orthogonality removes first-order sensitivity to the selected
+nuisance coefficients, but not to mean-misspecification. The regression
+channel is the unit-clustered sandwich, valid as the number of units
+\code{N -> infinity} with \strong{no} model for within-unit dependence (so a
+\code{gls = FALSE} fit, which skips GLS whitening, yields a valid cluster-robust
+SE; #307, paper Decision D1). GLS whitening (\code{gls = TRUE}) buys
+\emph{efficiency} (a smaller \code{var_reg}), not validity.
 \item \strong{(Low-dimensional \code{p < NT} only) Asymptotically negligible ridge,}
 \code{lambda = o((NT)^(-1/2))} (the theoretical condition; the leading case is
 the exact inverse \code{lambda = 0}). The implementation does \strong{not} use a

--- a/man/fetwfe.Rd
+++ b/man/fetwfe.Rd
@@ -28,7 +28,8 @@ fetwfe(
   cv_seed = NULL,
   ci_type = c("simultaneous", "pointwise"),
   fusion_structure = c("cohort", "event_study"),
-  fusion_matrix = NULL
+  fusion_matrix = NULL,
+  gls = TRUE
 )
 }
 \arguments{
@@ -252,6 +253,20 @@ changes only constant factors. A numerically near-singular (ill-conditioned)
 \code{D_N} still yields a valid point estimator but emits a \code{warning()} that its
 inverse may be unreliable. Default is \code{NULL} (use the built-in
 \code{fusion_structure}).}
+
+\item{gls}{(Optional.) Logical; default \code{TRUE}. When \code{TRUE}, the design is
+GLS-whitened using REML-estimated (or supplied) variance components --- the
+standard, efficient path. When \code{FALSE}, \code{fetwfe()} \strong{skips GLS whitening and
+variance-component estimation entirely}, fitting on the un-whitened
+(fusion-transformed) design. This is the high-dimensional (\code{p >= NT}) path:
+REML cannot estimate the variance components there (the \code{p < N(T - 1)} REML
+guard would otherwise stop the fit), and whitening buys efficiency, not
+validity --- the \code{\link[=debiasedATT]{debiasedATT()}} cluster-robust sandwich standard error needs
+no \code{Omega} (paper Decision D1). A \code{gls = FALSE} fit has \code{calc_ses = FALSE}
+(no within-selection oracle standard errors) and un-whitened
+\code{internal$X_final} / \code{internal$y_final}; pass it to \code{\link[=debiasedATT]{debiasedATT()}} for a
+valid cluster-robust SE. \code{add_ridge = TRUE} is not supported, and supplied
+\code{sig_eps_sq} / \code{sig_eps_c_sq} are ignored, under \code{gls = FALSE}.}
 }
 \value{
 An object of class \code{fetwfe} containing the following elements:

--- a/man/fetwfeWithSimulatedData.Rd
+++ b/man/fetwfeWithSimulatedData.Rd
@@ -20,7 +20,8 @@ fetwfeWithSimulatedData(
   cv_seed = NULL,
   ci_type = c("simultaneous", "pointwise"),
   fusion_structure = c("cohort", "event_study"),
-  fusion_matrix = NULL
+  fusion_matrix = NULL,
+  gls = TRUE
 )
 }
 \arguments{
@@ -176,6 +177,20 @@ changes only constant factors. A numerically near-singular (ill-conditioned)
 \code{D_N} still yields a valid point estimator but emits a \code{warning()} that its
 inverse may be unreliable. Default is \code{NULL} (use the built-in
 \code{fusion_structure}).}
+
+\item{gls}{(Optional.) Logical; default \code{TRUE}. When \code{TRUE}, the design is
+GLS-whitened using REML-estimated (or supplied) variance components --- the
+standard, efficient path. When \code{FALSE}, \code{fetwfe()} \strong{skips GLS whitening and
+variance-component estimation entirely}, fitting on the un-whitened
+(fusion-transformed) design. This is the high-dimensional (\code{p >= NT}) path:
+REML cannot estimate the variance components there (the \code{p < N(T - 1)} REML
+guard would otherwise stop the fit), and whitening buys efficiency, not
+validity --- the \code{\link[=debiasedATT]{debiasedATT()}} cluster-robust sandwich standard error needs
+no \code{Omega} (paper Decision D1). A \code{gls = FALSE} fit has \code{calc_ses = FALSE}
+(no within-selection oracle standard errors) and un-whitened
+\code{internal$X_final} / \code{internal$y_final}; pass it to \code{\link[=debiasedATT]{debiasedATT()}} for a
+valid cluster-robust SE. \code{add_ridge = TRUE} is not supported, and supplied
+\code{sig_eps_sq} / \code{sig_eps_c_sq} are ignored, under \code{gls = FALSE}.}
 }
 \value{
 An object of class \code{fetwfe} containing the following elements:

--- a/tests/testthat/test-debiased-att-highdim.R
+++ b/tests/testthat/test-debiased-att-highdim.R
@@ -56,7 +56,7 @@
 # ---- A genuine p >= NT fetwfe fit (the simulator cannot make one: it enforces
 # N >= (G+1)(d+1), so build the raw panel directly and supply the noise
 # variances to bypass REML). N=20, T=8, d=12 => p = 376 >> NT = 160. -----------
-.make_highdim_fit <- function() {
+.make_highdim_panel <- function() {
 	set.seed(3)
 	N <- 20L
 	T <- 8L
@@ -64,7 +64,7 @@
 	cohort_of_unit <- c(rep(0L, 8), rep(2L, 4), rep(3L, 4), rep(4L, 4))
 	eff <- c(`2` = 0.5, `3` = 1.75, `4` = 3.0)
 	covs <- matrix(stats::rnorm(N * d), N, d)
-	rows <- do.call(
+	do.call(
 		rbind,
 		lapply(seq_len(N), function(i) {
 			g <- cohort_of_unit[i]
@@ -86,12 +86,15 @@
 			df
 		})
 	)
+}
+
+.make_highdim_fit <- function() {
 	fetwfe(
-		pdata = rows,
+		pdata = .make_highdim_panel(),
 		time_var = "year",
 		unit_var = "unit",
 		treatment = "treat",
-		covs = paste0("x", 1:d),
+		covs = paste0("x", 1:12),
 		response = "y",
 		q = 0.5,
 		verbose = FALSE,
@@ -100,8 +103,26 @@
 	)
 }
 
+# gls = FALSE sibling (#307): the SAME panel, but NO supplied variances -- the fit
+# that errors today (the REML guard at p >= N(T-1)) and is the whole point of this
+# path. calc_ses = FALSE; the debiasedATT() cluster-robust sandwich SE needs no Omega.
+.make_highdim_fit_nogls <- function() {
+	fetwfe(
+		pdata = .make_highdim_panel(),
+		time_var = "year",
+		unit_var = "unit",
+		treatment = "treat",
+		covs = paste0("x", 1:12),
+		response = "y",
+		q = 0.5,
+		verbose = FALSE,
+		gls = FALSE
+	)
+}
+
 # Build the high-dim fit once (the fit is the slow part); reuse across tests.
 hd_fix <- .make_highdim_fit()
+hd_fix_nogls <- .make_highdim_fit_nogls()
 
 # ============================ solver-level tests =============================
 
@@ -329,4 +350,123 @@ test_that("debiasedATT validates the high-dim solver arguments", {
 	expect_error(debiasedATT(hd_fix, riesz_max_iter = 0), "riesz_max_iter")
 	expect_error(debiasedATT(hd_fix, riesz_tol = 0), "riesz_tol")
 	expect_error(debiasedATT(hd_fix, riesz_tol = -1e-9), "riesz_tol")
+})
+
+# ==============================================================================
+# #307: Omega-free high-dim cluster-robust SE (gls = FALSE). The headline -- a
+# p >= NT fit WITHOUT supplied variances (impossible today: the REML guard) --
+# plus the load-bearing plug-in V2 == att_var_2 cross-check.
+# ==============================================================================
+
+test_that("gls = FALSE fits a p >= NT panel without supplied variances (#307)", {
+	expect_s3_class(hd_fix_nogls, "fetwfe")
+	# genuinely high-dim, and no whitening / variance components were estimated.
+	expect_gte(
+		ncol(hd_fix_nogls$internal$X_final),
+		nrow(hd_fix_nogls$internal$X_final)
+	)
+	expect_false(isTRUE(hd_fix_nogls$internal$calc_ses))
+	expect_true(is.na(hd_fix_nogls$sig_eps_sq))
+	expect_true(is.na(hd_fix_nogls$sig_eps_c_sq))
+	# the oracle SE machinery did not run, so att_var_2 is absent.
+	av2 <- hd_fix_nogls$internal$variance_components$att_var_2
+	expect_true(is.null(av2) || is.na(av2))
+	# the headline ATT is still produced.
+	expect_true(is.finite(hd_fix_nogls$att_hat))
+})
+
+test_that("debiasedATT() returns a finite cluster-robust SE on a gls = FALSE fit (#307)", {
+	db <- debiasedATT(hd_fix_nogls)
+	expect_true(all(
+		c(
+			"att",
+			"se",
+			"ci_low",
+			"ci_high",
+			"var_reg",
+			"var_weight",
+			"feasibility",
+			"converged",
+			"lambda_node"
+		) %in%
+			names(db)
+	))
+	expect_true(is.finite(db$att))
+	expect_true(is.finite(db$se) && db$se > 0)
+	expect_true(is.finite(db$var_reg) && db$var_reg > 0) # V1 unit-clustered sandwich
+	expect_true(is.finite(db$var_weight) && db$var_weight > 0) # V2 plug-in
+	expect_equal(db$se, sqrt(db$var_reg + db$var_weight))
+	expect_equal(db$ci_low, db$att - stats::qnorm(0.975) * db$se)
+})
+
+test_that("debiasedATT() is deterministic on a gls = FALSE fit (#307)", {
+	a <- debiasedATT(hd_fix_nogls)
+	b <- debiasedATT(hd_fix_nogls)
+	expect_identical(a$att, b$att)
+	expect_identical(a$se, b$se)
+	expect_identical(a$lambda_node, b$lambda_node)
+})
+
+# The load-bearing validation: the plug-in V2 (`.plugin_v2`, used when att_var_2 is
+# absent) EQUALS the oracle `att_var_2` the whitened path uses. hd_fix has equal
+# treated cohorts; the inline fit below has UNEQUAL cohorts (4 / 6 / 8 treated
+# units), so the match is not a balanced-design coincidence. Mutation-checkable:
+# a wrong N_tau (e.g. N instead of N_treated) or dropping the cohort_probs
+# weighting in `.plugin_v2` breaks this past 1e-10.
+test_that(".plugin_v2 equals att_var_2 (equal AND unequal cohorts) (#307)", {
+	expect_equal(
+		fetwfe:::.plugin_v2(hd_fix),
+		hd_fix$internal$variance_components$att_var_2,
+		tolerance = 1e-10
+	)
+	set.seed(7)
+	Nq <- 24L
+	Tq <- 6L
+	cohort_of_unit <- c(rep(0L, 6), rep(3L, 4), rep(4L, 6), rep(5L, 8))
+	eff <- c(`3` = 1.0, `4` = 2.0, `5` = -1.0)
+	cv <- stats::rnorm(Nq)
+	rows <- do.call(
+		rbind,
+		lapply(seq_len(Nq), function(i) {
+			g <- cohort_of_unit[i]
+			df <- data.frame(
+				unit = sprintf("u%02d", i),
+				year = 1:Tq,
+				treat = as.integer(g > 0 & (1:Tq) >= g),
+				x1 = cv[i]
+			)
+			te <- if (g > 0) eff[[as.character(g)]] else 0
+			df$y <- 0.1 *
+				(1:Tq) +
+				te * df$treat +
+				0.3 * cv[i] +
+				stats::rnorm(Tq, 0, 0.5)
+			df
+		})
+	)
+	fit_uneq <- fetwfe(
+		pdata = rows,
+		time_var = "year",
+		unit_var = "unit",
+		treatment = "treat",
+		covs = "x1",
+		response = "y",
+		q = 0.5,
+		verbose = FALSE,
+		sig_eps_sq = 0.25,
+		sig_eps_c_sq = 0.1
+	)
+	# confirm the treated cohorts really are unequal (so the test bites weighting).
+	expect_gt(max(fit_uneq$cohort_probs) - min(fit_uneq$cohort_probs), 0.05)
+	expect_equal(
+		fetwfe:::.plugin_v2(fit_uneq),
+		fit_uneq$internal$variance_components$att_var_2,
+		tolerance = 1e-10
+	)
+})
+
+test_that("the att_var_2 path is byte-unchanged: supplied-var var_weight == att_var_2 (#307)", {
+	# the plug-in fallback must NOT perturb the whitened / supplied-variance path.
+	db <- debiasedATT(hd_fix)
+	expect_equal(db$var_weight, hd_fix$internal$variance_components$att_var_2)
 })

--- a/tests/testthat/test-debiased-att-highdim.R
+++ b/tests/testthat/test-debiased-att-highdim.R
@@ -413,7 +413,7 @@ test_that("debiasedATT() is deterministic on a gls = FALSE fit (#307)", {
 # units), so the match is not a balanced-design coincidence. Mutation-checkable:
 # a wrong N_tau (e.g. N instead of N_treated) or dropping the cohort_probs
 # weighting in `.plugin_v2` breaks this past 1e-10.
-test_that(".plugin_v2 equals att_var_2 (equal AND unequal cohorts) (#307)", {
+test_that(".plugin_v2 equals att_var_2 (equal, unequal, two-sample cohorts) (#307)", {
 	expect_equal(
 		fetwfe:::.plugin_v2(hd_fix),
 		hd_fix$internal$variance_components$att_var_2,
@@ -463,10 +463,82 @@ test_that(".plugin_v2 equals att_var_2 (equal AND unequal cohorts) (#307)", {
 		fit_uneq$internal$variance_components$att_var_2,
 		tolerance = 1e-10
 	)
+	# two-sample (indep_counts): the plug-in must match the TWO-SAMPLE att_var_2
+	# (the case the naive single-sample (1/N_T) recompute gets wrong). simulateData()
+	# auto-populates indep_counts; fetwfeWithSimulatedData() keeps it.
+	coefs_ic <- genCoefs(
+		G = 3,
+		T = 5,
+		d = 2,
+		density = 0.6,
+		eff_size = 1.5,
+		seed = 7
+	)
+	dat_ic <- simulateData(
+		coefs_ic,
+		N = 80,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 7
+	)
+	fit_indep <- fetwfeWithSimulatedData(dat_ic, q = 0.5)
+	expect_true(isTRUE(fit_indep$indep_counts_used))
+	expect_equal(
+		fetwfe:::.plugin_v2(fit_indep),
+		fit_indep$internal$variance_components$att_var_2,
+		tolerance = 1e-10
+	)
 })
 
 test_that("the att_var_2 path is byte-unchanged: supplied-var var_weight == att_var_2 (#307)", {
 	# the plug-in fallback must NOT perturb the whitened / supplied-variance path.
 	db <- debiasedATT(hd_fix)
 	expect_equal(db$var_weight, hd_fix$internal$variance_components$att_var_2)
+})
+
+# A gls = FALSE FIXED-p (p < NT) fit must error naming the REAL cause (the fixed-p
+# cluster-robust path is the #312 follow-up), not the misleading "requires q < 1"
+# (the fit IS q < 1). This is the PR #311 review's boundary-gap clarity ask.
+test_that("a gls = FALSE fixed-p fit errors with the real cause, not 'requires q < 1' (#307/#312)", {
+	set.seed(5)
+	N <- 30L
+	Tt <- 5L
+	cohort_of_unit <- c(rep(0L, 12), rep(3L, 9), rep(4L, 9))
+	eff <- c(`3` = 1, `4` = 2)
+	cv <- stats::rnorm(N)
+	rows <- do.call(
+		rbind,
+		lapply(seq_len(N), function(i) {
+			g <- cohort_of_unit[i]
+			df <- data.frame(
+				unit = sprintf("u%02d", i),
+				year = 1:Tt,
+				treat = as.integer(g > 0 & (1:Tt) >= g),
+				x1 = cv[i]
+			)
+			te <- if (g > 0) eff[[as.character(g)]] else 0
+			df$y <- 0.1 *
+				(1:Tt) +
+				te * df$treat +
+				0.3 * cv[i] +
+				stats::rnorm(Tt, 0, 0.5)
+			df
+		})
+	)
+	fit <- fetwfe(
+		pdata = rows,
+		time_var = "year",
+		unit_var = "unit",
+		treatment = "treat",
+		covs = "x1",
+		response = "y",
+		q = 0.5,
+		verbose = FALSE,
+		gls = FALSE
+	)
+	expect_lt(ncol(fit$internal$X_final), nrow(fit$internal$X_final)) # fixed-p
+	# the message names gls = FALSE + the #312 follow-up (NOT "requires q < 1"; the
+	# "bridge selection" q-attribution lives in the other branch only).
+	expect_error(debiasedATT(fit), "gls = FALSE")
+	expect_error(debiasedATT(fit), "follow-up")
 })


### PR DESCRIPTION
Closes #307 (core scope, parts 1+2).

Makes the high-dimensional (`p >= NT`) `debiasedATT()` path produce a cluster-robust SE **without estimating Ω**, so it runs on **real data** (no supplied `sig_eps_sq` / `sig_eps_c_sq`). Today every `fetwfe()` fit routes through GLS whitening, whose REML variance-component estimation hard-stops at `p >= N(T-1)` (`estOmegaSqrtInv`) — so a `p > NT` fit was only producible from supplied-variance simulations (the #310 review flagged exactly this).

## What changed

- **New `fetwfe(gls = TRUE)` argument.** `gls = FALSE` skips GLS whitening **and** variance-component estimation entirely: the fit uses the un-whitened (fusion-transformed) design, leaves the variance components `NA`, and has `calc_ses = FALSE`. Default `gls = TRUE` is byte-identical to current behavior. (`add_ridge` is rejected, and supplied variances are ignored with a warning, under `gls = FALSE`.) Also threaded through `fetwfeWithSimulatedData()`.
- **`debiasedATT()` cluster-robust SE on these fits.** Whitening buys *efficiency, not validity* (paper Decision D1 / `gregfaletto/fetwfe#90`): the SE is **V1** (the existing unit-clustered regression sandwich, robust to within-unit dependence) + **V2** (the cohort-weight channel). V2 falls back to the plug-in `(1/N_tau) sum_g pi_g (catt_g - att)^2` — new `.plugin_v2()` — when the fit carries no `att_var_2`; it equals `att_var_2` **exactly** when present. A regime-aware gate keeps requiring `calc_ses` in fixed-p; the high-dim branch accepts any `p >= NT` fit (it re-fits its own q=1 nuisance, #303). Fixed-p and the whitened V2 path are byte-unchanged.

## Scope (core only)

Parts 1+2. **Deferred follow-ups:** part 3 (small-N wild-cluster-bootstrap / CR2+Satterthwaite — the divorce app's ~42 units), part 4 (FGLS efficiency), and Ω-free `simultaneousCIs()` support (which errors *gracefully* on a `gls = FALSE` fit today, pointing to `debiasedATT()`). The `p >= NT` path stays **experimental** (coverage / `lambda_c` per #295).

## Verification

- **Headline:** a `p>NT` fit with **no supplied variances** now runs (impossible today) and `debiasedATT()` returns a finite cluster-robust SE.
- **Load-bearing cross-check:** `.plugin_v2()` == oracle `att_var_2` to machine precision — verified equal, **unequal**, and **two-sample (`indep_counts`)** cohorts; **mutation-checked** (breaking `N_tau` or the weighting makes it bite).
- Default `gls = TRUE` path **byte-identical** (`att_hat` / `att_se` / `X_final` / `variance_components` via `identical()`); `betwfe` / `etwfe` / `twfeCovs` unaffected.
- Independent **post-exec review: mergeable as experimental, no blockers** (its 1 Minor + 3 Nits — all doc/message — addressed in `84aa43f`).
- Full suite green (**3837** pass, 0 fail/warn); **`R CMD check --as-cran` clean** (0/0/0, vignettes built); version 1.35.0 → 1.36.0 + NEWS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
