### PR TITLE
feat: Omega-free simultaneousCIs() bootstrap bands for gls=FALSE high-dim fits (#313)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.38.0
+Version: 1.39.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,23 @@
 # NEWS
 
+## Version 1.39.0
+
+### New features
+
+- `simultaneousCIs(method = "bootstrap")` now accepts a **`gls = FALSE`
+  high-dimensional (`p >= NT`) fetwfe fit** (`calc_ses = FALSE`), producing
+  cluster-robust simultaneous bands for the `event_study` / `cohort` /
+  `all_post_treatment` / `custom` families without GLS whitening (#313). This is
+  the band analog of #307's Omega-free `debiasedATT()` SE: the high-dimensional
+  bootstrap variance is the empirical per-unit influence function (cluster-robust
+  by construction) and the band center is the same desparsified Theorem-6.6
+  estimate, so neither GLS whitening nor `sig_eps_sq` is needed; the band center
+  still matches `debiasedATT()$att` on the overall-ATT contrast. Previously such a
+  fit errored at the `calc_ses = FALSE` gate. `method = "analytic"` still requires
+  valid analytic SEs (a `q < 1`, `gls = TRUE`, rank-satisfied fit); the fixed-`p`
+  (`p < NT`) `gls = FALSE` band remains a planned follow-up (#312), and the
+  `p >= NT` path stays experimental (coverage validation under #295).
+
 ## Version 1.38.0
 
 ### Bug fixes

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -94,7 +94,12 @@ utils::globalVariables(c(
 #'   band is centered on the **debiased** estimate (the Theorem 6.6 correction,
 #'   equal to `debiasedATT()`'s point estimate for the matching contrast), not
 #'   the post-selection bridge estimate; fixed-p bands center on the (unbiased)
-#'   bridge estimate as before.
+#'   bridge estimate as before. Because this desparsified bootstrap band is
+#'   built from the empirical per-unit influence function -- needing neither GLS
+#'   whitening nor `sig_eps_sq` -- it also accepts a high-dimensional
+#'   **`gls = FALSE`** fetwfe fit (`calc_ses = FALSE`), the band analog of
+#'   `debiasedATT()`'s Omega-free SE (#307, #313). `method = "analytic"` still
+#'   requires valid analytic SEs (a `q < 1`, `gls = TRUE`, rank-satisfied fit).
 #' @param B Integer; number of multiplier-bootstrap replicates
 #'   (`method = "bootstrap"` only). Default `1000`.
 #' @param seed Optional integer; if supplied, the bootstrap draws are
@@ -529,14 +534,31 @@ simultaneousCIs.twfeCovs <- function(
 		cohort_offsets_int = cohort_offsets_int
 	)
 
-	# --- 5. Edge case 1: no valid SEs -> stop(). ---
-	if (!isTRUE(has_valid_ses)) {
+	# --- 5. Edge case 1: no valid SEs -> stop(), EXCEPT the Omega-free band. ---
+	# `calc_ses = FALSE` fits (gls = FALSE, or q >= 1) carry no analytic SEs. The one
+	# exception is the desparsified high-dimensional band: a `p >= NT` fetwfe fit
+	# under `method = "bootstrap"` builds a cluster-robust simultaneous band from the
+	# empirical per-unit influence function -- no GLS whitening, no `sig_eps_sq` --
+	# exactly as debiasedATT() does for the overall ATT (#307, #313). Every other
+	# calc_ses = FALSE case still errors: `method = "analytic"` needs `sig_eps_sq`
+	# (NA here, and would crash downstream in Sigma_1); fixed-p (`p < NT`) is #312's
+	# scope; a non-fetwfe `p >= NT` fit (betwfe) is #308's. `p`, `N`, `T_`,
+	# `is_fetwfe`, and the resolved `method` are all already in scope here.
+	proceed_omega_free_highdim <- !isTRUE(has_valid_ses) &&
+		is_fetwfe &&
+		identical(method, "bootstrap") &&
+		(p >= N * T_)
+	if (!isTRUE(has_valid_ses) && !proceed_omega_free_highdim) {
 		stop(
 			"simultaneousCIs(): the fitted object was constructed with ",
-			"calc_ses = FALSE; standard errors are not available. Re-fit ",
-			"with q < 1 (FETWFE/BETWFE) and a satisfied rank condition, or -- for ",
-			"a `gls = FALSE` high-dimensional fit -- use `debiasedATT()` for the ",
-			"overall-ATT standard error.",
+			"calc_ses = FALSE; an analytic simultaneous band is not available. For ",
+			"a `gls = FALSE` high-dimensional (`p >= NT`) fetwfe fit, use ",
+			"`method = \"bootstrap\"` for cluster-robust simultaneous bands (the ",
+			"Omega-free desparsified construction, the band analog of ",
+			"`debiasedATT()`). Otherwise re-fit with q < 1 and `gls = TRUE` (a ",
+			"satisfied rank condition gives valid analytic SEs); the fixed-p ",
+			"`gls = FALSE` band is a planned follow-up (#312). For the overall ATT ",
+			"specifically, `debiasedATT()` works in both regimes.",
 			call. = FALSE
 		)
 	}

--- a/man/simultaneousCIs.Rd
+++ b/man/simultaneousCIs.Rd
@@ -68,7 +68,12 @@ carries the propensity channel \code{F_pi}). In the high-dimensional regime the
 band is centered on the \strong{debiased} estimate (the Theorem 6.6 correction,
 equal to \code{debiasedATT()}'s point estimate for the matching contrast), not
 the post-selection bridge estimate; fixed-p bands center on the (unbiased)
-bridge estimate as before.}
+bridge estimate as before. Because this desparsified bootstrap band is
+built from the empirical per-unit influence function -- needing neither GLS
+whitening nor \code{sig_eps_sq} -- it also accepts a high-dimensional
+\strong{\code{gls = FALSE}} fetwfe fit (\code{calc_ses = FALSE}), the band analog of
+\code{debiasedATT()}'s Omega-free SE (#307, #313). \code{method = "analytic"} still
+requires valid analytic SEs (a \code{q < 1}, \code{gls = TRUE}, rank-satisfied fit).}
 
 \item{B}{Integer; number of multiplier-bootstrap replicates
 (\code{method = "bootstrap"} only). Default \code{1000}.}

--- a/tests/testthat/test-simultaneous-bootstrap-gls-false-313.R
+++ b/tests/testthat/test-simultaneous-bootstrap-gls-false-313.R
@@ -1,0 +1,183 @@
+# Tests for #313: Omega-free simultaneousCIs() bootstrap bands on gls = FALSE
+# high-dimensional (p >= NT) fits.
+#
+# #307 made debiasedATT()'s overall-ATT SE Omega-free (a gls = FALSE fit -- un-
+# whitened, calc_ses = FALSE, no GLS/REML, no sig_eps_sq -- gets a cluster-robust
+# SE). The high-dim simultaneousCIs() bootstrap band is built the same way (the
+# empirical per-unit influence function, cluster-robust by construction; the
+# center re-fits its own q=1 nuisance on the un-whitened design), so it composes
+# un-whitened too. Previously the `has_valid_ses` gate (R/simultaneous_cis.R)
+# errored on every calc_ses = FALSE fit; now it lets the high-dim fetwfe bootstrap
+# path through while STILL erroring for method = "analytic" (needs sig_eps_sq) and
+# for fixed-p (#312) / non-fetwfe (#308).
+
+# ---- gls = FALSE high-dim fixture (raw panel, no supplied variances) ----------
+# N=20, T=8, d=12 => p = 376 >> NT = 160 (mirrors test-debiased-att-highdim.R).
+.make_hd_panel_313 <- function() {
+	set.seed(3)
+	N <- 20L
+	T <- 8L
+	d <- 12L
+	cohort_of_unit <- c(rep(0L, 8), rep(2L, 4), rep(3L, 4), rep(4L, 4))
+	eff <- c(`2` = 0.5, `3` = 1.75, `4` = 3.0)
+	covs <- matrix(stats::rnorm(N * d), N, d)
+	do.call(
+		rbind,
+		lapply(seq_len(N), function(i) {
+			g <- cohort_of_unit[i]
+			df <- data.frame(
+				unit = sprintf("u%02d", i),
+				year = 1:T,
+				treat = as.integer(g > 0 & (1:T) >= g)
+			)
+			for (j in 1:d) {
+				df[[paste0("x", j)]] <- covs[i, j]
+			}
+			te <- if (g > 0) eff[[as.character(g)]] else 0
+			df$y <- 0.3 *
+				(1:T) /
+				T +
+				te * df$treat +
+				0.2 * covs[i, 1] +
+				stats::rnorm(T, 0, 0.4)
+			df
+		})
+	)
+}
+
+hd_nogls <- fetwfe(
+	pdata = .make_hd_panel_313(),
+	time_var = "year",
+	unit_var = "unit",
+	treatment = "treat",
+	covs = paste0("x", 1:12),
+	response = "y",
+	q = 0.5,
+	verbose = FALSE,
+	gls = FALSE
+)
+
+test_that("the #313 fixture is high-dim, gls = FALSE (calc_ses = FALSE, sig_eps_sq = NA)", {
+	expect_gte(
+		ncol(hd_nogls$internal$X_final),
+		nrow(hd_nogls$internal$X_final)
+	)
+	expect_false(isTRUE(hd_nogls$internal$calc_ses))
+	expect_true(is.na(hd_nogls$sig_eps_sq))
+})
+
+test_that("gls = FALSE high-dim bootstrap bands run for every family (finite, high-dim)", {
+	for (fam in c("event_study", "cohort", "all_post_treatment")) {
+		bo <- simultaneousCIs(
+			hd_nogls,
+			family = fam,
+			method = "bootstrap",
+			B = 300,
+			seed = 1
+		)
+		expect_s3_class(bo, "simultaneous_cis")
+		expect_identical(bo$regime, "high-dimensional")
+		expect_true(all(is.finite(bo$ci$simultaneous_ci_low)))
+		expect_true(all(is.finite(bo$ci$simultaneous_ci_high)))
+		expect_true(all(
+			c("feasibility", "converged", "lambda_node") %in% names(bo)
+		))
+		# studentized sup-t critical value in [pointwise, Bonferroni].
+		expect_gte(bo$critical_value, bo$pointwise_critical_value - 1e-8)
+		expect_lte(bo$critical_value, bo$bonferroni_critical_value + 1e-8)
+	}
+})
+
+test_that("gls = FALSE high-dim bootstrap band is deterministic at a fixed seed", {
+	a <- simultaneousCIs(
+		hd_nogls,
+		family = "event_study",
+		method = "bootstrap",
+		B = 300,
+		seed = 7
+	)
+	b <- simultaneousCIs(
+		hd_nogls,
+		family = "event_study",
+		method = "bootstrap",
+		B = 300,
+		seed = 7
+	)
+	expect_identical(a$critical_value, b$critical_value)
+	expect_identical(a$ci$estimate, b$ci$estimate)
+})
+
+test_that("gls = FALSE high-dim band center matches debiasedATT() on the overall ATT (#303 cross-check)", {
+	# The overall-ATT custom contrast: cohort g loads its treatment cells with
+	# weight cohort_probs[g] / (#cells). The desparsified band centers on the
+	# Theorem 6.6 debiased estimate, equal to debiasedATT()$att.
+	G <- length(hd_nogls$cohort_probs)
+	Tt <- hd_nogls$T
+	nt <- length(hd_nogls$treat_inds)
+	sizes <- (Tt - 1):(Tt - G)
+	cohort_of_treat <- rep(seq_len(G), times = sizes)
+	a_beta <- numeric(nt)
+	for (g in seq_len(G)) {
+		idx <- which(cohort_of_treat == g)
+		a_beta[idx] <- hd_nogls$cohort_probs[g] / length(idx)
+	}
+	sc <- simultaneousCIs(
+		hd_nogls,
+		family = "custom",
+		contrasts = matrix(a_beta, nrow = 1),
+		method = "bootstrap",
+		B = 100,
+		seed = 1
+	)
+	expect_identical(sc$regime, "high-dimensional")
+	expect_equal(sc$ci$estimate, debiasedATT(hd_nogls)$att, tolerance = 1e-9)
+})
+
+test_that("method = 'analytic' on a gls = FALSE fit still errors cleanly (not a cryptic NA crash)", {
+	# The analytic band needs sig_eps_sq (NA here); the gate must catch it with the
+	# calc_ses = FALSE message, NOT crash downstream in Sigma_1.
+	for (fam in c("cohort", "event_study")) {
+		expect_error(
+			simultaneousCIs(hd_nogls, family = fam, method = "analytic"),
+			"calc_ses = FALSE"
+		)
+	}
+})
+
+test_that("a fixed-p gls = FALSE fit still errors for the bootstrap band (the #312 scope boundary)", {
+	# Small d => p < NT (fixed-p). gls = FALSE => calc_ses = FALSE. The Omega-free
+	# band is high-dim-only here; the fixed-p cluster-robust band is #312.
+	coefs <- genCoefs(
+		G = 3,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		seed = 1
+	)
+	dat <- simulateData(
+		coefs,
+		N = 60,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 1
+	)
+	dat$indep_counts <- NA
+	fp_nogls <- fetwfe(
+		pdata = dat$pdata,
+		time_var = dat$time_var,
+		unit_var = dat$unit_var,
+		treatment = dat$treatment,
+		response = dat$response,
+		covs = dat$covs,
+		q = 0.5,
+		verbose = FALSE,
+		gls = FALSE
+	)
+	expect_lt(ncol(fp_nogls$internal$X_final), nrow(fp_nogls$internal$X_final))
+	expect_false(isTRUE(fp_nogls$internal$calc_ses))
+	expect_error(
+		simultaneousCIs(fp_nogls, family = "cohort", method = "bootstrap"),
+		"calc_ses = FALSE"
+	)
+})


### PR DESCRIPTION
## Summary

Extends `simultaneousCIs(method = "bootstrap")` to accept a **`gls = FALSE` high-dimensional (`p >= NT`) fetwfe fit** (`calc_ses = FALSE`), producing cluster-robust simultaneous bands for the `event_study` / `cohort` / `all_post_treatment` / `custom` families without GLS whitening — the band analog of #307's Omega-free `debiasedATT()` SE. Such fits previously errored at the `has_valid_ses` gate.

## The audit finding (why the change is one gate)

The high-dim bootstrap variance path is **already Omega-free**: it's the empirical per-unit influence function (cluster-robust by construction; `cadjust = N/(N-1)`, no `sig_eps_sq * gram_inv` term anywhere), and the band center re-fits its own q=1 nuisance on the un-whitened design — exactly as `debiasedATT()` does. So the only blocker was the gate. The change is a single predicate in `.simultaneous_cis_impl()`:

```r
proceed_omega_free_highdim <- !isTRUE(has_valid_ses) && is_fetwfe &&
    identical(method, "bootstrap") && (p >= N * T_)
if (!isTRUE(has_valid_ses) && !proceed_omega_free_highdim) stop(<rewritten message>)
```

This mirrors `debiasedATT()`'s regime-split gate. **The `bootstrap` clause is load-bearing:** `method = "analytic"` on a gls=FALSE fit must keep erroring because the analytic `Sigma_1` uses `sig_eps_sq` (= `NA`), which would otherwise crash cryptically downstream (the Gram-invertibility guard does *not* catch it — the selected support is low-dim, so the `NA` enters via `sig_eps_sq`, not a singular Gram).

## Scope boundaries (kept erroring, by design)
- **`method = "analytic"`** on a gls=FALSE fit → still errors cleanly (`calc_ses = FALSE` message).
- **Fixed-p (`p < NT`) gls=FALSE** → still errors; the fixed-p cluster-robust band is **#312**.
- **Non-fetwfe (`betwfe`) high-dim** → still errors (the `is_fetwfe` clause); that band is **#308**.

## Changes
- `R/simultaneous_cis.R`: the gate refinement (step 5) + a `@param method` roxygen sentence. No change to `simultaneous_bootstrap.R` / `debiased_att.R` — the bootstrap path was already Omega-free.
- Tests: `tests/testthat/test-simultaneous-bootstrap-gls-false-313.R` — bands run / finite / deterministic / `regime == "high-dimensional"` for all families; band center == `debiasedATT()$att` on the overall-ATT contrast (**|diff| = 0**); analytic still errors cleanly; fixed-p gls=FALSE still errors.
- NEWS / DESCRIPTION: 1.38.0 → 1.39.0.

## Verification
- `R CMD check --as-cran` (with vignettes): **1 benign NOTE** (local-dev `1.39.0` vs CRAN `1.10.0`), 0 WARNINGs / 0 ERRORs.
- Affected cluster (simultaneous-bootstrap / simultaneous-cis / debiased-att / cv-lambda-node / ci-type): **FAIL 0 / PASS 583**.
- Mutation check: dropping the gate exception → exactly the 3 band-producing gls=FALSE tests error (reverted).
- **Independent post-exec review: APPROVE**, no actionable findings — the audit (proven dynamically: poisoning `sig_eps_sq` leaves bands byte-identical), the analytic guard, byte-identity (exactly one new branch), and the `|diff| = 0` cross-check all verified by running code.

## Known boundary (pre-existing, out of scope)
A gls=FALSE fit that the bridge zeroes to *no selected features* takes the "no features selected" early-exit, which reports `calc_ses = TRUE` and returns the degenerate all-zero band on both methods (no crash) — the #304 degenerate-path boundary, unchanged by this PR. The `p >= NT` path remains experimental (coverage validation under #295).

Closes #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
