### PR TITLE
feat: Omega-free fixed-p cluster-robust debiasedATT() SE for gls=FALSE fits (#312)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.39.0
+Version: 1.40.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,23 @@
 # NEWS
 
+## Version 1.40.0
+
+### New features
+
+- `debiasedATT()` now produces its Omega-free cluster-robust standard error for
+  **`gls = FALSE` fixed-p (`p < NT`) fits** (`calc_ses = FALSE`), the fixed-p
+  analog of the high-dimensional path #307 already supported. Such fits
+  previously errored. The regression channel is the exact-inverse OLS direction
+  with the unit-clustered residual sandwich, and the cohort-weight channel falls
+  back to the propensity-only plug-in (`.plugin_v2`); both are `sig_eps_sq`-free,
+  so no GLS whitening is needed (paper Decision D1). This unblocks (1) the
+  boundary band `N(T-1) <= p < NT`, where REML cannot fit (`gls = TRUE` is
+  infeasible) but `gls = FALSE` can, and (2) a within-unit-dependence-robust
+  fixed-p SE generally. A GLS-whitened `q >= 1` fit still errors (no validated
+  debiased SE); an un-whitened fit is accepted for any `q` (the SE is
+  q-independent). The fixed-p `gls = FALSE` SE is valid (not experimental); see
+  also #313 for the simultaneous-band analog.
+
 ## Version 1.39.0
 
 ### New features

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -164,10 +164,12 @@
 #' [simultaneousCIs()] band center agree exactly) --- but it is not tunable via
 #' the fit's `cv_seed`.
 #'
-#' @param fit A fitted object from [fetwfe()] computed with `q < 1` (so the
-#'   bridge selection produces a valid standard error). [etwfe()] / [betwfe()] /
-#'   [twfeCovs()] are not supported (the construction is specific to the FETWFE
-#'   transformed-coefficient space).
+#' @param fit A fitted object from [fetwfe()]. In the fixed-p (`p < NT`) regime
+#'   the SE needs either bridge selection (`q < 1`, `gls = TRUE`) or an un-whitened
+#'   fit (`gls = FALSE`, any `q`, the Omega-free cluster-robust path; #312); a
+#'   GLS-whitened `q >= 1` fit is rejected. The high-dimensional (`p >= NT`) path
+#'   accepts any fit. [etwfe()] / [betwfe()] / [twfeCovs()] are not supported (the
+#'   construction is specific to the FETWFE transformed-coefficient space).
 #' @param alpha Numeric in `(0, 1)`; the confidence level is `1 - alpha`.
 #'   Defaults to the `alpha` stored on the fit.
 #' @param lambda_c The leading constant of the high-dimensional (`p >= NT`)
@@ -308,9 +310,13 @@ debiasedATT <- function(
 	highdim <- p >= n
 
 	# Standard-error gate, regime-aware.
-	#  - Fixed-p (p < NT): the SE is the OLS-identity construction, which needs the
-	#    bridge-selection regime (q < 1) -- exactly when the fit computed its oracle
-	#    SEs (`calc_ses = TRUE`). A q >= 1 fit has no valid debiased SE here.
+	#  - Fixed-p (p < NT): two valid SE paths. (i) A GLS-whitened bridge fit
+	#    (`gls = TRUE`, q < 1, `calc_ses = TRUE`) uses the OLS-identity oracle SE.
+	#    (ii) An un-whitened fit (`gls = FALSE`, `sig_eps_sq = NA`) uses the exact-
+	#    inverse OLS direction + unit-clustered residual sandwich -- Omega-free and
+	#    valid for ANY q, the fixed-p analog of the high-dim path (#312, paper
+	#    Decision D1). Only a WHITENED q >= 1 fit (`calc_ses = FALSE` but
+	#    `!is.na(sig_eps_sq)`) has no validated debiased SE and is rejected below.
 	#  - High-dim (p >= NT): the SE is the desparsified cluster-robust sandwich
 	#    (V1 unit-clustered + V2 plug-in), which needs neither the oracle SE
 	#    machinery nor Omega -- so a `gls = FALSE` fit (`calc_ses = FALSE`, no GLS
@@ -321,28 +327,20 @@ debiasedATT <- function(
 	#    |diff| = 0, q = 1 vs q < 1) -- the high-dim center uses the re-fit q=1
 	#    nuisance, not the input `theta_hat` (which seeds only the `a_theta` identity
 	#    check below). A high-dim q >= 1 fit is newly accepted (vs prior versions).
-	if (!highdim && !isTRUE(fit$internal$calc_ses)) {
-		if (is.na(fit$sig_eps_sq)) {
-			# A `gls = FALSE` (un-whitened) fixed-p fit -- including the boundary band
-			# N(T-1) <= p < NT where REML is infeasible but p < NT. The cluster-robust
-			# sandwich IS valid here, but the fixed-p `debiasedATT()` path is not yet
-			# wired for an un-whitened fit (the p >= NT path is; the fixed-p one is the
-			# #312 follow-up). Name the real cause, not the misleading "requires q < 1".
-			stop(
-				"debiasedATT(): a `gls = FALSE` (un-whitened) fit in the fixed-p ",
-				"(p < NT) regime is not yet supported -- the high-dimensional ",
-				"(p >= NT) cluster-robust path is implemented, but the fixed-p ",
-				"cluster-robust SE is a planned follow-up (#312). Re-fit with ",
-				"`gls = TRUE` (supplying `sig_eps_sq` / `sig_eps_c_sq` if ",
-				"`p >= N(T - 1)`), or use a `p >= NT` design.",
-				call. = FALSE
-			)
-		}
+	# A WHITENED (`gls = TRUE`) fixed-p fit with q >= 1: the exact inverse gives the
+	# GLS direction, whose validated SE is the oracle `calc_ses = TRUE` path that
+	# q >= 1 lacks -- so no validated debiased SE exists, and it is rejected. A
+	# `gls = FALSE` / un-whitened fit (`is.na(sig_eps_sq)`) is NOT rejected: it falls
+	# through to the exact-inverse OLS + unit-clustered sandwich, valid for any q
+	# (#312). `is.na(sig_eps_sq)` is an exact proxy for un-whitened: `gls = FALSE`
+	# leaves it NA, while REML estimates it under `gls = TRUE` even when q >= 1.
+	if (!highdim && !isTRUE(fit$internal$calc_ses) && !is.na(fit$sig_eps_sq)) {
 		stop(
 			"debiasedATT() requires a fit computed with q < 1 (bridge selection) in ",
-			"the fixed-p (p < NT) regime, so a valid debiased standard error exists. ",
-			"This fit has calc_ses = FALSE (q >= 1). Re-fit with q < 1 (e.g. ",
-			"q = 0.5).",
+			"the fixed-p (p < NT) regime when the design is GLS-whitened ",
+			"(`gls = TRUE`), so a valid debiased standard error exists. This fit has ",
+			"calc_ses = FALSE (q >= 1). Re-fit with q < 1 (e.g. q = 0.5), or with ",
+			"`gls = FALSE` for the cluster-robust SE.",
 			call. = FALSE
 		)
 	}

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -557,8 +557,9 @@ simultaneousCIs.twfeCovs <- function(
 			"Omega-free desparsified construction, the band analog of ",
 			"`debiasedATT()`). Otherwise re-fit with q < 1 and `gls = TRUE` (a ",
 			"satisfied rank condition gives valid analytic SEs); the fixed-p ",
-			"`gls = FALSE` band is a planned follow-up (#312). For the overall ATT ",
-			"specifically, `debiasedATT()` works in both regimes.",
+			"`gls = FALSE` simultaneous band is not yet built (the band analog of ",
+			"the point-estimate SE #312 ships). For the overall ATT specifically, ",
+			"`debiasedATT()` works in both regimes (including fixed-p `gls = FALSE`).",
 			call. = FALSE
 		)
 	}

--- a/man/debiasedATT.Rd
+++ b/man/debiasedATT.Rd
@@ -13,10 +13,12 @@ debiasedATT(
 )
 }
 \arguments{
-\item{fit}{A fitted object from \code{\link[=fetwfe]{fetwfe()}} computed with \code{q < 1} (so the
-bridge selection produces a valid standard error). \code{\link[=etwfe]{etwfe()}} / \code{\link[=betwfe]{betwfe()}} /
-\code{\link[=twfeCovs]{twfeCovs()}} are not supported (the construction is specific to the FETWFE
-transformed-coefficient space).}
+\item{fit}{A fitted object from \code{\link[=fetwfe]{fetwfe()}}. In the fixed-p (\code{p < NT}) regime
+the SE needs either bridge selection (\code{q < 1}, \code{gls = TRUE}) or an un-whitened
+fit (\code{gls = FALSE}, any \code{q}, the Omega-free cluster-robust path; #312); a
+GLS-whitened \code{q >= 1} fit is rejected. The high-dimensional (\code{p >= NT}) path
+accepts any fit. \code{\link[=etwfe]{etwfe()}} / \code{\link[=betwfe]{betwfe()}} / \code{\link[=twfeCovs]{twfeCovs()}} are not supported (the
+construction is specific to the FETWFE transformed-coefficient space).}
 
 \item{alpha}{Numeric in \verb{(0, 1)}; the confidence level is \code{1 - alpha}.
 Defaults to the \code{alpha} stored on the fit.}

--- a/tests/testthat/test-debiased-att-fixedp-gls-false-312.R
+++ b/tests/testthat/test-debiased-att-fixedp-gls-false-312.R
@@ -1,0 +1,186 @@
+# Tests for #312: Omega-free fixed-p (p < NT) cluster-robust debiasedATT() SE on
+# gls = FALSE fits. #307 made the high-dim (p >= NT) SE Omega-free; #312 extends
+# the SAME to the fixed-p regime. The fixed-p var_reg is the exact-inverse OLS
+# direction + unit-clustered residual sandwich (sig_eps_sq-free), and var_weight
+# falls back to the propensity-only plug-in (.plugin_v2). The gate now accepts any
+# un-whitened fit (`is.na(sig_eps_sq)`) regardless of q, rejecting only a WHITENED
+# q >= 1 fit (`!is.na(sig_eps_sq)`).
+
+.mk_fixedp_fit_312 <- function(gls, q = 0.5) {
+	coefs <- genCoefs(
+		G = 3,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		seed = 1
+	)
+	dat <- simulateData(
+		coefs,
+		N = 60,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 1
+	)
+	dat$indep_counts <- NA
+	args <- list(
+		pdata = dat$pdata,
+		time_var = dat$time_var,
+		unit_var = dat$unit_var,
+		treatment = dat$treatment,
+		response = dat$response,
+		covs = dat$covs,
+		q = q,
+		verbose = FALSE,
+		gls = gls
+	)
+	if (gls) {
+		args$sig_eps_sq <- 1
+		args$sig_eps_c_sq <- 0.5
+	}
+	do.call(fetwfe, args)
+}
+
+test_that("the fixed-p var_reg equals an independent unit-clustered sandwich reconstruction (#312)", {
+	# Load-bearing correctness pin: rebuild the cluster-robust sandwich from scratch
+	# (OLS theta_hat, exact-inverse direction, OLS residuals) -- NOT via the accessor.
+	f <- .mk_fixedp_fit_312(gls = FALSE, q = 0.5)
+	expect_lt(ncol(f$internal$X_final), nrow(f$internal$X_final))
+	db <- debiasedATT(f)
+	X <- f$internal$X_final
+	y <- as.numeric(f$internal$y_final)
+	n <- nrow(X)
+	p <- ncol(X)
+	Tt <- f$T
+	N <- f$N
+	G <- f$G
+	ti <- f$treat_inds
+	A <- genFullInvFusionTransformMat(
+		first_inds = getFirstInds(G = G, T = Tt),
+		T = Tt,
+		G = G,
+		d = f$d,
+		num_treats = length(ti),
+		fusion_structure = f$fusion_structure,
+		d_inv_treat = f$internal$d_inv_treat
+	)
+	sizes <- (Tt - 1):(Tt - G)
+	cot <- rep(seq_len(G), times = sizes)
+	a_beta <- numeric(p)
+	for (g in seq_len(G)) {
+		idx <- ti[cot == g]
+		a_beta[idx] <- f$cohort_probs[g] / length(idx)
+	}
+	a_theta <- c(0, as.numeric(crossprod(A, a_beta)))
+	Sig <- crossprod(X) / n
+	v <- solve(Sig + 1e-6 * mean(diag(Sig)) * diag(p), a_theta[-1])
+	th <- f$internal$theta_hat
+	resid <- as.numeric(y - th[1] - X %*% th[-1])
+	score <- as.numeric((X %*% v) * resid)
+	unit <- rep(seq_len(N), each = Tt)
+	var_reg_ref <- sum(tapply(score, unit, sum)^2) / n^2
+	expect_equal(db$var_reg, var_reg_ref, tolerance = 1e-10)
+	# var_weight is the Omega-free plug-in; both channels positive on this fixture.
+	expect_identical(db$var_weight, fetwfe:::.plugin_v2(f))
+	expect_gt(db$var_weight, 0)
+	expect_equal(db$se, sqrt(db$var_reg + db$var_weight))
+})
+
+test_that("gls = FALSE and gls = TRUE fixed-p agree on the point estimate but differ in SE (whitening buys efficiency)", {
+	# Structure check (NOT byte-equality): same target ATT, different var_reg
+	# (un-whitened sandwich is the less efficient, still-valid estimate).
+	f0 <- .mk_fixedp_fit_312(gls = FALSE, q = 0.5)
+	f1 <- .mk_fixedp_fit_312(gls = TRUE, q = 0.5)
+	d0 <- debiasedATT(f0)
+	d1 <- debiasedATT(f1)
+	expect_lt(abs(d0$att - d1$att), 0.25) # same overall-ATT target
+	expect_false(isTRUE(all.equal(d0$var_reg, d1$var_reg))) # whitening changes var_reg
+})
+
+test_that("a gls = FALSE fixed-p fit with q >= 1 is accepted (the SE is q-independent; #312)", {
+	# The cluster-robust sandwich + exact-inverse OLS identity are valid for ANY q;
+	# is.na(sig_eps_sq) (un-whitened) is what the gate keys on, not q. Pins the
+	# "accept regardless of q" decision so it can't be silently re-narrowed.
+	f <- .mk_fixedp_fit_312(gls = FALSE, q = 1)
+	expect_true(is.na(f$sig_eps_sq))
+	db <- debiasedATT(f)
+	expect_true(is.finite(db$att))
+	expect_gt(db$se, 0)
+})
+
+test_that("a WHITENED (gls = TRUE) q >= 1 fixed-p fit still errors (the kept boundary)", {
+	f <- .mk_fixedp_fit_312(gls = TRUE, q = 2)
+	expect_false(isTRUE(f$internal$calc_ses))
+	expect_false(is.na(f$sig_eps_sq)) # REML estimated it even at q >= 1
+	expect_error(debiasedATT(f), "q < 1")
+})
+
+# ---- the boundary band N(T-1) <= p < NT (REML infeasible, gls = FALSE only) ----
+.mk_band_panel_312 <- function() {
+	set.seed(4)
+	N <- 12L
+	T <- 5L
+	d <- 2L
+	cohort_of_unit <- c(rep(0L, 3), rep(2L, 3), rep(3L, 3), rep(4L, 3))
+	eff <- c(`2` = 1, `3` = 2.5, `4` = 4)
+	covs <- matrix(stats::rnorm(N * d), N, d)
+	do.call(
+		rbind,
+		lapply(seq_len(N), function(i) {
+			g <- cohort_of_unit[i]
+			df <- data.frame(
+				unit = sprintf("u%02d", i),
+				year = 1:T,
+				treat = as.integer(g > 0 & (1:T) >= g)
+			)
+			for (j in 1:d) {
+				df[[paste0("x", j)]] <- covs[i, j]
+			}
+			te <- if (g > 0) eff[[as.character(g)]] else 0
+			df$y <- 0.2 *
+				(1:T) +
+				te * df$treat +
+				0.3 * covs[i, 1] +
+				stats::rnorm(T, 0, 0.5)
+			df
+		})
+	)
+}
+
+test_that("the boundary band N(T-1) <= p < NT gets a finite SE (gls = TRUE infeasible there)", {
+	panel <- .mk_band_panel_312()
+	fb <- fetwfe(
+		pdata = panel,
+		time_var = "year",
+		unit_var = "unit",
+		treatment = "treat",
+		covs = c("x1", "x2"),
+		response = "y",
+		q = 0.5,
+		verbose = FALSE,
+		gls = FALSE
+	)
+	p <- ncol(fb$internal$X_final)
+	n <- nrow(fb$internal$X_final)
+	N <- fb$N
+	Tt <- fb$T
+	expect_gte(p, N * (Tt - 1)) # in the band ...
+	expect_lt(p, n) # ... but still fixed-p
+	# gls = TRUE is infeasible in the band (REML guard p < N(T-1)).
+	expect_error(
+		fetwfe(
+			pdata = panel,
+			time_var = "year",
+			unit_var = "unit",
+			treatment = "treat",
+			covs = c("x1", "x2"),
+			response = "y",
+			q = 0.5,
+			verbose = FALSE,
+			gls = TRUE
+		)
+	)
+	db <- debiasedATT(fb)
+	expect_true(is.finite(db$att))
+	expect_true(is.finite(db$se) && db$se > 0)
+})

--- a/tests/testthat/test-debiased-att-highdim.R
+++ b/tests/testthat/test-debiased-att-highdim.R
@@ -501,49 +501,7 @@ test_that("the att_var_2 path is byte-unchanged: supplied-var var_weight == att_
 	expect_equal(db$var_weight, hd_fix$internal$variance_components$att_var_2)
 })
 
-# A gls = FALSE FIXED-p (p < NT) fit must error naming the REAL cause (the fixed-p
-# cluster-robust path is the #312 follow-up), not the misleading "requires q < 1"
-# (the fit IS q < 1). This is the PR #311 review's boundary-gap clarity ask.
-test_that("a gls = FALSE fixed-p fit errors with the real cause, not 'requires q < 1' (#307/#312)", {
-	set.seed(5)
-	N <- 30L
-	Tt <- 5L
-	cohort_of_unit <- c(rep(0L, 12), rep(3L, 9), rep(4L, 9))
-	eff <- c(`3` = 1, `4` = 2)
-	cv <- stats::rnorm(N)
-	rows <- do.call(
-		rbind,
-		lapply(seq_len(N), function(i) {
-			g <- cohort_of_unit[i]
-			df <- data.frame(
-				unit = sprintf("u%02d", i),
-				year = 1:Tt,
-				treat = as.integer(g > 0 & (1:Tt) >= g),
-				x1 = cv[i]
-			)
-			te <- if (g > 0) eff[[as.character(g)]] else 0
-			df$y <- 0.1 *
-				(1:Tt) +
-				te * df$treat +
-				0.3 * cv[i] +
-				stats::rnorm(Tt, 0, 0.5)
-			df
-		})
-	)
-	fit <- fetwfe(
-		pdata = rows,
-		time_var = "year",
-		unit_var = "unit",
-		treatment = "treat",
-		covs = "x1",
-		response = "y",
-		q = 0.5,
-		verbose = FALSE,
-		gls = FALSE
-	)
-	expect_lt(ncol(fit$internal$X_final), nrow(fit$internal$X_final)) # fixed-p
-	# the message names gls = FALSE + the #312 follow-up (NOT "requires q < 1"; the
-	# "bridge selection" q-attribution lives in the other branch only).
-	expect_error(debiasedATT(fit), "gls = FALSE")
-	expect_error(debiasedATT(fit), "follow-up")
-})
+# (The gls = FALSE FIXED-p (p < NT) acceptance + cluster-robust SE -- the former
+# "#312 follow-up" placeholder error -- now lives in its own file,
+# test-debiased-att-fixedp-gls-false-312.R, with consecutive-cohort fixtures the
+# debiasedATT ATT-identity guard supports.)


### PR DESCRIPTION
## Summary

Extends `debiasedATT()`'s Omega-free cluster-robust SE from the high-dim (`p >= NT`) regime (#307) to the **fixed-p (`p < NT`)** regime for **`gls = FALSE`** fits. Such fits previously errored at the fixed-p gate.

## The audit finding (why the change is one gate)

The fixed-p variance machinery is **already** Omega-free: `var_reg` is the exact-inverse OLS direction with the unit-clustered residual sandwich (`sum(unit_scores^2)/n^2`, `sig_eps_sq`-free), and `var_weight` already falls back to the propensity-only plug-in `.plugin_v2()`. So the only change is the gate:

```r
# was:  if (!highdim && !calc_ses) { if (is.na(sig_eps_sq)) stop("#312 follow-up"); stop("requires q<1") }
# now:  if (!highdim && !calc_ses && !is.na(fit$sig_eps_sq)) stop("requires q<1 when gls=TRUE ...")
```

An **un-whitened** fit (`is.na(sig_eps_sq)` ⇔ `gls = FALSE`) now falls through to the sandwich path for **any q**; a **whitened `q >= 1`** fit still errors.

## Methodology (the load-bearing decision)
- **Accept `gls = FALSE` regardless of q:** on an un-whitened fit the exact-inverse OLS identity + cluster-robust sandwich are valid for any q (paper Decision D1 / `gregfaletto/fetwfe#90`); whitening buys efficiency, not validity. Verified: `var_reg` matches an independent unit-clustered-sandwich reconstruction to **|diff| = 0**.
- **Keep rejecting `gls = TRUE, q >= 1`:** a whitened fixed-p fit's exact inverse gives the GLS direction, whose validated SE is the `calc_ses = TRUE` oracle path that `q >= 1` lacks.
- `is.na(fit$sig_eps_sq)` is a **faithful** discriminator (verified across q ∈ {0.5,1,2}): `gls = FALSE` always leaves it NA; `gls = TRUE` REML-estimates it even at `q >= 1`.

## Unblocks
1. **The boundary band `N(T-1) <= p < NT`** — REML can't fit it (`gls = TRUE` infeasible), `gls = FALSE` can, and `debiasedATT()` now returns a finite, stable SE (the band Gram is well-conditioned since `n = NT > p`).
2. A within-unit-dependence-robust fixed-p SE generally.

## Changes
- `R/debiased_att.R`: the gate refactor + regime comment + `@param fit` roxygen. No change to the variance construction.
- `R/simultaneous_cis.R`: a one-line message reframe — this PR makes `#312` the *point-estimate* SE (shipped), so the `simultaneousCIs` "fixed-p `gls = FALSE` band is `#312`" wording is reframed to "the still-unbuilt band analog of #312" (surfaced by the review).
- Tests: `tests/testthat/test-debiased-att-fixedp-gls-false-312.R` (var_reg reconstruction `|diff|=0`, `var_weight==.plugin_v2`, structure-vs-`gls=TRUE`, `q>=1`-accepted, `q>=1`-whitened-errors, boundary band). Deleted the superseded `gls = FALSE` placeholder-error test in `test-debiased-att-highdim.R`.
- NEWS / DESCRIPTION: 1.39.0 → 1.40.0.

## Verification
- `R CMD check --as-cran` (vignettes): **1 benign NOTE, 0 WARN/ERROR**.
- Affected cluster (debiased-att / simultaneous-bootstrap / simultaneous-cis / cv-lambda-node / ci-type): **FAIL 0 / ERROR 0 / PASS 598**.
- Mutation check: dropping the `&& !is.na(sig_eps_sq)` clause → the gls=FALSE acceptance tests error (reverted).
- **Independent post-exec review: APPROVE**, no actionable findings — the audit (`var_reg` |diff|=0), the `is.na(sig_eps_sq)` discriminator across q, the boundary band, no-regression (gls=TRUE/high-dim byte-identical), and the mutation all verified by running code.

## Note (out of scope)
A scattered-cohort (non-consecutive adoption) fixed-p fit errors at the pre-existing ATT-identity guard under **both** gls modes (the `getFirstInds` limitation) — unchanged by this PR; the new behavior is now consistent across gls modes.

Closes #312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
