### PR TITLE
fix: debiasedATT() supports non-consecutive (scattered-cohort) adoption (#318)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.40.0
+Version: 1.41.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,23 @@
 # NEWS
 
+## Version 1.41.0
+
+### Bug fixes
+
+- `debiasedATT()` now supports fits with **non-consecutive (scattered-cohort)
+  adoption** -- adoption times with gaps, e.g. `bacondecomp::divorce` (#318). Its
+  overall-ATT weight vector was built under a consecutive-cohort assumption
+  (`getFirstInds()` + `sizes <- (T - 1):(T - G)`), so a scattered fit mis-assigned
+  the treatment cells to cohorts and tripped the ATT-identity guard. It now
+  resolves the *actual* adoption offsets via the same offset dispatcher the
+  disaggregated functions (`event_study()`, `cohortTimeATTs()`,
+  `simultaneousCIs()`) already use (v1.13.3, #174), so the identity holds for
+  scattered cohorts in **both** the fixed-p and high-dimensional regimes.
+  Consecutive-cohort fits are byte-identical (the resolver returns the same
+  offsets, and the block sizes reduce to `(T - 1):(T - G)`). This was the gap
+  behind the scattered-cohort notes in #316 / #317 and unblocks the divorce
+  high-dimensional application.
+
 ## Version 1.40.0
 
 ### New features

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -407,10 +407,28 @@ debiasedATT <- function(
 	}
 
 	# ---- theta-space ATT weight vector a_theta = c(0, A' a_beta) ----
-	first_inds <- getFirstInds(G = G, T = T)
-	# Cohort g has T - g post-treatment cells; a_beta loads treat_inds with weight
-	# cohort_probs[g] / (#cells in cohort g) so a_beta' beta = sum_g pi_g * catt_g.
-	sizes <- (T - 1):(T - G)
+	# Resolve the ACTUAL cohort offsets (#174 / #318): `getFirstInds(G, T)` and
+	# `sizes <- (T-1):(T-G)` assume CONSECUTIVE adoption (offsets 2..G+1), which
+	# mis-assigns the treatment cells under non-consecutive (scattered-cohort)
+	# adoption -- e.g. bacondecomp::divorce -- so the identity guard below would
+	# (correctly) fire on a wrong weight vector. The #174 dispatcher reads the real
+	# offsets from the fit's cohort labels (and falls back to `getFirstInds()` when
+	# the labels are not integer-coercible). Either way it returns exactly
+	# `getFirstInds()` for any CONSECUTIVE layout -- whether by deriving the
+	# consecutive labels `2..G+1` (e.g. genCoefs/simulateData fixtures) or by the
+	# no-label fallback -- so consecutive fits stay byte-identical.
+	# `genFullInvFusionTransformMat()` already takes `first_inds`, so the scattered
+	# offsets propagate into the transform automatically.
+	first_inds <- .resolve_event_study_offsets_and_first_inds(
+		fit,
+		G = G,
+		T = T
+	)$first_inds
+	# Cohort g's treatment-cell block runs from `first_inds[g]` to the next cohort's
+	# first index; a_beta loads treat_inds with weight cohort_probs[g] / (#cells in
+	# cohort g) so a_beta' beta = sum_g pi_g * catt_g. For consecutive cohorts the
+	# block sizes reduce to (T-1):(T-G).
+	sizes <- diff(c(first_inds, num_treats + 1L))
 	cohort_of_treat <- rep(seq_len(G), times = sizes)
 	a_beta <- numeric(p)
 	for (g in seq_len(G)) {

--- a/tests/testthat/test-debiased-att-scattered-cohorts-318.R
+++ b/tests/testthat/test-debiased-att-scattered-cohorts-318.R
@@ -1,0 +1,150 @@
+# Tests for #318: debiasedATT() supports non-consecutive (scattered-cohort)
+# adoption. Its overall-ATT weight vector `a_theta` previously used
+# `getFirstInds(G, T)` + `sizes <- (T-1):(T-G)`, both of which assume consecutive
+# adoption (offsets 2..G+1); on scattered adoption (gaps, e.g. years 2,4,7 --
+# bacondecomp::divorce) the treatment cells were mis-assigned and the ATT-identity
+# guard correctly fired. The fix resolves the ACTUAL offsets via the #174
+# dispatcher (`.resolve_event_study_offsets_and_first_inds`), so the identity
+# `a_theta' theta_hat == att_hat` holds for scattered cohorts too, in both regimes.
+
+# Raw panel with `adopt` adoption years (integer-coercible cohort labels, so the
+# #174 dispatcher derives the real offsets rather than the consecutive fallback).
+.mk_panel_318 <- function(adopt, d = 3L, N = 24L, T = 8L, seed = 5) {
+	set.seed(seed)
+	covs <- matrix(stats::rnorm(N * d), N, d)
+	cohort_of_unit <- c(
+		rep(0L, N - 3L * 6L),
+		rep(adopt[1], 6),
+		rep(adopt[2], 6),
+		rep(adopt[3], 6)
+	)
+	eff <- stats::setNames(c(0.5, 2.0, 3.5), as.character(adopt))
+	do.call(
+		rbind,
+		lapply(seq_len(N), function(i) {
+			g <- cohort_of_unit[i]
+			df <- data.frame(
+				unit = sprintf("u%02d", i),
+				year = 1:T,
+				treat = as.integer(g > 0 & (1:T) >= g)
+			)
+			for (j in 1:d) {
+				df[[paste0("x", j)]] <- covs[i, j]
+			}
+			te <- if (g > 0) eff[[as.character(g)]] else 0
+			df$y <- 0.3 *
+				(1:T) /
+				T +
+				te * df$treat +
+				0.2 * covs[i, 1] +
+				stats::rnorm(T, 0, 0.4)
+			df
+		})
+	)
+}
+
+.fit_318 <- function(panel, gls, ...) {
+	fetwfe(
+		pdata = panel,
+		time_var = "year",
+		unit_var = "unit",
+		treatment = "treat",
+		covs = grep("^x", names(panel), value = TRUE),
+		response = "y",
+		q = 0.5,
+		verbose = FALSE,
+		gls = gls,
+		...
+	)
+}
+
+# Independent reconstruction of the overall-ATT identity check the guard performs.
+.att_identity_gap <- function(fit) {
+	G <- fit$G
+	T <- fit$T
+	nt <- length(fit$treat_inds)
+	p <- ncol(fit$internal$X_final)
+	fi <- fetwfe:::.resolve_event_study_offsets_and_first_inds(
+		fit,
+		G = G,
+		T = T
+	)$first_inds
+	sizes <- diff(c(fi, nt + 1L))
+	cot <- rep(seq_len(G), times = sizes)
+	a_beta <- numeric(p)
+	for (g in seq_len(G)) {
+		idx <- fit$treat_inds[cot == g]
+		a_beta[idx] <- fit$cohort_probs[g] / length(idx)
+	}
+	A <- genFullInvFusionTransformMat(
+		first_inds = fi,
+		T = T,
+		G = G,
+		d = fit$d,
+		num_treats = nt,
+		fusion_structure = fit$fusion_structure,
+		d_inv_treat = fit$internal$d_inv_treat
+	)
+	a_theta <- c(0, as.numeric(crossprod(A, a_beta)))
+	abs(sum(a_theta * fit$internal$theta_hat) - fit$att_hat)
+}
+
+test_that("debiasedATT() runs on a scattered-cohort FIXED-p fit (#318)", {
+	f <- .fit_318(
+		.mk_panel_318(c(2L, 4L, 7L), d = 3L),
+		gls = TRUE,
+		sig_eps_sq = 0.16,
+		sig_eps_c_sq = 0.1
+	)
+	expect_lt(ncol(f$internal$X_final), nrow(f$internal$X_final)) # fixed-p
+	# the resolved offsets are the SCATTERED ones, not consecutive.
+	offs <- fetwfe:::.resolve_event_study_offsets_and_first_inds(
+		f,
+		G = f$G,
+		T = f$T
+	)
+	expect_identical(as.integer(offs$cohort_offsets_int), c(2L, 4L, 7L))
+	expect_false(identical(
+		as.integer(offs$first_inds),
+		as.integer(getFirstInds(G = f$G, T = f$T))
+	))
+	db <- debiasedATT(f)
+	expect_true(is.finite(db$att) && is.finite(db$se) && db$se > 0)
+	# the ATT-direction identity now holds (acceptance criterion, 1e-6 tol).
+	expect_lt(.att_identity_gap(f), 1e-6)
+})
+
+test_that("debiasedATT() runs on a scattered-cohort HIGH-dim fit (#318)", {
+	f <- .fit_318(.mk_panel_318(c(2L, 4L, 7L), d = 10L), gls = FALSE)
+	expect_gte(ncol(f$internal$X_final), nrow(f$internal$X_final)) # high-dim
+	db <- debiasedATT(f)
+	expect_true(is.finite(db$att) && is.finite(db$se) && db$se > 0)
+	expect_lt(.att_identity_gap(f), 1e-6)
+})
+
+test_that("consecutive-cohort fits are byte-identical (the resolver matches getFirstInds) (#318)", {
+	f <- .fit_318(
+		.mk_panel_318(c(2L, 3L, 4L), d = 3L),
+		gls = TRUE,
+		sig_eps_sq = 0.16,
+		sig_eps_c_sq = 0.1
+	)
+	# consecutive adoption: the resolver returns exactly getFirstInds() and the
+	# block sizes reduce to (T-1):(T-G), so the construction is unchanged.
+	fi_res <- fetwfe:::.resolve_event_study_offsets_and_first_inds(
+		f,
+		G = f$G,
+		T = f$T
+	)$first_inds
+	expect_identical(
+		as.integer(fi_res),
+		as.integer(getFirstInds(G = f$G, T = f$T))
+	)
+	nt <- length(f$treat_inds)
+	expect_identical(
+		as.integer(diff(c(fi_res, nt + 1L))),
+		as.integer((f$T - 1L):(f$T - f$G))
+	)
+	db <- debiasedATT(f)
+	expect_true(is.finite(db$att) && db$se > 0)
+})


### PR DESCRIPTION
## Summary

`debiasedATT()` errored on fits with **non-consecutive (scattered-cohort) adoption** — adoption times with gaps, e.g. `bacondecomp::divorce` — because its overall-ATT weight vector `a_theta` was built with `getFirstInds(G, T)` + `sizes <- (T - 1):(T - G)`, both of which assume consecutive adoption (offsets `2..G+1`). On scattered adoption the treatment cells were mis-assigned to cohorts, so `a_theta` was wrong and the ATT-identity guard correctly fired. The disaggregated functions (`event_study()`, `cohortTimeATTs()`, `simultaneousCIs()`) were already migrated to scattered cohorts in #174; this closes the overall-ATT **point** path the same way.

## The fix (~5 lines)

```r
# was:  first_inds <- getFirstInds(G = G, T = T); sizes <- (T - 1):(T - G)
first_inds <- .resolve_event_study_offsets_and_first_inds(fit, G = G, T = T)$first_inds
sizes      <- diff(c(first_inds, num_treats + 1L))
```

`.resolve_event_study_offsets_and_first_inds` (the #174 dispatcher) reads the real adoption offsets from the fit's cohort labels. `genFullInvFusionTransformMat()` already takes `first_inds`, so the scattered offsets propagate automatically. The identity `a_theta' theta_hat == att_hat` now holds for scattered cohorts in **both** the fixed-p and high-dimensional regimes.

**No regression — consecutive fits are byte-identical:** the resolver returns exactly `getFirstInds()` for any consecutive layout (whether by deriving consecutive labels `2..G+1` — e.g. genCoefs/simulateData fixtures — or by the no-label fallback), and `diff(c(first_inds, num_treats + 1L))` reduces to `(T - 1):(T - G)`.

## Changes
- `R/debiased_att.R`: resolve the real offsets in the `a_theta` construction. No change to the debiasing direction / SE channels (`var_reg`, `var_weight`) — they operate on the θ-space Gram + `a_theta`, already offset-agnostic.
- Tests: `tests/testthat/test-debiased-att-scattered-cohorts-318.R` (scattered fixed-p + high-dim run with the identity holding to 1e-6; the resolved offsets are the scattered ones; consecutive resolver `== getFirstInds` and sizes `== (T-1):(T-G)`, the byte-identity pins).
- NEWS / DESCRIPTION: 1.40.0 → 1.41.0.

## Verification
- `R CMD check --as-cran` (vignettes): **1 benign NOTE, 0 WARN/ERROR**.
- Affected cluster (debiased-att / simultaneous / event-study / cohort-time / cv-lambda-node / ci-type): **FAIL 0 / ERROR 0 / PASS 697** — the #174-migrated siblings and the consecutive/synthetic debiasedATT tests pass unchanged.
- Mutation check: reverting `first_inds` to `getFirstInds()` → the scattered tests error at the identity guard (reverted).
- **Independent post-exec review: APPROVE**, no actionable findings — verified on the synthetic scattered fixture **and the real `bacondecomp::divorce` data** (12 scattered cohorts, identity `|gap| = 1e-19`; `main` errors on the same fit), byte-identity to 17 digits, the `sizes` formula correct across edge cases (G==1, last cohort, single post-period), `cohort_probs` ordering consistent, and the identity guard a sufficient safety net (an adversarial wrong offset errors).

## Test-coverage note
The issue's acceptance offers "`bacondecomp::divorce` **or** a synthetic scattered fixture." The regression test uses the synthetic fixture (exercises the identical path, `|gap| = 0`, both regimes); the review independently confirmed the real divorce case works (a guarded divorce test was judged not worth the fixture-setup fragility).

Closes #318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
