### PR TITLE
refactor: rename the cohort-offset resolver to drop the misleading "event_study" (#318 review)

### DIFF
--- a/R/cohort_time_atts.R
+++ b/R/cohort_time_atts.R
@@ -192,7 +192,7 @@ cohortTimeATTs <- function(result, alpha = NULL) {
 	# uses: real panels map integer-coercible cohort labels to panel-time
 	# offsets; synthetic fixtures fall back to the consecutive-cohort
 	# assumption).
-	offs <- .resolve_event_study_offsets_and_first_inds(x, G = G, T = T)
+	offs <- .resolve_cohort_offsets_and_first_inds(x, G = G, T = T)
 	cohort_offsets_int <- offs$cohort_offsets_int
 	first_inds <- offs$first_inds
 	first_year <- x$internal$first_year

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -419,7 +419,7 @@ debiasedATT <- function(
 	# no-label fallback -- so consecutive fits stay byte-identical.
 	# `genFullInvFusionTransformMat()` already takes `first_inds`, so the scattered
 	# offsets propagate into the transform automatically.
-	first_inds <- .resolve_event_study_offsets_and_first_inds(
+	first_inds <- .resolve_cohort_offsets_and_first_inds(
 		fit,
 		G = G,
 		T = T

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -114,13 +114,16 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 	}
 }
 
-#' Resolve cohort offsets and first-treatment-effect indices for event-study
+#' Resolve cohort offsets and first-treatment-effect indices
 #'
-#' Wraps `.derive_cohort_offsets_from_fit(x)` and the conditional dispatch
-#' between `getFirstInds(G, T)` (the consecutive-cohort assumption, used as
-#' a fall-back when `cohort_probs` carry no integer-coercible names --- true
-#' of synthetic genCoefs-based fixtures) and `getFirstIndsFromOffsets(...)`
-#' (the scattered-cohort path used on real panels like `bacondecomp::divorce`).
+#' The package-wide cohort-offset resolver: **not** event-study-specific (despite
+#' living in this file), it is used by `event_study()`, `cohortTimeATTs()`,
+#' `simultaneousCIs()`, and `debiasedATT()` (#318). Wraps
+#' `.derive_cohort_offsets_from_fit(x)` and the conditional dispatch between
+#' `getFirstInds(G, T)` (the consecutive-cohort assumption, used as a fall-back
+#' when `cohort_probs` carry no integer-coercible names --- true of synthetic
+#' genCoefs-based fixtures) and `getFirstIndsFromOffsets(...)` (the
+#' scattered-cohort path used on real panels like `bacondecomp::divorce`).
 #'
 #' Extracted in v1.13.3 (#174) to eliminate a byte-identical 10-line block
 #' that had appeared in both `.event_study_etwfe_betwfe()` and
@@ -135,7 +138,7 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 #'   length `G`) and `first_inds` (integer vector of length `G`).
 #' @keywords internal
 #' @noRd
-.resolve_event_study_offsets_and_first_inds <- function(x, G, T) {
+.resolve_cohort_offsets_and_first_inds <- function(x, G, T) {
 	cohort_offsets_int <- .derive_cohort_offsets_from_fit(x)
 	if (is.null(cohort_offsets_int)) {
 		list(
@@ -198,7 +201,7 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 	# `cohort_offsets_int` is also used for the per-event-time validity
 	# set `V_e <- which(cohort_offsets_int <= T - e)`; for consecutive
 	# cohorts this reduces to the pre-#174 `seq_len(G) <= T - 1L - e`.
-	offs <- .resolve_event_study_offsets_and_first_inds(x, G = G, T = T)
+	offs <- .resolve_cohort_offsets_and_first_inds(x, G = G, T = T)
 	cohort_offsets_int <- offs$cohort_offsets_int
 	first_inds <- offs$first_inds
 	tes <- beta_hat[treat_inds]
@@ -423,10 +426,10 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 	se_type <- if (is.null(x$se_type)) "default" else x$se_type
 	is_indep <- isTRUE(x$indep_counts_used)
 	# v1.13.3 (#174): offset resolution lives in the shared helper
-	# `.resolve_event_study_offsets_and_first_inds()` at the top of this
+	# `.resolve_cohort_offsets_and_first_inds()` at the top of this
 	# file. The fall-back keeps synthetic-fixture results byte-identical
 	# to the pre-#174 path.
-	offs <- .resolve_event_study_offsets_and_first_inds(x, G = G, T = T)
+	offs <- .resolve_cohort_offsets_and_first_inds(x, G = G, T = T)
 	cohort_offsets_int <- offs$cohort_offsets_int
 	first_inds <- offs$first_inds
 	tes <- beta_hat[treat_inds]

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -483,7 +483,7 @@ simultaneousCIs.twfeCovs <- function(
 
 	# --- 3. Resolve cohort-time offsets + first_inds (same helper eventStudy
 	#        uses; preserves scattered-cohort support). ---
-	offs <- .resolve_event_study_offsets_and_first_inds(x, G = G, T = T_)
+	offs <- .resolve_cohort_offsets_and_first_inds(x, G = G, T = T_)
 	cohort_offsets_int <- offs$cohort_offsets_int
 	first_inds <- offs$first_inds
 

--- a/tests/testthat/test-debiased-att-scattered-cohorts-318.R
+++ b/tests/testthat/test-debiased-att-scattered-cohorts-318.R
@@ -4,7 +4,7 @@
 # adoption (offsets 2..G+1); on scattered adoption (gaps, e.g. years 2,4,7 --
 # bacondecomp::divorce) the treatment cells were mis-assigned and the ATT-identity
 # guard correctly fired. The fix resolves the ACTUAL offsets via the #174
-# dispatcher (`.resolve_event_study_offsets_and_first_inds`), so the identity
+# dispatcher (`.resolve_cohort_offsets_and_first_inds`), so the identity
 # `a_theta' theta_hat == att_hat` holds for scattered cohorts too, in both regimes.
 
 # Raw panel with `adopt` adoption years (integer-coercible cohort labels, so the
@@ -64,7 +64,7 @@
 	T <- fit$T
 	nt <- length(fit$treat_inds)
 	p <- ncol(fit$internal$X_final)
-	fi <- fetwfe:::.resolve_event_study_offsets_and_first_inds(
+	fi <- fetwfe:::.resolve_cohort_offsets_and_first_inds(
 		fit,
 		G = G,
 		T = T
@@ -98,7 +98,7 @@ test_that("debiasedATT() runs on a scattered-cohort FIXED-p fit (#318)", {
 	)
 	expect_lt(ncol(f$internal$X_final), nrow(f$internal$X_final)) # fixed-p
 	# the resolved offsets are the SCATTERED ones, not consecutive.
-	offs <- fetwfe:::.resolve_event_study_offsets_and_first_inds(
+	offs <- fetwfe:::.resolve_cohort_offsets_and_first_inds(
 		f,
 		G = f$G,
 		T = f$T
@@ -131,7 +131,7 @@ test_that("consecutive-cohort fits are byte-identical (the resolver matches getF
 	)
 	# consecutive adoption: the resolver returns exactly getFirstInds() and the
 	# block sizes reduce to (T-1):(T-G), so the construction is unchanged.
-	fi_res <- fetwfe:::.resolve_event_study_offsets_and_first_inds(
+	fi_res <- fetwfe:::.resolve_cohort_offsets_and_first_inds(
 		f,
 		G = f$G,
 		T = f$T

--- a/tests/testthat/test-degenerate-jacobian-225.R
+++ b/tests/testthat/test-degenerate-jacobian-225.R
@@ -130,7 +130,7 @@ test_that(".assemble_joint_cov_var2 (K=1) matches getSecondVarTermOLS on an even
 	tes <- fit$beta_hat[fit$treat_inds]
 	cpo <- fit$cohort_probs_overall
 
-	offs <- fetwfe:::.resolve_event_study_offsets_and_first_inds(
+	offs <- fetwfe:::.resolve_cohort_offsets_and_first_inds(
 		fit,
 		G = G,
 		T = T_

--- a/tests/testthat/test-indep-counts-late-adoption-288.R
+++ b/tests/testthat/test-indep-counts-late-adoption-288.R
@@ -103,12 +103,12 @@ for (est in c("fetwfe", "etwfe", "betwfe")) {
 				names(fit_no$cohort_probs)
 			)
 			expect_identical(names(fit_ic$cohort_probs), c("6", "7", "8", "9"))
-			fi_no <- .resolve_event_study_offsets_and_first_inds(
+			fi_no <- .resolve_cohort_offsets_and_first_inds(
 				fit_no,
 				fit_no$G,
 				fit_no$T
 			)$first_inds
-			fi_ic <- .resolve_event_study_offsets_and_first_inds(
+			fi_ic <- .resolve_cohort_offsets_and_first_inds(
 				fit_ic,
 				fit_ic$G,
 				fit_ic$T
@@ -147,7 +147,7 @@ test_that("legacy indep fit with unnamed cohort_probs is rescued via catt_df", {
 	expect_identical(as.integer(off), c(6L, 7L, 8L, 9L))
 	expect_identical(
 		as.integer(
-			.resolve_event_study_offsets_and_first_inds(
+			.resolve_cohort_offsets_and_first_inds(
 				legacy,
 				legacy$G,
 				legacy$T

--- a/tests/testthat/test-simultaneous-bootstrap-eventstudy-142.R
+++ b/tests/testthat/test-simultaneous-bootstrap-eventstudy-142.R
@@ -72,7 +72,7 @@
 	num_treats <- length(treat_inds)
 	cohort_probs_overall <- fit$cohort_probs_overall
 	theta_hat_full <- fit$internal$theta_hat
-	offs <- fetwfe:::.resolve_event_study_offsets_and_first_inds(
+	offs <- fetwfe:::.resolve_cohort_offsets_and_first_inds(
 		fit,
 		G = G,
 		T = T_
@@ -545,7 +545,7 @@ test_that("event_study bootstrap bands attain near-nominal family-wise coverage"
 		# per-cell effects across the cohorts treated by event time e (matches
 		# the truth construction in test-simultaneous-cis.R Test 3).
 		cpo <- fit$cohort_probs_overall
-		offs <- fetwfe:::.resolve_event_study_offsets_and_first_inds(
+		offs <- fetwfe:::.resolve_cohort_offsets_and_first_inds(
 			fit,
 			G = G,
 			T = T_

--- a/tests/testthat/test-simultaneous-bootstrap-fpi-desparsify-309.R
+++ b/tests/testthat/test-simultaneous-bootstrap-fpi-desparsify-309.R
@@ -76,7 +76,7 @@ hd309 <- .make_hd309_fit()
 	E <- matrix(0, p, nt)
 	E[cbind(ti, seq_len(nt))] <- 1
 	cell_targets <- crossprod(A, E) # p x num_treats
-	offs <- fetwfe:::.resolve_event_study_offsets_and_first_inds(
+	offs <- fetwfe:::.resolve_cohort_offsets_and_first_inds(
 		hd,
 		G = G,
 		T = Tt
@@ -251,7 +251,7 @@ test_that("high-dim event_study band matches the desparsified reconstruction (en
 	K <- pr$T - 1L
 	# Regression channel css_reg: the event-time family targets are the pooled cell
 	# targets, targets[,k] = sum_g w_{g,k} cell_targets[,g-cell].
-	offs <- fetwfe:::.resolve_event_study_offsets_and_first_inds(
+	offs <- fetwfe:::.resolve_cohort_offsets_and_first_inds(
 		hd309,
 		G = pr$G,
 		T = pr$T

--- a/tests/testthat/test-simultaneous-cis.R
+++ b/tests/testthat/test-simultaneous-cis.R
@@ -175,7 +175,7 @@ test_that("simultaneousCIs achieves ~nominal simultaneous coverage", {
 		sci_i <- simultaneousCIs(fit_i, family = "event_study", alpha = 0.05)
 
 		cpo_i <- fit_i$cohort_probs_overall
-		offs_i <- fetwfe:::.resolve_event_study_offsets_and_first_inds(
+		offs_i <- fetwfe:::.resolve_cohort_offsets_and_first_inds(
 			fit_i,
 			G = R_,
 			T = T_


### PR DESCRIPTION
## Summary

Renames the internal cohort-offset resolver to drop the misleading `event_study` in its name — a cleanup flagged in the #318 issue and the PR #319 review.

`.resolve_event_study_offsets_and_first_inds()` is the **package-wide** cohort-offset resolver, not event-study-specific. After #318 it has four R callers — `event_study()`, `cohortTimeATTs()`, `simultaneousCIs()`, and `debiasedATT()` — so the `event_study` in the name was a misnomer. Renamed to `.resolve_cohort_offsets_and_first_inds()`.

## Changes
- Renamed the definition + all callers + test references (10 files: 4 R, 6 test).
- Updated its roxygen title/description to note it is general (used across the four accessors).

## This is a pure refactor
- Internal `@noRd` helper → **no API / man / NAMESPACE change, no behavior change, no version bump** (per the package convention: pure refactors don't bump; only user-visible changes do).
- Verified byte-identical: the affected-cluster suite (event-study / cohort-time / simultaneous-* / debiased-att / indep-counts / degenerate-jacobian / ci-type — every caller + test reference) is **FAIL 0 / ERROR 0 / PASS 734**.
- `R CMD check --as-cran` (with vignettes): clean (no new NOTE/WARN/ERROR beyond the standing version-jump NOTE).
- Grepped the whole repo (R, tests, vignettes, `*.md`, `*.Rd`) — no remaining references to the old name.

Refs #318 (the PR #319 review suggestion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
