### PR TITLE
fix: high-dim all-zero-bridge informative band + calc_ses reconciliation (#304)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.41.0
+Version: 1.42.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,25 @@
 # NEWS
 
+## Version 1.42.0
+
+### Bug fixes
+
+- `simultaneousCIs(method = "bootstrap")` no longer returns a degenerate all-zero
+  band in the high-dimensional (`p >= NT`) regime when the bridge penalty zeroes
+  every treatment effect (#304). There the **debiased** band center (the
+  Theorem 6.6 desparsified construction) is generally non-zero and informative, so
+  the all-zero early-exit is now bypassed for the high-dim fetwfe bootstrap path,
+  which falls through to the desparsified band (it re-fits its own q=1 nuisance and
+  builds the directions from the full design, both selection-independent). Fixed-p
+  fits (where an all-zero bridge genuinely means a zero estimate), `method =
+  "analytic"`, and non-`fetwfe()` fits still return the degenerate band.
+- The "no treatment features selected" early-exit now reports
+  `calc_ses = (q < 1) && gls`, matching the normal path (previously `q < 1` alone).
+  So a `gls = FALSE` fit whose bridge zeroes all treatment effects correctly
+  reports `calc_ses = FALSE` with `NA` standard errors, and `simultaneousCIs(method
+  = "analytic")` / `debiasedATT()`-style gating treat it consistently (previously
+  it wrongly reported `calc_ses = TRUE` and bypassed the `gls = FALSE` SE gate).
+
 ## Version 1.41.0
 
 ### Bug fixes

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -596,6 +596,7 @@ fetwfe_core <- function(
 			G = G,
 			c_names = c_names,
 			q = q,
+			gls = gls,
 			beta_hat = rep(0, p), # Slopes are all zero
 			treat_inds = treat_inds,
 			treat_int_inds = treat_int_inds,
@@ -682,6 +683,7 @@ fetwfe_core <- function(
 			G = G,
 			c_names = c_names,
 			q = q,
+			gls = gls,
 			beta_hat = beta_hat_early_exit, # Untransformed slopes
 			treat_inds = treat_inds,
 			treat_int_inds = treat_int_inds,

--- a/R/result_assembly.R
+++ b/R/result_assembly.R
@@ -26,8 +26,13 @@
 #' @param G,N,T,d,p Integers; problem dimensions.
 #' @param c_names Character vector of length `G`; cohort labels for the
 #'   `catt_df_to_ret` rows.
-#' @param q Numeric; bridge regression exponent. Drives the
-#'   `ret_se <- if (q < 1) 0 else NA` SE-shape gate.
+#' @param q Numeric; bridge regression exponent. With `gls`, drives the
+#'   SE-validity gate `ses_valid <- (q < 1) && gls` that shapes `ret_se` /
+#'   `ret_var` / `calc_ses`.
+#' @param gls Logical; whether the fit used GLS whitening. A valid (zero)
+#'   degenerate SE needs `(q < 1) && gls` (mirrors the normal path's `calc_ses`);
+#'   a `gls = FALSE` fit reports `calc_ses = FALSE` with NA SEs (#304). Defaults
+#'   to `TRUE` so the BETWFE / OLS callers (which have no `gls`) keep `q < 1`.
 #' @param beta_hat Numeric vector of length `p`; the final slope estimates
 #'   (caller-computed). For BETWFE intercept-only this is
 #'   `beta_hat[2:(p+1)]` (all zero); for BETWFE no-treatment this is
@@ -73,6 +78,7 @@
 	G,
 	c_names,
 	q,
+	gls = TRUE,
 	beta_hat,
 	treat_inds,
 	treat_int_inds,
@@ -104,11 +110,15 @@
 		message(message_text)
 	}
 
-	if (q < 1) {
-		ret_se <- 0
-	} else {
-		ret_se <- NA
-	}
+	# A valid (zero) SE for this degenerate fit needs the SAME condition the normal
+	# path uses (`fetwfe_core.R`: `calc_ses = (q < 1) && gls`): bridge selection
+	# (q < 1) AND GLS whitening (gls). A `gls = FALSE` fit has no oracle SE, so its
+	# degenerate SE is NA -- and `calc_ses`, `ret_se`, and `ret_var` must agree, or
+	# the C1 SE-consistency validator (`att_se` must be NA when `calc_ses = FALSE`)
+	# trips at fit construction. (#304 reconciliation: previously keyed on `q < 1`
+	# alone, so a gls = FALSE degenerate fit wrongly reported calc_ses = TRUE.)
+	ses_valid <- (q < 1) && gls
+	ret_se <- if (ses_valid) 0 else NA
 
 	catt_df_to_ret <- data.frame(
 		cohort = c_names,
@@ -135,7 +145,7 @@
 	# out every coefficient, `att_var_1` / `att_var_2` are zero (mirroring
 	# `att_se = 0` under `q < 1`) or NA (mirroring `att_se = NA` under
 	# `q >= 1`).
-	ret_var <- if (q < 1) 0 else NA
+	ret_var <- if (ses_valid) 0 else NA
 
 	out <- list(
 		in_sample_att_hat = 0,
@@ -175,7 +185,7 @@
 		G = G,
 		d = d,
 		p = p,
-		calc_ses = q < 1,
+		calc_ses = ses_valid,
 		# v1.13.0 (#164): CV-path provenance. NA_integer_ when reached
 		# via the BIC path or an OLS-only early-exit (etwfe / twfeCovs).
 		cv_seed_used = cv_seed_used

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -604,18 +604,24 @@ simultaneousCIs.twfeCovs <- function(
 		d_inv_treat_sel <- diag(num_treats)
 	}
 
-	# --- 7. Degenerate support: all effects zeroed out by selection. Return
-	#        zero estimates / zero SEs / pointwise critical value. In fixed-p this
-	#        is consistent with selection consistency (the truth is ~ all-zero), so
-	#        a message() suffices. In the high-dimensional (p >= NT) regime
-	#        selection is NOT consistent and the debiased band center (generally
-	#        non-zero) is bypassed here, so an all-zero band must not be read as
-	#        "all effects are zero" -- a direct accessor call warns instead. The
-	#        silent fit-time precompute passes `warn_degenerate_highdim = FALSE`
-	#        and keeps the message() (swallowed by its suppressMessages()), so
-	#        fitting stays quiet. (The cleaner fall-through to the desparsified
-	#        path is the deferred #304.) ---
-	if (length(sel_treat_inds_shifted) == 0L) {
+	# --- 7. Degenerate support: the bridge zeroed every treatment effect. Normally
+	#        return a degenerate all-zero band. EXCEPT the high-dim (p >= NT) fetwfe
+	#        BOOTSTRAP case (#304): there the desparsified band center
+	#        (`estimates + colSums(F_reg)/(N*T)`) is generally NON-zero and
+	#        informative -- the bootstrap re-fits its OWN q=1 nuisance and builds
+	#        `targets` from the full design, both selection-independent -- so fall
+	#        THROUGH to the desparsified dispatch below rather than the all-zero band.
+	#        Every other case still returns the degenerate band: fixed-p (an all-zero
+	#        bridge genuinely means an empty support / zero estimate, consistent with
+	#        selection consistency), `method = "analytic"` (no Gram inverse in
+	#        high-dim anyway), and non-fetwfe high-dim (betwfe -- no desparsified
+	#        path). A direct accessor call to one of those WARNS (the debiased center
+	#        is bypassed); the silent fit-time precompute passes
+	#        `warn_degenerate_highdim = FALSE` and keeps the message(). ---
+	highdim_fetwfe_bootstrap <- is_fetwfe &&
+		identical(method, "bootstrap") &&
+		(p >= N * T_)
+	if (length(sel_treat_inds_shifted) == 0L && !highdim_fetwfe_bootstrap) {
 		if (p >= N * T_ && isTRUE(warn_degenerate_highdim)) {
 			warning(
 				"simultaneousCIs(): the bridge penalty zeroed out every treatment ",
@@ -658,8 +664,17 @@ simultaneousCIs.twfeCovs <- function(
 
 	# --- 8. Shape Psi (p_sel x K): map each effect's per-cell contrast into the
 	#        selected support (theta-space for FETWFE, beta-space for OLS family).
-	#        Used by both the analytic Sigma assembly and the bootstrap IF. ---
-	Psi <- t(psi_tes_mat %*% d_inv_treat_sel)
+	#        Used by both the analytic Sigma assembly and the bootstrap IF. The
+	#        empty selected-support case (`d_inv_treat_sel = NULL`) is reachable ONLY
+	#        via the #304 high-dim-bootstrap fall-through above (every other empty
+	#        support returned at the degenerate early-exit); there the high-dim
+	#        branch uses `targets` (full design), never this `Psi`, so a `K x 0`
+	#        placeholder suffices and must just not error on `m %*% NULL`. ---
+	Psi <- if (length(sel_treat_inds_shifted) == 0L) {
+		matrix(0, nrow = K, ncol = 0L)
+	} else {
+		t(psi_tes_mat %*% d_inv_treat_sel)
+	}
 
 	# --- Bootstrap method (#142): build + perturb the per-unit IF matrix instead
 	#     of the analytic qmvnorm critical value. Runs BEFORE getGramInv() so the
@@ -723,7 +738,14 @@ simultaneousCIs.twfeCovs <- function(
 		# analytic path uses (Step 10 below) so the bootstrap propensity IF and the
 		# analytic Sigma_2 are provably consistent. NULL for the other families
 		# (Sigma_2 = 0), which keeps their bootstrap byte-identical to Phase 1/2.
-		J_list <- if (identical(family, "event_study")) {
+		# Empty selected support (`d_inv_treat_sel = NULL`) is reachable ONLY via the
+		# #304 high-dim-bootstrap fall-through; there the propensity channel uses the
+		# debiased `j_cells` / `A_db` (below), NOT this `J_list`, so skip the build
+		# (it would otherwise crash on `ncol(NULL)` in `.build_j_list_for_family`).
+		J_list <- if (
+			identical(family, "event_study") &&
+				length(sel_treat_inds_shifted) > 0L
+		) {
 			.build_j_list_for_family(
 				family = family,
 				K = K,

--- a/tests/testthat/test-build-selected-out-result-80.R
+++ b/tests/testthat/test-build-selected-out-result-80.R
@@ -283,6 +283,28 @@ test_that("q gating: q >= 1 -> ret_se = NA, calc_ses = FALSE; q < 1 -> ret_se = 
 	expect_false(res_high$calc_ses)
 })
 
+test_that("gls gating (#304): q < 1 but gls = FALSE -> ret_se = NA, calc_ses = FALSE", {
+	# A gls = FALSE degenerate fit has no oracle SE, so its degenerate SE is NA and
+	# calc_ses is FALSE -- mirroring the normal path's `(q < 1) && gls`. calc_ses,
+	# the SEs, and the variance components must all agree (else the C1 SE-consistency
+	# validator trips at fit construction).
+	args <- .make_helper_args()
+	args$q <- 0.5
+	args$gls <- FALSE
+	res <- do.call(fetwfe:::.build_selected_out_result, args)
+	expect_false(res$calc_ses)
+	expect_identical(res$in_sample_att_se, NA)
+	expect_identical(res$indep_att_se, NA)
+	expect_true(all(is.na(res$catt_ses)))
+	expect_true(all(is.na(res$catt_df$se)))
+	# the default (gls absent) keeps the old q < 1 -> calc_ses = TRUE behavior.
+	args_default <- .make_helper_args()
+	args_default$q <- 0.5
+	expect_true(
+		do.call(fetwfe:::.build_selected_out_result, args_default)$calc_ses
+	)
+})
+
 test_that("verbose = TRUE emits the supplied message_text; verbose = FALSE is silent", {
 	args <- .make_helper_args()
 	args$verbose <- TRUE

--- a/tests/testthat/test-simultaneous-bootstrap-highdim-142.R
+++ b/tests/testthat/test-simultaneous-bootstrap-highdim-142.R
@@ -353,7 +353,7 @@ test_that("high-dim event_study band/adjusted-p duality holds with the debiased 
 # guard) drops the warning and fails expect_warning(). Fixed-p behavior (a
 # message(), no warning) is unchanged -- covered by test-degenerate-jacobian-225.R.
 # ------------------------------------------------------------------------------
-test_that("high-dim all-zero degenerate band warns (not a silent message) (#304)", {
+test_that("high-dim all-zero-bridge bootstrap returns an INFORMATIVE band, not the degenerate one (#304)", {
 	coefs <- genCoefs(
 		G = 3,
 		T = 5,
@@ -382,24 +382,140 @@ test_that("high-dim all-zero degenerate band warns (not a silent message) (#304)
 		sig_eps_sq = 1,
 		sig_eps_c_sq = 0.5
 	)
-	# Fixture invariants: genuinely high-dim AND the bridge zeroed EVERY treat cell
-	# (so the degenerate early-exit fires in the high-dim regime).
+	# Fixture invariants: genuinely high-dim AND the bridge zeroed EVERY treat cell.
 	expect_gte(ncol(fit6$internal$X_final), nrow(fit6$internal$X_final))
 	expect_true(all(fit6$internal$theta_hat[-1][fit6$treat_inds] == 0))
 
-	expect_warning(
-		bo <- simultaneousCIs(
+	# #304: the high-dim bootstrap now FALLS THROUGH to the desparsified band -- the
+	# debiased centers (Theorem 6.6) are non-zero and informative -- instead of the
+	# all-zero degenerate early-exit. So NO "zeroed out every" degenerate warning,
+	# and the band is informative.
+	# Capture warnings: assert NO degenerate ("zeroed out every") warning fires (the
+	# #304 fall-through is taken, not the all-zero early-exit), while tolerating the
+	# standing high-dim experimental-feasibility warning (orthogonal; fit-specific).
+	w <- character(0)
+	bo <- withCallingHandlers(
+		simultaneousCIs(
 			fit6,
 			family = "cohort",
 			method = "bootstrap",
-			B = 100,
+			B = 300,
 			seed = 1
 		),
-		"degenerate|unreliable|zeroed out every"
+		warning = function(cond) {
+			w <<- c(w, conditionMessage(cond))
+			invokeRestart("muffleWarning")
+		}
 	)
-	# the degenerate band is the all-zero early-exit return, as documented.
-	expect_true(all(bo$ci$simultaneous_ci_low == 0))
-	expect_true(all(bo$ci$simultaneous_ci_high == 0))
+	expect_false(any(grepl("zeroed out every|degenerate", w)))
+	expect_identical(bo$regime, "high-dimensional")
+	expect_false(all(bo$ci$estimate == 0)) # informative debiased centers
+	ses <- (bo$ci$simultaneous_ci_high - bo$ci$estimate) / bo$critical_value
+	expect_true(all(is.finite(ses)) && all(ses > 0))
+	expect_true(any(
+		bo$ci$simultaneous_ci_low != bo$ci$simultaneous_ci_high
+	)) # non-degenerate
+
+	# event_study (the headline Theorem 6.6 family, which builds a J_list) must ALSO
+	# fall through to an informative band, not crash on the empty selected support.
+	wes <- character(0)
+	boES <- withCallingHandlers(
+		simultaneousCIs(
+			fit6,
+			family = "event_study",
+			method = "bootstrap",
+			B = 200,
+			seed = 1
+		),
+		warning = function(cond) {
+			wes <<- c(wes, conditionMessage(cond))
+			invokeRestart("muffleWarning")
+		}
+	)
+	expect_identical(boES$regime, "high-dimensional")
+	expect_false(all(boES$ci$estimate == 0))
+	expect_false(any(grepl("zeroed out every|degenerate", wes)))
+
+	# #303 identity: the overall-ATT band center == debiasedATT()$att at lambda_c=1.0.
+	G <- fit6$G
+	ti <- fit6$treat_inds
+	Tt <- fit6$T
+	sizes <- (Tt - 1):(Tt - G)
+	cot <- rep(seq_len(G), times = sizes)
+	a_beta <- numeric(length(ti))
+	for (g in seq_len(G)) {
+		a_beta[which(cot == g)] <- fit6$cohort_probs[g] / sum(cot == g)
+	}
+	sc <- simultaneousCIs(
+		fit6,
+		family = "custom",
+		contrasts = matrix(a_beta, nrow = 1),
+		method = "bootstrap",
+		B = 100,
+		seed = 1
+	)
+	expect_equal(sc$ci$estimate, debiasedATT(fit6)$att, tolerance = 1e-9)
+})
+
+test_that("gls=FALSE high-dim all-zero-bridge: calc_ses=FALSE, analytic errors, bootstrap informative (#304)", {
+	# Same seed=6 all-zero-bridge fixture, but gls=FALSE (no supplied variances).
+	coefs <- genCoefs(
+		G = 3,
+		T = 5,
+		d = 22,
+		density = 0.5,
+		eff_size = 2,
+		seed = 6
+	)
+	dat <- simulateData(
+		coefs,
+		N = 40,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 6
+	)
+	dat$indep_counts <- NA
+	fitF <- fetwfe(
+		pdata = dat$pdata,
+		time_var = dat$time_var,
+		unit_var = dat$unit_var,
+		treatment = dat$treatment,
+		response = dat$response,
+		covs = dat$covs,
+		q = 0.5,
+		verbose = FALSE,
+		gls = FALSE
+	)
+	expect_true(all(fitF$internal$theta_hat[-1][fitF$treat_inds] == 0)) # all zeroed
+	# Part B: the degenerate gls=FALSE fit now reports calc_ses=FALSE (was TRUE) with
+	# NA SE (so the C1 SE-consistency validator passes at fit construction).
+	expect_false(isTRUE(fitF$internal$calc_ses))
+	expect_true(is.na(fitF$att_se))
+	# Part B reconciliation: analytic now errors at the calc_ses gate (was: returned
+	# the degenerate band because calc_ses was wrongly TRUE).
+	expect_error(
+		simultaneousCIs(fitF, family = "cohort", method = "analytic"),
+		"calc_ses = FALSE"
+	)
+	# Part A: bootstrap still falls through to the informative desparsified band
+	# (no degenerate warning; the experimental-feasibility warning is tolerated).
+	wF <- character(0)
+	boF <- withCallingHandlers(
+		simultaneousCIs(
+			fitF,
+			family = "cohort",
+			method = "bootstrap",
+			B = 200,
+			seed = 1
+		),
+		warning = function(cond) {
+			wF <<- c(wF, conditionMessage(cond))
+			invokeRestart("muffleWarning")
+		}
+	)
+	expect_false(any(grepl("zeroed out every|degenerate", wF)))
+	expect_identical(boF$regime, "high-dimensional")
+	expect_false(all(boF$ci$estimate == 0))
 })
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two related fixes for the high-dimensional (`p >= NT`) degenerate case where the bridge penalty zeroes **every** treatment effect (e.g. seed=6 on the `G=3,T=5,d=22,N=40` fixture).

### Part A — informative band instead of the degenerate all-zero one
`.simultaneous_cis_impl()`'s degenerate early-exit returned a collapsed all-zero band. That's correct for fixed-p (an all-zero bridge genuinely means a zero estimate), but **wrong in the high-dim regime**, where the *debiased* band center (Theorem 6.6 desparsified construction) is non-zero and informative. The early-exit is now gated `&& !highdim_fetwfe_bootstrap`, so the high-dim fetwfe bootstrap case **falls through** to the desparsified band (it re-fits its own q=1 nuisance and builds the directions from the full design — both selection-independent). The band center matches `debiasedATT()$att` (**|diff| = 4e-16**, #303 identity). Two empty-support landmines on the fall-through are guarded: the `Psi` shape and the `event_study` `J_list` build (both crash on `NULL d_inv_treat_sel`, but are unused on the high-dim path). Fixed-p, `method = "analytic"`, and non-`fetwfe()` fits **still** return the degenerate band.

### Part B — `calc_ses` reconciliation (the #316-review item)
The "no treatment features selected" early-exit set `calc_ses = q < 1`, dropping the `&& gls` the normal path uses. Threaded `gls` into `.build_selected_out_result()` and key `ret_se` / `ret_var` / `calc_ses` all off `ses_valid <- (q < 1) && gls` (all three together — or the C1 SE-consistency validator trips at fit construction). So a `gls = FALSE` degenerate fit reports `calc_ses = FALSE` with NA SEs, and `simultaneousCIs(method = "analytic")` errors consistently (was: wrongly returned the degenerate band).

## Changes
- `R/simultaneous_cis.R`: the early-exit gate + the `Psi` / `J_list` empty-support guards.
- `R/result_assembly.R` + `R/fetwfe_core.R`: the `gls`-aware degenerate `calc_ses`.
- Tests: rewrote the #304 degenerate-warns test → informative band (cohort + **event_study** + custom, #303 identity cross-check, gls=FALSE composition); added the gls=FALSE `calc_ses` pin in `test-build-selected-out-result-80.R`.
- NEWS / DESCRIPTION: 1.41.0 → 1.42.0.

## Verification
- `R CMD check --as-cran` (vignettes): 1 benign NOTE, 0 WARN/ERROR.
- Broad cluster (fit-construction + bands + betwfe): **FAIL 0 / ERROR 0 / WARN 0 / PASS 1002**.
- **3 mutation checks** (all bit, reverted): the early-exit gate → degenerate band; `&& gls` → gls=FALSE calc_ses=TRUE; the `J_list` empty-support guard → event_study crash.
- **Independent post-exec review caught a Major event_study crash on the fall-through** (my tests only covered cohort/custom) — **this PR fixes it** (the `J_list` guard) and adds the event_study assertion. Otherwise APPROVE: the #303 identity, the C1 interaction, gating completeness (fixed-p / analytic / betwfe still degenerate, byte-identical), and both original mutations all verified by running code.

Closes #304 (and the `calc_ses`/`&& gls` reconciliation item filed there from the #316 review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
