### PR TITLE
fix: simultaneousCIs() inherits the fit's alpha instead of hard-coding 0.05 (#324)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.43.0
+Version: 1.44.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,11 @@
   breaking the documented identity that the displayed bounds are the
   `simultaneousCIs(fit, family = …)` bounds. Passing an explicit `alpha` still
   overrides, and default (`alpha = 0.05`) fits are unaffected (#324).
+  **Behavior change on upgrade:** if you called `simultaneousCIs()` (or read its
+  bands) on a fit built at a non-default `alpha` *without* passing an explicit
+  `alpha`, the returned bounds now use the fit's level rather than `0.05`, so
+  their widths will shift — pass `alpha = 0.05` explicitly to reproduce the
+  pre-1.44.0 output.
 
 ## Version 1.43.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # NEWS
 
+## Version 1.44.0
+
+### Bug fixes
+
+- `simultaneousCIs()` now **inherits the fit's `alpha`** when `alpha` is not
+  supplied (the default is now `alpha = NULL`), matching `eventStudy()` and every
+  other accessor. Previously it hard-coded `alpha = 0.05`, so a fit built at a
+  non-default level (e.g. `fetwfe(..., alpha = 0.10)`) displayed 90% simultaneous
+  `catt_df` bands while `simultaneousCIs(fit)` silently returned 95% bands —
+  breaking the documented identity that the displayed bounds are the
+  `simultaneousCIs(fit, family = …)` bounds. Passing an explicit `alpha` still
+  overrides, and default (`alpha = 0.05`) fits are unaffected (#324).
+
 ## Version 1.43.0
 
 ### Improvements

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -55,7 +55,10 @@ utils::globalVariables(c(
 #' @param family Character; one of `"event_study"`, `"cohort"`,
 #'   `"all_post_treatment"`, or `"custom"`. See Details for each family's
 #'   resolution.
-#' @param alpha Numeric in `(0, 1)`; significance level. Default `0.05`.
+#' @param alpha Numeric in `(0, 1)`; significance level. Default `NULL`, which
+#'   inherits the fit's own `alpha` (the level its `catt_df` / displayed
+#'   simultaneous bands were built at), so `simultaneousCIs(fit)` reproduces the
+#'   fit's shown simultaneous bounds. Pass an explicit value to override.
 #' @param contrasts For `family = "custom"`, a `K x num_treats` matrix whose
 #'   rows give the `K` linear combinations of the underlying per-`(g, t)`
 #'   treatment-effect vector (the `multcomp::glht()` convention; `num_treats`
@@ -240,7 +243,7 @@ utils::globalVariables(c(
 simultaneousCIs <- function(
 	result,
 	family = c("event_study", "cohort", "all_post_treatment", "custom"),
-	alpha = 0.05,
+	alpha = NULL,
 	contrasts = NULL,
 	method = c("analytic", "bootstrap"),
 	B = 1000L,
@@ -257,7 +260,7 @@ simultaneousCIs <- function(
 simultaneousCIs.fetwfe <- function(
 	result,
 	family = c("event_study", "cohort", "all_post_treatment", "custom"),
-	alpha = 0.05,
+	alpha = NULL,
 	contrasts = NULL,
 	method = c("analytic", "bootstrap"),
 	B = 1000L,
@@ -289,7 +292,7 @@ simultaneousCIs.fetwfe <- function(
 simultaneousCIs.etwfe <- function(
 	result,
 	family = c("event_study", "cohort", "all_post_treatment", "custom"),
-	alpha = 0.05,
+	alpha = NULL,
 	contrasts = NULL,
 	method = c("analytic", "bootstrap"),
 	B = 1000L,
@@ -321,7 +324,7 @@ simultaneousCIs.etwfe <- function(
 simultaneousCIs.betwfe <- function(
 	result,
 	family = c("event_study", "cohort", "all_post_treatment", "custom"),
-	alpha = 0.05,
+	alpha = NULL,
 	contrasts = NULL,
 	method = c("analytic", "bootstrap"),
 	B = 1000L,
@@ -362,7 +365,7 @@ simultaneousCIs.betwfe <- function(
 simultaneousCIs.twfeCovs <- function(
 	result,
 	family = c("event_study", "cohort", "all_post_treatment", "custom"),
-	alpha = 0.05,
+	alpha = NULL,
 	contrasts = NULL,
 	method = c("analytic", "bootstrap"),
 	B = 1000L,
@@ -398,7 +401,8 @@ simultaneousCIs.twfeCovs <- function(
 #'   `.plans/feat-simultaneous-cis-192/PLAN.md`.
 #' @param x A validated fitted estimator object.
 #' @param family Character (already `match.arg`-resolved by the caller).
-#' @param alpha Numeric significance level.
+#' @param alpha Numeric significance level, or `NULL` to inherit `.alpha_of(x)`
+#'   (the level the fit's bands were built at).
 #' @param contrasts For `family = "custom"`, the `K x num_treats` contrast
 #'   matrix; `NULL` otherwise.
 #' @param has_valid_ses Logical; from `.check_for_simultaneous_cis()`.
@@ -425,6 +429,14 @@ simultaneousCIs.twfeCovs <- function(
 	warn_degenerate_highdim = TRUE
 ) {
 	# --- 1. Argument validation (mvtnorm guard deferred to step 11). ---
+	# `alpha = NULL` (the accessor default) inherits the level the fit's catt_df /
+	# displayed simultaneous bands were built at (`.alpha_of(x)`), matching
+	# `eventStudy()` and every other accessor (#324); an explicit `alpha`
+	# overrides. Internal callers (the fit-time band precompute, the event-study
+	# bounds helper) always pass an explicit `alpha`, so they are unaffected.
+	if (is.null(alpha)) {
+		alpha <- .alpha_of(x)
+	}
 	stopifnot(is.numeric(alpha), length(alpha) == 1L, alpha > 0, alpha < 1)
 	method <- match.arg(method, c("analytic", "bootstrap"))
 	# `lambda_c` is validated unconditionally (symmetric with debiasedATT()). It is

--- a/man/simultaneousCIs.Rd
+++ b/man/simultaneousCIs.Rd
@@ -8,7 +8,7 @@ treatment effects}
 simultaneousCIs(
   result,
   family = c("event_study", "cohort", "all_post_treatment", "custom"),
-  alpha = 0.05,
+  alpha = NULL,
   contrasts = NULL,
   method = c("analytic", "bootstrap"),
   B = 1000L,
@@ -27,7 +27,10 @@ or \code{"twfeCovs"}.}
 \code{"all_post_treatment"}, or \code{"custom"}. See Details for each family's
 resolution.}
 
-\item{alpha}{Numeric in \verb{(0, 1)}; significance level. Default \code{0.05}.}
+\item{alpha}{Numeric in \verb{(0, 1)}; significance level. Default \code{NULL}, which
+inherits the fit's own \code{alpha} (the level its \code{catt_df} / displayed
+simultaneous bands were built at), so \code{simultaneousCIs(fit)} reproduces the
+fit's shown simultaneous bounds. Pass an explicit value to override.}
 
 \item{contrasts}{For \code{family = "custom"}, a \verb{K x num_treats} matrix whose
 rows give the \code{K} linear combinations of the underlying per-\verb{(g, t)}

--- a/tests/testthat/test-simultaneouscis-alpha-inherit-324.R
+++ b/tests/testthat/test-simultaneouscis-alpha-inherit-324.R
@@ -1,0 +1,79 @@
+# Regression test for #324: simultaneousCIs() inherits the fit's `alpha`.
+#
+# Before the fix, the accessor hard-coded `alpha = 0.05`, so a fit built at a
+# non-default level (e.g. 0.10) showed 90% `catt_df` simultaneous bands, yet
+# `simultaneousCIs(fit)` returned 95% bands -- breaking the documented identity
+# ("the `catt_df` bounds ARE the `simultaneousCIs(fit, family=...)` bounds", the
+# `ci_type` docs) and diverging from every other accessor (`eventStudy()` already
+# resolves the level via `x$alpha`). The fix defaults `alpha = NULL` across the
+# generic + 4 S3 methods and resolves `if (is.null(alpha)) alpha <- .alpha_of(x)`
+# once in `.simultaneous_cis_impl()`, before validation.
+#
+# Mutation-checkable: reverting the signature default to `0.05` (or deleting the
+# `if (is.null(alpha)) alpha <- .alpha_of(x)` resolution) makes the inherited
+# call fall back to 0.05, failing the `sci$alpha == 0.10` and catt_df-identity
+# assertions below. All four S3 methods are byte-identical wrappers over the same
+# impl, so fetwfe + twfeCovs cover the fusion and OLS dispatch paths.
+
+make_alpha_panel <- function(seed = 101, G = 4, T = 6, d = 2, N = 200) {
+	coefs <- genCoefs(
+		G = G,
+		T = T,
+		d = d,
+		density = 0.5,
+		eff_size = 2,
+		seed = seed
+	)
+	simulateData(coefs, N = N, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = seed)
+}
+
+test_that("simultaneousCIs() inherits the fit's alpha when not supplied (#324)", {
+	sim <- make_alpha_panel()
+
+	check_inherits <- function(fit, label) {
+		# fixture invariant: the fit was built at the non-default alpha = 0.10.
+		expect_equal(fit$alpha, 0.10, info = label)
+
+		# (1) the inherited call (no `alpha`) uses the fit's 0.10, NOT the old
+		#     hard-coded 0.05.
+		sci <- simultaneousCIs(fit, family = "cohort") # method = "analytic" default
+		expect_equal(sci$alpha, 0.10, info = label)
+
+		# (2) documented identity: the inherited bounds ARE the fit's `catt_df`
+		#     simultaneous bounds (positional, cohort-block order; degenerate rows
+		#     match by construction since catt_df's bounds come from this band).
+		expect_equal(
+			sci$ci$simultaneous_ci_low,
+			fit$catt_df$ci_low,
+			info = label
+		)
+		expect_equal(
+			sci$ci$simultaneous_ci_high,
+			fit$catt_df$ci_high,
+			info = label
+		)
+
+		# (3) inherited == explicit-0.10 (the inheritance is exactly `x$alpha`).
+		sci_explicit <- simultaneousCIs(fit, family = "cohort", alpha = 0.10)
+		expect_equal(
+			sci$ci$simultaneous_ci_low,
+			sci_explicit$ci$simultaneous_ci_low,
+			info = label
+		)
+
+		# (4) an explicit alpha still overrides -> the 90% band is strictly
+		#     narrower than the 95% band on finite-SE cohorts.
+		sci05 <- simultaneousCIs(fit, family = "cohort", alpha = 0.05)
+		expect_equal(sci05$alpha, 0.05, info = label)
+		fin <- is.finite(fit$catt_df$se) & fit$catt_df$se > 0
+		skip_if_not(sum(fin) >= 1L)
+		w10 <- (sci$ci$simultaneous_ci_high - sci$ci$simultaneous_ci_low)[fin]
+		w05 <- (sci05$ci$simultaneous_ci_high - sci05$ci$simultaneous_ci_low)[
+			fin
+		]
+		expect_true(all(w10 < w05), info = label)
+	}
+
+	check_inherits(fetwfeWithSimulatedData(sim, alpha = 0.10), "fetwfe")
+	check_inherits(twfeCovsWithSimulatedData(sim, alpha = 0.10), "twfeCovs")
+})


### PR DESCRIPTION
## Summary

Fixes **#324** (a confirmed MEDIUM bug from the 2026-06-19 periodic review): `simultaneousCIs()` ignored the fit's `alpha`.

Every fit carries `x$alpha` — the level its `catt_df` / displayed simultaneous bands were built at — and the fit-time band uses it (`.finalize_ci_type(out, alpha = alpha)`). But the user-facing accessor hard-coded `alpha = 0.05`, so a fit built at a non-default level silently diverged:

```r
fit <- fetwfe(..., alpha = 0.10)          # catt_df shows 90% simultaneous bounds
simultaneousCIs(fit, family = "cohort")    # BEFORE: 95% bounds (hard-coded 0.05)
                                           # AFTER:  90% bounds (inherits x$alpha)
```

This broke the documented `ci_type` identity (the displayed bounds **are** the `simultaneousCIs(fit, family = …)` bounds) and made `simultaneousCIs()` the lone accessor not inheriting the fit's level — `eventStudy()`, `print`, `summary`, and `broom::tidy` all resolve via `.alpha_of(x)`.

## Fix

- The generic `simultaneousCIs` + all four S3 methods (`.fetwfe`/`.etwfe`/`.betwfe`/`.twfeCovs`) now default **`alpha = NULL`** (was `0.05`).
- `.simultaneous_cis_impl()` resolves `if (is.null(alpha)) alpha <- .alpha_of(x)` once, **before** the `stopifnot` validation — mirroring `eventStudy()`'s established pattern. An explicit `alpha` still overrides; the two internal callers (the fit-time precompute and the event-study bounds helper) already pass an explicit `alpha`, so they're unaffected.

Behavior change is limited to **non-default-`alpha` fits called without an explicit `alpha`** — and the previous behavior was the surprising one. Default (`alpha = 0.05`) fits are byte-identical.

## Changes
- `R/simultaneous_cis.R`: 5 signature defaults `0.05 → NULL`; the single-site resolution in the impl; `@param alpha` roxygen.
- `man/simultaneousCIs.Rd`: regenerated. **NEWS / DESCRIPTION**: 1.43.0 → 1.44.0.
- `tests/testthat/test-simultaneouscis-alpha-inherit-324.R` (new): asserts the inherited call equals the fit's `catt_df` bounds, inherited == explicit-0.10, and that explicit-0.05 still overrides (narrower band), across `fetwfe` + `twfeCovs`.

## Verification
- New test: **FAIL 0 / WARN 0 / PASS 14** (~1s).
- Full suite: **FAIL 0** (default-`alpha` fits unchanged; the #204 explicit-`alpha` test still passes).
- `R CMD check --as-cran` (with vignettes): 0 ERROR / 0 WARN, benign NOTEs only.
- **Mutation check** (bit, reverted): reverting the resolution to the hard-coded `0.05` fails the new test (FAIL 10).
- Independent multi-agent post-exec review (3 lenses: completeness/regression, sibling-hunt/edge-cases, test/docs).

Closes #324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
