### PR TITLE
fix: high-dim lambda_c="cv" band uses offset-resolved cohort sizes for scattered adoption (#323)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.44.0
+Version: 1.45.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,23 @@
 # NEWS
 
+## Version 1.45.0
+
+### Bug fixes
+
+- `simultaneousCIs(method = "bootstrap", lambda_c = "cv")` now selects its
+  nodewise penalty constant on the correct overall-ATT direction under **scattered
+  (non-consecutive) cohort adoption**. The cross-validation direction `a_att` was
+  built with hard-coded consecutive-adoption per-cohort sizes `(T - 1):(T - G)`,
+  which under scattered offsets both mis-weight and overrun the treatment-effect
+  index, so the band cross-validated a different penalty constant than
+  `debiasedATT()` — silently breaking the documented "one `lambda_c` for the point
+  estimate and the band" guarantee (the band center no longer equalled
+  `debiasedATT()$att`). It now uses the offset-resolved sizes
+  `diff(c(first_inds, num_treats + 1L))`, matching `debiasedATT()`. Consecutive
+  adoption (the common case) and the default `lambda_c = 1.0` are byte-identical;
+  this only affected the experimental `lambda_c = "cv"` path on scattered data
+  (#323).
+
 ## Version 1.44.0
 
 ### Bug fixes

--- a/R/simultaneous_bootstrap.R
+++ b/R/simultaneous_bootstrap.R
@@ -584,12 +584,13 @@
 		# desparsification (#309) -- so they do ONE O(NT p^2) crossprod, not several.
 		Sig_hd <- crossprod(X_final) / n
 		# Resolve the node-penalty constant ONCE on the overall-ATT direction (#295
-		# D2: one `lambda_c` serves the point estimate AND every band effect). For the
-		# common consecutive-cohort layout `a_att` equals debiasedATT()'s direction
-		# exactly (same fit's Sig / X / data-derived seed), so the band center matches
-		# `debiasedATT()$att` under `lambda_c = "cv"`; for scattered adoption times
-		# high-dim debiasedATT() is unsupported (it errors at its identity guard), so
-		# only the band runs and CVs on its own correct direction. Each effect's
+		# D2: one `lambda_c` serves the point estimate AND every band effect). `a_att`
+		# is built (in `.simultaneous_cis_impl`) with the offset-resolved per-cohort
+		# block sizes, the SAME construction debiasedATT() uses, so it equals
+		# debiasedATT()'s direction exactly -- and the band center matches
+		# `debiasedATT()$att` under `lambda_c = "cv"` for BOTH consecutive and
+		# scattered (non-consecutive) adoption (#318 made debiasedATT() support
+		# scattered; #323 aligned this CV direction with it). Each effect's
 		# `lambda_node_k` then scales the shared constant by its own `max(|a_k|)`
 		# inside `.build_regression_if_highdim()`. The SAME resolved `lambda_c_used`
 		# also scales the #309 per-cell propensity directions below -- D2's "one

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -735,16 +735,21 @@ simultaneousCIs.twfeCovs <- function(
 			}
 			# Overall-ATT theta-space direction (cohort_probs-weighted), the direction
 			# the shared CV penalty constant is selected on (#295 D2: one lambda_c for
-			# point + band). For the common consecutive-cohort layout this equals
-			# debiasedATT()'s `a_th` exactly (same A / cohort_probs / first_inds), so
-			# the CV'd constant -- hence the band center -- matches debiasedATT() under
-			# `lambda_c = "cv"`. (For scattered adoption times the two use different
-			# `first_inds` -- getFirstInds() in debiasedATT() vs the offset resolver
-			# here -- but high-dim debiasedATT() is unsupported there anyway: it errors
-			# at its ATT-identity guard, so no shared-constant divergence can ship and
-			# the band simply CVs on its own correct direction.)
+			# point + band). Built with the offset-resolved per-cohort block sizes
+			# `diff(c(first_inds, num_treats + 1L))` -- the SAME construction
+			# debiasedATT() uses (R/debiased_att.R) -- so the CV'd constant, hence the
+			# band center, matches debiasedATT() under `lambda_c = "cv"`, including for
+			# scattered (non-consecutive) adoption, which #318 made debiasedATT()
+			# support. A hard-coded `(T_ - 1):(T_ - G)` assumes consecutive adoption and
+			# under scattered offsets both mis-weights AND overruns `treat_inds` (its
+			# sizes can sum past num_treats), so the band would CV a wrong/fallback
+			# constant and diverge from debiasedATT() (#323). For consecutive adoption
+			# the resolved sizes reduce to `(T_ - 1):(T_ - G)`, so this is byte-identical.
 			a_beta_att <- numeric(p)
-			cohort_of_treat <- rep(seq_len(G), times = (T_ - 1):(T_ - G))
+			cohort_of_treat <- rep(
+				seq_len(G),
+				times = diff(c(first_inds, num_treats + 1L))
+			)
 			for (g in seq_len(G)) {
 				idx <- treat_inds[cohort_of_treat == g]
 				a_beta_att[idx] <- x$cohort_probs[g] / length(idx)

--- a/tests/testthat/test-aatt-scattered-cv-323.R
+++ b/tests/testthat/test-aatt-scattered-cv-323.R
@@ -1,0 +1,113 @@
+# Regression test for #323: the high-dim `lambda_c = "cv"` band must CV its penalty
+# constant on the SAME overall-ATT direction debiasedATT() uses, INCLUDING under
+# scattered (non-consecutive) cohort adoption.
+#
+# `.simultaneous_cis_impl()` built the CV-selection direction `a_att` with hard-coded
+# consecutive-adoption block sizes `(T-1):(T-G)`. Under scattered adoption (offsets
+# 2,4,7 here) the real per-cohort sizes differ -- (7,5,2) vs the consecutive (7,6,5)
+# -- and the consecutive sizes both mis-weight AND OVERRUN `treat_inds` (they sum to
+# 18 > num_treats = 14), so the band CV'd a wrong/fallback constant and diverged from
+# debiasedATT(). #318 had made debiasedATT() support scattered cohorts, invalidating
+# the stale comment that claimed "debiasedATT() errors on scattered, so no divergence
+# can ship". The fix uses `diff(c(first_inds, num_treats + 1L))` (the resolver's
+# sizes, matching debiased_att.R) -- byte-identical on consecutive adoption.
+#
+# Mutation-checkable: reverting the construction at R/simultaneous_cis.R to
+# `(T-1):(T-G)` makes the band CV a different constant on this scattered fit, so the
+# overall-ATT band center no longer equals debiasedATT(lambda_c = "cv")$att (the #295
+# "one constant for point + band" identity) -> the final expect_equal FAILs.
+
+.mk_panel_323 <- function(
+	adopt = c(2L, 4L, 7L),
+	d = 10L,
+	N = 24L,
+	T = 8L,
+	seed = 5
+) {
+	set.seed(seed)
+	covs <- matrix(stats::rnorm(N * d), N, d)
+	cohort_of_unit <- c(
+		rep(0L, N - 3L * 6L),
+		rep(adopt[1], 6),
+		rep(adopt[2], 6),
+		rep(adopt[3], 6)
+	)
+	eff <- stats::setNames(c(0.5, 2.0, 3.5), as.character(adopt))
+	do.call(
+		rbind,
+		lapply(seq_len(N), function(i) {
+			g <- cohort_of_unit[i]
+			df <- data.frame(
+				unit = sprintf("u%02d", i),
+				year = 1:T,
+				treat = as.integer(g > 0 & (1:T) >= g)
+			)
+			for (j in 1:d) {
+				df[[paste0("x", j)]] <- covs[i, j]
+			}
+			te <- if (g > 0) eff[[as.character(g)]] else 0
+			df$y <- 0.3 *
+				(1:T) /
+				T +
+				te * df$treat +
+				0.2 * covs[i, 1] +
+				stats::rnorm(T, 0, 0.4)
+			df
+		})
+	)
+}
+
+test_that("high-dim lambda_c='cv' band CVs the same constant as debiasedATT() on scattered cohorts (#323)", {
+	fit <- fetwfe(
+		pdata = .mk_panel_323(),
+		time_var = "year",
+		unit_var = "unit",
+		treatment = "treat",
+		covs = paste0("x", 1:10),
+		response = "y",
+		q = 0.5,
+		verbose = FALSE,
+		gls = FALSE
+	)
+	# fixture invariants: genuinely high-dim full design + scattered adoption.
+	expect_gte(ncol(fit$internal$X_final), nrow(fit$internal$X_final))
+	G <- fit$G
+	T_ <- fit$T
+	num_treats <- length(fit$treat_inds)
+	first_inds <- fetwfe:::.resolve_cohort_offsets_and_first_inds(
+		fit,
+		G = G,
+		T = T_
+	)$first_inds
+	sizes <- diff(c(first_inds, num_treats + 1L))
+	# the bug's root: the resolved sizes differ from the consecutive assumption AND
+	# the consecutive sizes overrun treat_inds under scattered adoption.
+	expect_identical(as.integer(sizes), c(7L, 5L, 2L))
+	expect_false(identical(as.integer(sizes), as.integer((T_ - 1L):(T_ - G))))
+	expect_gt(sum((T_ - 1L):(T_ - G)), num_treats)
+
+	# overall-ATT custom contrast, built with the CORRECT resolved sizes.
+	cohort_of_treat <- rep(seq_len(G), times = sizes)
+	contrast <- numeric(num_treats)
+	for (g in seq_len(G)) {
+		idx <- which(cohort_of_treat == g)
+		contrast[idx] <- fit$cohort_probs[g] / length(idx)
+	}
+	expect_equal(sum(contrast), sum(fit$cohort_probs[seq_len(G)]))
+
+	sc <- suppressWarnings(simultaneousCIs(
+		fit,
+		family = "custom",
+		contrasts = matrix(contrast, nrow = 1L),
+		method = "bootstrap",
+		B = 200,
+		seed = 1,
+		lambda_c = "cv"
+	))
+	expect_identical(sc$regime, "high-dimensional")
+	db <- debiasedATT(fit, lambda_c = "cv")
+	# #295 identity: one CV'd lambda_c serves point + band, so the overall-ATT band
+	# center equals debiasedATT()$att. The buggy consecutive-size a_att CVs a
+	# different constant on scattered data and breaks this.
+	expect_equal(sc$ci$estimate, db$att, tolerance = 1e-7)
+})


### PR DESCRIPTION
## Summary

Fixes **#323** (a confirmed MEDIUM bug from the 2026-06-19 periodic review): the high-dimensional `simultaneousCIs(method = "bootstrap", lambda_c = "cv")` band cross-validated its penalty constant on a **consecutive-adoption** overall-ATT direction, so it diverged from `debiasedATT()` under **scattered (non-consecutive) cohort adoption**.

`.simultaneous_cis_impl()` built the CV-selection direction `a_att` with hard-coded per-cohort block sizes `(T - 1):(T - G)` — correct only for consecutive adoption. Under scattered offsets (e.g. adoption years 2, 4, 7) the real sizes differ — `(7, 5, 2)` vs the consecutive `(7, 6, 5)` — and the consecutive sizes both **mis-weight and overrun** the treatment-effect index (they sum to 18 > `num_treats` = 14). So the band CV'd a wrong/fallback constant, silently breaking the documented #295 guarantee that one `lambda_c` serves both the point estimate and the band (the band center no longer equalled `debiasedATT()$att`).

The guarding comment claimed this "can't ship" because high-dim `debiasedATT()` *errors* on scattered cohorts — but **#318 made it work**, so the premise was stale and the divergence shipped.

## Fix

Use the offset-resolved sizes `diff(c(first_inds, num_treats + 1L))` — the **same construction `debiasedATT()` uses** (`R/debiased_att.R`). `first_inds` here is already the `.resolve_cohort_offsets_and_first_inds()` output. For consecutive adoption the resolved sizes reduce to `(T - 1):(T - G)`, so the change is **byte-identical** there; only the experimental `lambda_c = "cv"` path on scattered data changes. The default `lambda_c = 1.0` never touches `a_att`, so it's unaffected. The duplicated stale comment in `R/simultaneous_bootstrap.R` is corrected too.

## Changes
- `R/simultaneous_cis.R`: `a_att` uses the resolved per-cohort sizes; corrected comment.
- `R/simultaneous_bootstrap.R`: corrected the duplicated stale comment.
- `tests/testthat/test-aatt-scattered-cv-323.R` (new, ~1.5s, runs on CRAN like the sibling #295/#318 tests): a scattered high-dim fixture (offsets 2,4,7) asserting (a) the resolved sizes `(7,5,2)` differ from and are overrun by the consecutive `(7,6,5)`, and (b) the **#295 identity** — the overall-ATT custom-contrast band center under `lambda_c = "cv"` equals `debiasedATT(lambda_c = "cv")$att` (observed `|diff| = 0`).
- **NEWS / DESCRIPTION**: 1.44.0 → 1.45.0.

## Verification
- New test: **FAIL 0 / PASS 7** (~1.5s).
- Empirically reproduced the bug: with the consecutive sizes the band CV'd `lambda_node ≈ 0.484`; the fix gives `≈ 0.363`, and the overall-ATT band center then matches `debiasedATT()$att` exactly.
- Full suite: **FAIL 0** (consecutive-adoption fixtures byte-identical).
- `R CMD check --as-cran` (with vignettes): 0 ERROR / 0 WARN, benign NOTEs only.
- **Mutation check** (bit, reverted): reverting to `(T - 1):(T - G)` fails the #295 identity assertion (FAIL 1).
- Independent post-exec review: **APPROVE** — independently reproduced the bug and the `0.000e+00` match to `debiasedATT()` on scattered data, confirmed byte-identity on consecutive, and a **sibling hunt confirmed line 749 was the only hard-coded `(T-1):(T-G)` in production** (the `cell_targets` / `j_cells` / #309 propensity channels already use the resolver), with the fix aligning *every* family (event-study scattered `cv` now selects the same `lambda_c` as `debiasedATT()`).

Closes #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
