### PR TITLE
chore: 2026-06-19 review cleanup sweep — paper anchors, DRY, eventStudy message (#325)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.46.0
+Version: 1.47.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # NEWS
 
+## Version 1.47.0
+
+### Improvements
+
+- `eventStudy()` now names the offending class when called on an unsupported
+  object (e.g. `Got class: lm`), matching `cohortStudy()`'s error and making
+  misuse easier to debug (#325).
+
+### Internal
+
+- Cleanup batch from the 2026-06-19 periodic review (#325): corrected stale paper
+  cross-references in the ATT-variance machinery (the estimated-propensity variance
+  term now points to Theorem 6.4(b) / eq. `v.n.r.t.att.rand`, and the cohort-share
+  Jacobian to the proof of Theorem 6.1 — both verified against `paper_arxiv.tex`);
+  de-duplicated the `in_sample_counts` named/unique validation into a single helper;
+  removed two dead commented-out parameters; and documented the `riesz_lasso`
+  feasibility-certificate and bootstrap degeneracy semantics to prevent future
+  mis-"fixes". No change to estimates, standard errors, or returned values.
+
 ## Version 1.46.0
 
 ### Improvements

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -90,7 +90,11 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 		return(.event_study_etwfe_betwfe(x, alpha, ci_type))
 	}
 	stop(
-		"eventStudy() requires an object of class 'fetwfe', 'etwfe', or 'betwfe'."
+		"eventStudy() requires an object of class 'fetwfe', 'etwfe', or ",
+		"'betwfe'. Got class: ",
+		paste(class(x), collapse = ", "),
+		".",
+		call. = FALSE
 	)
 }
 

--- a/R/input_prep.R
+++ b/R/input_prep.R
@@ -3,6 +3,30 @@
 # the input validation, design-matrix prep, and cohort-probability helpers that
 # run before the GLS step (see R/gls_machinery.R).
 
+#' @title Validate that `in_sample_counts` is fully named with unique names
+#' @description `prep_for_etwfe_core()` and `check_etwfe_core_inputs()` both
+#'   require `in_sample_counts` to have one uniquely-named entry per cohort.
+#'   Factored out of the two byte-identical validation blocks (#325) so the
+#'   error message lives in a single place.
+#' @param in_sample_counts The (named) count vector to validate.
+#' @return `invisible(NULL)`; errors via `stop()` if the names are missing or
+#'   non-unique.
+#' @keywords internal
+#' @noRd
+.validate_in_sample_counts_named_unique <- function(in_sample_counts) {
+	nm <- names(in_sample_counts)
+	if (
+		length(nm) != length(in_sample_counts) ||
+			length(nm) != length(unique(nm))
+	) {
+		stop(
+			"in_sample_counts must have all unique named entries (with names corresponding to the names of each cohort)",
+			call. = FALSE
+		)
+	}
+	invisible(NULL)
+}
+
 #' @title Prepare Transformed Design Matrix and Response for ETWFE Regression
 #'
 #' @description
@@ -353,19 +377,7 @@ prep_for_etwfe_core <- function(
 			"No never-treated units detected in data to fit model; estimating treatment effects is not possible"
 		)
 	}
-	if (length(names(in_sample_counts)) != length(in_sample_counts)) {
-		stop(
-			"in_sample_counts must have all unique named entries (with names corresponding to the names of each cohort)"
-		)
-	}
-	if (
-		length(names(in_sample_counts)) !=
-			length(unique(names(in_sample_counts)))
-	) {
-		stop(
-			"in_sample_counts must have all unique named entries (with names corresponding to the names of each cohort)"
-		)
-	}
+	.validate_in_sample_counts_named_unique(in_sample_counts)
 	if (indep_count_data_available) {
 		if (sum(indep_counts) != N) {
 			stop(
@@ -612,20 +624,7 @@ check_etwfe_core_inputs <- function(
 			"No never-treated units detected in data to fit model; estimating treatment effects is not possible"
 		)
 	}
-	if (length(names(in_sample_counts)) != length(in_sample_counts)) {
-		stop(
-			"in_sample_counts must have all unique named entries (with names corresponding to the names of each cohort)"
-		)
-	}
-
-	if (
-		length(names(in_sample_counts)) !=
-			length(unique(names(in_sample_counts)))
-	) {
-		stop(
-			"in_sample_counts must have all unique named entries (with names corresponding to the names of each cohort)"
-		)
-	}
+	.validate_in_sample_counts_named_unique(in_sample_counts)
 
 	# Mirror prep_for_etwfe_core()'s friendly message (#208) so that whichever
 	# validator fires first, the user sees the same actionable text rather than

--- a/R/riesz_lasso.R
+++ b/R/riesz_lasso.R
@@ -39,7 +39,10 @@ riesz_lasso <- function(Sig, a, lambda, max_iter = 5000L, tol = 1e-9) {
 		max_change <- 0
 		for (j in seq_len(p)) {
 			if (dgSig[j] <= 0) {
-				next # all-zero column: leave v_j = 0
+				# All-zero (or non-positive-diagonal) Gram column: leave v_j = 0.
+				# Its residual |Sv - a|_j = |a_j| still enters `feasibility` below --
+				# see the note there; this is intentional, not an oversight.
+				next
 			}
 			cj <- Sv[j] - dgSig[j] * v[j] # (Sig v)_j without the j-th term
 			rho <- a[j] - cj
@@ -59,6 +62,16 @@ riesz_lasso <- function(Sig, a, lambda, max_iter = 5000L, tol = 1e-9) {
 			break
 		}
 	}
+	# Feasibility certificate ||Sig v - a||_inf, the KKT residual. Semantics note
+	# (#325): the max is taken over ALL p coordinates, INCLUDING any skipped
+	# zero-diagonal columns (whose residual is the full |a_j|). This is deliberate:
+	# a zero Gram column with a nonzero target means the Riesz representer genuinely
+	# does not exist in that coordinate, so the constraint truly cannot be met and
+	# reporting infeasibility is correct. Do NOT "fix" this by restricting the max
+	# to active (`dgSig > 0`) coordinates -- that would mask a real infeasibility and
+	# let an undefined direction pass the gate. Unreachable from the real pipeline
+	# (the full design's `min(diag(Sig))` is bounded well above 0), so this guards a
+	# theoretical corner, not an observed one.
 	attr(v, "feasibility") <- max(abs(Sv - a)) # ||Sig v - a||_inf
 	attr(v, "iters") <- it
 	attr(v, "converged") <- converged # FALSE => lambda likely too small

--- a/R/simultaneous_bootstrap.R
+++ b/R/simultaneous_bootstrap.R
@@ -773,6 +773,16 @@
 	# effect `boot_max` is NULL and the band uses the exact qnorm crit, so the
 	# matching dual is the two-sided normal p-value 2 * pnorm(-|z|) (mirrors the
 	# analytic K = 1 path; keeps "outside band iff adjusted p < alpha" exact).
+	# Degeneracy semantics (#325): the band endpoints use `ses` directly (finite
+	# for every effect), while the adjusted p-value gates on `bc$nondeg` (the
+	# combined-column-sum test `col_ss > var_tol`). So a near-zero-variance effect
+	# classified degenerate (`nondeg = FALSE`) still gets a finite -- but near-
+	# zero-width -- band from its tiny `ses`, yet an `NA` adjusted p-value: the
+	# package's degenerate-effect convention (a collapsed band, no p-value), not an
+	# inconsistency. The two gates cannot disagree the other way: `nondeg` implies
+	# `col_ss > 0`, and `ses^2 = (cadjust*css_reg + css_pi)/n^2 >= col_ss/n^2 > 0`
+	# since `cadjust >= 1`, so `ses > 0` whenever `nondeg` -- the `& ses > 0` here is
+	# a defensive belt against floating-point only.
 	t_stat <- ifelse(bc$nondeg & ses > 0, abs(estimates_used) / ses, NA_real_)
 	adjusted_p_values <- if (is.null(bc$boot_max)) {
 		2 * stats::pnorm(-abs(t_stat))

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -116,7 +116,6 @@
 #' @keywords internal
 #' @noRd
 getTeResultsOLS <- function(
-	# model,
 	sig_eps_sq,
 	N,
 	T,
@@ -267,7 +266,8 @@ getSecondVarTermOLS <- function(
 
 	# Construct Jacobian matrix corresponding to the mapping from the
 	# individual cohort probabilities to the proportions calculated for the ATT.
-	# See Proof of Theorem 6.1 for form. Consolidated into `.build_jacobian()`
+	# See the Proof of Theorem 6.1 (Consistency of FETWFE), paper_arxiv.tex:2678,
+	# for the explicit form (verified #325). Consolidated into `.build_jacobian()`
 	# (#192, WORKFLOW_LESSONS §14 Class A); the OLS-family path (d_inv = NULL)
 	# returns the G x G column-indexed Jacobian byte-identically.
 	jacobian_mat <- .build_jacobian(
@@ -283,7 +283,10 @@ getSecondVarTermOLS <- function(
 	stopifnot(length(tes) == nrow(psi_mat))
 
 	# Finally, calculate variance term for ATT from Sigma_pi_hat, Jacobian
-	# matrix, psi_mat, and beta_hat. See proof of Theorem D.2 for details.
+	# matrix, psi_mat, and beta_hat. This is the estimated-propensity variance
+	# term: see Theorem 6.4(b) (Asymptotic Confidence Intervals for FETWFE),
+	# eq. (v.n.r.t.att.rand) at paper_arxiv.tex:2876, for details (was a stale
+	# "Theorem D.2" reference; corrected #325).
 
 	# Issue #127: floor `att_var_2` at zero, mirroring the `att_var_1`
 	# floor PR #111 added at the analogous sibling sites in this file. The
@@ -631,7 +634,6 @@ getPsiGUnfused <- function(
 #' @keywords internal
 #' @noRd
 getTeResults2 <- function(
-	# model,
 	sig_eps_sq,
 	N,
 	T,
@@ -959,7 +961,8 @@ getSecondVarTermDataApp <- function(
 	stopifnot(nrow(Sigma_pi_hat) == G)
 	stopifnot(ncol(Sigma_pi_hat) == G)
 
-	# Jacobian (paper Theorem 6.3, paper_arxiv.tex:2577-2592):
+	# Jacobian (paper Theorem 6.1 proof, paper_arxiv.tex:2678; was a stale
+	# "Theorem 6.3 / 2577-2592" reference, corrected #325):
 	##
 	## J_{rs} =  (S-pi_g)/S^2      if g = s
 	##           -pi_s   /S^2      if g != s    (off-diagonal uses COLUMN index s)
@@ -1022,9 +1025,10 @@ getSecondVarTermDataApp <- function(
 #' `simultaneousCIs()` call site into one helper (WORKFLOW_LESSONS section 14 Class A:
 #' the third copy triggers a refactor). All four sites implement the same
 #' delta-method gradient of \eqn{f_g(\pi)=\pi_g/\sum_k \pi_k}; the column-index
-#' off-diagonal coefficient \eqn{J_{rs}=-\pi_s/S^2} matches paper Theorem 6.3
-#' (`paper_arxiv.tex:2577-2592`). Prior to v1.8.0 the off-diagonal used the
-#' outer-loop row index; see issue #46.
+#' off-diagonal coefficient \eqn{J_{rs}=-\pi_s/S^2} matches the explicit Jacobian
+#' in the proof of paper Theorem 6.1 (`paper_arxiv.tex:2678`; was a stale
+#' "Theorem 6.3 / 2577-2592" reference, corrected #325). Prior to v1.8.0 the
+#' off-diagonal used the outer-loop row index; see issue #46.
 #' @param cohort_probs_overall Numeric vector of length `G`; marginal cohort
 #'   probabilities P(W = g). For `mode = "per_effect_masked"` the caller passes
 #'   the full (un-masked) vector; this helper masks to `V_e` internally.

--- a/man/tidy.debiased_att.Rd
+++ b/man/tidy.debiased_att.Rd
@@ -17,5 +17,7 @@ A one-row data frame with columns \code{term}, \code{estimate}, \code{std.error}
 }
 \description{
 One-row \code{broom::tidy()} data frame for a \code{\link[=debiasedATT]{debiasedATT()}} result,
-matching the \code{tidy.simultaneous_cis} column convention.
+following the package's \code{broom} column convention (\code{term}, \code{estimate},
+\code{std.error}, \code{conf.low}, \code{conf.high}) -- the same columns \code{tidy.fetwfe()} /
+\code{tidy.eventStudy()} return.
 }

--- a/tests/testthat/test-cleanup-review-325.R
+++ b/tests/testthat/test-cleanup-review-325.R
@@ -1,0 +1,37 @@
+# Regression tests for the behavior-touching items of the 2026-06-19 review
+# cleanup sweep (#325). The other items (theorem-anchor corrections, the dead
+# `# model,` comments, the riesz_lasso feasibility-semantics comment, the
+# col_ss/ses degeneracy comment) are comment-only and carry no testable behavior.
+
+test_that("eventStudy() dispatch error echoes the offending class (#325 item 4)", {
+	# Matches the cohortStudy() sibling pattern: the message names the class it got.
+	expect_error(
+		eventStudy(42L),
+		"requires an object of class.*Got class: integer",
+		fixed = FALSE
+	)
+	expect_error(
+		eventStudy(structure(list(), class = "lm")),
+		"Got class: lm",
+		fixed = FALSE
+	)
+	# a genuinely fitted object still dispatches (no error from the guard).
+	# (covered elsewhere; here we only pin the failure message.)
+})
+
+test_that(".validate_in_sample_counts_named_unique enforces named + unique (#325 item 3)", {
+	validate <- fetwfe:::.validate_in_sample_counts_named_unique
+	msg <- "must have all unique named entries"
+
+	# valid: fully named, unique -> silent (returns invisibly).
+	expect_silent(validate(c(a = 5L, b = 3L, c = 2L)))
+	expect_null(validate(c(a = 5L, b = 3L)))
+
+	# unnamed -> error (names() is NULL, length 0 != length(x)). This and the
+	# duplicate-names case are exactly what the original two inline blocks caught;
+	# a single empty name among otherwise-named entries is NOT caught by either the
+	# old code or the helper (byte-faithful refactor), so it is not asserted here.
+	expect_error(validate(c(5L, 3L, 2L)), msg)
+	# duplicate names -> error.
+	expect_error(validate(c(a = 5L, a = 3L)), msg)
+})


### PR DESCRIPTION
## Summary

Cleanup sweep from the 2026-06-19 periodic review (#325). Comment/doc corrections, one small DRY refactor, and two user-visible error-message improvements. **No change to estimates, standard errors, or returned values.**

## Items

**1. Stale theorem anchors in the ATT-variance machinery — verified against `paper_arxiv.tex`, and the issue's suggestion was partly *wrong*.** The issue proposed changing `getSecondVarTermOLS()`'s Jacobian anchor (`R/variance_machinery.R:270`) from "Theorem 6.1" to "Theorem 6.3". I read the paper before touching anything (the don't-fix-on-a-number-match rule):
  - The **explicit Jacobian form** (`J_{rs} = -π_s/S²`, column-index) is derived in the **Proof of Theorem 6.1 (Consistency)**, `paper_arxiv.tex:2678`. So line 270's "Theorem 6.1" was **already correct** — the issue's "→ 6.3" would have introduced an error (Theorem 6.3 is the *Oracle Property*). **Left as-is** (added the precise line anchor).
  - The **variance term** the function computes *is* stale-anchored: `v.n.r.t.att.rand` is the estimated-propensity variance estimator in **Theorem 6.4(b)** (Asymptotic CIs), `paper_arxiv.tex:2876` — the old "Theorem D.2" doesn't exist. **Fixed → 6.4(b).**
  - The *actually*-stale Jacobian citations were the parallel ones at `:962`/`:1025` ("Theorem 6.3 / 2577-2592" — same Jacobian object, wrong theorem and wrong lines). **Fixed → Theorem 6.1 proof / :2678** for consistency with line 270.

**2.** Removed two dead commented-out `# model,` parameters (`getTeResultsOLS`, `getTeResults2`).

**3.** De-duplicated the `in_sample_counts` named/unique validation (4 copies of one error string across two functions) into a single `.validate_in_sample_counts_named_unique()` helper. Byte-faithful: it catches exactly what the originals did (fully-unnamed + duplicate names; a lone empty name among named entries was never caught, and still isn't).

**4.** `eventStudy()`'s dispatch `stop()` now names the offending class (`Got class: lm`), matching the `cohortStudy()` sibling and adding `call. = FALSE`.

**5.** Documented the `riesz_lasso` feasibility-certificate semantics: a skipped zero-diagonal column's residual *intentionally* still enters `feasibility` (a zero Gram column with nonzero target means the representer genuinely doesn't exist) — a guard comment so a future reader doesn't "fix" it by restricting the max to active coordinates and mask a real infeasibility.

**7.** Documented the bootstrap degeneracy semantics: the band uses finite `ses` while the adjusted p-value gates on `nondeg` (`col_ss`), so a near-zero-variance effect gets a collapsed band + `NA` p-value (the package convention), and the two gates cannot disagree the other way (`cadjust >= 1` ⇒ `ses > 0` whenever `nondeg`).

**Item 6 (WORDLIST)** is deferred to **#301** per the issue ("listed here only for completeness").

Incidentally syncs `man/tidy.debiased_att.Rd` to its roxygen (a latent roxygen↔man drift from #326 — the source had the corrected wording but the man page wasn't regenerated).

## Verification
- New test `test-cleanup-review-325.R` (the two behavior items): **FAIL 0 / PASS 6**; both **mutation-checked** (revert the `eventStudy` class echo or neuter the validator → the asserts fail, FAIL 4).
- Full suite: **FAIL 0**.
- `R CMD check --as-cran` (with vignettes): 0 ERROR / 0 WARN, benign NOTEs only.
- NEWS / DESCRIPTION: 1.46.0 → 1.47.0.
- The paper cross-reference corrections are the load-bearing claim — please sanity-check the four anchors against `paper_arxiv.tex` (lines 2678 for the Jacobian / Theorem 6.1 proof, 2876 for `v.n.r.t.att.rand` / Theorem 6.4(b)).

Closes #325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
