### PR TITLE
feat: targeted-sparsity mode for genCoefs() (high-dim p>=NT coverage DGP) (#332)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.47.0
+Version: 1.48.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,25 @@
 # NEWS
 
+## Version 1.48.0
+
+### Improvements
+
+- `genCoefs()` / `genCoefsCore()` gain a **targeted-sparsity mode** via two new
+  (mutually exclusive) arguments, `n_signal_cohorts` and `treat_base_levels`. It
+  places a small, controllable, **heterogeneous** treatment-effect signal on the
+  per-cohort fused base levels (with the covariate / interaction block left at
+  zero), producing a coefficient vector that is simultaneously sparse
+  (`||theta||_0` equal to the signal count) and non-degenerate (overall ATT
+  `!= 0` and positive cohort-weight variance `V2 > 0`). This is the
+  data-generating process the high-dimensional (`p >= NT`) desparsified /
+  nodewise debiased-ATT coverage study needs — which the default uniform-`density`
+  placement cannot produce, because at `p >> num_treats` it almost never lands
+  signal on the tiny treatment-effect coordinate block (#332). The default
+  uniform-`density` behavior (both new arguments `NULL`) is unchanged and
+  byte-identical. `n_signal_cohorts = k` is the count convenience (a deterministic
+  staircase on `k` cohorts); `treat_base_levels` gives explicit per-cohort fused
+  base levels. `simulateData()` / `getTes()` consume the result unchanged.
+
 ## Version 1.47.0
 
 ### Improvements

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -3,6 +3,88 @@
 # `getTes()` / `getActualCohortTes()`. Moved from R/gen_funcs.R in
 # 1.9.25.
 
+#' @title Validate the targeted-sparsity arguments of `genCoefs()` (#332)
+#' @description Shared, RNG-free validation of `n_signal_cohorts` /
+#'   `treat_base_levels` for `genCoefs()` and `genCoefsCore()`. Both `NULL`
+#'   (the default) is the uniform-`density` mode and is accepted silently. The
+#'   numeric non-degeneracy of the resulting cohort effects (`att != 0`,
+#'   `V2 > 0`) is enforced separately by a build-time assertion in
+#'   `genCoefsCore()` once `beta` is assembled.
+#' @param n_signal_cohorts `NULL`, or a length-1 value coercible to a positive
+#'   integer in `1..(G - 1)` (the count of signal cohorts beyond the baseline).
+#' @param treat_base_levels `NULL`, or a finite numeric vector of length `G`.
+#' @param G Integer; the resolved cohort count.
+#' @return `invisible(NULL)`; errors via `stop()` on an invalid spec.
+#' @keywords internal
+#' @noRd
+.validate_targeted_sparsity <- function(
+	n_signal_cohorts,
+	treat_base_levels,
+	G
+) {
+	if (is.null(n_signal_cohorts) && is.null(treat_base_levels)) {
+		return(invisible(NULL)) # uniform-`density` mode
+	}
+	if (!is.null(n_signal_cohorts) && !is.null(treat_base_levels)) {
+		stop(
+			"genCoefs(): supply at most one of `n_signal_cohorts` or ",
+			"`treat_base_levels` (the count convenience OR the explicit ",
+			"per-cohort base-level vector), not both.",
+			call. = FALSE
+		)
+	}
+	if (G < 2) {
+		stop(
+			"genCoefs(): targeted sparsity requires G >= 2 (cross-cohort ",
+			"heterogeneity, V2 > 0, needs at least two cohorts).",
+			call. = FALSE
+		)
+	}
+	if (!is.null(n_signal_cohorts)) {
+		k <- n_signal_cohorts
+		if (
+			!is.numeric(k) ||
+				length(k) != 1L ||
+				!is.finite(k) ||
+				k != round(k) ||
+				k < 1
+		) {
+			stop(
+				"genCoefs(): `n_signal_cohorts` must be a single positive ",
+				"integer.",
+				call. = FALSE
+			)
+		}
+		if (k > G - 1) {
+			stop(
+				"genCoefs(): `n_signal_cohorts` (",
+				as.integer(k),
+				") must be ",
+				"<= G - 1 (",
+				G - 1,
+				"): at least one cohort must stay at the ",
+				"baseline for the cohort effects to be heterogeneous (V2 > 0).",
+				call. = FALSE
+			)
+		}
+	} else {
+		if (
+			!is.numeric(treat_base_levels) ||
+				length(treat_base_levels) != G ||
+				any(!is.finite(treat_base_levels))
+		) {
+			stop(
+				"genCoefs(): `treat_base_levels` must be a finite numeric vector ",
+				"of length G (",
+				G,
+				"), one fused base level per cohort.",
+				call. = FALSE
+			)
+		}
+	}
+	invisible(NULL)
+}
+
 #' Generate Coefficient Vector for Data Generation
 #'
 #' This function generates a coefficient vector \code{beta} for simulation studies of the fused
@@ -91,6 +173,35 @@
 #'   downstream differences (without simultaneously cranking the linear
 #'   angle). Ignored when \code{assignment_interactions = NULL}. New in
 #'   1.14.1.
+#' @param n_signal_cohorts (Optional) Targeted-sparsity mode (#332). A single
+#'   positive integer \code{k} in \code{1..(G - 1)}. When supplied, the
+#'   coefficient vector is built \emph{deterministically} with the treatment
+#'   signal placed on exactly \code{k} cohorts' fused base levels (and the
+#'   covariate / interaction blocks left at zero), giving \code{||theta||_0 = k}
+#'   non-zeros with a guaranteed non-zero, \emph{heterogeneous} cohort effect
+#'   (overall ATT \eqn{\neq 0} and positive cohort-weight variance \eqn{V_2 > 0}).
+#'   This produces the simultaneously sparse and non-degenerate
+#'   high-dimensional (\eqn{p \ge NT}) data-generating process the desparsified /
+#'   nodewise debiased-ATT coverage study needs, which the default uniform
+#'   \code{density} placement cannot (it almost never lands signal on the tiny
+#'   treatment-effect coordinate block). Cohort 1 is held at the baseline and
+#'   cohorts \code{2..(k + 1)} receive the distinct magnitudes
+#'   \code{eff_size * (1, 2, ..., k)} (so \code{eff_size} must be non-zero).
+#'   Defaults to \code{NULL}; \code{NULL} (with \code{treat_base_levels = NULL})
+#'   is the unchanged, byte-identical uniform-\code{density} behavior. Mutually
+#'   exclusive with \code{treat_base_levels}.
+#' @param treat_base_levels (Optional) Targeted-sparsity mode (#332), explicit
+#'   form. A finite numeric vector of length \code{G} giving each cohort's fused
+#'   base level directly (placed on \code{getTreatInds()[getFirstInds()]}); every
+#'   other coordinate is left at zero, so \code{||theta||_0} is the number of
+#'   non-zero entries. Note these are \emph{fused} base levels, not the per-cohort
+#'   ATTs: under \code{fusion_structure = "cohort"} a vector
+#'   \code{(b_1, ..., b_G)} maps to the cumulative cohort effects
+#'   \code{cumsum(b)} (e.g. \code{c(0, m, 0)} gives cohort ATTs \code{(0, m, m)}),
+#'   and \code{"event_study"} uses a different but still heterogeneity-preserving
+#'   map. The result must be non-degenerate and heterogeneous (\eqn{V_2 > 0}); an
+#'   all-zero or constant-effect specification is rejected. Defaults to
+#'   \code{NULL}. Mutually exclusive with \code{n_signal_cohorts}.
 #' @param seed (Optional) Integer. Seed for reproducibility. Three
 #'   deterministic offsets share this seed: the main coefficient draw uses
 #'   \code{seed}; the assignment coefficients use \code{seed + 1L}; the
@@ -241,6 +352,8 @@ genCoefs <- function(
 	assignment_strength = 1.0,
 	assignment_interactions = NULL,
 	assignment_interaction_strength = NULL,
+	n_signal_cohorts = NULL,
+	treat_base_levels = NULL,
 	seed = NULL,
 	verbose = FALSE,
 	R = NULL
@@ -249,6 +362,10 @@ genCoefs <- function(
 	# alias and warning if it is supplied (#41). The body below uses `G`
 	# directly.
 	G <- .resolve_cohort_count_arg(G, R, "genCoefs")
+
+	# Validate the targeted-sparsity arguments (#332) up front (pure checks,
+	# consume no RNG). Both NULL => uniform-`density` mode, byte-identical.
+	.validate_targeted_sparsity(n_signal_cohorts, treat_base_levels, G)
 
 	# Check that T is a numeric scalar and at least 2.
 	if (!is.numeric(T) || length(T) != 1 || T < 2) {
@@ -389,6 +506,8 @@ genCoefs <- function(
 		density = density,
 		eff_size = eff_size,
 		fusion_structure = fusion_structure,
+		n_signal_cohorts = n_signal_cohorts,
+		treat_base_levels = treat_base_levels,
 		seed = seed
 	)
 	if (is.null(core_obj$beta)) {
@@ -670,6 +789,12 @@ getTes <- function(coefs_obj) {
 #' effects are sparse. \code{"cohort"} is byte-identical to previous behavior;
 #' \code{"event_study"} fuses effects at the same time since treatment across
 #' cohorts. See \code{genCoefs()} for details.
+#' @param n_signal_cohorts,treat_base_levels (Optional) Targeted-sparsity mode
+#' (#332). Both \code{NULL} (the default) is the unchanged, byte-identical
+#' uniform-\code{density} path. Otherwise the treatment signal is placed
+#' deterministically on the per-cohort fused base levels for a sparse,
+#' non-degenerate, heterogeneous high-dimensional DGP. See \code{genCoefs()} for
+#' the full description; the two are mutually exclusive.
 #' @param seed (Optional) Integer. Seed for reproducibility. \code{NA} (or
 #' \code{NULL}) means "draw from the ambient random-number generator" --- no
 #' \code{set.seed()} is called.
@@ -746,6 +871,8 @@ genCoefsCore <- function(
 	density,
 	eff_size,
 	fusion_structure = c("cohort", "event_study"),
+	n_signal_cohorts = NULL,
+	treat_base_levels = NULL,
 	seed = NULL,
 	R = NULL
 ) {
@@ -755,6 +882,10 @@ genCoefsCore <- function(
 	G <- .resolve_cohort_count_arg(G, R, "genCoefsCore")
 
 	fusion_structure <- match.arg(fusion_structure)
+
+	# Defensive re-validation (genCoefsCore is exported and callable directly);
+	# pure checks, no RNG, before `.apply_seed` (#332).
+	.validate_targeted_sparsity(n_signal_cohorts, treat_base_levels, G)
 
 	.apply_seed(seed)
 
@@ -805,19 +936,65 @@ genCoefsCore <- function(
 
 	theta <- rep(0, p)
 
-	# Make sure at least one feature is selected
-	pass_condition <- FALSE
-	while (!pass_condition) {
-		theta_inds <- which(as.logical(rbinom(n = p, size = 1, prob = density)))
-		pass_condition <- length(theta_inds) > 0
+	targeted <- !is.null(n_signal_cohorts) || !is.null(treat_base_levels)
+	if (!targeted) {
+		# ---- Default uniform-`density` path. Kept VERBATIM so that, when the
+		#      targeted-sparsity args are unset, the RNG stream (the rbinom at this
+		#      line, re-drawn on an all-zero result, then the rfunc sign draw whose
+		#      length depends on it) and hence `theta`/`beta` are byte-identical to
+		#      pre-#332 behavior. ----
+		# Make sure at least one feature is selected
+		pass_condition <- FALSE
+		while (!pass_condition) {
+			theta_inds <- which(as.logical(rbinom(
+				n = p,
+				size = 1,
+				prob = density
+			)))
+			pass_condition <- length(theta_inds) > 0
+		}
+
+		num_coefs <- length(theta_inds)
+		# Generate signs of coefficients in transformed space, and bias away from
+		# 0.5 (as described in paper)
+		signs <- rfunc(num_coefs, prob = 0.6)
+
+		theta[theta_inds] <- eff_size * signs
+	} else {
+		# ---- Targeted-sparsity path (#332): place a small, heterogeneous signal
+		#      on the per-cohort fused BASE levels and leave everything else --
+		#      including the covariate/interaction blocks -- at zero, so
+		#      `s = ||theta||_0` is exactly the treatment-signal count. FULLY
+		#      DETERMINISTIC: no rbinom/rfunc/sample/rnorm here, so this branch
+		#      cannot perturb the default RNG stream and is reproducible from its
+		#      args alone.
+		#
+		#      `theta[treat_inds]` are FUSED differences; `treat_inds[first_inds[g]]`
+		#      is cohort g's base level. Cohort 1's base (`first_inds[1]`) is the
+		#      unique all-ones column of the inverse treatment-fusion transform --
+		#      it lifts EVERY cohort's effect equally, contributing to `att` but
+		#      0 to the cohort-weight variance V2. The count mode therefore SKIPS
+		#      cohort 1 and writes distinct magnitudes on cohorts 2..(k+1), which
+		#      load only cohorts {g..G} (a nested staircase) and so produce
+		#      heterogeneous cohort effects (V2 > 0). The build-time assertion
+		#      after `beta` is assembled enforces the same non-degeneracy for the
+		#      free-form `treat_base_levels` vector. See issue #332 (high-dim
+		#      p > NT desparsified-ATT coverage study). ----
+		ts_first_inds <- getFirstInds(G = G, T = T)
+		ts_treat_inds <- getTreatInds(
+			G = G,
+			T = T,
+			d = d,
+			num_treats = num_treats
+		)
+		if (!is.null(n_signal_cohorts)) {
+			k <- as.integer(n_signal_cohorts)
+			theta[ts_treat_inds[ts_first_inds[2:(k + 1)]]] <- eff_size *
+				seq_len(k)
+		} else {
+			theta[ts_treat_inds[ts_first_inds]] <- treat_base_levels
+		}
 	}
-
-	num_coefs <- length(theta_inds)
-	# Generate signs of coefficients in transformed space, and bias away from
-	# 0.5 (as described in paper)
-	signs <- rfunc(num_coefs, prob = 0.6)
-
-	theta[theta_inds] <- eff_size * signs
 
 	# Now we have coefficients that are sparse in the appropriate feature space.
 	# The last step is to transform them to the original feature space. Since
@@ -927,6 +1104,44 @@ genCoefsCore <- function(
 	}
 
 	stopifnot(all(!is.na(beta)))
+
+	# Targeted-sparsity non-degeneracy contract (#332): in targeted mode the
+	# point of the DGP is a NON-degenerate, HETEROGENEOUS cohort effect (att != 0
+	# AND V2 > 0). V2 > 0 iff the per-cohort effects are not all equal, so this is
+	# checked on the assembled `beta` (intrinsic to it, DGP-weight-independent).
+	# It catches `eff_size = 0`, an all-zero `treat_base_levels`, and the
+	# homogeneous trap (e.g. signal only on cohort 1's all-ones base, or any
+	# constant `treat_base_levels`) -- for either fusion_structure -- without the
+	# caller having to reason about the fused map. (The count mode cannot reach
+	# either failure given the validated 1 <= k <= G-1, but the check is cheap
+	# insurance and the only guard for the free-form vector.)
+	if (targeted) {
+		catt_built <- getActualCohortTes(
+			G = G,
+			first_inds = first_inds,
+			treat_inds = treat_inds,
+			coefs = beta,
+			num_treats = num_treats
+		)
+		if (all(catt_built == 0)) {
+			stop(
+				"genCoefs() targeted mode produced all-zero cohort effects ",
+				"(att == 0). Supply a nonzero `eff_size` (count mode) or a ",
+				"`treat_base_levels` with a nonzero entry.",
+				call. = FALSE
+			)
+		}
+		if (length(unique(catt_built)) == 1L) {
+			stop(
+				"genCoefs() targeted mode produced homogeneous cohort effects ",
+				"(V2 == 0): all cohorts have the same effect, so there is no ",
+				"cohort-weight variance. Place signal on at least one non-baseline ",
+				"cohort with a distinct level (count mode does this automatically; ",
+				"for `treat_base_levels` use entries that are not all equal).",
+				call. = FALSE
+			)
+		}
+	}
 
 	# Confirm beta satisfies input requirements of genRandomData() (make
 	# up values for N, sig_eps_sq, and sig_eps_c_sq that meet requirements)

--- a/man/genCoefs.Rd
+++ b/man/genCoefs.Rd
@@ -15,6 +15,8 @@ genCoefs(
   assignment_strength = 1,
   assignment_interactions = NULL,
   assignment_interaction_strength = NULL,
+  n_signal_cohorts = NULL,
+  treat_base_levels = NULL,
   seed = NULL,
   verbose = FALSE,
   R = NULL
@@ -102,6 +104,37 @@ stress-testing whether the nonlinear-propensity angle alone drives
 downstream differences (without simultaneously cranking the linear
 angle). Ignored when \code{assignment_interactions = NULL}. New in
 1.14.1.}
+
+\item{n_signal_cohorts}{(Optional) Targeted-sparsity mode (#332). A single
+positive integer \code{k} in \code{1..(G - 1)}. When supplied, the
+coefficient vector is built \emph{deterministically} with the treatment
+signal placed on exactly \code{k} cohorts' fused base levels (and the
+covariate / interaction blocks left at zero), giving \code{||theta||_0 = k}
+non-zeros with a guaranteed non-zero, \emph{heterogeneous} cohort effect
+(overall ATT \eqn{\neq 0} and positive cohort-weight variance \eqn{V_2 > 0}).
+This produces the simultaneously sparse and non-degenerate
+high-dimensional (\eqn{p \ge NT}) data-generating process the desparsified /
+nodewise debiased-ATT coverage study needs, which the default uniform
+\code{density} placement cannot (it almost never lands signal on the tiny
+treatment-effect coordinate block). Cohort 1 is held at the baseline and
+cohorts \code{2..(k + 1)} receive the distinct magnitudes
+\code{eff_size * (1, 2, ..., k)} (so \code{eff_size} must be non-zero).
+Defaults to \code{NULL}; \code{NULL} (with \code{treat_base_levels = NULL})
+is the unchanged, byte-identical uniform-\code{density} behavior. Mutually
+exclusive with \code{treat_base_levels}.}
+
+\item{treat_base_levels}{(Optional) Targeted-sparsity mode (#332), explicit
+form. A finite numeric vector of length \code{G} giving each cohort's fused
+base level directly (placed on \code{getTreatInds()[getFirstInds()]}); every
+other coordinate is left at zero, so \code{||theta||_0} is the number of
+non-zero entries. Note these are \emph{fused} base levels, not the per-cohort
+ATTs: under \code{fusion_structure = "cohort"} a vector
+\code{(b_1, ..., b_G)} maps to the cumulative cohort effects
+\code{cumsum(b)} (e.g. \code{c(0, m, 0)} gives cohort ATTs \code{(0, m, m)}),
+and \code{"event_study"} uses a different but still heterogeneity-preserving
+map. The result must be non-degenerate and heterogeneous (\eqn{V_2 > 0}); an
+all-zero or constant-effect specification is rejected. Defaults to
+\code{NULL}. Mutually exclusive with \code{n_signal_cohorts}.}
 
 \item{seed}{(Optional) Integer. Seed for reproducibility. Three
 deterministic offsets share this seed: the main coefficient draw uses

--- a/man/genCoefsCore.Rd
+++ b/man/genCoefsCore.Rd
@@ -11,6 +11,8 @@ genCoefsCore(
   density,
   eff_size,
   fusion_structure = c("cohort", "event_study"),
+  n_signal_cohorts = NULL,
+  treat_base_levels = NULL,
   seed = NULL,
   R = NULL
 )
@@ -39,6 +41,13 @@ treatment-effect block, controlling the basis in which the true treatment
 effects are sparse. \code{"cohort"} is byte-identical to previous behavior;
 \code{"event_study"} fuses effects at the same time since treatment across
 cohorts. See \code{genCoefs()} for details.}
+
+\item{n_signal_cohorts, treat_base_levels}{(Optional) Targeted-sparsity mode
+(#332). Both \code{NULL} (the default) is the unchanged, byte-identical
+uniform-\code{density} path. Otherwise the treatment signal is placed
+deterministically on the per-cohort fused base levels for a sparse,
+non-degenerate, heterogeneous high-dimensional DGP. See \code{genCoefs()} for
+the full description; the two are mutually exclusive.}
 
 \item{seed}{(Optional) Integer. Seed for reproducibility. \code{NA} (or
 \code{NULL}) means "draw from the ambient random-number generator" --- no

--- a/tests/testthat/test-gencoefs-targeted-sparsity-332.R
+++ b/tests/testthat/test-gencoefs-targeted-sparsity-332.R
@@ -1,0 +1,352 @@
+# Tests for the genCoefs() / genCoefsCore() targeted-sparsity mode (#332):
+# n_signal_cohorts (count) and treat_base_levels (explicit per-cohort fused base
+# levels). The mode places a small, heterogeneous treatment signal so the DGP is
+# simultaneously sparse (||theta||_0 = signal count) and non-degenerate
+# (att != 0, cohort-weight variance V2 > 0) at p >> num_treats -- which the
+# uniform-`density` path cannot do in the high-dim regime. Both new args NULL is
+# the unchanged uniform path, and must be BYTE-IDENTICAL.
+#
+# V2 has no field on the FETWFE_tes object, so "V2 > 0" is operationalized as
+# sum(cohort_weights * (actual_cohort_tes - att_true)^2) > 0 (the same sign as
+# the fit-side .plugin_v2): positive iff the per-cohort effects are heterogeneous.
+
+# Golden vectors captured from the pre-#332 code (origin/main) and verified
+# byte-identical there; they pin the default uniform path against drift.
+GOLD0_BETA <- c(0, 0, 0, 2, 2, 2, 0, 0, 2, 2, 2, 0, 2, 4, 2, 2)
+GOLD0_THETA <- c(0, 0, 0, 0, 0, 2, 0, 0, 2, 0, 0, 0, 2, 2, 2, 0)
+GOLD2_BETA <- c(
+	0,
+	0,
+	0,
+	-2,
+	-2,
+	-2,
+	0,
+	0,
+	2,
+	0,
+	0,
+	0,
+	2,
+	-2,
+	-2,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	2,
+	0,
+	0,
+	0,
+	2,
+	0,
+	0,
+	0,
+	2,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	2,
+	0,
+	0,
+	0,
+	-2,
+	0,
+	0,
+	0,
+	-2,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	2,
+	0,
+	0,
+	-2,
+	-2,
+	0,
+	0,
+	-2,
+	-2,
+	0,
+	0,
+	-2,
+	-2,
+	2,
+	0,
+	-2,
+	-2,
+	0,
+	0,
+	-2,
+	-2,
+	0,
+	0
+)
+GOLD2_THETA <- c(
+	0,
+	0,
+	0,
+	0,
+	0,
+	-2,
+	0,
+	0,
+	2,
+	0,
+	0,
+	0,
+	2,
+	-2,
+	-2,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	2,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	2,
+	0,
+	0,
+	0,
+	-2,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	2,
+	0,
+	0,
+	0,
+	2,
+	0,
+	0,
+	-2,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	2,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0
+)
+
+v2_truth <- function(te) {
+	sum(te$cohort_weights * (te$actual_cohort_tes - te$att_true)^2)
+}
+
+test_that("default (both new args NULL) is byte-identical to the uniform path (#332)", {
+	# Golden pin: the uniform-`density` output is unchanged by the new arguments.
+	set.seed(7)
+	g0 <- genCoefs(G = 3, T = 5, d = 0, density = 0.3, eff_size = 2, seed = 11L)
+	expect_identical(g0$beta, GOLD0_BETA)
+	expect_identical(g0$theta, GOLD0_THETA)
+
+	set.seed(7)
+	g2 <- genCoefs(G = 3, T = 5, d = 4, density = 0.3, eff_size = 2, seed = 11L)
+	expect_identical(g2$beta, GOLD2_BETA)
+	expect_identical(g2$theta, GOLD2_THETA)
+
+	# Explicitly passing NULL == omitting the args (Convention B: re-seed before
+	# each compared call since data-gen advances the ambient stream).
+	set.seed(7)
+	a <- genCoefs(G = 3, T = 5, d = 4, density = 0.3, eff_size = 2, seed = 11L)
+	set.seed(7)
+	b <- genCoefs(
+		G = 3,
+		T = 5,
+		d = 4,
+		density = 0.3,
+		eff_size = 2,
+		n_signal_cohorts = NULL,
+		treat_base_levels = NULL,
+		seed = 11L
+	)
+	expect_identical(a$beta, b$beta)
+	expect_identical(a$theta, b$theta)
+})
+
+test_that("count mode yields exact sparsity + att != 0 + V2 > 0 at p >> num_treats (#332)", {
+	# High-dim fixture: G=3,T=5,d=40 -> num_treats=9, p=696, NT=200 (p > NT and
+	# p >> num_treats), sub-second.
+	num_treats <- getNumTreats(G = 3, T = 5)
+	p <- getP(G = 3, T = 5, d = 40, num_treats = num_treats)
+	expect_gt(p, 3 * 5 * 40 / 3) # sanity: p >> num_treats
+	expect_gt(p, 40 * 5) # p > N*T at N = 40
+
+	for (fs in c("cohort", "event_study")) {
+		for (k in 1:2) {
+			coefs <- genCoefs(
+				G = 3,
+				T = 5,
+				d = 40,
+				density = 0.2,
+				eff_size = 2,
+				fusion_structure = fs,
+				n_signal_cohorts = k,
+				seed = 1L
+			)
+			info <- paste0(fs, " k=", k)
+			# exact sparsity s = k
+			expect_identical(sum(coefs$theta != 0), k, info = info)
+			te <- getTes(coefs)
+			expect_true(te$att_true != 0, info = info) # non-degenerate ATT
+			expect_gt(v2_truth(te), 0) # heterogeneity == V2 > 0
+			expect_gt(length(unique(round(te$actual_cohort_tes, 8))), 1L)
+			# cohort 1 stays at the baseline (the count mode skips first_inds[1])
+			expect_equal(te$actual_cohort_tes[1], 0, info = info)
+		}
+	}
+})
+
+test_that("explicit treat_base_levels places exact bases and stays heterogeneous (#332)", {
+	# c(0, m, 0): only cohort 2's base is set -> s = 1, cohorts {2,3} lifted.
+	coefs <- genCoefs(
+		G = 3,
+		T = 5,
+		d = 40,
+		density = 0.2,
+		eff_size = 2,
+		treat_base_levels = c(0, 1.5, 0),
+		seed = 1L
+	)
+	expect_identical(sum(coefs$theta != 0), 1L)
+	te <- getTes(coefs)
+	expect_true(te$att_true != 0)
+	expect_gt(v2_truth(te), 0)
+	# under cohort fusion the bases map cumulatively: (0, 1.5, 0) -> (0, 1.5, 1.5)
+	expect_equal(te$actual_cohort_tes, c(0, 1.5, 1.5))
+})
+
+test_that("simulateData() / getTes() consume a targeted coefs object unchanged (#332)", {
+	coefs <- genCoefs(
+		G = 3,
+		T = 5,
+		d = 40,
+		density = 0.2,
+		eff_size = 2,
+		n_signal_cohorts = 2,
+		seed = 1L
+	)
+	sim <- simulateData(
+		coefs,
+		N = 40,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 1,
+		seed = 7L
+	)
+	# simulateData reads only beta + metadata; the truth round-trips.
+	expect_identical(sim$coefs, coefs$beta)
+})
+
+test_that("targeted-sparsity validation + non-degeneracy guards fire (#332)", {
+	mk <- function(...) {
+		genCoefs(
+			G = 3,
+			T = 5,
+			d = 40,
+			density = 0.2,
+			eff_size = 2,
+			seed = 1L,
+			...
+		)
+	}
+	# mutual exclusion
+	expect_error(
+		mk(n_signal_cohorts = 1, treat_base_levels = c(0, 1, 0)),
+		"at most one of"
+	)
+	# count out of range / non-integer
+	expect_error(mk(n_signal_cohorts = 3), "<= G - 1")
+	expect_error(mk(n_signal_cohorts = 1.5), "positive ")
+	# explicit vector wrong length
+	expect_error(mk(treat_base_levels = c(1, 2)), "length G")
+	# G < 2
+	expect_error(
+		genCoefs(
+			G = 1,
+			T = 5,
+			d = 40,
+			density = 0.2,
+			eff_size = 2,
+			n_signal_cohorts = 1,
+			seed = 1L
+		),
+		"requires G >= 2"
+	)
+	# build-time att == 0 guard (eff_size 0 zeroes the staircase)
+	expect_error(
+		genCoefs(
+			G = 3,
+			T = 5,
+			d = 40,
+			density = 0.2,
+			eff_size = 0,
+			n_signal_cohorts = 2,
+			seed = 1L
+		),
+		"all-zero cohort effects"
+	)
+	# build-time V2 == 0 guard: c(m, 0, 0) is the all-ones baseline column ->
+	# homogeneous (m, m, m).
+	expect_error(
+		mk(treat_base_levels = c(2, 0, 0)),
+		"homogeneous cohort effects"
+	)
+})


### PR DESCRIPTION
## Summary

Resolves **#332**: adds a **targeted-sparsity mode** to `genCoefs()` / `genCoefsCore()` so the high-dimensional (`p >= NT`) desparsified / nodewise debiased-ATT coverage study (`gregfaletto/fetwfe#88`/`#71`, which gates retiring the package's experimental flag `#295`) can generate a DGP that is **simultaneously sparse and non-degenerate** — which the uniform-`density` placement cannot.

**The problem:** in the high-dim regime the `num_treats` treatment-effect coordinates are a tiny fraction of `p` (e.g. `G=3,T=5,d=300` → `num_treats=9`, `p=5116`, 0.18%). A density sparse enough for the `s·log(p)/√N → 0` rate almost never lands signal on a treatment coordinate (att = 0, degenerate); a density that does hit them gives `s` in the hundreds (rate blows up). Mutually unsatisfiable under uniform placement.

**The fix:** place the signal *deliberately* on the per-cohort fused **base levels**, leaving everything else (including the covariate/interaction block) at zero, so `s = ||theta||_0` is exactly the signal count, with a **guaranteed heterogeneous** cohort effect (att ≠ 0 **and** cohort-weight variance V2 > 0).

## API (designed via a multi-agent design workflow; two maintainer decisions confirmed)

Two mutually-exclusive, `NULL`-default arguments on both functions:

- **`n_signal_cohorts = k`** — count convenience: a deterministic staircase placing `eff_size·(1..k)` on cohorts `2..(k+1)` (skipping cohort 1), giving exactly `s = k`.
- **`treat_base_levels = b`** — explicit length-`G` fused base levels for full per-cohort control.

Both `NULL` ⇒ the unchanged uniform-`density` path, **byte-identical**.

**Why V2 > 0 is *guaranteed*, not hoped-for:** cohort 1's base (`first_inds[1]`) is the unique all-ones column of the inverse treatment-fusion transform — it lifts every cohort equally (contributes to att but 0 to V2, the exact degeneracy uniform placement stumbles into). The count mode skips it; columns `first_inds[g≥2]` load only cohorts `{g..G}` (nested staircase), so distinct magnitudes ⇒ heterogeneous CATTs. A **build-time assertion** (after `beta` is assembled, via `getActualCohortTes`) enforces att ≠ 0 **and** heterogeneity for the free-form `treat_base_levels` vector too — turning the subtlety into a contract, for both fusion structures.

The covariate block stays exactly zero this PR (smallest `s`, fully deterministic); a `cov_density` noise knob is a clean non-breaking follow-up if the study needs nuisance realism (maintainer-confirmed).

## Changes
- `R/gen_coefs.R`: the two args + thread-through; `.validate_targeted_sparsity()` (RNG-free, shared); the deterministic targeted branch (replaces only the θ-construction block under `if/else`, default arm verbatim); the build-time non-degeneracy assertion; roxygen.
- `man/`: regenerated. **NEWS / DESCRIPTION**: 1.47.0 → 1.48.0.
- `tests/testthat/test-gencoefs-targeted-sparsity-332.R` (new).

## Verification
- New test: **FAIL 0 / PASS 40** (both modes × both fusion structures; exact `s`; att ≠ 0; V2 > 0; `simulateData()`/`getTes()` consume it unchanged; all validation + guard errors).
- **Default path proven byte-identical to `origin/main`** out-of-band (sourced pre-change `genCoefs` over the new namespace; identical `$beta`/`$theta` for d=0, d>0, and event_study). The test pins golden vectors captured from pre-change `main`.
- **Two mutation checks** (bit, reverted): leaking an RNG draw into the default arm → the golden byte-identity pins fail (FAIL 4); disabling the build-time non-degeneracy assertion → the att/V2 guard tests fail (FAIL 2).
- Full suite: **FAIL 0**.
- `R CMD check --as-cran` (with vignettes): 0 ERROR / 0 WARN, benign NOTEs only.
- Independent post-exec review.

Per the standing paper-xref convention, the docs/NEWS anchor the math to the paper-repo issue (`#88`/`#71`) and "desparsified / nodewise high-dimensional (`p >= NT`) regime" — **not** a local "Theorem 6.6" (this repo's `paper_arxiv.tex` has none; `p >= NT` is a stated future extension).

Closes #332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
