### PR TITLE
fix: off-by-one in twfeCovs treatment-column collapse (#339)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.48.0
+Version: 1.49.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # NEWS
 
+## Version 1.49.0
+
+### Bug fixes
+
+- `twfeCovs()`: fixed an off-by-one in the internal collapse of the
+  treatment-effect columns (`.collapse_design_for_twfe_covs()`). The pre-collapse
+  extraction began one column too low — it summed a covariate-interaction column
+  into the per-cohort treatment block and dropped the last treatment column — and
+  now uses the validated `getTreatInds()` indices (the same ones the `etwfe()`
+  path uses). As a result, **`twfeCovs()` output changes versus `<= 1.48.0`**.
+  This is a correction, but anyone reproducing the `twfeCovs` benchmark from the
+  Faletto (2025) simulation studies should note that those numbers will differ.
+  No other estimator (`fetwfe()`, `etwfe()`, `betwfe()`) is affected — none uses
+  this collapse (#339).
+
 ## Version 1.48.0
 
 ### Improvements

--- a/R/input_prep.R
+++ b/R/input_prep.R
@@ -451,8 +451,14 @@ prep_for_etwfe_core <- function(
 
 	X <- X_gls[, 1:(G + T - 1 + d * (1 + G + T - 1) + num_treats)]
 
-	first_treat_ind <- G + T - 1 + d * (1 + G + T - 1)
-	treat_inds <- first_treat_ind:(first_treat_ind + num_treats - 1)
+	# Treatment columns in the (pre-collapse) GLS design. Use the validated helper
+	# getTreatInds() rather than an inline formula, so the pre-collapse treatment
+	# block matches the etwfe path exactly and cannot drift. This fixes a previous
+	# off-by-one: the old inline `first_treat_ind <- G + T - 1 + d*(1 + G + T - 1)`
+	# was the *count* of pre-treatment columns, so `first_treat_ind:(...)` started
+	# one column too low -- it pulled the last covariate-interaction column into the
+	# treatment block and dropped the last treatment column (#339).
+	treat_inds <- getTreatInds(G = G, T = T, d = d, num_treats = num_treats)
 	stopifnot(length(treat_inds) == num_treats)
 
 	X <- X[, c(1:(G + T - 1 + d), treat_inds)]

--- a/tests/testthat/test-2x2-support-251.R
+++ b/tests/testthat/test-2x2-support-251.R
@@ -98,8 +98,11 @@
 #
 # tau = 2 is injected, so att_hat recovery is numerical (tolerance), not just
 # finiteness. twfeCovs is the naive benchmark -- biased under staggering, but at
-# a clean 2x2 with one cohort it should still be in the right ballpark; we assert
-# only finiteness for it to stay robust.
+# a clean 2x2 with one cohort it recovers tau too. Asserting that recovery is the
+# external-truth anchor for the #339 collapse off-by-one fix: pre-fix the
+# extraction summed a covariate-interaction column instead of the lone treatment
+# column (getTreatInds(1,2,2,1) = 9, buggy formula gave 8), so twfeCovs could NOT
+# recover tau here -- this assertion would have FAILED before the fix.
 # ------------------------------------------------------------------------------
 
 test_that("all four estimators fit a 2x2 (T = 2, G = 1) panel", {
@@ -132,6 +135,10 @@ test_that("all four estimators fit a 2x2 (T = 2, G = 1) panel", {
 	expect_equal(res_t$T, 2)
 	expect_true(is.finite(res_t$att_hat))
 	expect_true(is.finite(res_t$att_se))
+	# External-truth anchor for the #339 collapse fix (see header note above):
+	# twfeCovs recovers the injected tau = 2 once the right treatment column is
+	# summed. Would have failed pre-fix (summed a covariate-interaction column).
+	expect_equal(res_t$att_hat, 2, tolerance = 0.3)
 })
 
 test_that("fetwfe add_ridge fits a 2x2 panel (the relaxed T >= 2L fusion guard)", {
@@ -221,6 +228,9 @@ test_that("all four estimators fit a late-adopting (G = 1, T = 5) num_treats = 1
 	res_t <- .s251_fit(plate, twfeCovs)
 	expect_s3_class(res_t, "twfeCovs")
 	expect_true(is.finite(res_t$att_hat))
+	# External-truth anchor for the #339 collapse fix (would have failed pre-fix,
+	# which summed a covariate-interaction column instead of the treatment column).
+	expect_equal(res_t$att_hat, 2, tolerance = 0.4)
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-ols-core-unification-guardrail-327.R
+++ b/tests/testthat/test-ols-core-unification-guardrail-327.R
@@ -14,8 +14,9 @@
 # (the c7_indep configs), which exercises the indep getTeResultsOLS() call -- the
 # full catt_df, and the coefficient vector) and reduces it to collision-resistant
 # aggregates; the position-weighted sum (`wsum`) catches reorderings/swaps that
-# plain sum/sumsq would miss. Goldens captured from the pre-refactor code (commit
-# f1c8cca).
+# plain sum/sumsq would miss. The etwfe goldens are captured from the pre-refactor
+# code (commit f1c8cca); the twfeCovs goldens were re-captured after the #339
+# collapse off-by-one fix (see the note on the twfeCovs_* block below).
 
 .fp_327 <- function(fit) {
 	v <- c(
@@ -170,68 +171,72 @@
 		mx = 6.1470871639,
 		mn = -4.3501244277
 	),
+	# twfeCovs goldens re-captured after the #339 collapse off-by-one fix (the
+	# pre-collapse treatment-column extraction now uses getTreatInds()), so these
+	# rows are post-#339 values, NOT the pre-refactor f1c8cca byte-identical
+	# values; the etwfe goldens above remain pre-refactor (etwfe never collapses).
 	twfeCovs_c1_base = c(
 		n = 36,
-		sum = 40.3928807217,
-		sumsq = 143.179199422,
-		sumabs = 40.684445326,
-		wsum = 1055.74546402,
-		mx = 8.48022246831,
-		mn = -0.145782302154
+		sum = 28.2113851932,
+		sumsq = 174.5039823141,
+		sumabs = 48.4404221105,
+		wsum = 889.6701501748,
+		mx = 8.5910974771,
+		mn = -2.0282300035
 	),
 	twfeCovs_c2_cluster = c(
 		n = 36,
-		sum = 45.6229901083,
-		sumsq = 161.68019933,
-		sumabs = 51.4796001752,
-		wsum = 1137.28023272,
-		mx = 8.48022246831,
-		mn = -1.64492081469
+		sum = 34.8652761713,
+		sumsq = 221.8957842605,
+		sumabs = 64.6894233615,
+		wsum = 986.9970631622,
+		mx = 8.5910974771,
+		mn = -3.1887787766
 	),
 	twfeCovs_c3_ridge = c(
 		n = 36,
-		sum = 40.3929796973,
-		sumsq = 143.179930206,
-		sumabs = 40.684542513,
-		wsum = 1055.74808929,
-		mx = 8.48024443005,
-		mn = -0.145781407869
+		sum = 28.2114481934,
+		sumsq = 174.5048553094,
+		sumabs = 48.4405272317,
+		wsum = 889.6722529844,
+		mx = 8.5911197332,
+		mn = -2.0282336359
 	),
 	twfeCovs_c4_d0 = c(
 		n = 34,
-		sum = -35.0606655433,
-		sumsq = 81.3634195152,
-		sumabs = 42.0840786104,
-		wsum = -620.146197574,
-		mx = 0.874312552911,
-		mn = -2.86568612327
+		sum = -29.9224949548,
+		sumsq = 96.4450430598,
+		sumabs = 39.8082659448,
+		wsum = -562.3335794533,
+		mx = 1.0096134340,
+		mn = -4.2026152336
 	),
 	twfeCovs_c5_bigGT = c(
 		n = 47,
-		sum = 30.8793423015,
-		sumsq = 190.00469572,
-		sumabs = 67.5089511377,
-		wsum = 596.753874573,
-		mx = 5.11653367631,
-		mn = -6.09899877872
+		sum = 20.9958565766,
+		sumsq = 151.4808010364,
+		sumabs = 58.7333446913,
+		wsum = 478.5060668888,
+		mx = 4.8163044763,
+		mn = -5.3625646504
 	),
 	twfeCovs_c6_reml = c(
 		n = 36,
-		sum = 40.4838258143,
-		sumsq = 143.323584631,
-		sumabs = 40.8177266326,
-		wsum = 1057.30820486,
-		mx = 8.48022246831,
-		mn = -0.166950409144
+		sum = 28.3713380297,
+		sumsq = 174.8449365058,
+		sumabs = 48.7203315275,
+		wsum = 892.4322530116,
+		mx = 8.5910974771,
+		mn = -2.0548339806
 	),
 	twfeCovs_c7_indep = c(
 		n = 36,
-		sum = 40.3357038891,
-		sumsq = 143.1233086215,
-		sumabs = 40.6272684934,
-		wsum = 1055.6800476111,
-		mx = 8.4802224683,
-		mn = -0.1457823022
+		sum = 28.5235274621,
+		sumsq = 174.3981994637,
+		sumabs = 48.4130630864,
+		wsum = 890.2587409090,
+		mx = 8.5910974771,
+		mn = -2.0282300035
 	)
 )
 

--- a/tests/testthat/test-prep-helpers-81.R
+++ b/tests/testthat/test-prep-helpers-81.R
@@ -71,6 +71,19 @@ test_that(".collapse_design_for_twfe_covs returns expected shape (#81)", {
 	# of truth for the collapsed-design layout consumed by the core (#337).
 	expect_equal(out$treat_inds, (R + T - 1 + d + 1):out$p_short)
 	expect_equal(length(out$treat_inds), R)
+
+	# #339 regression: the collapse must sum the genuine treatment columns
+	# (getTreatInds()), NOT an off-by-one range. Each treatment column is summed
+	# into exactly one cohort, so the collapsed treatment block totals the sum of
+	# all getTreatInds() columns of X_gls -- a total that shifts if the
+	# pre-collapse extraction drifts by even one column (the previous inline
+	# formula started one column too low, pulling in a covariate-interaction
+	# column and dropping the last treatment column).
+	gti <- fetwfe:::getTreatInds(G = R, T = T, d = d, num_treats = num_treats)
+	expect_equal(
+		sum(out$X_collapsed[, out$treat_inds]),
+		sum(X_gls[, gti])
+	)
 })
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #339.

## The bug

`.collapse_design_for_twfe_covs()` extracted the pre-collapse treatment columns **one position too low**. The inline `first_treat_ind <- G + T - 1 + d*(1 + G + T - 1)` is the *count* of pre-treatment columns, so `first_treat_ind:(first_treat_ind + num_treats - 1)` started one column early — it summed the last covariate-interaction column into the per-cohort treatment block and **dropped the last treatment column**.

Verified empirically (G=3, T=5, d=2): the treatment columns are 24–32 (= the named `c#_t#` columns, = `getTreatInds()`), but the old formula extracted 23–31.

## The fix

```r
treat_inds <- getTreatInds(G = G, T = T, d = d, num_treats = num_treats)
```

Use the validated helper — the same indices the `etwfe()`/`fetwfe()`/`betwfe()` path uses via `.compute_treat_inds()` — so the pre-collapse treatment block matches that path and can't drift. Off-by-one holds (and is fixed) for all `d`, including `d = 0`.

## Behavior change (twfeCovs only)

`.collapse_design_for_twfe_covs()` is invoked **only** on the `is_twfe_covs = TRUE` path, so **only `twfeCovs()` output changes**. `etwfe()`/`fetwfe()`/`betwfe()` never call it — their #327 guardrail goldens are byte-identical, a built-in isolation check.

`twfeCovs()` is documented as the simulation-only benchmark from Faletto (2025); anyone reproducing that baseline should note its numbers now differ from `<= 1.48.0`. Minor version bump (1.49.0) + NEWS entry, per the behavior-change convention.

## Verification

- ✅ Full suite **FAIL 0** (90 files / 821 tests). Suite-wide, the **only** test affected was the #327 guardrail's 7 `twfeCovs_c*` goldens.
- ✅ **Recaptured** the 7 `twfeCovs_*` goldens from the fixed code; the 7 `etwfe_*` goldens are byte-identical to before (isolation + capture-script faithfulness), counts (`n`) unchanged.
- ✅ **Regression test** (`test-prep-helpers-81.R`): the collapsed treatment block totals `sum(X_gls[, getTreatInds()])` — shifts under any off-by-one.
- ✅ **External-truth anchors** (`test-2x2-support-251.R`): the 2×2 and late-adopt `twfeCovs` checks now assert τ recovery (att_hat ≈ 2). These *prove the fix is more correct, not just different* — pre-fix the off-by-one summed a covariate-interaction column instead of the treatment column, so τ could not be recovered.
- ✅ **Mutation-check**: reintroducing the off-by-one (`getTreatInds(...) - 1L`) fails the regression test, both anchors, and all 7 twfeCovs goldens — while the 8 etwfe expectations stay green.
- ✅ Plan-review + adversarial post-exec review: no blocker, no should-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLT4YkWVYWpjBw9P7Z9tJ3
