### PR TITLE
refactor: rename internal testGenRandomDataInputs() -> testSimulateDataCoreInputs() (#346)

### DIFF
--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -1154,7 +1154,7 @@ genCoefsCore <- function(
 	# Confirm beta satisfies input requirements of simulateDataCore() (make
 	# up values for N, sig_eps_sq, and sig_eps_c_sq that meet requirements)
 
-	testGenRandomDataInputs(
+	testSimulateDataCoreInputs(
 		beta = beta,
 		G = G,
 		T = T,

--- a/R/gen_data.R
+++ b/R/gen_data.R
@@ -428,7 +428,7 @@ simulateDataCore <- function(
 		))
 	}
 
-	res <- testGenRandomDataInputs(
+	res <- testSimulateDataCoreInputs(
 		beta = beta,
 		G = G,
 		T = T,

--- a/R/sim_helpers.R
+++ b/R/sim_helpers.R
@@ -1,6 +1,6 @@
 # Internal helpers shared by the simulation pipeline:
 # `generateBaseEffects()`, `genCohortTimeFE()`, `genAssignments()`,
-# `genTreatVarsSim()`, `rfunc()`, and `testGenRandomDataInputs()`.
+# `genTreatVarsSim()`, `rfunc()`, and `testSimulateDataCoreInputs()`.
 # Moved from R/gen_funcs.R in 1.9.25.
 
 #' Draw covariates and their long-format expansion
@@ -529,7 +529,7 @@ rfunc <- function(n, prob) {
 #' @seealso \code{\link{getNumTreats}}, \code{\link{getP}}
 #' @keywords internal
 #' @noRd
-testGenRandomDataInputs <- function(
+testSimulateDataCoreInputs <- function(
 	beta,
 	G,
 	T,

--- a/tests/testthat/test-simulateData.R
+++ b/tests/testthat/test-simulateData.R
@@ -442,7 +442,7 @@ test_that("print.FETWFE_simulated summarizes instead of dumping (#84 item 13)", 
 # Case 2 from #109: simulateData() accepts sig_eps_c_sq = 0 (no unit-level
 # random effects). Pre-fix, simulateData() rejected sig_eps_c_sq <= 0 while
 # the validators downstream of fetwfe() accepted sig_eps_c_sq >= 0.
-# Loosened simulateData (and testGenRandomDataInputs) to match.
+# Loosened simulateData (and testSimulateDataCoreInputs) to match.
 # ------------------------------------------------------------------------------
 test_that("simulateData accepts sig_eps_c_sq = 0 (#109 Case 2)", {
 	coefs <- genCoefs(


### PR DESCRIPTION
## Summary

Pure **internal rename** (Closes #346): `testGenRandomDataInputs()` → `testSimulateDataCoreInputs()`.

The `@noRd` validator embedded the defunct name `genRandomData()` (renamed long ago to `simulateData()` / `simulateDataCore()`), so its name referenced a function that no longer exists anywhere in the package. The new name names the function whose input requirements it actually validates (`simulateDataCore()`). This is the follow-up to the #342 / #345 doc cleanup, which purged `genRandomData()` from the user-facing docs but (deliberately, at the time) left the internal helper's name.

## Changes

Renamed across all 5 sites (the only `testGenRandomDataInputs` occurrences in the package): the definition (`R/sim_helpers.R`), both callers (`simulateDataCore()` in `R/gen_data.R`, `genCoefsCore()` in `R/gen_coefs.R`), and two comments (`R/sim_helpers.R` header + `tests/testthat/test-simulateData.R`). Kept the camelCase `test*Inputs` style to match its `sim_helpers.R` siblings (`genTreatVarsSim`, `rfunc`, `genAssignments`, …) rather than introduce a lone snake_case name.

## Verification

- `git grep testGenRandomDataInputs` → 0; new name at exactly the 5 expected sites
- `devtools::document()` a no-op (the function is `@noRd`, so no man page)
- Full suite **FAIL 0 | WARN 0 | PASS 4187**; `spell_check()` clean
- Post-exec review subagent: LGTM, confirmed behavior-preserving + complete

## Version

**No version bump / no NEWS entry** — this is a purely internal `@noRd` rename with no user-visible change (per `.workflow/DEV_INSTRUCTIONS.md:72`).

One historical `NEWS.md` changelog entry (from #109) still names the old helper; deliberately left, since rewriting a frozen changelog entry would falsify what the function was actually called at that past release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
