### PR TITLE
test/hardening: bridge field-order pin, collapse cross-cohort guard, validator symmetry, coverage (#343)

### DIFF
--- a/R/input_prep.R
+++ b/R/input_prep.R
@@ -641,7 +641,11 @@ check_etwfe_core_inputs <- function(
 	if (any(!is.na(sig_eps_sq))) {
 		stopifnot(is.numeric(sig_eps_sq) | is.integer(sig_eps_sq))
 		stopifnot(length(sig_eps_sq) == 1)
-		stopifnot(sig_eps_sq >= 0)
+		# `> 0` (not `>= 0`): `sig_eps_sq = 0` makes the GLS transform's
+		# `1 / sqrt(sig_eps_sq)` non-finite (#185). Matches the public validator
+		# `.collect_etwfe_input_violations()` (utility.R), which rejects `<= 0`;
+		# `sig_eps_c_sq` correctly still allows `0` (no unit-level effects).
+		stopifnot(sig_eps_sq > 0)
 	}
 
 	if (any(!is.na(sig_eps_c_sq))) {

--- a/tests/testthat/test-bridge-out-list-field-order-343.R
+++ b/tests/testthat/test-bridge-out-list-field-order-343.R
@@ -1,0 +1,162 @@
+library(testthat)
+library(fetwfe)
+
+# ------------------------------------------------------------------------------
+# #343: pin the EXACT top-level and $internal field ORDER of the assembled
+# betwfe()/fetwfe() fit objects. test-ols-out-list-field-order-270.R pins the OLS
+# pair (etwfe/twfeCovs); the bridge pair had no order pin -- the class validators
+# (test-class-validators.R) and doc-slot-parity test check the field SET, not the
+# order. identical()-based consumers, print snapshots, and the planned
+# .assemble_bridge_estimator() consolidation (#344) all depend on this order, so
+# lock it against silent drift. (Note the two estimators legitimately differ:
+# betwfe carries X_ints/y/X_final/y_final at the top level while fetwfe nests
+# them in $internal and instead carries fusion_structure/fusion_matrix at the
+# top; fetwfe also orders alpha before calc_ses, and its $internal adds theta_hat
+# and d_inv_treat.)
+# ------------------------------------------------------------------------------
+test_that("betwfe()/fetwfe() top-level and internal field order is stable (#343)", {
+	cf <- genCoefs(G = 4, T = 5, d = 2, density = 0.5, eff_size = 2, seed = 270)
+	sim <- simulateData(
+		cf,
+		N = 160,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 270
+	)
+	base <- list(
+		pdata = sim$pdata,
+		time_var = sim$time_var,
+		unit_var = sim$unit_var,
+		treatment = sim$treatment,
+		response = sim$response,
+		covs = sim$covs,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		verbose = FALSE
+	)
+	b <- do.call(betwfe, base)
+	f <- do.call(fetwfe, base)
+
+	betwfe_top <- c(
+		"att_hat",
+		"att_se",
+		"att_p_value",
+		"att_selected",
+		"catt_hats",
+		"catt_ses",
+		"cohort_probs",
+		"cohort_probs_overall",
+		"catt_df",
+		"beta_hat",
+		"treat_inds",
+		"treat_int_inds",
+		"sig_eps_sq",
+		"sig_eps_c_sq",
+		"lambda.max",
+		"lambda.max_model_size",
+		"lambda.min",
+		"lambda.min_model_size",
+		"lambda_star",
+		"lambda_star_model_size",
+		"lambda_selection",
+		"cv_folds",
+		"cv_seed",
+		"X_ints",
+		"y",
+		"X_final",
+		"y_final",
+		"N",
+		"T",
+		"G",
+		"R",
+		"d",
+		"p",
+		"calc_ses",
+		"alpha",
+		"se_type",
+		"indep_counts_used",
+		"y_mean",
+		"response_col_name",
+		"time_var",
+		"unit_var",
+		"treatment",
+		"covs",
+		"ci_type",
+		"internal"
+	)
+	fetwfe_top <- c(
+		"att_hat",
+		"att_se",
+		"att_p_value",
+		"att_selected",
+		"catt_hats",
+		"catt_ses",
+		"cohort_probs",
+		"cohort_probs_overall",
+		"catt_df",
+		"beta_hat",
+		"treat_inds",
+		"treat_int_inds",
+		"sig_eps_sq",
+		"sig_eps_c_sq",
+		"lambda.max",
+		"lambda.max_model_size",
+		"lambda.min",
+		"lambda.min_model_size",
+		"lambda_star",
+		"lambda_star_model_size",
+		"lambda_selection",
+		"cv_folds",
+		"cv_seed",
+		"fusion_structure",
+		"fusion_matrix",
+		"N",
+		"T",
+		"G",
+		"R",
+		"d",
+		"p",
+		"alpha",
+		"calc_ses",
+		"se_type",
+		"indep_counts_used",
+		"y_mean",
+		"response_col_name",
+		"time_var",
+		"unit_var",
+		"treatment",
+		"covs",
+		"ci_type",
+		"internal"
+	)
+
+	expect_identical(names(b), betwfe_top)
+	expect_identical(names(f), fetwfe_top)
+
+	expect_identical(
+		names(b$internal),
+		c(
+			"X_ints",
+			"y",
+			"X_final",
+			"y_final",
+			"calc_ses",
+			"variance_components",
+			"first_year"
+		)
+	)
+	expect_identical(
+		names(f$internal),
+		c(
+			"X_ints",
+			"y",
+			"X_final",
+			"y_final",
+			"theta_hat",
+			"calc_ses",
+			"variance_components",
+			"first_year",
+			"d_inv_treat"
+		)
+	)
+})

--- a/tests/testthat/test-gencoefs-targeted-sparsity-332.R
+++ b/tests/testthat/test-gencoefs-targeted-sparsity-332.R
@@ -274,6 +274,31 @@ test_that("explicit treat_base_levels places exact bases and stays heterogeneous
 	expect_equal(te$actual_cohort_tes, c(0, 1.5, 1.5))
 })
 
+test_that("explicit treat_base_levels under event_study fusion is non-degenerate (#343)", {
+	# Same explicit base vector as the cohort-fusion test above, but mapped
+	# through the event-study inverse fusion transform. Pins the cumulative ->
+	# fused mapping for the explicit-vector x event_study combination (previously
+	# only the count mode exercised event_study fusion; the explicit-vector mode
+	# tested only the default "cohort" fusion).
+	coefs <- genCoefs(
+		G = 3,
+		T = 5,
+		d = 40,
+		density = 0.2,
+		eff_size = 2,
+		treat_base_levels = c(0, 1.5, 0),
+		fusion_structure = "event_study",
+		seed = 1L
+	)
+	expect_identical(sum(coefs$theta != 0), 1L)
+	te <- getTes(coefs)
+	expect_true(te$att_true != 0)
+	expect_gt(v2_truth(te), 0)
+	# event_study fusion maps the bases differently from cohort fusion (which
+	# gives c(0, 1.5, 1.5) above).
+	expect_equal(te$actual_cohort_tes, c(0, 0.5, 0.75))
+})
+
 test_that("simulateData() / getTes() consume a targeted coefs object unchanged (#332)", {
 	coefs <- genCoefs(
 		G = 3,

--- a/tests/testthat/test-hardening-343.R
+++ b/tests/testthat/test-hardening-343.R
@@ -1,0 +1,58 @@
+library(testthat)
+library(fetwfe)
+
+# ------------------------------------------------------------------------------
+# #343 Item 1: the internal core validator check_etwfe_core_inputs() rejects
+# sig_eps_sq = 0, matching the public validator (.collect_etwfe_input_violations,
+# the #185 fix -- 0 makes 1/sqrt(sig_eps_sq) non-finite in the GLS transform).
+# This is defense-in-depth: the public validator gates first on every exported
+# path, so 0 cannot reach the core via the public API, but the two validators
+# should agree. sig_eps_c_sq = 0 stays allowed (no unit-level random effects).
+# ------------------------------------------------------------------------------
+test_that("check_etwfe_core_inputs() rejects sig_eps_sq = 0, allows sig_eps_c_sq = 0 (#343)", {
+	mk <- function(sig_eps_sq = 1, sig_eps_c_sq = 1) {
+		fetwfe:::check_etwfe_core_inputs(
+			in_sample_counts = c("0" = 2L, "2" = 3L),
+			N = 5L,
+			T = 3L,
+			sig_eps_sq = sig_eps_sq,
+			sig_eps_c_sq = sig_eps_c_sq,
+			indep_counts = NA,
+			verbose = FALSE,
+			alpha = 0.05,
+			add_ridge = FALSE
+		)
+	}
+	expect_no_error(mk()) # valid: positive idiosyncratic variance
+	expect_error(mk(sig_eps_sq = 0), "sig_eps_sq") # now rejected (was >= 0)
+	expect_no_error(mk(sig_eps_c_sq = 0)) # 0 unit-level variance still allowed
+})
+
+# ------------------------------------------------------------------------------
+# #343 Item 4c: is_twfe_covs x add_ridge x indep_counts interact cleanly. These
+# three are independent in the code (the collapse sets p before the ridge rows
+# are appended, and indep_counts only feeds the cohort-probability / ATT branch),
+# but the combined path was untested. Pin that it runs and yields a finite ATT.
+# ------------------------------------------------------------------------------
+test_that("twfeCovs() runs with add_ridge + indep_counts together (#343)", {
+	cf <- genCoefs(G = 3, T = 4, d = 2, density = 0.5, eff_size = 2, seed = 343)
+	sim <- simulateData(
+		cf,
+		N = 90,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 343
+	)
+	# the simulated object supplies indep_counts; add_ridge = TRUE turns on the
+	# ridge-row augmentation on the collapsed design.
+	res <- twfeCovsWithSimulatedData(sim, add_ridge = TRUE)
+	expect_s3_class(res, "twfeCovs")
+	expect_true(is.finite(res$att_hat))
+	expect_true(isTRUE(res$indep_counts_used))
+
+	# Prove add_ridge is actually active on this combined path (not silently
+	# dropped): the ridge-augmented fit must differ from the unaugmented one.
+	res_noridge <- twfeCovsWithSimulatedData(sim, add_ridge = FALSE)
+	expect_true(is.finite(res_noridge$att_hat))
+	expect_false(isTRUE(all.equal(res$att_hat, res_noridge$att_hat)))
+})

--- a/tests/testthat/test-prep-helpers-81.R
+++ b/tests/testthat/test-prep-helpers-81.R
@@ -84,6 +84,18 @@ test_that(".collapse_design_for_twfe_covs returns expected shape (#81)", {
 		sum(out$X_collapsed[, out$treat_inds]),
 		sum(X_gls[, gti])
 	)
+
+	# #343: a grand-total check cannot catch a CROSS-COHORT permutation (columns
+	# summed into the wrong cohort give the same overall total). Pin each
+	# collapsed treatment column to the sum of exactly its cohort's getTreatInds()
+	# columns -- mirroring the collapse's own per-cohort loop.
+	for (g in 1:R) {
+		inds_g <- fetwfe:::.cohort_block_inds(g, R, first_inds, num_treats)
+		expect_equal(
+			out$X_collapsed[, out$treat_inds[g]],
+			rowSums(X_gls[, gti[inds_g], drop = FALSE])
+		)
+	}
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-print-highdim-diagnostics-326.R
+++ b/tests/testthat/test-print-highdim-diagnostics-326.R
@@ -119,6 +119,16 @@ test_that("print.debiased_att shows the high-dim diagnostics only in the high-di
 	expect_true(any(grepl("EXPERIMENTAL", out_hd)))
 	expect_true(any(grepl("nodewise penalty: lambda_c", out_hd)))
 	expect_true(any(grepl("converged.*KKT-feasible", out_hd)))
+
+	# #343: tidy.debiased_att in the HIGH-DIM regime (the fixed-p tidy schema is
+	# pinned above; confirm the high-dim object stays broom-compatible too).
+	td_hd <- tidy(db_hd)
+	expect_s3_class(td_hd, "data.frame")
+	expect_equal(nrow(td_hd), 1L)
+	expect_named(
+		td_hd,
+		c("term", "estimate", "std.error", "conf.low", "conf.high")
+	)
 })
 
 test_that("print.simultaneous_cis shows the high-dim diagnostics block only in the high-dim regime (#326)", {


### PR DESCRIPTION
## Summary

Tier-4 **hardening + test guardrails** from the 2026-06-27 periodic review. All behavior-preserving except a defense-in-depth validator tightening (item 1) that is unreachable via the public API. Closes #343.

## Changes

1. **`sig_eps_sq` validator symmetry** (`R/input_prep.R`): the internal core validator `check_etwfe_core_inputs()` now rejects `sig_eps_sq = 0` (was `>= 0`), matching the public validator (#185: `0` makes `1/sqrt(sig_eps_sq)` non-finite in the GLS transform). Defense-in-depth — the public validator gates first on every exported path, so `0` can't reach the core via the public API. (`sig_eps_c_sq = 0` stays allowed.)
2. **Bridge `names()`-order guardrail** (new `test-bridge-out-list-field-order-343.R`): pins the exact top-level **and** `$internal` field order of `betwfe()`/`fetwfe()` fits. The OLS pair was pinned in #270; the bridge pair wasn't (the class validators check the field *set*, not order). This is the prerequisite guardrail for the planned `.assemble_bridge_estimator()` consolidation (#344).
3. **Collapse cross-cohort assertion** (`test-prep-helpers-81.R`): the existing grand-total check can't catch a cohort permutation; the new per-cohort assertion can. **Mutation-verified** — reversing the cohort assignment in the collapse fails the new assertion (12/12 mismatches per cohort) while the grand-total and the rest of the suite stay green.
4. **Coverage adds**: explicit `treat_base_levels × fusion_structure = "event_study"` (`test-gencoefs-targeted-sparsity-332`, pinning the event_study mapping `c(0, 0.5, 0.75)` vs the cohort-fusion `c(0, 1.5, 1.5)`); `tidy.debiased_att` in the high-dim regime (`test-print-highdim-diagnostics-326`); and the combined `is_twfe_covs × add_ridge × indep_counts` path, with an assertion that `add_ridge` actually changes the fit (new `test-hardening-343.R`).

## Verification

- Full suite **FAIL 0 | WARN 0 | PASS 4206** (+19) · `devtools::document()` no-op · `spell_check()` clean · **R CMD check `--as-cran` (with vignettes): Status OK**
- Full workflow: plan-review (supplied the exact validator-test call, the event_study value, and confirmed both guardrail mutations bite) + post-exec review (one SHOULD-FIX — a missing `add_ridge`-effect assertion in item 4c — now added)
- Item-3 guardrail mutation-checked (reversed-cohort → new assertion fails, grand-total stays green; restored)

## Version

**No version bump / no NEWS entry** — item 1 is internal defense-in-depth (unreachable via the public API) and items 2–4 are test-only. Flagged per `.workflow/DEV_INSTRUCTIONS.md:72`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
