### PR TITLE
fix: high-dim feasibility check no longer false-flags binding nodewise directions (#351)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.50.0
+Version: 1.51.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,23 @@
 # NEWS
 
+## Version 1.51.0
+
+### Bug fixes
+
+- High-dimensional nodewise debiasing: the KKT feasibility check no longer reuses
+  the coordinate-descent convergence tolerance (`riesz_tol`, `1e-9`) as its
+  feasibility slack, which sat below solver precision and so spuriously flagged
+  legitimately-binding nodewise directions as infeasible. The slack is now a
+  fixed `1e-6` relative tolerance (`.riesz_feasible()`), fixing over-pessimistic
+  `debiasedATT()` / `simultaneousCIs()` feasibility warnings and the high-dim
+  print diagnostics' under-reported "KKT-feasible" counts. Surfaced by the
+  `p > NT` coverage study (`gregfaletto/fetwfe#88`) (#351).
+- As part of the same fix, `lambda_c = "cv"` may now select a slightly smaller
+  penalty constant for fits sitting exactly at the feasibility edge (a
+  genuinely-feasible grid point previously excluded by round-off can now win).
+  Default `lambda_c = 1.0` fits -- which never invoke the CV feasibility gate --
+  are unchanged (#351).
+
 ## Version 1.50.0
 
 ### Improvements

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -519,7 +519,7 @@ debiasedATT <- function(
 		converged <- attr(v, "converged")
 		# The KKT certificate ||Sig v - a||_inf <= lambda_node is exactly the
 		# relaxed-inverse feasibility the Theorem 6.6 remainder bound needs.
-		if (feasibility > lambda_node * (1 + riesz_tol)) {
+		if (!.riesz_feasible(feasibility, lambda_node)) {
 			warning(
 				"debiasedATT(): the high-dimensional nodewise direction did not meet ",
 				"its feasibility constraint (||Sig v - a||_inf = ",

--- a/R/riesz_lasso.R
+++ b/R/riesz_lasso.R
@@ -90,6 +90,38 @@ lambda_node_default <- function(p, N, const = 1.0, scale = 1.0) {
 	const * scale * sqrt(log(p) / N)
 }
 
+# Relative tolerance for the high-dim nodewise KKT feasibility certificate. The
+# desparsified L1 direction BINDS its constraint by construction
+# (||Sig v - a||_inf = lambda_node at the L1 optimum), so a converged solver
+# overshoots only by coordinate-descent round-off (~1e-9..1e-8 relative). The
+# feasibility slack must therefore floor ABOVE solver precision -- it is
+# deliberately DECOUPLED from the convergence control `riesz_tol`, which
+# previously doubled as the slack at 1e-9 (below precision), spuriously flagging
+# legitimately-binding directions as infeasible (gregfaletto/fetwfe#88). A
+# genuine infeasibility (lambda_c too small / non-convergence) overshoots by
+# >> 1e-6, so 1e-6 cleanly separates round-off from a real constraint violation.
+.RIESZ_FEASIBILITY_RTOL <- 1e-6
+
+#' @title KKT feasibility test for a high-dim nodewise direction
+#' @description `TRUE` iff the relaxed-inverse certificate holds to within the
+#'   feasibility tolerance: `feasibility <= lambda_node * (1 + rtol)`. Vectorized.
+#'   The single source for every nodewise feasibility check -- the `debiasedATT()`
+#'   / `simultaneousCIs()` warnings, the `lambda_c = "cv"` grid gate, and the
+#'   high-dim print diagnostics -- so they always agree. See `.RIESZ_FEASIBILITY_RTOL`.
+#' @param feasibility Numeric (scalar or vector); `||Sig v - a||_inf`.
+#' @param lambda_node Numeric (scalar or vector); the nodewise penalty scale.
+#' @param rtol Relative feasibility tolerance; defaults to `.RIESZ_FEASIBILITY_RTOL`.
+#' @return Logical of the recycled length of `feasibility` / `lambda_node`.
+#' @keywords internal
+#' @noRd
+.riesz_feasible <- function(
+	feasibility,
+	lambda_node,
+	rtol = .RIESZ_FEASIBILITY_RTOL
+) {
+	feasibility <= lambda_node * (1 + rtol)
+}
+
 #' Cross-validate the high-dimensional nodewise penalty constant `lambda_c`
 #'
 #' @description
@@ -176,7 +208,7 @@ lambda_node_default <- function(p, N, const = 1.0, scale = 1.0) {
 				tol = riesz_tol
 			)
 			isTRUE(attr(vf, "converged")) &&
-				attr(vf, "feasibility") <= lam * (1 + riesz_tol)
+				.riesz_feasible(attr(vf, "feasibility"), lam)
 		},
 		logical(1)
 	)

--- a/R/simultaneous_bootstrap.R
+++ b/R/simultaneous_bootstrap.R
@@ -725,7 +725,7 @@
 	# may be unreliable; the returned diagnostics flag which effects).
 	if (isTRUE(attr(F_mat, "highdim"))) {
 		dg <- attr(F_mat, "diagnostics")
-		bad <- (dg$feasibility > dg$lambda_node * (1 + riesz_tol)) |
+		bad <- !.riesz_feasible(dg$feasibility, dg$lambda_node) |
 			!dg$converged
 		# Fold in the per-cell propensity-channel directions (#309): they also feed
 		# the band (through Sigma_2), so an infeasible cell direction is equally a
@@ -733,8 +733,10 @@
 		if (!is.null(cell_diag)) {
 			bad <- c(
 				bad,
-				(cell_diag$feasibility >
-					cell_diag$lambda_node * (1 + riesz_tol)) |
+				!.riesz_feasible(
+					cell_diag$feasibility,
+					cell_diag$lambda_node
+				) |
 					!cell_diag$converged
 			)
 		}

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -1492,10 +1492,11 @@ print.simultaneous_cis <- function(x, ...) {
 		max(x$lambda_node)
 	))
 	nk <- length(x$converged)
-	# KKT-feasible iff `||Sigma v - a||_inf <= lambda_node`, with the same default
-	# `riesz_tol` slack the band's feasibility gate / experimental warning use, so
-	# "K/K KKT-feasible" here means "no feasibility warning fired".
-	nfeas <- sum(x$feasibility <= x$lambda_node * (1 + 1e-9))
+	# KKT-feasible iff `||Sigma v - a||_inf <= lambda_node` to within the shared
+	# `.riesz_feasible()` tolerance (the band's feasibility gate and the
+	# experimental warning use the same helper), so "K/K KKT-feasible" here means
+	# "no feasibility warning fired".
+	nfeas <- sum(.riesz_feasible(x$feasibility, x$lambda_node))
 	feas_ratio <- x$feasibility / x$lambda_node
 	feas_ratio <- feas_ratio[is.finite(feas_ratio)]
 	worst_txt <- if (length(feas_ratio)) {
@@ -1517,13 +1518,14 @@ print.simultaneous_cis <- function(x, ...) {
 			"  propensity channel (#309): %d/%d converged, %d/%d KKT-feasible\n",
 			sum(x$propensity_converged),
 			pk,
-			# same `riesz_tol` slack as the per-effect line above (the nodewise solver
-			# routinely binds the constraint to ~1e-10, so a strict `<=` would report
-			# 0/K feasible exactly when the band's gate fired no warning).
-			sum(
-				x$propensity_feasibility <=
-					x$propensity_lambda_node * (1 + 1e-9)
-			),
+			# same feasibility tolerance as the per-effect line above (via
+			# `.riesz_feasible()`; the nodewise solver routinely binds the
+			# constraint to ~1e-10, so a strict `<=` would report 0/K feasible
+			# exactly when the band's gate fired no warning).
+			sum(.riesz_feasible(
+				x$propensity_feasibility,
+				x$propensity_lambda_node
+			)),
 			pk
 		))
 	}

--- a/tests/testthat/test-feasibility-tol-351.R
+++ b/tests/testthat/test-feasibility-tol-351.R
@@ -1,0 +1,42 @@
+library(testthat)
+library(fetwfe)
+
+# ------------------------------------------------------------------------------
+# #351: the high-dim nodewise KKT feasibility check `.riesz_feasible()` floors
+# its relative slack ABOVE coordinate-descent round-off, decoupled from the
+# convergence control `riesz_tol`. The desparsified L1 direction binds its
+# constraint (||Sig v - a||_inf = lambda_node) by construction, so a converged
+# solver overshoots only by ~1e-9..1e-8 (relative); the old slack (riesz_tol /
+# hardcoded 1e-9) sat below that and spuriously flagged binding directions as
+# infeasible (gregfaletto/fetwfe#88). The fixed 1e-6 tolerance separates
+# round-off from a genuine constraint violation (which overshoots by >> 1e-6).
+# ------------------------------------------------------------------------------
+test_that(".riesz_feasible() accepts round-off but rejects genuine infeasibility (#351)", {
+	ln <- 0.19 # a representative lambda_node (the #88 anchor scale)
+
+	# Binding direction, overshooting only by coordinate-descent round-off:
+	# must read FEASIBLE under the 1e-6 tolerance.
+	expect_true(fetwfe:::.riesz_feasible(ln, ln)) # exactly binding
+	expect_true(fetwfe:::.riesz_feasible(ln * (1 + 1e-9), ln))
+	expect_true(fetwfe:::.riesz_feasible(ln * (1 + 1e-8), ln))
+	expect_true(fetwfe:::.riesz_feasible(ln * (1 + 1e-7), ln))
+
+	# Genuine infeasibility (lambda_c too small / non-convergence) overshoots by
+	# >> 1e-6: must read INFEASIBLE.
+	expect_false(fetwfe:::.riesz_feasible(ln * (1 + 1e-3), ln))
+	expect_false(fetwfe:::.riesz_feasible(ln * 17, ln)) # the test-142 magnitude
+
+	# Vectorized over per-effect / per-cell directions.
+	expect_identical(
+		fetwfe:::.riesz_feasible(
+			c(ln * (1 + 1e-8), ln * (1 + 1e-3)),
+			c(ln, ln)
+		),
+		c(TRUE, FALSE)
+	)
+
+	# The bug, pinned: the old slack (riesz_tol = 1e-9) wrongly rejects a binding
+	# direction overshooting by 1e-8 round-off; the 1e-6 default accepts it.
+	expect_false(fetwfe:::.riesz_feasible(ln * (1 + 1e-8), ln, rtol = 1e-9))
+	expect_true(fetwfe:::.riesz_feasible(ln * (1 + 1e-8), ln, rtol = 1e-6))
+})

--- a/tests/testthat/test-print-highdim-diagnostics-326.R
+++ b/tests/testthat/test-print-highdim-diagnostics-326.R
@@ -163,7 +163,8 @@ test_that("print.simultaneous_cis shows the high-dim diagnostics block only in t
 
 test_that("the high-dim event_study propensity-channel feasibility count uses the gate's slack (#326)", {
 	# The propensity (#309) channel's KKT-feasible count must use the same
-	# `riesz_tol` slack as the per-effect line and the band's warning gate. The
+	# feasibility tolerance (via `.riesz_feasible()`) as the per-effect line and
+	# the band's warning gate. The
 	# nodewise solver binds the constraint to ~1e-10, so a strict `<=` reports
 	# 0/K feasible exactly when no feasibility warning fired -- the most alarming
 	# possible output, shown when everything is fine.


### PR DESCRIPTION
## Summary

Fixes the high-dimensional nodewise feasibility check that **false-flagged legitimately-binding directions as infeasible** — surfaced by the now-complete `p > NT` coverage study (`gregfaletto/fetwfe#88`). Closes #351.

## The bug

The KKT feasibility check `feasibility <= lambda_node * (1 + slack)` used `slack = riesz_tol` (the coordinate-descent **convergence** tolerance, default `1e-9`) — or a hardcoded `1e-9` in the print diagnostics. But the desparsified L1 nodewise direction **binds** its constraint (`||Sig v - a||_inf = lambda_node`) by construction, so a converged solver overshoots only by coordinate-descent round-off (~`1e-9`–`1e-8` relative). The slack sat *below* that precision → spurious "infeasible" flags on directions that are fine.

## The fix

A single `.riesz_feasible(feasibility, lambda_node, rtol = .RIESZ_FEASIBILITY_RTOL)` helper (`R/riesz_lasso.R`) with a fixed **`1e-6`** relative tolerance, **decoupled** from the convergence `riesz_tol`. All six feasibility sites route through it: the `debiasedATT()` warning, the `lambda_c="cv"` grid-feasibility gate, the `simultaneousCIs()` bootstrap warnings (×2), and the #326 print diagnostics (×2). `1e-6` cleanly separates round-off (~`4e-11` measured) from a genuine constraint violation (~`17` measured), so genuine-infeasibility warnings still fire.

## Effects (both disclosed in NEWS)

1. Over-pessimistic `debiasedATT()` / `simultaneousCIs()` feasibility warnings and the high-dim print diagnostics' under-reported "KKT-feasible" counts are fixed.
2. As part of the same fix, `lambda_c="cv"` may select a slightly smaller penalty constant for fits sitting exactly at the feasibility edge (a genuinely-feasible grid point previously excluded by round-off can now win). **Default `lambda_c=1.0` fits never invoke the CV gate and are unchanged.**

## Verification

- Full suite **FAIL 0 | WARN 0 | PASS 4217** (+9) · `document()` no-op · `spell_check()` clean · **R CMD check `--as-cran` (with vignettes): Status OK**.
- New `test-feasibility-tol-351.R` unit-tests `.riesz_feasible()` with directly-constructed inputs (deterministic, not solver/BLAS-dependent); **mutation-verified** (reverting the constant to `1e-9` fails the round-off cases).
- Full workflow: plan-review (empirically confirmed the CV-gate change is a no-op at the real `hd295` anchor — `att`/`se` byte-identical — and that `test-cv-lambda-node-295.R` stays green; confirmed `1e-6` sits safely between round-off and genuine infeasibility) + post-exec review.

## Version

**1.50.0 → 1.51.0** + NEWS `### Bug fixes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
