### PR TITLE
docs: add high-dimensional (p >= NT) debiased-inference section to the inference vignette (#353)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.52.0
+Version: 1.53.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # NEWS
 
+## Version 1.53.0
+
+### Improvements
+
+- The inference vignette now documents **high-dimensional (`p >= NT`) debiased
+  inference**: a new section with a worked `debiasedATT()` / `simultaneousCIs()`
+  example on a `p > NT` panel, the feasibility / `lambda_c` diagnostics to
+  inspect, and the high-dimensional coverage result from `gregfaletto/fetwfe#88`
+  (debiased ~93% vs fused ~77% at the studied anchor). Closes the last major
+  post-1.10.0 vignette gap (#353).
+
 ## Version 1.52.0
 
 ### Improvements

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -58,6 +58,7 @@ deduplicated
 Deprecations
 desparsified
 desparsifies
+desparsifying
 deterministically
 df
 DGP

--- a/vignettes/inference_vignette.Rmd
+++ b/vignettes/inference_vignette.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Standard errors in fetwfe: tight Gaussian CIs, the conservative fallback, and the experimental cluster option"
+title: "Standard errors in fetwfe: tight Gaussian CIs, the conservative fallback, the experimental cluster option, and high-dimensional debiased inference"
 author: "Gregory Faletto"
 date: "`r Sys.Date()`"
 output:
@@ -8,7 +8,7 @@ output:
     math_method: "mathml"
     output_file: "FETWFE_Inference_Vignette.html"
 vignette: >
-  %\VignetteIndexEntry{Standard errors in fetwfe: tight Gaussian CIs, the conservative fallback, and the experimental cluster option}
+  %\VignetteIndexEntry{Standard errors in fetwfe: tight Gaussian CIs, the conservative fallback, the experimental cluster option, and high-dimensional debiased inference}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -320,7 +320,7 @@ c(pointwise  = es_boot$pointwise_critical_value,
   bonferroni = es_boot$bonferroni_critical_value)
 ```
 
-**High-dimensional `p \ge NT`.** When the (full) design is high-dimensional --- where the analytic Gram inverse need not exist, so there is no analytic sup-t band --- the bootstrap automatically switches to the full-design **desparsified** construction of `debiasedATT()` (paper Theorem 6.6): each effect's debiasing direction becomes a nodewise (`riesz_lasso`) relaxed inverse over the singular Gram, with the bridge residuals. This is *uniformly valid* (not post-selection) and is the only route to simultaneous bands in that regime. It is **experimental** (`fetwfe()` fits only): its underlying overall-ATT coverage is validated near-nominally at the `p > NT` anchor of Faletto (2025), but the family-wise band coverage is not itself simulation-validated, so the returned object carries a `regime` field and per-effect `feasibility` / `converged` / `lambda_node` diagnostics, and `lambda_c` tunes the nodewise penalty `lambda_node = lambda_c * max(|a|) * sqrt(log(p) / N)` --- too-small values leave the directions infeasible and trigger a warning. `lambda_c` accepts either a fixed positive number (default the theory scale `1.0`) or the string `"cv"`, which selects the constant **per fit** by cross-validating the Riesz loss over the KKT-feasible region (the desparsified-lasso / auto-DML standard), falling back to `1.0` when no grid penalty is feasible; one constant then serves both the `debiasedATT()` point estimate and every bootstrap band effect (issue #295). The default stays the fixed `1.0` (the opt-in CV selector picks the feasibility-appropriate constant; #88 validated overall-ATT coverage with it at the studied anchor). The simulator can generate the `p > NT` panels this needs (see the `simulateData()` documentation). `family = "event_study"` uses this desparsified path too in the high-dimensional regime, additionally carrying the per-unit propensity channel (the two-channel $\Sigma_1 + \Sigma_2$ bootstrap). In the high-dimensional regime the band is **centered on the debiased estimate** (the Theorem 6.6 correction, matching `debiasedATT()`) rather than the post-selection bridge estimate, which would otherwise carry the selection bias. The desparsified path is `fetwfe()`-only; a non-`fetwfe()` `p \ge NT` fit (e.g. `betwfe()`) has no debiased band, so it falls back to the fixed-$p$ selected-support band (rather than erroring) but emits a `warning()`. A coverage study (issue #308) shows that fallback band substantially **under-covers** in the `p \ge NT` regime --- even when the selected support is low-dimensional --- because the bridge shrinks the band center toward zero (so it is biased away from the truth) and the post-selection standard error understates the sampling variability; treat such a band as unreliable and use a `fetwfe()` fit for valid high-dimensional simultaneous bands.
+**High-dimensional $p \geq NT$.** When the (full) design is high-dimensional --- where the analytic Gram inverse need not exist, so there is no analytic sup-t band --- the bootstrap automatically switches to the full-design **desparsified** construction of `debiasedATT()` (paper Theorem 6.6): each effect's debiasing direction becomes a nodewise (`riesz_lasso`) relaxed inverse over the singular Gram, with the bridge residuals. This is *uniformly valid* (not post-selection) and is the only route to simultaneous bands in that regime. It is **experimental** (`fetwfe()` fits only): its underlying overall-ATT coverage is validated near-nominally at the `p > NT` anchor of Faletto (2025), but the family-wise band coverage is not itself simulation-validated, so the returned object carries a `regime` field and per-effect `feasibility` / `converged` / `lambda_node` diagnostics, and `lambda_c` tunes the nodewise penalty `lambda_node = lambda_c * max(|a|) * sqrt(log(p) / N)` --- too-small values leave the directions infeasible and trigger a warning. `lambda_c` accepts either a fixed positive number (default the theory scale `1.0`) or the string `"cv"`, which selects the constant **per fit** by cross-validating the Riesz loss over the KKT-feasible region (the desparsified-lasso / auto-DML standard), falling back to `1.0` when no grid penalty is feasible; one constant then serves both the `debiasedATT()` point estimate and every bootstrap band effect (issue #295). The default stays the fixed `1.0` (the opt-in CV selector picks the feasibility-appropriate constant; #88 validated overall-ATT coverage with it at the studied anchor). The simulator can generate the `p > NT` panels this needs (see the `simulateData()` documentation). `family = "event_study"` uses this desparsified path too in the high-dimensional regime, additionally carrying the per-unit propensity channel (the two-channel $\Sigma_1 + \Sigma_2$ bootstrap). In the high-dimensional regime the band is **centered on the debiased estimate** (the Theorem 6.6 correction, matching `debiasedATT()`) rather than the post-selection bridge estimate, which would otherwise carry the selection bias. The desparsified path is `fetwfe()`-only; a non-`fetwfe()` $p \geq NT$ fit (e.g. `betwfe()`) has no debiased band, so it falls back to the fixed-$p$ selected-support band (rather than erroring) but emits a `warning()`. A coverage study (issue #308) shows that fallback band substantially **under-covers** in the $p \geq NT$ regime --- even when the selected support is low-dimensional --- because the bridge shrinks the band center toward zero (so it is biased away from the truth) and the post-selection standard error understates the sampling variability; treat such a band as unreliable and use a `fetwfe()` fit for valid high-dimensional simultaneous bands.
 
 ## Simultaneous bands are the default: the `ci_type` argument
 
@@ -387,6 +387,74 @@ The true effects are $(-1.6, 0, 1.333)$: cohort 3's effect is exactly zero. FETW
 ## Scope: this is the *post-treatment* zero-effect test
 
 The package currently estimates only post-treatment treatment effects (event times $e \geq 0$), so the demonstration above is specifically the **post-treatment** zero-effect test, surfaced through `catt_df`. The same selection-consistency logic would support two further applications once the corresponding extended regression specifications exist: (a) selecting out pre-treatment placebo coefficients would give a **parallel-trends test**, and (b) selecting out heterogeneous-trend augmenting parameters would give a **homogeneous-trends test**. The package does not estimate those terms today, so this vignette makes no claim to perform either test; they are noted only as the natural extensions the same `selected`-as-implicit-test reasoning will cover when the specifications land.
+
+# 8. High-dimensional inference ($p \geq NT$): `debiasedATT()`
+
+Everything above assumes a low-dimensional design ($p < NT$), where the analytic Gram inverse exists and the fit's standard errors are the asymptotically valid ones from Section 1. When the design is **high-dimensional** --- the number of design columns $p$ (cohort and time fixed effects, covariates, and all their treatment interactions) meets or exceeds the number of observations $NT$ --- two things change:
+
+1. The fused fit is a *regularized* (bridge) estimate, and its pointwise standard errors (and the simultaneous bands of Section 6) are **post-selection**: valid conditional on the selected support, not *uniformly* valid. They can under-cover, because the bridge's regularization biases the point estimate (it shrinks and prunes effects) and the post-selection standard error does not account for the selection.
+
+2. `debiasedATT()` returns a **uniformly valid** confidence interval for the overall ATT by *desparsifying* the fit (the nodewise relaxed-inverse construction of Theorem 6.6 in Faletto 2025), which removes the regularization bias. This is "one estimator, two regimes": the call and the returned object are identical to the $p < NT$ case; only the internal nuisance changes.
+
+The $p \geq NT$ regime arises with many covariates, short panels, or many cohorts. `simulateData()` can generate such panels.
+
+## A worked example
+
+```{r highdim-setup}
+# d = 12 covariates, N = 40 units, T = 5 periods, G = 3 cohorts.
+coefs_hd <- genCoefs(G = 3, T = 5, d = 12, density = 0.2, eff_size = 2, seed = 2)
+sim_hd <- simulateData(
+  coefs_hd, N = 40, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 2
+)
+c(p = sim_hd$p, NT = sim_hd$N * sim_hd$T) # p >= NT: high-dimensional
+```
+
+```{r highdim-fit}
+fit_hd <- fetwfeWithSimulatedData(sim_hd, q = 0.5)
+# The fused (post-selection, pointwise) overall ATT:
+round(c(att = fit_hd$att_hat, se = fit_hd$att_se), 3)
+```
+
+That fused estimate is post-selection. For uniformly valid inference, pass the fit to `debiasedATT()`:
+
+```{r highdim-debiased}
+db <- debiasedATT(fit_hd)
+db
+```
+
+The print surfaces the high-dimensional diagnostics worth inspecting: the resolved nodewise penalty (`lambda_c` / `lambda_node`) and, per debiasing direction, whether it **converged** and met its **KKT feasibility** certificate. A direction that fails to converge or stay feasible flags a potentially unreliable standard error --- raise `riesz_max_iter` and/or `lambda_c` and re-inspect.
+
+## Why debiased, and how well it covers
+
+In any single draw the fused and debiased point estimates can be close, so the value of `debiasedATT()` is not visible from one fit --- it is a **repeated-sampling** guarantee. A coverage study at a $p > NT$ anchor ([issue #88](https://github.com/gregfaletto/fetwfe/issues/88)) found:
+
+| Overall-ATT interval | Coverage (nominal 95%) |
+|---|---|
+| Debiased (`debiasedATT()`, Theorem 6.6) | **≈ 93%** |
+| Fused plug-in (pointwise)               | ≈ 77%                  |
+
+The fused interval under-covers because of the post-selection non-uniformity; the debiased interval is near-nominal. This is validated at the studied anchor (with the feasibility-appropriate penalty); treat the $p \geq NT$ path as **experimental** outside that regime --- which is why the diagnostics above matter.
+
+## Simultaneous bands at $p \geq NT$
+
+`simultaneousCIs()` also switches to the desparsified construction in the high-dimensional regime (via `method = "bootstrap"`; the analytic Gram-inverse band does not exist when $p \geq NT$):
+
+```{r highdim-bands}
+sc_hd <- simultaneousCIs(
+  fit_hd,
+  family = "cohort",
+  method = "bootstrap",
+  B = 500,
+  seed = 1
+)
+sc_hd$regime
+```
+
+One scope caveat: #88 validated the **scalar overall-ATT** (`debiasedATT()`); the **family-wise band** coverage at $p \geq NT$ is not itself simulation-validated, so the band is the more experimental of the two.
+
+## Controlled high-dimensional truth
+
+The default `density` placement spreads signal across all coordinates, which when $p$ greatly exceeds the number of treatment-effect parameters rarely lands signal on the treatment-effect block. For a controlled, sparse, non-degenerate high-dimensional data-generating process, `genCoefs()` offers a **targeted-sparsity** mode (`n_signal_cohorts` or `treat_base_levels`) that places a heterogeneous treatment-effect signal directly on the per-cohort base levels --- the DGP the #88 coverage study uses. See `?genCoefs`.
 
 # References
 


### PR DESCRIPTION
## Summary

Adds the one real post-CRAN-1.10.0 vignette gap: a **high-dimensional (`p >= NT`) debiased-inference** section in the inference vignette, with a worked example. **Doc-only — no code or numeric change.** Closes #353.

## What

A new section ("8. High-dimensional inference") in `vignettes/inference_vignette.Rmd`:
- **Worked `p > NT` example** (`genCoefs` / `simulateData` at d=12, N=40 → p=220 > NT=200; builds in ~0.3s): `fetwfe()` → `debiasedATT()` with the high-dim print diagnostics, plus a `simultaneousCIs()` bootstrap band.
- **Why debiased + the #88 coverage result** (debiased ≈93% vs fused ≈77% at the studied anchor), framed as the *repeated-sampling* motivation (a single draw shows little).
- The **overall-ATT (validated) vs family-wise band (not separately validated)** distinction, consistent with the #352 roxygen.
- A note on `genCoefs()` **targeted-sparsity** for controlled high-dimensional DGPs.

Updated the vignette title + `VignetteIndexEntry`; added `desparsifying` to `inst/WORDLIST`.

## Scope note

The broom (`tidy`/`glance`/`augment`) and `plot()`-method "gaps" listed in #353 were a **malformed-grep false positive** — both are already documented (`vignette.Rmd`, `etwfe_betwfe_vignette.Rmd`), so no redundant section was added. The high-dim example was the only real gap.

## Verification

- Vignette **knits clean** (all new chunks run; no warnings) · `spell_check()` clean · **R CMD check `--as-cran` (builds vignettes): Status OK**.
- Doc-only; post-exec review (no plan-review — the worked example was prototyped first to confirm it's fast + clean).

## Version

**1.52.0 → 1.53.0** + NEWS `### Improvements`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
