### PR TITLE
refactor: extract shared .build_att_beta_direction() (#344 rec #4)

### DIFF
--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -433,17 +433,17 @@ debiasedATT <- function(
 		G = G,
 		T = T
 	)$first_inds
-	# Cohort g's treatment-cell block runs from `first_inds[g]` to the next cohort's
-	# first index; a_beta loads treat_inds with weight cohort_probs[g] / (#cells in
-	# cohort g) so a_beta' beta = sum_g pi_g * catt_g. For consecutive cohorts the
-	# block sizes reduce to (T-1):(T-G).
-	sizes <- diff(c(first_inds, num_treats + 1L))
-	cohort_of_treat <- rep(seq_len(G), times = sizes)
-	a_beta <- numeric(p)
-	for (g in seq_len(G)) {
-		idx <- treat_inds[cohort_of_treat == g]
-		a_beta[idx] <- cohort_probs[g] / length(idx)
-	}
+	# a_beta loads treat_inds so a_beta' beta = sum_g pi_g * catt_g (the overall
+	# ATT); see .build_att_beta_direction() for the offset-resolved per-cohort
+	# weighting.
+	a_beta <- .build_att_beta_direction(
+		first_inds = first_inds,
+		num_treats = num_treats,
+		G = G,
+		p = p,
+		treat_inds = treat_inds,
+		cohort_probs = cohort_probs
+	)
 	# Use the SAME fusion transform the fit used (#236 custom matrices included),
 	# NOT a hard-coded "cohort" transform -- otherwise event-study / custom fits
 	# violate the ATT-direction identity below.

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -749,25 +749,19 @@ simultaneousCIs.twfeCovs <- function(
 			}
 			# Overall-ATT theta-space direction (cohort_probs-weighted), the direction
 			# the shared CV penalty constant is selected on (#295 D2: one lambda_c for
-			# point + band). Built with the offset-resolved per-cohort block sizes
-			# `diff(c(first_inds, num_treats + 1L))` -- the SAME construction
-			# debiasedATT() uses (R/debiased_att.R) -- so the CV'd constant, hence the
-			# band center, matches debiasedATT() under `lambda_c = "cv"`, including for
-			# scattered (non-consecutive) adoption, which #318 made debiasedATT()
-			# support. A hard-coded `(T_ - 1):(T_ - G)` assumes consecutive adoption and
-			# under scattered offsets both mis-weights AND overruns `treat_inds` (its
-			# sizes can sum past num_treats), so the band would CV a wrong/fallback
-			# constant and diverge from debiasedATT() (#323). For consecutive adoption
-			# the resolved sizes reduce to `(T_ - 1):(T_ - G)`, so this is byte-identical.
-			a_beta_att <- numeric(p)
-			cohort_of_treat <- rep(
-				seq_len(G),
-				times = diff(c(first_inds, num_treats + 1L))
+			# point + band). Built via the shared `.build_att_beta_direction()` -- the
+			# SAME construction debiasedATT() uses (R/debiased_att.R), now
+			# single-sourced -- so the CV'd constant, hence the band center, matches
+			# debiasedATT() under `lambda_c = "cv"`, including for scattered
+			# (non-consecutive) adoption, which #318 made debiasedATT() support (#323).
+			a_beta_att <- .build_att_beta_direction(
+				first_inds = first_inds,
+				num_treats = num_treats,
+				G = G,
+				p = p,
+				treat_inds = treat_inds,
+				cohort_probs = x$cohort_probs
 			)
-			for (g in seq_len(G)) {
-				idx <- treat_inds[cohort_of_treat == g]
-				a_beta_att[idx] <- x$cohort_probs[g] / length(idx)
-			}
 			a_att <- as.numeric(crossprod(A, a_beta_att))
 		} else if (p >= N * T_) {
 			# Non-fetwfe high-dimensional (`p >= NT`) bootstrap (e.g. betwfe): the

--- a/R/utility.R
+++ b/R/utility.R
@@ -1509,6 +1509,60 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 	first_ind_g:last_ind_g
 }
 
+#' @title Cohort-probability-weighted overall-ATT direction (beta space)
+#' @description
+#' Builds the length-`p` vector `a_beta` for which `a_beta' beta` equals the
+#' overall ATT `sum_g pi_g * catt_g`: each treated cohort `g`'s treatment-effect
+#' cells (the `treat_inds` columns in `g`'s offset-resolved block) are loaded
+#' with weight `cohort_probs[g] / (#cells in g)`. The per-cohort block sizes are
+#' the offset-resolved `diff(c(first_inds, num_treats + 1L))`, which reduce to
+#' `(T - 1):(T - G)` for consecutive adoption but stay correct under scattered
+#' (non-consecutive) adoption (#318/#323) -- do NOT hard-code `(T - 1):(T - G)`,
+#' which under scattered offsets both mis-weights and overruns `treat_inds` (its
+#' block sizes can sum past `num_treats`), diverging the band center from
+#' `debiasedATT()` (#323).
+#'
+#' Single-sources the construction shared by `debiasedATT()` (R/debiased_att.R)
+#' and the high-dimensional bootstrap band in `simultaneousCIs()`
+#' (R/simultaneous_cis.R). Because both call this, the band center matches
+#' `debiasedATT()$att` by construction under `lambda_c = "cv"` (the #295
+#' shared-penalty / #323 coupling) rather than via a hand-maintained parallel
+#' copy. The callers apply the fit's fusion transform `A` to the result
+#' themselves (`crossprod(A, a_beta)`), since they need it in slightly different
+#' shapes.
+#' @param first_inds Integer vector (length `G`); the first treatment-effect
+#'   index of each cohort's block.
+#' @param num_treats Integer; the total number of treatment-effect parameters.
+#' @param G Integer; the number of treated cohorts.
+#' @param p Integer; the number of design columns (length of the returned
+#'   vector).
+#' @param treat_inds Integer vector; the design-column indices of the treatment
+#'   effects.
+#' @param cohort_probs Numeric vector (length `G`); estimated cohort-assignment
+#'   probabilities `pi_g`.
+#' @return Numeric vector of length `p`: the overall-ATT direction in beta space.
+#' @keywords internal
+#' @noRd
+.build_att_beta_direction <- function(
+	first_inds,
+	num_treats,
+	G,
+	p,
+	treat_inds,
+	cohort_probs
+) {
+	cohort_of_treat <- rep(
+		seq_len(G),
+		times = diff(c(first_inds, num_treats + 1L))
+	)
+	a_beta <- numeric(p)
+	for (g in seq_len(G)) {
+		idx <- treat_inds[cohort_of_treat == g]
+		a_beta[idx] <- cohort_probs[g] / length(idx)
+	}
+	a_beta
+}
+
 #' @title Multinomial covariance matrix from cohort-membership probabilities
 #' @description
 #' Returns the `length(probs) x length(probs)` covariance matrix of the


### PR DESCRIPTION
## Summary

Extracts the shared cohort-probability-weighted overall-ATT direction (`a_beta`) into `.build_att_beta_direction()`, so the `debiasedATT()` / `simultaneousCIs()` coupling holds by construction rather than by a hand-maintained parallel copy. **Pure refactor, proven byte-identical.** Closes #344 (the last of its four recs).

## What & why

`a_beta` — the length-`p` vector with `a_beta' beta = sum_g pi_g * catt_g` (the overall ATT) — was built by two parallel copies: `debiasedATT()` (`R/debiased_att.R`) and the high-dimensional bootstrap band in `simultaneousCIs()` (`R/simultaneous_cis.R`). They **must** agree, or the band center diverges from `debiasedATT()$att` under `lambda_c="cv"` (#295/#323) — a correctness coupling previously enforced only by a comment ("the SAME construction debiasedATT() uses").

Extracted into `.build_att_beta_direction()` in `R/utility.R` (beside `.cohort_block_inds`); both call sites now share one definition. The callers keep their differing tails — `crossprod(A, a_beta)` plus the `c(0, ...)` intercept prefix in `debiasedATT()` — since those genuinely differ.

## Verification

- **Byte-identity proof**: full `debiasedATT()` + `simultaneousCIs()` (cohort + event_study bootstrap, `lambda_c="cv"`) results `identical()` before/after on **both** a scattered-adoption fit (the #323 offset-resolver path) and a consecutive fit.
- Full suite **FAIL 0 | WARN 0 | PASS 4217** · `document()` no-op (`@noRd`) · **R CMD check `--as-cran`: Status OK**.

## No version bump

Pure internal refactor (byte-identical, `@noRd` helper, no exported surface) → no DESCRIPTION/NEWS change, consistent with rec #1 (#349) / rec #3 (#350).

## Closes #344

rec #1 (#349) + rec #3 (#350) merged; **rec #2 intentionally skipped** (fake-DRY — the block it targeted is interleaved, not cleanly separable); rec #4 = this PR. All four recommendations are now decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
