### PR TITLE
docs: document genCoefs() targeted-sparsity mode in the simulation vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.53.0
+Version: 1.54.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # NEWS
 
+## Version 1.54.0
+
+### Improvements
+
+- The simulation vignette now documents the **targeted-sparsity** coefficient
+  mode (`genCoefs(n_signal_cohorts = ...)` / `treat_base_levels`, added in
+  1.48.0): a new section explaining how it builds a sparse, non-degenerate,
+  heterogeneous high-dimensional (`p >= NT`) truth that the default uniform
+  `density` placement cannot, with a worked example (#353 follow-up).
+
 ## Version 1.53.0
 
 ### Improvements

--- a/vignettes/simulation_vignette.Rmd
+++ b/vignettes/simulation_vignette.Rmd
@@ -356,8 +356,35 @@ The `cohort_weights` slot is new in 1.14.0. Under the marginal DGP it is exactly
 
 The per-cohort CATT vector `actual_cohort_tes` is unchanged across DGPs — it is intrinsic to the coefficient vector $\beta$ and does not depend on how cohorts are assigned.
 
+# Targeted-sparsity coefficients for high-dimensional DGPs
+
+The `density` argument spreads the true signal uniformly across *all* coefficient coordinates. That is fine for low-dimensional designs, but when the design is **high-dimensional** ($p \geq NT$) — many covariates and/or short panels — the treatment-effect coordinates are a tiny fraction of the $p$ entries, so a density-based draw almost never lands signal there: the overall ATT comes out (near) zero and the data-generating process is *degenerate* for studying treatment-effect inference.
+
+Version 1.48.0 added a **targeted-sparsity** mode to `genCoefs()` (the mutually-exclusive arguments `n_signal_cohorts` and `treat_base_levels`) that builds the coefficient vector *deterministically*, placing the treatment signal directly on a few cohorts' fused base levels and leaving every other coordinate at zero. This builds a sparse, **non-degenerate, heterogeneous** truth with positive cohort-weight variance $V_2 > 0$ (and, for the `n_signal_cohorts` form, a guaranteed non-zero overall ATT — a free-form `treat_base_levels` with mixed-sign levels could cancel to a zero ATT) — the data-generating process behind the high-dimensional debiased-ATT coverage study (see the high-dimensional section of `vignette("inference_vignette", package = "fetwfe")` and `debiasedATT()`).
+
+`n_signal_cohorts = k` is the quick form: it places a heterogeneous signal on `k` cohorts (cohort 1 stays at the baseline; cohorts `2..(k + 1)` receive the fused base levels `eff_size * (1, 2, ..., k)`), giving exactly `k` non-zero coordinates.
+
+```{r targeted-sparsity}
+# A high-dimensional design (d = 12 covariates) with a controlled, sparse,
+# heterogeneous truth -- signal on 2 cohorts' fused base levels:
+hd_coefs <- genCoefs(
+  G = 3, T = 5, d = 12,
+  density = 0.2, # ignored in targeted-sparsity mode, but still required
+  eff_size = 2,
+  n_signal_cohorts = 2,
+  seed = 2
+)
+te <- getTes(hd_coefs)
+# A guaranteed non-zero, heterogeneous truth (which a density-based draw at this
+# dimension almost never produces):
+c(overall_ATT = te$att_true)
+te$actual_cohort_tes # per-cohort: baseline 0, then two distinct effects
+```
+
+For full control, `treat_base_levels` takes an explicit length-`G` vector of per-cohort *fused base levels* — not the per-cohort ATTs: under `fusion_structure = "cohort"` a vector `(b_1, ..., b_G)` maps to the cumulative cohort effects `cumsum(b)`, so `c(0, m, 0)` yields cohort ATTs `(0, m, m)`. See `?genCoefs`.
+
 # Conclusion
 
-In this vignette, we walked through how to use the simulation functions in the `{fetwfe}` package to simulate data and run simulations similar to the ones in the simulation studies section of [the FETWFE paper](https://arxiv.org/abs/2312.05985). Version 1.14.0 adds covariate-dependent cohort-assignment DGPs (multinomial-logit and ordered-logit) so Monte Carlo studies can stress-test FETWFE against the realistic regime where cohort selection depends on observable characteristics.
+In this vignette, we walked through how to use the simulation functions in the `{fetwfe}` package to simulate data and run simulations similar to the ones in the simulation studies section of [the FETWFE paper](https://arxiv.org/abs/2312.05985). Version 1.14.0 adds covariate-dependent cohort-assignment DGPs (multinomial-logit and ordered-logit) so Monte Carlo studies can stress-test FETWFE against the realistic regime where cohort selection depends on observable characteristics, and version 1.48.0 adds a targeted-sparsity coefficient mode (`n_signal_cohorts` / `treat_base_levels`) for controlled, non-degenerate high-dimensional data-generating processes.
 
 This pipeline streamlines simulation experiments so you can rapidly evaluate FETWFE’s performance under varying scenarios. For more details, consult the package documentation or reach out to the author.


### PR DESCRIPTION
## Summary

Adds a **targeted-sparsity** section to the simulation vignette — the one new-since-1.10.0 feature the pre-release vignette audit found with a thin documentation home. **Doc-only — no code or numeric change.** Refs #353.

## What & why

The targeted-sparsity coefficient mode (`genCoefs(n_signal_cohorts = ...)` / `treat_base_levels`, #332 / v1.48.0) was documented in `?genCoefs` and briefly in the inference vignette's high-dim section, but **absent from the simulation vignette** — its natural DGP home (which already documents the `assignment_type` DGPs).

New section "Targeted-sparsity coefficients for high-dimensional DGPs":
- **Why**: the default uniform `density` placement almost never lands signal on the tiny treatment-effect block at large `p`, so the overall ATT comes out ~0 / degenerate.
- **How**: `n_signal_cohorts = k` (deterministic signal on `k` cohorts' fused base levels → a sparse, non-degenerate, heterogeneous truth, ATT ≠ 0 and V₂ > 0) and the explicit `treat_base_levels` form (with the `cumsum` fused-level → cohort-ATT mapping spelled out).
- **Worked example** (runs in the build): `att_true = 2.667`, cohort ATTs `0 / 2 / 6`.

Updated the conclusion to mention it.

## Verification

- Vignette **knits clean** (the new chunk runs; no warnings) · `spell_check()` clean · **R CMD check `--as-cran` (builds vignettes): Status OK**.
- Doc-only; post-exec review (accuracy checked against `?genCoefs`).

## Version

**1.53.0 → 1.54.0** + NEWS `### Improvements`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
