### PR TITLE
docs: retitle the inference vignette to a concise umbrella

### DIFF
--- a/vignettes/inference_vignette.Rmd
+++ b/vignettes/inference_vignette.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Standard errors in fetwfe: tight Gaussian CIs, the conservative fallback, the experimental cluster option, and high-dimensional debiased inference"
+title: "Inference in fetwfe: standard errors, simultaneous bands, and high-dimensional debiasing"
 author: "Gregory Faletto"
 date: "`r Sys.Date()`"
 output:
@@ -8,7 +8,7 @@ output:
     math_method: "mathml"
     output_file: "FETWFE_Inference_Vignette.html"
 vignette: >
-  %\VignetteIndexEntry{Standard errors in fetwfe: tight Gaussian CIs, the conservative fallback, the experimental cluster option, and high-dimensional debiased inference}
+  %\VignetteIndexEntry{Inference in fetwfe: standard errors, simultaneous bands, and high-dimensional debiasing}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -24,7 +24,7 @@ knitr::opts_chunk$set(
 library(fetwfe)
 ```
 
-This vignette documents how `fetwfe()`, `betwfe()`, `etwfe()`, and `twfeCovs()` compute their standard errors, what assumptions those standard errors rely on, and the three values `se_type` can take. The four estimators share the same inferential machinery, so the discussion applies to all of them; we use `fetwfe()` in the running example.
+This vignette documents inference in the package: how `fetwfe()`, `betwfe()`, `etwfe()`, and `twfeCovs()` compute their standard errors (and the three values `se_type` can take), the family-wise simultaneous confidence bands from `simultaneousCIs()`, and the high-dimensional ($p \geq NT$) debiased path of `debiasedATT()`. The four estimators share the same inferential machinery, so the discussion applies to all of them; we use `fetwfe()` in the running example.
 
 # 1. The headline: tight Gaussian CIs by default under (Ψ-IF)
 


### PR DESCRIPTION
## Summary

Retitles the inference vignette from an unwieldy multi-clause title to a concise umbrella, and broadens the intro to match. **Doc-only, no version bump** (pure relabel — and conflict-free with the open #358).

## What

The inference vignette's title had grown unwieldy as sections accreted (#352 / #353):

> ~~Standard errors in fetwfe: tight Gaussian CIs, the conservative fallback, the experimental cluster option, and high-dimensional debiased inference~~

The content is a coherent whole (all of inference), so:
- **Title + matching `\VignetteIndexEntry`** → *"Inference in fetwfe: standard errors, simultaneous bands, and high-dimensional debiasing"*.
- **Intro sentence** broadened to also name `simultaneousCIs()` (the family-wise bands, §6) and `debiasedATT()` (the high-dim `p >= NT` path, §8) — it previously mentioned only standard errors.

Per the earlier discussion, kept as **one** vignette rather than split — the sections build on each other and the HTML TOC handles navigation. The high-dim section can be peeled into its own vignette later if that content grows.

## Verification

- Vignette **knits clean** (RENDER OK; new title in the rendered HTML) · `spell_check()` clean · **R CMD check `--as-cran`: Status OK**.
- Doc-only; post-exec review.

## No version bump

Pure title/intro relabel — no new content or behavior — so DESCRIPTION/NEWS are untouched (which also keeps it conflict-free with the open #358's bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
