### PR TITLE
feat: wild cluster bootstrap SE for the debiased overall ATT (few clusters) (#360)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.54.0
+Version: 1.55.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,23 @@
 # NEWS
 
+## Version 1.55.0
+
+### New features
+
+- `debiasedATT()` gains a **wild cluster bootstrap** confidence interval for the
+  overall ATT via the new `se_method = "wild_bootstrap"` argument (with `B`,
+  `seed`, and `multiplier = c("rademacher", "mammen", "webb")`). It is a
+  few-clusters correction for the analytic two-channel sandwich SE, which is
+  downward-biased when the number of units (clusters) is small --- the regime the
+  high-dimensional path targets (e.g. state-level panels). A studentized score /
+  influence-function bootstrap re-signs the per-unit influence summands (no refit
+  per replicate), so the point estimate and the reported `se` are unchanged and
+  only the interval's critical value is refined. The default
+  `se_method = "analytic"` is unchanged; the new path is not supported for
+  `indep_counts` (two-sample) fits. Also adds the Webb (2013) six-point
+  multiplier (`multiplier = "webb"`), recommended when the number of clusters is
+  very small. Implements the deferred small-`N` half of #307 (#360).
+
 ## Version 1.54.0
 
 ### Improvements

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,17 +6,26 @@
 
 - `debiasedATT()` gains a **wild cluster bootstrap** confidence interval for the
   overall ATT via the new `se_method = "wild_bootstrap"` argument (with `B`,
-  `seed`, and `multiplier = c("rademacher", "mammen", "webb")`). It is a
-  few-clusters correction for the analytic two-channel sandwich SE, which is
-  downward-biased when the number of units (clusters) is small --- the regime the
-  high-dimensional path targets (e.g. state-level panels). A studentized score /
-  influence-function bootstrap re-signs the per-unit influence summands (no refit
-  per replicate), so the point estimate and the reported `se` are unchanged and
-  only the interval's critical value is refined. The default
-  `se_method = "analytic"` is unchanged; the new path is not supported for
-  `indep_counts` (two-sample) fits. Also adds the Webb (2013) six-point
-  multiplier (`multiplier = "webb"`), recommended when the number of clusters is
-  very small. Implements the deferred small-`N` half of #307 (#360).
+  `seed`, and `multiplier`). It is a few-clusters correction for the analytic
+  two-channel sandwich SE, which is downward-biased when the number of units
+  (clusters) is small --- the regime the high-dimensional path targets (e.g.
+  state-level panels). A studentized score / influence-function bootstrap
+  re-signs the per-unit influence summands (no refit per replicate), so the point
+  estimate and the reported `se` are unchanged and only the interval's critical
+  value is refined. The default `se_method = "analytic"` is unchanged; the new
+  path is not supported for `indep_counts` (two-sample) fits. Implements the
+  deferred small-`N` half of #307 (#360).
+- Adds the **Webb (2013) six-point** multiplier (`multiplier = "webb"`) to the
+  bootstrap machinery, available to both `debiasedATT()`'s wild bootstrap and
+  `simultaneousCIs(method = "bootstrap")`. It is the **default** for
+  `debiasedATT()`'s wild bootstrap, because it delivers the studentized
+  bootstrap-t refinement that `"rademacher"`'s constant studentization does not
+  --- exactly what the few-clusters regime needs. Recommended whenever the number
+  of clusters is very small.
+- `simultaneousCIs(method = "bootstrap")` and `debiasedATT(se_method =
+  "wild_bootstrap")` now share their `B` / `seed` validation; a non-integer
+  `seed` (previously truncated silently by `set.seed()`) is now rejected with a
+  clear message.
 
 ## Version 1.54.0
 

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -191,10 +191,15 @@
 #' @param seed `NULL` (draw from the ambient RNG, the default) or a single
 #'   integer for a reproducible bootstrap (the RNG state is saved and restored).
 #'   Ignored unless `se_method = "wild_bootstrap"`.
-#' @param multiplier The wild-bootstrap weight distribution: `"rademacher"`
-#'   (default), `"mammen"`, or `"webb"` (the Webb (2013) six-point distribution,
-#'   recommended when `N` is very small, where the `2^N` Rademacher sign vectors
-#'   are too coarse). Ignored unless `se_method = "wild_bootstrap"`.
+#' @param multiplier The wild-bootstrap weight distribution: `"webb"` (default),
+#'   `"rademacher"`, or `"mammen"`. The default is the Webb (2013) six-point
+#'   distribution because this few-clusters correction is where it matters most:
+#'   with `"rademacher"` (`±1`) the studentization denominator is constant, so
+#'   the interval reduces to a *percentile* wild bootstrap, whereas `"webb"` and
+#'   `"mammen"` vary the denominator and deliver the *studentized* bootstrap-t
+#'   refinement; Webb's finer six-point support is also preferable to the `2^N`
+#'   Rademacher sign vectors when the number of clusters is very small. Ignored
+#'   unless `se_method = "wild_bootstrap"`.
 #' @param lambda_c The leading constant of the high-dimensional (`p >= NT`)
 #'   nodewise penalty `lambda_node = lambda_c * max(|a|) * sqrt(log(p) / N)` (`N` =
 #'   number of units). Either a single positive number (a fixed constant; default
@@ -268,7 +273,7 @@ debiasedATT <- function(
 	se_method = c("analytic", "wild_bootstrap"),
 	B = 1000L,
 	seed = NULL,
-	multiplier = c("rademacher", "mammen", "webb"),
+	multiplier = c("webb", "rademacher", "mammen"),
 	lambda_c = 1.0,
 	riesz_max_iter = 5000L,
 	riesz_tol = 1e-9
@@ -303,29 +308,7 @@ debiasedATT <- function(
 	}
 
 	if (se_method == "wild_bootstrap") {
-		if (
-			!is.numeric(B) ||
-				length(B) != 1L ||
-				is.na(B) ||
-				B < 1 ||
-				B != round(B)
-		) {
-			stop(
-				"debiasedATT(): `B` (bootstrap replicates) must be a single ",
-				"positive integer.",
-				call. = FALSE
-			)
-		}
-		B <- as.integer(B)
-		if (
-			!is.null(seed) &&
-				(!is.numeric(seed) || length(seed) != 1L || is.na(seed))
-		) {
-			stop(
-				"debiasedATT(): `seed` must be NULL or a single integer.",
-				call. = FALSE
-			)
-		}
+		B <- .validate_boot_args(B, seed, "debiasedATT")
 		if (isTRUE(fit$indep_counts_used)) {
 			stop(
 				"debiasedATT(se_method = \"wild_bootstrap\") is not supported for ",
@@ -805,9 +788,18 @@ debiasedATT <- function(
 		# Degenerate variance: the interval collapses to the point estimate.
 		return(list(crit = 0, ci_low = att, ci_high = att))
 	}
+	# Studentized bootstrap-t draw. This is the scalar analogue of
+	# `.simultaneous_bootstrap_crit()` (R/simultaneous_bootstrap.R), which does the
+	# K-dimensional sup-t with a FIXED per-effect studentization; here the scalar
+	# denominator `den` is re-drawn per replicate (a genuine bootstrap-t).
+	# INVARIANT: `psi1` is in fit-unit order and `psi2` in cohort-block order, so
+	# they index DIFFERENT physical units -- the two multiplier streams MUST stay
+	# independent. A shared stream would pair unit i's regression influence with a
+	# different unit's propensity influence; independence makes the statistic
+	# order-invariant, so the order mismatch is harmless.
 	draw_boot <- function() {
 		xi <- .draw_multipliers(N, B, multiplier) # N x B
-		eta <- .draw_multipliers(N, B, multiplier) # N x B, independent stream
+		eta <- .draw_multipliers(N, B, multiplier) # N x B, INDEPENDENT (see above)
 		num <- crossprod(psi1, xi) + crossprod(psi2, eta) # 1 x B
 		den <- sqrt(crossprod(psi1^2, xi^2) + crossprod(psi2^2, eta^2)) # 1 x B
 		as.numeric(num / den)

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -174,6 +174,27 @@
 #'   construction is specific to the FETWFE transformed-coefficient space).
 #' @param alpha Numeric in `(0, 1)`; the confidence level is `1 - alpha`.
 #'   Defaults to the `alpha` stored on the fit.
+#' @param se_method How to form the confidence interval. `"analytic"` (default)
+#'   uses the two-channel unit-clustered sandwich SE with a Gaussian critical
+#'   value (unchanged, backward-compatible). `"wild_bootstrap"` replaces the
+#'   Gaussian critical value with a studentized score / influence-function
+#'   **wild cluster bootstrap** (#360) --- a few-clusters correction for the
+#'   analytic sandwich, which is downward-biased when the number of units (`N`,
+#'   the clusters) is small. The point estimate and the reported `se` are
+#'   unchanged; only the interval half-width (`crit * se`) changes. This is the
+#'   unrestricted score/IF wild bootstrap (no refit per replicate); it refines
+#'   the reference distribution but does not relax the additive-channel
+#'   assumption of the analytic SE. Not supported for `indep_counts` (two-sample)
+#'   fits.
+#' @param B Integer; the number of wild-bootstrap replicates (default `1000`).
+#'   Ignored unless `se_method = "wild_bootstrap"`.
+#' @param seed `NULL` (draw from the ambient RNG, the default) or a single
+#'   integer for a reproducible bootstrap (the RNG state is saved and restored).
+#'   Ignored unless `se_method = "wild_bootstrap"`.
+#' @param multiplier The wild-bootstrap weight distribution: `"rademacher"`
+#'   (default), `"mammen"`, or `"webb"` (the Webb (2013) six-point distribution,
+#'   recommended when `N` is very small, where the `2^N` Rademacher sign vectors
+#'   are too coarse). Ignored unless `se_method = "wild_bootstrap"`.
 #' @param lambda_c The leading constant of the high-dimensional (`p >= NT`)
 #'   nodewise penalty `lambda_node = lambda_c * max(|a|) * sqrt(log(p) / N)` (`N` =
 #'   number of units). Either a single positive number (a fixed constant; default
@@ -195,8 +216,11 @@
 #'     \item{att}{Numeric scalar; the debiased overall-ATT point estimate.}
 #'     \item{se}{Numeric scalar; the uniformly-valid standard error,
 #'       `sqrt(var_reg + var_weight)`.}
-#'     \item{ci_low, ci_high}{Numeric; the `1 - alpha` Wald interval
-#'       `att +/- qnorm(1 - alpha/2) * se`.}
+#'     \item{ci_low, ci_high}{Numeric; the `1 - alpha` interval. With
+#'       `se_method = "analytic"` (default) this is the Wald interval
+#'       `att +/- qnorm(1 - alpha/2) * se`; with `se_method = "wild_bootstrap"`
+#'       the critical value is the bootstrap `crit_value` in place of
+#'       `qnorm(1 - alpha/2)`.}
 #'     \item{var_reg}{Numeric; the regression (outcome) channel's contribution to
 #'       `se^2`, per-unit-clustered.}
 #'     \item{var_weight}{Numeric; the cohort-weight channel's contribution to
@@ -217,6 +241,11 @@
 #'   per-grid feasibility flags and CV losses, and whether the theory-scale
 #'   fallback fired). These are absent for `p < NT` fits.
 #'
+#'   With `se_method = "wild_bootstrap"` the list additionally contains
+#'   `se_method`, `crit_value` (the studentized wild-bootstrap critical value
+#'   replacing `qnorm(1 - alpha/2)`), `B`, `multiplier`, and `alpha`. The analytic
+#'   default adds none of these, so its `names()` are unchanged.
+#'
 #' @references
 #' Faletto, G (2025). Fused Extended Two-Way Fixed Effects for
 #' Difference-in-Differences with Staggered Adoptions.
@@ -236,10 +265,16 @@
 debiasedATT <- function(
 	fit,
 	alpha = NULL,
+	se_method = c("analytic", "wild_bootstrap"),
+	B = 1000L,
+	seed = NULL,
+	multiplier = c("rademacher", "mammen", "webb"),
 	lambda_c = 1.0,
 	riesz_max_iter = 5000L,
 	riesz_tol = 1e-9
 ) {
+	se_method <- match.arg(se_method)
+	multiplier <- match.arg(multiplier)
 	if (!inherits(fit, "fetwfe")) {
 		stop(
 			"debiasedATT() requires a fitted object from fetwfe(). The debiased ",
@@ -265,6 +300,44 @@ debiasedATT <- function(
 			"debiasedATT(): `alpha` must be a single number in (0, 1).",
 			call. = FALSE
 		)
+	}
+
+	if (se_method == "wild_bootstrap") {
+		if (
+			!is.numeric(B) ||
+				length(B) != 1L ||
+				is.na(B) ||
+				B < 1 ||
+				B != round(B)
+		) {
+			stop(
+				"debiasedATT(): `B` (bootstrap replicates) must be a single ",
+				"positive integer.",
+				call. = FALSE
+			)
+		}
+		B <- as.integer(B)
+		if (
+			!is.null(seed) &&
+				(!is.numeric(seed) || length(seed) != 1L || is.na(seed))
+		) {
+			stop(
+				"debiasedATT(): `seed` must be NULL or a single integer.",
+				call. = FALSE
+			)
+		}
+		if (isTRUE(fit$indep_counts_used)) {
+			stop(
+				"debiasedATT(se_method = \"wild_bootstrap\") is not supported for ",
+				"`indep_counts` (two-sample) fits: the cohort-weight variance ",
+				"channel is estimated from the separate count sample, so it has no ",
+				"per-unit influence-function decomposition over the main sample's ",
+				"clusters. Use the analytic SE (the default) here, or refit without ",
+				"`indep_counts` -- a simulation-only feature -- to use the wild ",
+				"bootstrap (real single-sample panels are supported directly).",
+				call. = FALSE
+			)
+		}
 	}
 
 	# High-dimensional nodewise-solver controls. These only affect the p >= NT
@@ -611,11 +684,145 @@ debiasedATT <- function(
 			out$lambda_cv <- riesz_diag$lambda_cv
 		}
 	}
+	# Few-clusters SE (#360): replace the Gaussian critical value with a
+	# studentized score / influence-function wild cluster bootstrap. The analytic
+	# `se` (sqrt(var_reg + var_weight)) is unchanged; only the reference
+	# distribution -- hence the CI half-width -- changes. `unit_scores` is the
+	# per-unit V1 (regression) influence summand; the per-unit V2 (cohort-weight)
+	# summands are built inside the helper. The analytic default leaves `out`
+	# byte-identical (no extra fields), preserving the `names()` contract.
+	if (se_method == "wild_bootstrap") {
+		boot <- .debiased_att_wild_boot(
+			fit = fit,
+			psi1 = unit_scores,
+			var_reg = var_reg,
+			var_weight = var_weight,
+			att = att_db,
+			alpha = alpha,
+			n = n,
+			G = G,
+			T = T,
+			B = B,
+			seed = seed,
+			multiplier = multiplier
+		)
+		out$ci_low <- boot$ci_low
+		out$ci_high <- boot$ci_high
+		out$se_method <- "wild_bootstrap"
+		out$crit_value <- boot$crit
+		out$B <- B
+		out$multiplier <- multiplier
+		out$alpha <- alpha
+	}
 	# Lightweight S3 class for a `print` / `tidy` method (#326). The list contents
 	# are unchanged -- the regime is inferred from the presence of `lambda_node` --
 	# so existing `$`-accessor and `names()` code is unaffected.
 	class(out) <- "debiased_att"
 	out
+}
+
+#' @title Studentized wild cluster bootstrap for the debiased overall ATT
+#' @description
+#' Few-clusters critical value for [debiasedATT()]'s overall-ATT CI via a
+#' studentized score / influence-function wild cluster bootstrap (#360), with NO
+#' refit per replicate. The debiased ATT is asymptotically linear with per-unit
+#' (per-cluster) influence summands in two asymptotically-independent channels:
+#' the regression channel `psi1 = unit_scores` (already computed;
+#' `sum(psi1^2) / n^2 == var_reg`) and the cohort-weight channel `psi2`, built
+#' here from the closed-form overall-ATT gradient `a_att_G = (catt - att_hat) / S`
+#' (`S` = treated fraction) fed to [.build_propensity_if()]
+#' (`sum(psi2^2) / n^2 == var_weight`, checked). Each channel is re-signed with an
+#' INDEPENDENT stream of cluster-level multipliers (reproducing
+#' `var_reg + var_weight` with no cross term), and the `(1 - alpha)` quantile of
+#' the studentized statistic
+#' `|sum(xi psi1) + sum(eta psi2)| / sqrt(sum((xi psi1)^2) + sum((eta psi2)^2))`
+#' is the critical value: `CI = att +/- crit * se`. Uses the BRIDGE `catt` /
+#' `att_hat` (matching `.plugin_v2()` / the analytic `var_weight`) in both
+#' regimes, so the bootstrap reproduces the reported `se` and only refines the
+#' reference distribution.
+#' @param fit The `"fetwfe"` fit (supplies `catt_df$estimate`, `att_hat`,
+#'   `cohort_probs_overall`).
+#' @param psi1 Numeric length-N (number of clusters / units); the per-unit V1
+#'   regression influence summands (`unit_scores`).
+#' @param var_reg,var_weight Numeric scalars; the analytic V1 / V2 variance
+#'   components (`se^2 = var_reg + var_weight`), for the anchor check and `se`.
+#' @param att Numeric scalar; the debiased overall-ATT point estimate (CI center).
+#' @param alpha Numeric in `(0, 1)`.
+#' @param n Integer; the number of observations `N * T` (for the anchor check).
+#' @param G,T Integer; number of treated cohorts / time periods.
+#' @param B Integer; bootstrap replicates.
+#' @param seed `NULL` (ambient RNG) or an integer (reproducible via
+#'   [.with_preserved_rng()]).
+#' @param multiplier Weight type passed to [.draw_multipliers()].
+#' @return A list with `crit` (the bootstrap critical value), `ci_low`, `ci_high`.
+#' @keywords internal
+#' @noRd
+.debiased_att_wild_boot <- function(
+	fit,
+	psi1,
+	var_reg,
+	var_weight,
+	att,
+	alpha,
+	n,
+	G,
+	T,
+	B,
+	seed,
+	multiplier
+) {
+	N <- length(psi1)
+	se <- sqrt(var_reg + var_weight)
+	# Per-unit V2 (cohort-weight) influence: closed-form overall-ATT gradient
+	# a_att_G[g] = (catt_g - att_hat) / S fed to the existing per-unit propensity
+	# IF. Uses the BRIDGE catt / att_hat (fit$catt_df$estimate / fit$att_hat), the
+	# same quantities .plugin_v2() uses, so sum(psi2^2) / n^2 == var_weight. The
+	# marginal `cohort_probs_overall` (sums to the treated fraction) is required by
+	# .build_propensity_if()'s cohort-count recovery.
+	cohort_probs_overall <- fit$cohort_probs_overall
+	S <- sum(cohort_probs_overall[seq_len(G)])
+	a_att_G <- (fit$catt_df$estimate - fit$att_hat) / S
+	psi2 <- as.numeric(.build_propensity_if(
+		cohort_probs_overall = cohort_probs_overall,
+		G = G,
+		N = N,
+		T = T,
+		A = matrix(a_att_G, nrow = G, ncol = 1L)
+	))
+	# Anchor: the per-unit V2 IF must reproduce the analytic cohort-weight
+	# variance. A mismatch means the V2 gradient / probabilities are inconsistent
+	# with `var_weight` (e.g. an unhandled two-sample fit) -- fail loudly.
+	if (abs(sum(psi2^2) / n^2 - var_weight) > 1e-6 * max(1, abs(var_weight))) {
+		stop(
+			"debiasedATT(): internal wild-bootstrap V2 influence-function anchor ",
+			"failed (the per-unit cohort-weight IF does not reproduce ",
+			"`var_weight`). This should not happen for a supported fit; please ",
+			"report it.",
+			call. = FALSE
+		)
+	}
+	if (!is.finite(se) || se <= 0) {
+		# Degenerate variance: the interval collapses to the point estimate.
+		return(list(crit = 0, ci_low = att, ci_high = att))
+	}
+	draw_boot <- function() {
+		xi <- .draw_multipliers(N, B, multiplier) # N x B
+		eta <- .draw_multipliers(N, B, multiplier) # N x B, independent stream
+		num <- crossprod(psi1, xi) + crossprod(psi2, eta) # 1 x B
+		den <- sqrt(crossprod(psi1^2, xi^2) + crossprod(psi2^2, eta^2)) # 1 x B
+		as.numeric(num / den)
+	}
+	t_boot <- if (is.null(seed)) {
+		draw_boot()
+	} else {
+		.with_preserved_rng(seed, draw_boot())
+	}
+	crit <- as.numeric(stats::quantile(
+		abs(t_boot),
+		probs = 1 - alpha,
+		names = FALSE
+	))
+	list(crit = crit, ci_low = att - crit * se, ci_high = att + crit * se)
 }
 
 #' @title Print a debiased overall-ATT estimate
@@ -630,11 +837,17 @@ debiasedATT <- function(
 #' @export
 print.debiased_att <- function(x, ...) {
 	highdim <- !is.null(x$lambda_node)
+	boot <- identical(x$se_method, "wild_bootstrap")
 	cat(sprintf(
 		"Debiased overall ATT (%s regime)\n",
 		if (highdim) "high-dimensional" else "fixed-p"
 	))
-	level <- if (is.finite(x$se) && x$se > 0) {
+	# The wild-bootstrap CI half-width is `crit * se` with a bootstrap `crit`, so
+	# the nominal level cannot be read back off the Gaussian quantile -- use the
+	# stored `alpha`. The analytic path (no `se_method`) keeps its inference.
+	level <- if (boot) {
+		round(100 * (1 - x$alpha))
+	} else if (is.finite(x$se) && x$se > 0) {
 		round(100 * (2 * stats::pnorm((x$ci_high - x$att) / x$se) - 1))
 	} else {
 		NA_real_
@@ -643,6 +856,14 @@ print.debiased_att <- function(x, ...) {
 	cat(sprintf("  Estimate:   %.4f\n", x$att))
 	cat(sprintf("  Std. Error: %.4f\n", x$se))
 	cat(sprintf("  %s: [%.4f, %.4f]\n", ci_label, x$ci_low, x$ci_high))
+	if (boot) {
+		cat(sprintf(
+			"  CI method:  wild cluster bootstrap (B = %d, %s weights; crit = %.3f)\n",
+			x$B,
+			x$multiplier,
+			x$crit_value
+		))
+	}
 	if (highdim) {
 		.print_highdim_diagnostics(x)
 	}

--- a/R/simultaneous_bootstrap.R
+++ b/R/simultaneous_bootstrap.R
@@ -23,14 +23,25 @@
 #' @description `N x B` matrix of mean-zero, unit-variance multipliers, one column
 #'   per bootstrap replicate. `"rademacher"` draws `+/-1` with probability 1/2;
 #'   `"mammen"` draws the two-point distribution of Mammen (1993) (mean 0,
-#'   variance 1, third moment 1).
+#'   variance 1, third moment 1); `"webb"` draws the six-point distribution of
+#'   Webb (2013), values `+/- sqrt(1.5)`, `+/- 1`, `+/- sqrt(0.5)` each with
+#'   probability 1/6 (mean 0, variance 1) -- preferred with very few clusters,
+#'   where the `2^N` Rademacher sign vectors are too coarse.
 #' @keywords internal
 #' @noRd
-.draw_multipliers <- function(N, B, type = c("rademacher", "mammen")) {
+.draw_multipliers <- function(N, B, type = c("rademacher", "mammen", "webb")) {
 	type <- match.arg(type)
 	if (type == "rademacher") {
 		matrix(
 			sample(c(-1, 1), size = N * B, replace = TRUE),
+			nrow = N,
+			ncol = B
+		)
+	} else if (type == "webb") {
+		# Webb (2013) six-point distribution: mean 0, E[w^2] = 1.
+		webb_vals <- c(-sqrt(1.5), -1, -sqrt(0.5), sqrt(0.5), 1, sqrt(1.5))
+		matrix(
+			sample(webb_vals, size = N * B, replace = TRUE),
 			nrow = N,
 			ncol = B
 		)

--- a/R/simultaneous_bootstrap.R
+++ b/R/simultaneous_bootstrap.R
@@ -60,6 +60,46 @@
 	}
 }
 
+#' @title Validate shared multiplier-bootstrap `B` / `seed` arguments
+#' @description Shared validation for the bootstrap replicate count `B` (a single
+#'   positive integer) and `seed` (`NULL` or a single integer) used by both
+#'   `simultaneousCIs(method = "bootstrap")` and
+#'   `debiasedATT(se_method = "wild_bootstrap")`, so the two cannot silently drift
+#'   on what they accept. `seed` must be integer-valued (a non-integer would be
+#'   silently truncated by `set.seed()`).
+#' @param B,seed The arguments to validate.
+#' @param fn_name Character; the caller's name, for the error message prefix.
+#' @return `B` coerced to integer.
+#' @keywords internal
+#' @noRd
+.validate_boot_args <- function(B, seed, fn_name) {
+	if (
+		!is.numeric(B) ||
+			length(B) != 1L ||
+			is.na(B) ||
+			B < 1 ||
+			B != round(B)
+	) {
+		stop(
+			sprintf("%s(): `B` must be a single positive integer.", fn_name),
+			call. = FALSE
+		)
+	}
+	if (
+		!is.null(seed) &&
+			(!is.numeric(seed) ||
+				length(seed) != 1L ||
+				is.na(seed) ||
+				seed != round(seed))
+	) {
+		stop(
+			sprintf("%s(): `seed` must be NULL or a single integer.", fn_name),
+			call. = FALSE
+		)
+	}
+	as.integer(B)
+}
+
 #' Per-unit regression influence-function matrix `F_reg` (N_units x K), fixed-p
 #'
 #' @description
@@ -435,7 +475,7 @@
 	n,
 	alpha,
 	B,
-	multiplier = c("rademacher", "mammen"),
+	multiplier = c("rademacher", "mammen", "webb"),
 	seed = NULL
 ) {
 	multiplier <- match.arg(multiplier)

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -119,8 +119,9 @@ utils::globalVariables(c(
 #'   them). If `NULL` (default), the draws come from the ambient generator, so
 #'   results vary run to run. Ignored when `method = "analytic"`.
 #' @param multiplier Character; the multiplier-weight distribution for the
-#'   bootstrap: `"rademacher"` (default, `+/-1`) or `"mammen"` (the Mammen 1993
-#'   two-point distribution). Ignored when `method = "analytic"`.
+#'   bootstrap: `"rademacher"` (default, `+/-1`), `"mammen"` (the Mammen 1993
+#'   two-point distribution), or `"webb"` (the Webb 2013 six-point distribution,
+#'   preferred with very few clusters). Ignored when `method = "analytic"`.
 #' @param lambda_c,riesz_max_iter,riesz_tol Controls for the high-dimensional
 #'   (`p >= NT`) bootstrap, where each effect's debiasing direction is a nodewise
 #'   (desparsified-lasso) `riesz_lasso()` solve. `lambda_c` is the leading
@@ -252,7 +253,7 @@ simultaneousCIs <- function(
 	method = c("analytic", "bootstrap"),
 	B = 1000L,
 	seed = NULL,
-	multiplier = c("rademacher", "mammen"),
+	multiplier = c("rademacher", "mammen", "webb"),
 	lambda_c = 1.0,
 	riesz_max_iter = 5000L,
 	riesz_tol = 1e-9
@@ -279,7 +280,7 @@ simultaneousCIs.fetwfe <- function(
 	method = c("analytic", "bootstrap"),
 	B = 1000L,
 	seed = NULL,
-	multiplier = c("rademacher", "mammen"),
+	multiplier = c("rademacher", "mammen", "webb"),
 	lambda_c = 1.0,
 	riesz_max_iter = 5000L,
 	riesz_tol = 1e-9
@@ -311,7 +312,7 @@ simultaneousCIs.etwfe <- function(
 	method = c("analytic", "bootstrap"),
 	B = 1000L,
 	seed = NULL,
-	multiplier = c("rademacher", "mammen"),
+	multiplier = c("rademacher", "mammen", "webb"),
 	lambda_c = 1.0,
 	riesz_max_iter = 5000L,
 	riesz_tol = 1e-9
@@ -343,7 +344,7 @@ simultaneousCIs.betwfe <- function(
 	method = c("analytic", "bootstrap"),
 	B = 1000L,
 	seed = NULL,
-	multiplier = c("rademacher", "mammen"),
+	multiplier = c("rademacher", "mammen", "webb"),
 	lambda_c = 1.0,
 	riesz_max_iter = 5000L,
 	riesz_tol = 1e-9
@@ -384,7 +385,7 @@ simultaneousCIs.twfeCovs <- function(
 	method = c("analytic", "bootstrap"),
 	B = 1000L,
 	seed = NULL,
-	multiplier = c("rademacher", "mammen"),
+	multiplier = c("rademacher", "mammen", "webb"),
 	lambda_c = 1.0,
 	riesz_max_iter = 5000L,
 	riesz_tol = 1e-9
@@ -470,28 +471,7 @@ simultaneousCIs.twfeCovs <- function(
 		)
 	}
 	if (method == "bootstrap") {
-		if (
-			!is.numeric(B) ||
-				length(B) != 1L ||
-				is.na(B) ||
-				B < 1 ||
-				B != round(B)
-		) {
-			stop(
-				"simultaneousCIs(): `B` must be a single positive integer.",
-				call. = FALSE
-			)
-		}
-		B <- as.integer(B)
-		if (
-			!is.null(seed) &&
-				(!is.numeric(seed) || length(seed) != 1L || is.na(seed))
-		) {
-			stop(
-				"simultaneousCIs(): `seed` must be NULL or a single number.",
-				call. = FALSE
-			)
-		}
+		B <- .validate_boot_args(B, seed, "simultaneousCIs")
 	}
 
 	# --- 2. Read fit slots via class-aware shims. ---

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -190,6 +190,7 @@ sd
 SEs
 Springer
 SSRN
+studentization
 subagent
 subgaussian
 Subgaussian

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -173,6 +173,7 @@ PRs
 PSD
 qmvnorm
 qquad
+Rademacher
 README
 recomputation
 reframed

--- a/man/debiasedATT.Rd
+++ b/man/debiasedATT.Rd
@@ -10,7 +10,7 @@ debiasedATT(
   se_method = c("analytic", "wild_bootstrap"),
   B = 1000L,
   seed = NULL,
-  multiplier = c("rademacher", "mammen", "webb"),
+  multiplier = c("webb", "rademacher", "mammen"),
   lambda_c = 1,
   riesz_max_iter = 5000L,
   riesz_tol = 1e-09
@@ -47,10 +47,15 @@ Ignored unless \code{se_method = "wild_bootstrap"}.}
 integer for a reproducible bootstrap (the RNG state is saved and restored).
 Ignored unless \code{se_method = "wild_bootstrap"}.}
 
-\item{multiplier}{The wild-bootstrap weight distribution: \code{"rademacher"}
-(default), \code{"mammen"}, or \code{"webb"} (the Webb (2013) six-point distribution,
-recommended when \code{N} is very small, where the \code{2^N} Rademacher sign vectors
-are too coarse). Ignored unless \code{se_method = "wild_bootstrap"}.}
+\item{multiplier}{The wild-bootstrap weight distribution: \code{"webb"} (default),
+\code{"rademacher"}, or \code{"mammen"}. The default is the Webb (2013) six-point
+distribution because this few-clusters correction is where it matters most:
+with \code{"rademacher"} (\verb{±1}) the studentization denominator is constant, so
+the interval reduces to a \emph{percentile} wild bootstrap, whereas \code{"webb"} and
+\code{"mammen"} vary the denominator and deliver the \emph{studentized} bootstrap-t
+refinement; Webb's finer six-point support is also preferable to the \code{2^N}
+Rademacher sign vectors when the number of clusters is very small. Ignored
+unless \code{se_method = "wild_bootstrap"}.}
 
 \item{lambda_c}{The leading constant of the high-dimensional (\code{p >= NT})
 nodewise penalty \verb{lambda_node = lambda_c * max(|a|) * sqrt(log(p) / N)} (\code{N} =

--- a/man/debiasedATT.Rd
+++ b/man/debiasedATT.Rd
@@ -7,6 +7,10 @@
 debiasedATT(
   fit,
   alpha = NULL,
+  se_method = c("analytic", "wild_bootstrap"),
+  B = 1000L,
+  seed = NULL,
+  multiplier = c("rademacher", "mammen", "webb"),
   lambda_c = 1,
   riesz_max_iter = 5000L,
   riesz_tol = 1e-09
@@ -22,6 +26,31 @@ construction is specific to the FETWFE transformed-coefficient space).}
 
 \item{alpha}{Numeric in \verb{(0, 1)}; the confidence level is \code{1 - alpha}.
 Defaults to the \code{alpha} stored on the fit.}
+
+\item{se_method}{How to form the confidence interval. \code{"analytic"} (default)
+uses the two-channel unit-clustered sandwich SE with a Gaussian critical
+value (unchanged, backward-compatible). \code{"wild_bootstrap"} replaces the
+Gaussian critical value with a studentized score / influence-function
+\strong{wild cluster bootstrap} (#360) --- a few-clusters correction for the
+analytic sandwich, which is downward-biased when the number of units (\code{N},
+the clusters) is small. The point estimate and the reported \code{se} are
+unchanged; only the interval half-width (\code{crit * se}) changes. This is the
+unrestricted score/IF wild bootstrap (no refit per replicate); it refines
+the reference distribution but does not relax the additive-channel
+assumption of the analytic SE. Not supported for \code{indep_counts} (two-sample)
+fits.}
+
+\item{B}{Integer; the number of wild-bootstrap replicates (default \code{1000}).
+Ignored unless \code{se_method = "wild_bootstrap"}.}
+
+\item{seed}{\code{NULL} (draw from the ambient RNG, the default) or a single
+integer for a reproducible bootstrap (the RNG state is saved and restored).
+Ignored unless \code{se_method = "wild_bootstrap"}.}
+
+\item{multiplier}{The wild-bootstrap weight distribution: \code{"rademacher"}
+(default), \code{"mammen"}, or \code{"webb"} (the Webb (2013) six-point distribution,
+recommended when \code{N} is very small, where the \code{2^N} Rademacher sign vectors
+are too coarse). Ignored unless \code{se_method = "wild_bootstrap"}.}
 
 \item{lambda_c}{The leading constant of the high-dimensional (\code{p >= NT})
 nodewise penalty \verb{lambda_node = lambda_c * max(|a|) * sqrt(log(p) / N)} (\code{N} =
@@ -46,8 +75,11 @@ and a \code{tidy} method) with elements:
 \item{att}{Numeric scalar; the debiased overall-ATT point estimate.}
 \item{se}{Numeric scalar; the uniformly-valid standard error,
 \code{sqrt(var_reg + var_weight)}.}
-\item{ci_low, ci_high}{Numeric; the \code{1 - alpha} Wald interval
-\verb{att +/- qnorm(1 - alpha/2) * se}.}
+\item{ci_low, ci_high}{Numeric; the \code{1 - alpha} interval. With
+\code{se_method = "analytic"} (default) this is the Wald interval
+\verb{att +/- qnorm(1 - alpha/2) * se}; with \code{se_method = "wild_bootstrap"}
+the critical value is the bootstrap \code{crit_value} in place of
+\code{qnorm(1 - alpha/2)}.}
 \item{var_reg}{Numeric; the regression (outcome) channel's contribution to
 \code{se^2}, per-unit-clustered.}
 \item{var_weight}{Numeric; the cohort-weight channel's contribution to
@@ -67,6 +99,11 @@ and \code{lambda_c_selection} (\code{"fixed"} or \code{"cv"}). When \code{lambda
 also contains \code{lambda_cv}, the cross-validation diagnostics (the grid, the
 per-grid feasibility flags and CV losses, and whether the theory-scale
 fallback fired). These are absent for \code{p < NT} fits.
+
+With \code{se_method = "wild_bootstrap"} the list additionally contains
+\code{se_method}, \code{crit_value} (the studentized wild-bootstrap critical value
+replacing \code{qnorm(1 - alpha/2)}), \code{B}, \code{multiplier}, and \code{alpha}. The analytic
+default adds none of these, so its \code{names()} are unchanged.
 }
 \description{
 Computes a \emph{debiased} estimate of the overall average treatment effect on the

--- a/man/simultaneousCIs.Rd
+++ b/man/simultaneousCIs.Rd
@@ -13,7 +13,7 @@ simultaneousCIs(
   method = c("analytic", "bootstrap"),
   B = 1000L,
   seed = NULL,
-  multiplier = c("rademacher", "mammen"),
+  multiplier = c("rademacher", "mammen", "webb"),
   lambda_c = 1,
   riesz_max_iter = 5000L,
   riesz_tol = 1e-09
@@ -96,8 +96,9 @@ them). If \code{NULL} (default), the draws come from the ambient generator, so
 results vary run to run. Ignored when \code{method = "analytic"}.}
 
 \item{multiplier}{Character; the multiplier-weight distribution for the
-bootstrap: \code{"rademacher"} (default, \verb{+/-1}) or \code{"mammen"} (the Mammen 1993
-two-point distribution). Ignored when \code{method = "analytic"}.}
+bootstrap: \code{"rademacher"} (default, \verb{+/-1}), \code{"mammen"} (the Mammen 1993
+two-point distribution), or \code{"webb"} (the Webb 2013 six-point distribution,
+preferred with very few clusters). Ignored when \code{method = "analytic"}.}
 
 \item{lambda_c, riesz_max_iter, riesz_tol}{Controls for the high-dimensional
 (\code{p >= NT}) bootstrap, where each effect's debiasing direction is a nodewise

--- a/tests/testthat/test-debiased-att-wild-bootstrap-360.R
+++ b/tests/testthat/test-debiased-att-wild-bootstrap-360.R
@@ -200,9 +200,64 @@ test_that("wild bootstrap validates B and seed (#360)", {
 		debiasedATT(fit, se_method = "wild_bootstrap", seed = c(1, 2)),
 		"`seed`"
 	)
+	# A non-integer seed is rejected (it would be silently truncated by set.seed).
+	expect_error(
+		debiasedATT(fit, se_method = "wild_bootstrap", seed = 1.5),
+		"`seed`"
+	)
 	expect_error(
 		debiasedATT(fit, se_method = "wild_bootstrap", multiplier = "gaussian")
 	)
+})
+
+test_that("the default wild-bootstrap multiplier is webb (#360, review 1)", {
+	# Webb is the default so the *studentized* bootstrap-t refinement is delivered
+	# by default in the few-clusters regime this targets -- rademacher's constant
+	# denominator would instead give the (unstudentized) percentile variant.
+	w <- debiasedATT(.wb_fixedp, se_method = "wild_bootstrap", seed = 1)
+	expect_identical(w$multiplier, "webb")
+})
+
+test_that("wild bootstrap handles a single-cohort fit, var_weight = 0 (#360, review 6)", {
+	# One treated cohort => no cohort-weight variance => psi2 == 0 => the bootstrap
+	# degrades cleanly to a V1-only wild bootstrap (anchor 0 == 0 holds, no NaN).
+	cf <- genCoefs(G = 1, T = 5, d = 2, density = 0.5, eff_size = 2, seed = 4)
+	sim <- simulateData(
+		cf,
+		N = 60,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 4
+	)
+	fit <- fetwfe(
+		pdata = sim$pdata,
+		time_var = sim$time_var,
+		unit_var = sim$unit_var,
+		treatment = sim$treatment,
+		response = sim$response,
+		covs = sim$covs,
+		q = 0.5,
+		verbose = FALSE
+	)
+	a <- debiasedATT(fit)
+	expect_equal(a$var_weight, 0)
+	w <- debiasedATT(fit, se_method = "wild_bootstrap", seed = 1)
+	expect_equal(w$se, a$se)
+	expect_true(is.finite(w$crit_value) && w$crit_value > 0)
+	expect_equal(w$ci_high - w$att, w$crit_value * w$se)
+})
+
+test_that("webb is reachable from simultaneousCIs() too (#360, review 5)", {
+	sc <- suppressWarnings(simultaneousCIs(
+		.wb_fixedp,
+		family = "cohort",
+		method = "bootstrap",
+		B = 200,
+		seed = 1,
+		multiplier = "webb"
+	))
+	expect_s3_class(sc, "simultaneous_cis")
+	expect_true(is.finite(sc$critical_value) && sc$critical_value > 0)
 })
 
 test_that("print.debiased_att surfaces the bootstrap method and level (#360)", {

--- a/tests/testthat/test-debiased-att-wild-bootstrap-360.R
+++ b/tests/testthat/test-debiased-att-wild-bootstrap-360.R
@@ -1,0 +1,224 @@
+library(testthat)
+library(fetwfe)
+
+# ------------------------------------------------------------------------------
+# #360: small-number-of-clusters SE for the debiased overall ATT via a
+# studentized score / influence-function WILD CLUSTER BOOTSTRAP (se_method =
+# "wild_bootstrap"). The analytic sandwich SE is downward-biased with few
+# clusters; the bootstrap replaces the Gaussian critical value with a
+# few-cluster-corrected one WITHOUT a refit per replicate, by re-signing the
+# per-unit influence summands (V1 regression `unit_scores` + V2 cohort-weight,
+# built from a_att_G = (catt - att_hat)/S). Point estimate and reported `se` are
+# unchanged; only the CI half-width changes. Default se_method = "analytic" is
+# byte-identical to the previous behavior.
+# ------------------------------------------------------------------------------
+
+# Single-sample fixtures (the wild bootstrap requires single-sample fits;
+# fetwfeWithSimulatedData() uses indep_counts, which is unsupported -- see below).
+.wb_fixedp <- local({
+	cf <- genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = 2, seed = 1)
+	sim <- simulateData(
+		cf,
+		N = 60,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 1
+	)
+	fetwfe(
+		pdata = sim$pdata,
+		time_var = sim$time_var,
+		unit_var = sim$unit_var,
+		treatment = sim$treatment,
+		response = sim$response,
+		covs = sim$covs,
+		q = 0.5,
+		verbose = FALSE
+	)
+})
+
+.wb_highdim <- local({
+	cf <- genCoefs(G = 3, T = 5, d = 22, density = 0.5, eff_size = 2, seed = 1)
+	sim <- simulateData(
+		cf,
+		N = 30,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 1
+	)
+	fetwfe(
+		pdata = sim$pdata,
+		time_var = sim$time_var,
+		unit_var = sim$unit_var,
+		treatment = sim$treatment,
+		response = sim$response,
+		covs = sim$covs,
+		q = 0.5,
+		gls = FALSE, # Omega-free high-dim path (REML can't run at p >= NT)
+		verbose = FALSE
+	)
+})
+
+test_that("analytic default is unchanged and adds no bootstrap fields (#360)", {
+	for (fit in list(.wb_fixedp, .wb_highdim)) {
+		a0 <- debiasedATT(fit)
+		a1 <- debiasedATT(fit, se_method = "analytic")
+		# se_method = "analytic" is the default and is identical.
+		expect_identical(a0, a1)
+		# No bootstrap fields on the analytic object.
+		expect_false(any(
+			c("se_method", "crit_value", "B", "multiplier") %in% names(a0)
+		))
+	}
+	# fixed-p analytic keeps EXACTLY the documented names (the #326 contract).
+	expect_identical(
+		names(debiasedATT(.wb_fixedp)),
+		c("att", "se", "ci_low", "ci_high", "var_reg", "var_weight")
+	)
+})
+
+test_that("wild bootstrap leaves att and se unchanged, only the CI changes (#360)", {
+	for (fit in list(.wb_fixedp, .wb_highdim)) {
+		a <- debiasedATT(fit)
+		w <- debiasedATT(fit, se_method = "wild_bootstrap", seed = 1)
+		expect_equal(w$att, a$att)
+		expect_equal(w$se, a$se) # analytic sandwich SE is reused verbatim
+		expect_identical(w$se_method, "wild_bootstrap")
+		expect_true(all(
+			c("crit_value", "B", "multiplier", "alpha") %in% names(w)
+		))
+		# CI is centered on att with half-width crit * se.
+		expect_equal(w$ci_high - w$att, w$crit_value * w$se)
+		expect_equal(w$att - w$ci_low, w$crit_value * w$se)
+		expect_gt(w$crit_value, 0)
+	}
+})
+
+test_that("the V2 cohort-weight influence function reproduces var_weight (the anchor) (#360)", {
+	# The correctness gate: the per-unit V2 summands psi2 built from the
+	# closed-form gradient a_att_G = (catt - att_hat)/S must satisfy
+	# sum(psi2^2)/n^2 == var_weight (== .plugin_v2). Mutating the gradient breaks
+	# this, so the test is sensitive to a wrong V2 construction.
+	for (fit in list(.wb_fixedp, .wb_highdim)) {
+		db <- debiasedATT(fit)
+		G <- fit$G
+		Tt <- fit$T
+		N <- fit$N
+		n <- N * Tt
+		S <- sum(fit$cohort_probs_overall[seq_len(G)])
+		a_att_G <- (fit$catt_df$estimate - fit$att_hat) / S
+		psi2 <- as.numeric(fetwfe:::.build_propensity_if(
+			cohort_probs_overall = fit$cohort_probs_overall,
+			G = G,
+			N = N,
+			T = Tt,
+			A = matrix(a_att_G, nrow = G, ncol = 1L)
+		))
+		expect_equal(sum(psi2^2) / n^2, db$var_weight)
+	}
+})
+
+test_that("wild bootstrap is reproducible with a seed and ambient without (#360)", {
+	fit <- .wb_fixedp
+	w1 <- debiasedATT(fit, se_method = "wild_bootstrap", seed = 42)
+	w2 <- debiasedATT(fit, se_method = "wild_bootstrap", seed = 42)
+	expect_identical(w1$crit_value, w2$crit_value)
+	expect_identical(w1$ci_low, w2$ci_low)
+	# A different seed (almost surely) gives a different critical value.
+	w3 <- debiasedATT(fit, se_method = "wild_bootstrap", seed = 7)
+	expect_false(isTRUE(all.equal(w1$crit_value, w3$crit_value)))
+	# seed = NULL draws from the ambient stream and still returns a finite crit.
+	set.seed(1)
+	w_null <- debiasedATT(fit, se_method = "wild_bootstrap")
+	expect_true(is.finite(w_null$crit_value) && w_null$crit_value > 0)
+	# Seeded draw does not disturb the ambient RNG stream (.with_preserved_rng).
+	set.seed(100)
+	u_before <- runif(1)
+	set.seed(100)
+	invisible(debiasedATT(fit, se_method = "wild_bootstrap", seed = 42))
+	u_after <- runif(1)
+	expect_identical(u_before, u_after)
+})
+
+test_that("all three multiplier types produce finite critical values (#360)", {
+	fit <- .wb_fixedp
+	for (m in c("rademacher", "mammen", "webb")) {
+		w <- debiasedATT(
+			fit,
+			se_method = "wild_bootstrap",
+			multiplier = m,
+			seed = 1
+		)
+		expect_identical(w$multiplier, m)
+		expect_true(is.finite(w$crit_value) && w$crit_value > 0)
+	}
+})
+
+test_that(".draw_multipliers webb has the right support and moments (#360)", {
+	set.seed(1)
+	w <- fetwfe:::.draw_multipliers(1L, 2e5L, "webb")
+	expect_setequal(
+		round(sort(unique(as.numeric(w))), 6),
+		round(c(-sqrt(1.5), -1, -sqrt(0.5), sqrt(0.5), 1, sqrt(1.5)), 6)
+	)
+	expect_equal(mean(w), 0, tolerance = 0.02) # mean 0
+	expect_equal(mean(w^2), 1, tolerance = 0.02) # unit variance
+})
+
+test_that("wild bootstrap errors on indep_counts (two-sample) fits (#360)", {
+	# fetwfeWithSimulatedData() uses the simulator's indep_counts, so its fits are
+	# two-sample: the single-sample per-unit V2 IF cannot reproduce var_weight.
+	cf <- genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = 2, seed = 3)
+	sim <- simulateData(
+		cf,
+		N = 80,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 3
+	)
+	fit_ic <- fetwfeWithSimulatedData(sim, q = 0.5, verbose = FALSE)
+	expect_true(isTRUE(fit_ic$indep_counts_used))
+	# Analytic still works on indep_counts fits.
+	expect_s3_class(debiasedATT(fit_ic), "debiased_att")
+	# The wild bootstrap refuses, with an actionable message.
+	expect_error(
+		debiasedATT(fit_ic, se_method = "wild_bootstrap"),
+		"indep_counts"
+	)
+})
+
+test_that("wild bootstrap validates B and seed (#360)", {
+	fit <- .wb_fixedp
+	expect_error(
+		debiasedATT(fit, se_method = "wild_bootstrap", B = -1),
+		"`B`"
+	)
+	expect_error(
+		debiasedATT(fit, se_method = "wild_bootstrap", B = 2.5),
+		"`B`"
+	)
+	expect_error(
+		debiasedATT(fit, se_method = "wild_bootstrap", seed = c(1, 2)),
+		"`seed`"
+	)
+	expect_error(
+		debiasedATT(fit, se_method = "wild_bootstrap", multiplier = "gaussian")
+	)
+})
+
+test_that("print.debiased_att surfaces the bootstrap method and level (#360)", {
+	fit <- .wb_fixedp
+	w <- debiasedATT(
+		fit,
+		se_method = "wild_bootstrap",
+		multiplier = "webb",
+		seed = 1
+	)
+	out <- capture.output(print(w))
+	expect_true(any(grepl("wild cluster bootstrap", out)))
+	expect_true(any(grepl("webb weights", out)))
+	# Level read from stored alpha (0.05 -> 95%), NOT inferred from crit * se.
+	expect_true(any(grepl("95% CI", out)))
+	# The analytic print does NOT show the bootstrap line.
+	out_a <- capture.output(print(debiasedATT(fit)))
+	expect_false(any(grepl("wild cluster bootstrap", out_a)))
+})

--- a/vignettes/inference_vignette.Rmd
+++ b/vignettes/inference_vignette.Rmd
@@ -435,6 +435,18 @@ In any single draw the fused and debiased point estimates can be close, so the v
 
 The fused interval under-covers because of the post-selection non-uniformity; the debiased interval is near-nominal. This is validated at the studied anchor (with the feasibility-appropriate penalty); treat the $p \geq NT$ path as **experimental** outside that regime --- which is why the diagnostics above matter.
 
+## Few clusters: the wild cluster bootstrap
+
+The analytic standard error above is a unit-clustered sandwich: consistent as the number of units (clusters) grows, but **downward-biased when there are few clusters** --- exactly the regime the high-dimensional path often lives in (state-level panels have tens of units, not thousands), so the Gaussian interval can over-reject. `se_method = "wild_bootstrap"` replaces the Gaussian critical value with a studentized score / influence-function **wild cluster bootstrap** that re-signs the per-unit influence summands (no refit per replicate), leaving the point estimate and the reported `se` unchanged and only replacing the Gaussian critical value with a few-cluster-corrected one (usually wider, occasionally slightly narrower at moderate cluster counts):
+
+```{r highdim-wild-boot, eval = FALSE}
+# `fit` must be a single-sample fetwfe() fit -- not an `indep_counts` fit, which
+# the worked example above (via fetwfeWithSimulatedData) happens to be.
+debiasedATT(fit, se_method = "wild_bootstrap", multiplier = "webb", seed = 1)
+```
+
+Prefer `multiplier = "webb"` (the Webb six-point weights) when the number of units is very small, where the default `"rademacher"` ($\pm 1$) has too few distinct sign vectors. The bootstrap is defined only for **single-sample** fits; real observational panels --- the few-cluster case this targets --- are single-sample.
+
 ## Simultaneous bands at $p \geq NT$
 
 `simultaneousCIs()` also switches to the desparsified construction in the high-dimensional regime (via `method = "bootstrap"`; the analytic Gram-inverse band does not exist when $p \geq NT$):


### PR DESCRIPTION
## Summary

Adds a **wild cluster bootstrap** confidence interval to `debiasedATT()` for the few-clusters regime — the deferred small-`N` half of #307. New argument `se_method = "wild_bootstrap"` (default `"analytic"`, fully backward-compatible). Closes #360.

## Motivation

The high-dim `debiasedATT()` reports a unit-clustered two-channel sandwich SE — consistent as `N → ∞`, but **downward-biased with few clusters** (Cameron–Gelbach–Miller), so it over-rejects. That is exactly the regime the high-dimensional path targets (e.g. the paper's `p = 4847 > NT`, `N = 42` divorce application). The wild bootstrap supplies a few-cluster-corrected critical value.

## Approach — studentized score / influence-function wild bootstrap (no refit per replicate)

The debiased ATT is asymptotically linear with per-unit influence summands in two asymptotically-independent channels:
- **V1** (regression) `= unit_scores` — already computed; `Σψ²/n² = var_reg`.
- **V2** (cohort-weight) — built from the closed-form overall-ATT gradient `a_att_G = (catt − att_hat)/S` fed to the existing `.build_propensity_if()`, **anchored so `Σψ²/n² = var_weight`** (checked internally + tested — the correctness gate).

Each channel is re-signed with an **independent** cluster-level multiplier stream; the `(1−α)` quantile of the studentized statistic `|Σξψ₁ + Σηψ₂| / √(Σ(ξψ₁)² + Σ(ηψ₂)²)` is the critical value. The point estimate and the reported `se` are unchanged; only the CI half-width (`crit·se`) changes.

The design was validated by a statistical plan-review, which caught two things now handled: **V2 uses the bridge `catt` in both regimes** (to match `.plugin_v2()` / the analytic `var_weight`), and **`indep_counts` two-sample fits are cleanly refused** (their two-sample `var_weight` cannot be reproduced by a single-sample per-unit IF — verified: 0.0189 vs 0.0201).

## API

`debiasedATT(fit, se_method = c("analytic", "wild_bootstrap"), B = 1000L, seed = NULL, multiplier = c("rademacher", "mammen", "webb"), ...)` — reusing `simultaneousCIs()`'s bootstrap conventions. Added the **Webb (2013) six-point** multiplier (`multiplier = "webb"`, recommended for very few clusters).

The four new args are inserted after `alpha` (grouping the CI-method args), which shifts `lambda_c` from positional slot 3 → 7. Every internal/test/vignette caller passes `lambda_c`/`riesz_*` **by name** (verified), so nothing breaks; an external *positional* `lambda_c` call would now error loudly (not misbehave silently). Say the word if you'd rather I append the new args at the end to preserve positions.

## Verification

- New `test-debiased-att-wild-bootstrap-360.R` (**45 assertions**): the **V2 anchor** (`Σψ²/n² == var_weight`, **mutation-checked** — reverting the gradient's `/S` fails 4 tests via the internal anchor), analytic-default byte-identity + the `names()` contract from #326, se/att invariance, `CI = att ± crit·se`, seed reproducibility + ambient-RNG preservation, all three multipliers, Webb-6 support/moments, the `indep_counts` error, `B`/`seed` validation, and the print.
- Full suite **FAIL 0** · `document()` clean · `spell_check` clean · **R CMD check `--as-cran`**.
- The analytic default is **byte-identical** to before (the `debiasedATT()` `names()` contract preserved), and a short note is added to the inference vignette's high-dim section.

## Review fixes (folded into this branch)

Addressing the review pass:
- **Webb is now the default multiplier** for the wild bootstrap (review #1A) — it delivers the *studentized* bootstrap-t, whereas `rademacher`'s constant denominator gives only the percentile variant, and studentization is the point in the few-clusters regime.
- **Shared `.validate_boot_args(B, seed, caller)`** (review #2) de-duplicates the `debiasedATT()` / `simultaneousCIs()` bootstrap-arg validation (they had already drifted on the seed message), and now **rejects a non-integer `seed`** that `set.seed()` would silently truncate (the nit).
- **Webb wired through `simultaneousCIs()`'s public `multiplier` arg** too (review #5) — it was half-wired (in the shared helper but unreachable), the same few-cluster regime it targets.
- Comments pinning the **order-invariance invariant** (psi1 unit-order vs psi2 cohort-order → streams must stay independent) and **cross-referencing** `.simultaneous_bootstrap_crit()` (reviews #3, #4).
- New tests for the **single-cohort `var_weight == 0`** V1-only path (review #6), the webb default, and webb-via-`simultaneousCIs()`.

The arg-order note stands: the four new args sit after `alpha` (shifting `lambda_c` 3→7); the review confirmed every caller uses named args, so nothing breaks. Say the word if you'd still prefer them appended at the end.

## Scope

Wild bootstrap only; **CR2/CR3 deferred** to a follow-up (per discussion — the CR2 adjustment for the desparsified two-channel score is its own derivation). Filed as #361.

## Version

**1.54.0 → 1.55.0** + NEWS. **Closes #360.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
