### PR TITLE
fix: floor the debiasedATT wild-bootstrap CI at the Gaussian quantile + reframe (#363)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.55.0
+Version: 1.56.0
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,27 +1,44 @@
 # NEWS
 
+## Version 1.56.0
+
+### Bug fixes
+
+- **Corrected the `debiasedATT(se_method = "wild_bootstrap")` few-clusters framing
+  (#363).** The wild bootstrap added in 1.55.0 was documented as a few-clusters
+  correction that widens the interval, but as an *unrestricted, no-refit*
+  score / influence-function bootstrap it does the opposite: under heterogeneous
+  cluster influence its self-normalized critical value falls *below* the Gaussian
+  quantile, narrowing the interval (mildly anti-conservative) in exactly the
+  small-`N` regime it was meant to help. The critical value is now **floored at
+  `qnorm(1 - alpha/2)`**, so the interval is never narrower than the analytic Wald
+  interval, and the documentation is reframed: it is an asymptotically-valid
+  alternative reference distribution that only *widens* the interval (under
+  near-homogeneous cluster influence), **not** a few-clusters remedy. A genuine
+  few-clusters correction (a restricted wild-cluster bootstrap-t or a CR2-type
+  analytic adjustment) is tracked as future work (#361). Affects only
+  `se_method = "wild_bootstrap"` (which never appeared in a CRAN release); the
+  default analytic path is unchanged.
+
 ## Version 1.55.0
 
 ### New features
 
 - `debiasedATT()` gains a **wild cluster bootstrap** confidence interval for the
   overall ATT via the new `se_method = "wild_bootstrap"` argument (with `B`,
-  `seed`, and `multiplier`). It is a few-clusters correction for the analytic
-  two-channel sandwich SE, which is downward-biased when the number of units
-  (clusters) is small --- the regime the high-dimensional path targets (e.g.
-  state-level panels). A studentized score / influence-function bootstrap
+  `seed`, and `multiplier`). It was introduced as a few-clusters correction for
+  the analytic two-channel sandwich SE (**reframed in 1.56.0** --- it is *not* a
+  few-clusters remedy). A studentized score / influence-function bootstrap
   re-signs the per-unit influence summands (no refit per replicate), so the point
   estimate and the reported `se` are unchanged and only the interval's critical
-  value is refined. The default `se_method = "analytic"` is unchanged; the new
-  path is not supported for `indep_counts` (two-sample) fits. Implements the
-  deferred small-`N` half of #307 (#360).
+  value changes. The default `se_method = "analytic"` is unchanged; the new path
+  is not supported for `indep_counts` (two-sample) fits. Implements the deferred
+  small-`N` half of #307 (#360).
 - Adds the **Webb (2013) six-point** multiplier (`multiplier = "webb"`) to the
   bootstrap machinery, available to both `debiasedATT()`'s wild bootstrap and
   `simultaneousCIs(method = "bootstrap")`. It is the **default** for
-  `debiasedATT()`'s wild bootstrap, because it delivers the studentized
-  bootstrap-t refinement that `"rademacher"`'s constant studentization does not
-  --- exactly what the few-clusters regime needs. Recommended whenever the number
-  of clusters is very small.
+  `debiasedATT()`'s wild bootstrap, because it varies the studentization
+  denominator (`"rademacher"`'s is constant).
 - `simultaneousCIs(method = "bootstrap")` and `debiasedATT(se_method =
   "wild_bootstrap")` now share their `B` / `seed` validation; a non-integer
   `seed` (previously truncated silently by `set.seed()`) is now rejected with a

--- a/NEWS.md
+++ b/NEWS.md
@@ -386,7 +386,10 @@
   `calc_ses` (a high-dimensional `q >= 1` fit is now accepted; previously an
   error). The `p >= NT` path remains **experimental**
   (coverage / `lambda_c` per #295); small-cluster applications (few treated
-  units) should prefer a wild-cluster bootstrap (a planned follow-up).
+  units) can under-cover --- a genuine few-clusters correction (restricted
+  wild-cluster bootstrap-t or CR2) is tracked as #361. (The
+  `se_method = "wild_bootstrap"` option added later in 1.55.0 is *not* that
+  remedy; see 1.56.0.)
 
 ## Version 1.35.0
 

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -176,30 +176,35 @@
 #'   Defaults to the `alpha` stored on the fit.
 #' @param se_method How to form the confidence interval. `"analytic"` (default)
 #'   uses the two-channel unit-clustered sandwich SE with a Gaussian critical
-#'   value (unchanged, backward-compatible). `"wild_bootstrap"` replaces the
-#'   Gaussian critical value with a studentized score / influence-function
-#'   **wild cluster bootstrap** (#360) --- a few-clusters correction for the
-#'   analytic sandwich, which is downward-biased when the number of units (`N`,
-#'   the clusters) is small. The point estimate and the reported `se` are
-#'   unchanged; only the interval half-width (`crit * se`) changes. This is the
-#'   unrestricted score/IF wild bootstrap (no refit per replicate); it refines
-#'   the reference distribution but does not relax the additive-channel
-#'   assumption of the analytic SE. Not supported for `indep_counts` (two-sample)
-#'   fits.
+#'   value. `"wild_bootstrap"` replaces the Gaussian critical value with a
+#'   studentized score / influence-function **wild cluster bootstrap** (#360),
+#'   **floored at the Gaussian quantile** so the interval is never narrower than
+#'   the analytic Wald interval. The point estimate and the reported `se` are
+#'   unchanged; only the critical value changes.
+#'
+#'   **This is not a few-clusters remedy.** As an *unrestricted, no-refit* score
+#'   bootstrap it does not reproduce the tail inflation of the *restricted*
+#'   wild-cluster bootstrap-t, and under heterogeneous cluster influence its
+#'   critical value (before the floor) falls *below* the Gaussian --- so under the
+#'   floor it reduces to the analytic interval exactly in the small-`N` regime, and
+#'   only
+#'   ever *widens* the interval when cluster influence is near-homogeneous. For a
+#'   genuine few-clusters correction the restricted bootstrap-t or a CR2-type
+#'   analytic adjustment is required (tracked as future work, #361). Not supported
+#'   for `indep_counts` (two-sample) fits.
 #' @param B Integer; the number of wild-bootstrap replicates (default `1000`).
 #'   Ignored unless `se_method = "wild_bootstrap"`.
 #' @param seed `NULL` (draw from the ambient RNG, the default) or a single
 #'   integer for a reproducible bootstrap (the RNG state is saved and restored).
 #'   Ignored unless `se_method = "wild_bootstrap"`.
 #' @param multiplier The wild-bootstrap weight distribution: `"webb"` (default),
-#'   `"rademacher"`, or `"mammen"`. The default is the Webb (2013) six-point
-#'   distribution because this few-clusters correction is where it matters most:
-#'   with `"rademacher"` (`±1`) the studentization denominator is constant, so
-#'   the interval reduces to a *percentile* wild bootstrap, whereas `"webb"` and
-#'   `"mammen"` vary the denominator and deliver the *studentized* bootstrap-t
-#'   refinement; Webb's finer six-point support is also preferable to the `2^N`
-#'   Rademacher sign vectors when the number of clusters is very small. Ignored
-#'   unless `se_method = "wild_bootstrap"`.
+#'   `"rademacher"`, or `"mammen"`. `"rademacher"` (`±1`) gives a constant
+#'   studentization denominator (a *percentile* bootstrap); `"webb"` and
+#'   `"mammen"` vary it (a *studentized* statistic). Because the critical value is
+#'   floored at the Gaussian quantile, the multiplier only affects the
+#'   near-homogeneous case where the bootstrap widens above the floor; in the
+#'   small-`N` / heterogeneous regime the interval is the analytic one regardless
+#'   of the weight. Ignored unless `se_method = "wild_bootstrap"`.
 #' @param lambda_c The leading constant of the high-dimensional (`p >= NT`)
 #'   nodewise penalty `lambda_node = lambda_c * max(|a|) * sqrt(log(p) / N)` (`N` =
 #'   number of units). Either a single positive number (a fixed constant; default
@@ -224,8 +229,9 @@
 #'     \item{ci_low, ci_high}{Numeric; the `1 - alpha` interval. With
 #'       `se_method = "analytic"` (default) this is the Wald interval
 #'       `att +/- qnorm(1 - alpha/2) * se`; with `se_method = "wild_bootstrap"`
-#'       the critical value is the bootstrap `crit_value` in place of
-#'       `qnorm(1 - alpha/2)`.}
+#'       the critical value is the bootstrap `crit_value` (floored at
+#'       `qnorm(1 - alpha/2)`, so never narrower than the Wald interval) in place
+#'       of `qnorm(1 - alpha/2)`.}
 #'     \item{var_reg}{Numeric; the regression (outcome) channel's contribution to
 #'       `se^2`, per-unit-clustered.}
 #'     \item{var_weight}{Numeric; the cohort-weight channel's contribution to
@@ -247,8 +253,8 @@
 #'   fallback fired). These are absent for `p < NT` fits.
 #'
 #'   With `se_method = "wild_bootstrap"` the list additionally contains
-#'   `se_method`, `crit_value` (the studentized wild-bootstrap critical value
-#'   replacing `qnorm(1 - alpha/2)`), `B`, `multiplier`, and `alpha`. The analytic
+#'   `se_method`, `crit_value` (the studentized wild-bootstrap critical value,
+#'   floored at `qnorm(1 - alpha/2)`), `B`, `multiplier`, and `alpha`. The analytic
 #'   default adds none of these, so its `names()` are unchanged.
 #'
 #' @references
@@ -667,8 +673,9 @@ debiasedATT <- function(
 			out$lambda_cv <- riesz_diag$lambda_cv
 		}
 	}
-	# Few-clusters SE (#360): replace the Gaussian critical value with a
-	# studentized score / influence-function wild cluster bootstrap. The analytic
+	# Wild-bootstrap CI (#360, floored at the Gaussian quantile per #363): replace
+	# the Gaussian critical value with a studentized score / IF wild cluster
+	# bootstrap. The analytic
 	# `se` (sqrt(var_reg + var_weight)) is unchanged; only the reference
 	# distribution -- hence the CI half-width -- changes. `unit_scores` is the
 	# per-unit V1 (regression) influence summand; the per-unit V2 (cohort-weight)
@@ -706,9 +713,8 @@ debiasedATT <- function(
 
 #' @title Studentized wild cluster bootstrap for the debiased overall ATT
 #' @description
-#' Few-clusters critical value for [debiasedATT()]'s overall-ATT CI via a
-#' studentized score / influence-function wild cluster bootstrap (#360), with NO
-#' refit per replicate. The debiased ATT is asymptotically linear with per-unit
+#' Critical value for [debiasedATT()]'s overall-ATT CI via a studentized score /
+#' influence-function wild cluster bootstrap (#360), with NO refit per replicate. The debiased ATT is asymptotically linear with per-unit
 #' (per-cluster) influence summands in two asymptotically-independent channels:
 #' the regression channel `psi1 = unit_scores` (already computed;
 #' `sum(psi1^2) / n^2 == var_reg`) and the cohort-weight channel `psi2`, built
@@ -719,10 +725,13 @@ debiasedATT <- function(
 #' `var_reg + var_weight` with no cross term), and the `(1 - alpha)` quantile of
 #' the studentized statistic
 #' `|sum(xi psi1) + sum(eta psi2)| / sqrt(sum((xi psi1)^2) + sum((eta psi2)^2))`
-#' is the critical value: `CI = att +/- crit * se`. Uses the BRIDGE `catt` /
-#' `att_hat` (matching `.plugin_v2()` / the analytic `var_weight`) in both
-#' regimes, so the bootstrap reproduces the reported `se` and only refines the
-#' reference distribution.
+#' is the critical value, **floored at `qnorm(1 - alpha/2)`** so the interval is
+#' never narrower than the analytic Wald interval (#363; before the floor, the
+#' self-normalized statistic can fall below the Gaussian under heterogeneous
+#' cluster influence, so this is *not* a few-clusters remedy): `CI = att +/- crit
+#' * se`. Uses the BRIDGE `catt` / `att_hat` (matching `.plugin_v2()` / the
+#' analytic `var_weight`) in both regimes, so the bootstrap reproduces the
+#' reported `se` and only refines the reference distribution.
 #' @param fit The `"fetwfe"` fit (supplies `catt_df$estimate`, `att_hat`,
 #'   `cohort_probs_overall`).
 #' @param psi1 Numeric length-N (number of clusters / units); the per-unit V1
@@ -814,6 +823,16 @@ debiasedATT <- function(
 		probs = 1 - alpha,
 		names = FALSE
 	))
+	# Floor at the Gaussian quantile (#363). The unrestricted, no-refit score/IF
+	# wild bootstrap self-normalizes, so under heterogeneous / dominant-cluster
+	# influence its critical value falls BELOW qnorm(1 - alpha/2) -- narrowing the
+	# interval in exactly the few-clusters regime, the opposite of a correction
+	# (MacKinnon-Webb: this statistic does not reproduce the tail inflation of the
+	# restricted wild-cluster bootstrap-t). Flooring guarantees the interval is
+	# never narrower than the analytic Wald interval; it only ever WIDENS (crit > z,
+	# near-homogeneous influence). This is NOT a few-clusters remedy -- see the CR2
+	# follow-up (#361).
+	crit <- max(crit, stats::qnorm(1 - alpha / 2))
 	list(crit = crit, ci_low = att - crit * se, ci_high = att + crit * se)
 }
 

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -127,8 +127,11 @@
 #'     and cancels in the OLS-identity case.
 #'   \item **Growing number of clusters,** `N -> infinity`. The CLT is over the
 #'     `N` independent units, not the `NT` rows. With few treated units the
-#'     cluster approximation is poor; prefer a wild-cluster bootstrap when `N` is
-#'     small.
+#'     cluster approximation is poor and the interval can under-cover; a genuine
+#'     few-clusters correction (a restricted wild-cluster bootstrap-t or a
+#'     CR2-type analytic adjustment, #361) is future work. The
+#'     `se_method = "wild_bootstrap"` option does *not* remedy this (see its
+#'     documentation).
 #'   \item **Regularity / two regimes.** When `p < NT` (Theorem
 #'     `debiased.att.thm`) the full design Gram is nonsingular and the debiasing
 #'     direction is the exact inverse; the accessor reduces to debiased ETWFE.
@@ -186,9 +189,9 @@
 #'   bootstrap it does not reproduce the tail inflation of the *restricted*
 #'   wild-cluster bootstrap-t, and under heterogeneous cluster influence its
 #'   critical value (before the floor) falls *below* the Gaussian --- so under the
-#'   floor it reduces to the analytic interval exactly in the small-`N` regime, and
-#'   only
-#'   ever *widens* the interval when cluster influence is near-homogeneous. For a
+#'   floor it reduces to the analytic interval exactly in the small-`N` regime; it
+#'   only ever *widens* the interval when cluster influence is near-homogeneous.
+#'   For a
 #'   genuine few-clusters correction the restricted bootstrap-t or a CR2-type
 #'   analytic adjustment is required (tracked as future work, #361). Not supported
 #'   for `indep_counts` (two-sample) fits.
@@ -794,8 +797,14 @@ debiasedATT <- function(
 		)
 	}
 	if (!is.finite(se) || se <= 0) {
-		# Degenerate variance: the interval collapses to the point estimate.
-		return(list(crit = 0, ci_low = att, ci_high = att))
+		# Degenerate variance: the interval collapses to the point estimate. Report
+		# the floored crit (#363) for consistency with the `@return` contract -- the
+		# CI is the point [att, att] regardless, since se = 0.
+		return(list(
+			crit = stats::qnorm(1 - alpha / 2),
+			ci_low = att,
+			ci_high = att
+		))
 	}
 	# Studentized bootstrap-t draw. This is the scalar analogue of
 	# `.simultaneous_bootstrap_crit()` (R/simultaneous_bootstrap.R), which does the

--- a/man/debiasedATT.Rd
+++ b/man/debiasedATT.Rd
@@ -39,9 +39,9 @@ unchanged; only the critical value changes.
 bootstrap it does not reproduce the tail inflation of the \emph{restricted}
 wild-cluster bootstrap-t, and under heterogeneous cluster influence its
 critical value (before the floor) falls \emph{below} the Gaussian --- so under the
-floor it reduces to the analytic interval exactly in the small-\code{N} regime, and
-only
-ever \emph{widens} the interval when cluster influence is near-homogeneous. For a
+floor it reduces to the analytic interval exactly in the small-\code{N} regime; it
+only ever \emph{widens} the interval when cluster influence is near-homogeneous.
+For a
 genuine few-clusters correction the restricted bootstrap-t or a CR2-type
 analytic adjustment is required (tracked as future work, #361). Not supported
 for \code{indep_counts} (two-sample) fits.}
@@ -188,8 +188,11 @@ vanishing schedule --- it adds a fixed numerical stabilizer
 and cancels in the OLS-identity case.
 \item \strong{Growing number of clusters,} \code{N -> infinity}. The CLT is over the
 \code{N} independent units, not the \code{NT} rows. With few treated units the
-cluster approximation is poor; prefer a wild-cluster bootstrap when \code{N} is
-small.
+cluster approximation is poor and the interval can under-cover; a genuine
+few-clusters correction (a restricted wild-cluster bootstrap-t or a
+CR2-type analytic adjustment, #361) is future work. The
+\code{se_method = "wild_bootstrap"} option does \emph{not} remedy this (see its
+documentation).
 \item \strong{Regularity / two regimes.} When \code{p < NT} (Theorem
 \code{debiased.att.thm}) the full design Gram is nonsingular and the debiasing
 direction is the exact inverse; the accessor reduces to debiased ETWFE.

--- a/man/debiasedATT.Rd
+++ b/man/debiasedATT.Rd
@@ -29,16 +29,22 @@ Defaults to the \code{alpha} stored on the fit.}
 
 \item{se_method}{How to form the confidence interval. \code{"analytic"} (default)
 uses the two-channel unit-clustered sandwich SE with a Gaussian critical
-value (unchanged, backward-compatible). \code{"wild_bootstrap"} replaces the
-Gaussian critical value with a studentized score / influence-function
-\strong{wild cluster bootstrap} (#360) --- a few-clusters correction for the
-analytic sandwich, which is downward-biased when the number of units (\code{N},
-the clusters) is small. The point estimate and the reported \code{se} are
-unchanged; only the interval half-width (\code{crit * se}) changes. This is the
-unrestricted score/IF wild bootstrap (no refit per replicate); it refines
-the reference distribution but does not relax the additive-channel
-assumption of the analytic SE. Not supported for \code{indep_counts} (two-sample)
-fits.}
+value. \code{"wild_bootstrap"} replaces the Gaussian critical value with a
+studentized score / influence-function \strong{wild cluster bootstrap} (#360),
+\strong{floored at the Gaussian quantile} so the interval is never narrower than
+the analytic Wald interval. The point estimate and the reported \code{se} are
+unchanged; only the critical value changes.
+
+\strong{This is not a few-clusters remedy.} As an \emph{unrestricted, no-refit} score
+bootstrap it does not reproduce the tail inflation of the \emph{restricted}
+wild-cluster bootstrap-t, and under heterogeneous cluster influence its
+critical value (before the floor) falls \emph{below} the Gaussian --- so under the
+floor it reduces to the analytic interval exactly in the small-\code{N} regime, and
+only
+ever \emph{widens} the interval when cluster influence is near-homogeneous. For a
+genuine few-clusters correction the restricted bootstrap-t or a CR2-type
+analytic adjustment is required (tracked as future work, #361). Not supported
+for \code{indep_counts} (two-sample) fits.}
 
 \item{B}{Integer; the number of wild-bootstrap replicates (default \code{1000}).
 Ignored unless \code{se_method = "wild_bootstrap"}.}
@@ -48,14 +54,13 @@ integer for a reproducible bootstrap (the RNG state is saved and restored).
 Ignored unless \code{se_method = "wild_bootstrap"}.}
 
 \item{multiplier}{The wild-bootstrap weight distribution: \code{"webb"} (default),
-\code{"rademacher"}, or \code{"mammen"}. The default is the Webb (2013) six-point
-distribution because this few-clusters correction is where it matters most:
-with \code{"rademacher"} (\verb{±1}) the studentization denominator is constant, so
-the interval reduces to a \emph{percentile} wild bootstrap, whereas \code{"webb"} and
-\code{"mammen"} vary the denominator and deliver the \emph{studentized} bootstrap-t
-refinement; Webb's finer six-point support is also preferable to the \code{2^N}
-Rademacher sign vectors when the number of clusters is very small. Ignored
-unless \code{se_method = "wild_bootstrap"}.}
+\code{"rademacher"}, or \code{"mammen"}. \code{"rademacher"} (\verb{±1}) gives a constant
+studentization denominator (a \emph{percentile} bootstrap); \code{"webb"} and
+\code{"mammen"} vary it (a \emph{studentized} statistic). Because the critical value is
+floored at the Gaussian quantile, the multiplier only affects the
+near-homogeneous case where the bootstrap widens above the floor; in the
+small-\code{N} / heterogeneous regime the interval is the analytic one regardless
+of the weight. Ignored unless \code{se_method = "wild_bootstrap"}.}
 
 \item{lambda_c}{The leading constant of the high-dimensional (\code{p >= NT})
 nodewise penalty \verb{lambda_node = lambda_c * max(|a|) * sqrt(log(p) / N)} (\code{N} =
@@ -83,8 +88,9 @@ and a \code{tidy} method) with elements:
 \item{ci_low, ci_high}{Numeric; the \code{1 - alpha} interval. With
 \code{se_method = "analytic"} (default) this is the Wald interval
 \verb{att +/- qnorm(1 - alpha/2) * se}; with \code{se_method = "wild_bootstrap"}
-the critical value is the bootstrap \code{crit_value} in place of
-\code{qnorm(1 - alpha/2)}.}
+the critical value is the bootstrap \code{crit_value} (floored at
+\code{qnorm(1 - alpha/2)}, so never narrower than the Wald interval) in place
+of \code{qnorm(1 - alpha/2)}.}
 \item{var_reg}{Numeric; the regression (outcome) channel's contribution to
 \code{se^2}, per-unit-clustered.}
 \item{var_weight}{Numeric; the cohort-weight channel's contribution to
@@ -106,8 +112,8 @@ per-grid feasibility flags and CV losses, and whether the theory-scale
 fallback fired). These are absent for \code{p < NT} fits.
 
 With \code{se_method = "wild_bootstrap"} the list additionally contains
-\code{se_method}, \code{crit_value} (the studentized wild-bootstrap critical value
-replacing \code{qnorm(1 - alpha/2)}), \code{B}, \code{multiplier}, and \code{alpha}. The analytic
+\code{se_method}, \code{crit_value} (the studentized wild-bootstrap critical value,
+floored at \code{qnorm(1 - alpha/2)}), \code{B}, \code{multiplier}, and \code{alpha}. The analytic
 default adds none of these, so its \code{names()} are unchanged.
 }
 \description{

--- a/tests/testthat/test-debiased-att-wild-bootstrap-360.R
+++ b/tests/testthat/test-debiased-att-wild-bootstrap-360.R
@@ -320,4 +320,17 @@ test_that("the wild-bootstrap crit is floored at the Gaussian quantile (#363)", 
 	a_het <- debiasedATT(fit_het)
 	expect_equal(w_het$ci_low, a_het$att - z * a_het$se)
 	expect_equal(w_het$ci_high, a_het$att + z * a_het$se)
+	# The floor is alpha-dependent (qnorm(1 - alpha/2), not a hardcoded 1.96): at
+	# alpha = 0.1 the same heterogeneous fit floors to qnorm(0.95). A mutant that
+	# floored at a literal qnorm(0.975) would pass at the default alpha but fail
+	# here.
+	w_het_90 <- debiasedATT(
+		fit_het,
+		se_method = "wild_bootstrap",
+		multiplier = "webb",
+		seed = 1,
+		B = 2000,
+		alpha = 0.1
+	)
+	expect_equal(w_het_90$crit_value, stats::qnorm(0.95))
 })

--- a/tests/testthat/test-debiased-att-wild-bootstrap-360.R
+++ b/tests/testthat/test-debiased-att-wild-bootstrap-360.R
@@ -2,14 +2,15 @@ library(testthat)
 library(fetwfe)
 
 # ------------------------------------------------------------------------------
-# #360: small-number-of-clusters SE for the debiased overall ATT via a
-# studentized score / influence-function WILD CLUSTER BOOTSTRAP (se_method =
-# "wild_bootstrap"). The analytic sandwich SE is downward-biased with few
-# clusters; the bootstrap replaces the Gaussian critical value with a
-# few-cluster-corrected one WITHOUT a refit per replicate, by re-signing the
-# per-unit influence summands (V1 regression `unit_scores` + V2 cohort-weight,
-# built from a_att_G = (catt - att_hat)/S). Point estimate and reported `se` are
-# unchanged; only the CI half-width changes. Default se_method = "analytic" is
+# #360 / #363: the debiased overall ATT via a studentized score /
+# influence-function WILD CLUSTER BOOTSTRAP (se_method = "wild_bootstrap"),
+# re-signing the per-unit influence summands (V1 regression `unit_scores` + V2
+# cohort-weight, built from a_att_G = (catt - att_hat)/S) WITHOUT a refit per
+# replicate. Point estimate and reported `se` are unchanged; only the critical
+# value changes, and it is FLOORED at qnorm(1 - alpha/2) (#363) so the interval is
+# never narrower than the analytic Wald interval -- this is NOT a few-clusters
+# remedy (an unrestricted no-refit score bootstrap narrows below the Gaussian
+# under heterogeneous cluster influence). Default se_method = "analytic" is
 # byte-identical to the previous behavior.
 # ------------------------------------------------------------------------------
 
@@ -211,9 +212,9 @@ test_that("wild bootstrap validates B and seed (#360)", {
 })
 
 test_that("the default wild-bootstrap multiplier is webb (#360, review 1)", {
-	# Webb is the default so the *studentized* bootstrap-t refinement is delivered
-	# by default in the few-clusters regime this targets -- rademacher's constant
-	# denominator would instead give the (unstudentized) percentile variant.
+	# Webb is kept as the default (a studentized statistic, vs rademacher's constant
+	# denominator); given the #363 floor the multiplier choice only matters in the
+	# near-homogeneous case where the bootstrap widens above the floor.
 	w <- debiasedATT(.wb_fixedp, se_method = "wild_bootstrap", seed = 1)
 	expect_identical(w$multiplier, "webb")
 })
@@ -276,4 +277,47 @@ test_that("print.debiased_att surfaces the bootstrap method and level (#360)", {
 	# The analytic print does NOT show the bootstrap line.
 	out_a <- capture.output(print(debiasedATT(fit)))
 	expect_false(any(grepl("wild cluster bootstrap", out_a)))
+})
+
+test_that("the wild-bootstrap crit is floored at the Gaussian quantile (#363)", {
+	z <- stats::qnorm(0.975)
+	# The (floored) crit is never below z on any fit.
+	for (fit in list(.wb_fixedp, .wb_highdim)) {
+		w <- debiasedATT(fit, se_method = "wild_bootstrap", seed = 1)
+		expect_gte(w$crit_value, z)
+	}
+	# The floor BITES: on a heterogeneous few-cluster fit whose pre-floor crit is
+	# ~1.44 (< z -- the anti-conservative narrowing this fix removes, #363), the
+	# returned crit equals z exactly, so the interval is the analytic Wald interval.
+	# Remove the `max(crit, z)` floor and this returns ~1.44 != z.
+	cf <- genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = 2, seed = 1)
+	sim <- simulateData(
+		cf,
+		N = 18,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 1
+	)
+	fit_het <- fetwfe(
+		pdata = sim$pdata,
+		time_var = sim$time_var,
+		unit_var = sim$unit_var,
+		treatment = sim$treatment,
+		response = sim$response,
+		covs = sim$covs,
+		q = 0.5,
+		gls = FALSE,
+		verbose = FALSE
+	)
+	w_het <- debiasedATT(
+		fit_het,
+		se_method = "wild_bootstrap",
+		multiplier = "webb",
+		seed = 1,
+		B = 2000
+	)
+	expect_equal(w_het$crit_value, z)
+	a_het <- debiasedATT(fit_het)
+	expect_equal(w_het$ci_low, a_het$att - z * a_het$se)
+	expect_equal(w_het$ci_high, a_het$att + z * a_het$se)
 })

--- a/vignettes/inference_vignette.Rmd
+++ b/vignettes/inference_vignette.Rmd
@@ -435,9 +435,11 @@ In any single draw the fused and debiased point estimates can be close, so the v
 
 The fused interval under-covers because of the post-selection non-uniformity; the debiased interval is near-nominal. This is validated at the studied anchor (with the feasibility-appropriate penalty); treat the $p \geq NT$ path as **experimental** outside that regime --- which is why the diagnostics above matter.
 
-## Few clusters: the wild cluster bootstrap
+## An asymptotic alternative: the wild bootstrap
 
-The analytic standard error above is a unit-clustered sandwich: consistent as the number of units (clusters) grows, but **downward-biased when there are few clusters** --- exactly the regime the high-dimensional path often lives in (state-level panels have tens of units, not thousands), so the Gaussian interval can over-reject. `se_method = "wild_bootstrap"` replaces the Gaussian critical value with a studentized score / influence-function **wild cluster bootstrap** that re-signs the per-unit influence summands (no refit per replicate), leaving the point estimate and the reported `se` unchanged and only replacing the Gaussian critical value with a few-cluster-corrected one (usually wider, occasionally slightly narrower at moderate cluster counts):
+`se_method = "wild_bootstrap"` offers an alternative, asymptotically-valid reference distribution for the overall-ATT interval: a studentized score / influence-function **wild cluster bootstrap** that re-signs the per-unit influence summands (no refit per replicate), leaving the point estimate and the reported `se` unchanged and changing only the critical value. It is **floored at the Gaussian quantile**, so the interval is never narrower than the analytic Wald interval.
+
+**It is not a few-clusters remedy.** The analytic sandwich SE is downward-biased with few clusters, but this bootstrap does not fix that: as an *unrestricted, no-refit* score bootstrap it does not reproduce the tail inflation the *restricted* wild-cluster bootstrap-t uses for few-cluster coverage, and under heterogeneous cluster influence its critical value (before the floor) actually falls *below* the Gaussian --- so the floor reduces it to the analytic interval in exactly the small-`N` regime. Its only effect is to *widen* the interval when cluster influence is near-homogeneous. For genuine few-clusters inference a restricted bootstrap-t or a CR2-type analytic correction is required (future work).
 
 ```{r highdim-wild-boot, eval = FALSE}
 # `fit` must be a single-sample fetwfe() fit -- not an `indep_counts` fit, which
@@ -445,7 +447,7 @@ The analytic standard error above is a unit-clustered sandwich: consistent as th
 debiasedATT(fit, se_method = "wild_bootstrap", multiplier = "webb", seed = 1)
 ```
 
-Prefer `multiplier = "webb"` (the Webb six-point weights) when the number of units is very small, where the default `"rademacher"` ($\pm 1$) has too few distinct sign vectors. The bootstrap is defined only for **single-sample** fits; real observational panels --- the few-cluster case this targets --- are single-sample.
+The `multiplier` (`"webb"`, the default; `"rademacher"`; or `"mammen"`) only affects the near-homogeneous case where the bootstrap widens above the floor --- in the small-`N` / heterogeneous regime the interval is the analytic one regardless of the weight. The bootstrap is defined only for **single-sample** fits (real observational panels are single-sample), not `indep_counts` two-sample fits.
 
 ## Simultaneous bands at $p \geq NT$
 


### PR DESCRIPTION
## Summary

Fixes #363: the `debiasedATT(se_method = "wild_bootstrap")` few-clusters guarantee was backwards. Per the issue decision, this **floors the critical value at the Gaussian quantile [(b)]** and **reframes the docs honestly [(a)]**. Closes #363.

## The problem (from the v1.49→1.55 package review, verified)

#360's wild bootstrap was documented as a few-clusters correction that *widens* the CI, but as an *unrestricted, no-refit* score/influence-function bootstrap it *narrows* below the Gaussian in the small-`N` regime: the self-normalized statistic is bounded by the largest multiplier weight when one cluster's influence dominates, so its tails are lighter than Gaussian and `crit < z` (MacKinnon–Webb). Verified — `crit ≈ 1.44` at N=18; a 200-rep Monte-Carlo shows it slightly *worsens* the sandwich's under-coverage; and the paper's own **N=42 divorce** application lands at `crit = 1.89 < 1.96`.

## The fix (a + b)

- **(b) Floor `crit` at `qnorm(1 - alpha/2)`** — one line in `.debiased_att_wild_boot`. The interval is now never narrower than the analytic Wald interval; it only ever *widens* (when `crit > z`, near-homogeneous influence).
- **(a) Reframe the docs** — `@param se_method` / `multiplier`, the helper `@description`, `@return`, the inference-vignette section (retitled "An asymptotic alternative"), and NEWS: it is an asymptotically-valid alternative reference distribution, **not** a few-clusters remedy. A genuine few-clusters correction (restricted wild-cluster bootstrap-t or CR2, #361) is tracked as future work.

## Verification

- **New floor-applied regression tests**: `crit >= z` on any fit; on a heterogeneous N=18 fit (pre-floor `crit ≈ 1.44`) the returned `crit == z` and the interval equals the analytic Wald interval; and the floor's `alpha`-dependence (`qnorm(1 - alpha/2)`, not a hardcoded `1.96`) is checked at `alpha = 0.1`. Both are **mutation-checked** — removing the floor, and hardcoding `1.96`, each fail the relevant assertions.
- Full suite **FAIL 0** · `document()` + `spell_check` clean · **R CMD check `--as-cran`**.
- Affects only `se_method = "wild_bootstrap"` (never in a CRAN release); the analytic default is byte-identical.

## Review fixes (folded in)

Addressing the PR review: fixed a stale `@details` "Growing number of clusters" bullet that still said *"prefer a wild-cluster bootstrap when `N` is small"* — a self-contradiction on the same help page (now points at the genuine remedy, #361); added the `alpha = 0.1` floor test (a hardcoded-`1.96` mutant would otherwise pass the suite); floored the degenerate `se <= 0` return's `crit` for `@return` consistency; and annotated the NEWS 1.36.0 entry. In a follow-up commit.

## Scope / follow-ups

- **#365** (rename `se_method`→`method`) is left open — since we're keeping `se_method`, that's a separate quick change to fold in whenever you decide it; this PR keeps the current name.
- The `.print_highdim_diagnostics` coverage-banner over-claim is **#364** (separate).
- Genuine few-clusters correction: **#361** (CR2 — theory-gated).

## Version

**1.55.0 → 1.56.0** + NEWS `### Bug fixes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
