### PR TITLE
feat: add a pkgdown documentation website (#283)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -28,3 +28,7 @@
 ^TODO_
 ^issue_
 ^mybib2fin\.bib$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$
+^\.github$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,49 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown.yaml
+
+permissions: read-all
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .Rhistory
 inst/doc
 /doc/
+/docs/
 /Meta/
 /..Rcheck
 /.claude/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Maintainer: Gregory Faletto <gfaletto@gmail.com>
 Depends: 
     R (>= 4.1.0)
 Description: Calculates the fused extended two-way fixed effects (FETWFE) estimator for unbiased and efficient estimation of difference-in-differences in panel data with staggered treatment adoption. This estimator eliminates bias inherent in conventional two-way fixed effects estimators, while also employing a novel bridge regression regularization approach to improve efficiency and yield valid standard errors. Also implements extended TWFE (etwfe) and bridge-penalized ETWFE (betwfe). Provides S3 classes for streamlined workflow and supports flexible tuning (ridge and rank-condition guarantees), automatic covariate centering/scaling, and detailed overall and cohort-specific effect estimates with valid standard errors. Includes simulation and formatting utilities, extensive diagnostic tools, vignettes, and examples. See Faletto (2025) (<doi:10.48550/arXiv.2312.05985>).
-URL: https://github.com/gregfaletto/fetwfePackage
+URL: https://gregfaletto.github.io/fetwfePackage/, https://github.com/gregfaletto/fetwfePackage
 BugReports: https://github.com/gregfaletto/fetwfePackage/issues
 License: MIT + file LICENSE
 Encoding: UTF-8
@@ -33,3 +33,4 @@ Suggests:
 VignetteBuilder:
     knitr
 Config/roxygen2/version: 8.0.0
+Config/Needs/website: pkgdown

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Fused Extended Two-Way Fixed Effects
 
+<!-- badges: start -->
+[![CRAN status](https://www.r-pkg.org/badges/version/fetwfe)](https://CRAN.R-project.org/package=fetwfe)
+[![CRAN downloads](https://cranlogs.r-pkg.org/badges/grand-total/fetwfe)](https://CRAN.R-project.org/package=fetwfe)
+[![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
+<!-- badges: end -->
+
 The `{fetwfe}` package implements *fused extended two-way fixed effects* (FETWFE), a methodology for estimating treatment effects in difference-in-differences with staggered adoptions.
 
 * For a brief introduction to the methodology, as well as background on difference-in-differences with staggered adoptions and motivation for FETWFE, see this [blog post](https://gregoryfaletto.com/2023/12/13/new-paper-fused-extended-two-way-fixed-effects-for-difference-in-differences-with-staggered-adoptions/).

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,86 @@
+url: https://gregfaletto.github.io/fetwfePackage/
+
+template:
+  bootstrap: 5
+
+navbar:
+  structure:
+    left: [reference, articles, news]
+    right: [search, paper, github]
+  components:
+    paper:
+      text: Paper
+      href: https://arxiv.org/abs/2312.05985
+      aria-label: FETWFE paper on arXiv
+
+articles:
+- title: Get started
+  contents:
+  - vignette
+- title: Topics
+  desc: >
+    Deeper dives into fusion structures, inference, simulation, and the
+    comparison estimators.
+  contents:
+  - fusion_structure_vignette
+  - inference_vignette
+  - simulation_vignette
+  - etwfe_betwfe_vignette
+
+reference:
+- title: Estimators
+  desc: >
+    Fit fused extended two-way fixed effects (FETWFE) and its comparison
+    estimators for difference-in-differences with staggered adoptions.
+  contents:
+  - fetwfe
+  - etwfe
+  - betwfe
+  - twfeCovs
+- title: Inference
+  desc: Confidence intervals and debiased overall-ATT inference.
+  contents:
+  - debiasedATT
+  - simultaneousCIs
+- title: Treatment-effect summaries
+  desc: Extract cohort, event-study, and cohort-by-time treatment effects.
+  contents:
+  - getTes
+  - cohortStudy
+  - eventStudy
+  - cohortTimeATTs
+- title: Simulation
+  desc: Generate coefficients and panel data for simulation studies.
+  contents:
+  - genCoefs
+  - genCoefsCore
+  - simulateData
+  - simulateDataCore
+- title: Fit on simulated data
+  desc: Convenience drivers that fit directly on simulateData() output.
+  contents:
+  - fetwfeWithSimulatedData
+  - etwfeWithSimulatedData
+  - betwfeWithSimulatedData
+  - twfeCovsWithSimulatedData
+  - debiasedATTWithSimulatedData
+- title: Data conversion
+  desc: Convert data frames from other DiD packages into the FETWFE format.
+  contents:
+  - attgtToFetwfeDf
+  - etwfeToFetwfeDf
+- title: Methods
+  desc: >
+    broom (tidy / glance / augment) and base S3 methods (plot, print) for the
+    fitted objects.
+  contents:
+  - starts_with("tidy.")
+  - starts_with("glance.")
+  - starts_with("augment.")
+  - starts_with("plot.")
+  - starts_with("print.")
+- title: Classes and low-level accessors
+  desc: Class definitions and the `catt_df` element accessors.
+  contents:
+  - ends_with("-class")
+  - matches("catt_df")


### PR DESCRIPTION
## Summary

Adds a **pkgdown documentation website** for `fetwfe` (Closes #283), so the five vignettes and the full function reference are browsable in a navbar + organized index instead of only via `browseVignettes()` / the CRAN vignette list. Structure modeled on the cssr-project site (see the notes on #283).

## What's added

- **`_pkgdown.yml`** — Bootstrap 5; a navbar with an arXiv **Paper** link; an **Articles** section grouping the vignettes (the fusion-structure article featured first, per #282/#283); and a **Reference** index organizing all 59 exported topics into labeled groups (Estimators · Inference · Treatment-effect summaries · Simulation · Fit-on-simulated-data drivers · Data conversion · Methods · Classes/accessors).
- **`.github/workflows/pkgdown.yaml`** — the canonical r-lib build + deploy-to-`gh-pages` workflow (deploys on push to `main` / release; build-only on PRs).
- **`DESCRIPTION`** — the site URL added to `URL:`; `Config/Needs/website: pkgdown`.
- **`.Rbuildignore`** — keeps `_pkgdown.yml`, `docs/`, `.github/`, `pkgdown/` out of the built package.
- **`README.md`** — CRAN-version, downloads, and lifecycle-stable badges.
- `inst/CITATION` already exists → pkgdown auto-renders a "Citing" page.

## Verification

- `pkgdown::check_pkgdown()` → **"No problems found"** (all 59 topics covered exactly once; all articles resolve).
- Full local `pkgdown::build_site()` → builds the home, all five articles, 60 reference pages, the news page, and the auto-generated citation page.
- `R CMD check --as-cran` → **Status: OK** (no NOTEs). Website artifacts are `.Rbuildignore`d and **no package code changed** (no version bump).

## Maintainer action to go live (one-time)

The deploy step auto-creates the `gh-pages` branch on the first `main`/release run, but **GitHub Pages must then be enabled**: Settings → Pages → Source = "Deploy from a branch" → `gh-pages` / `/ (root)`. (If the deploy 403s, Settings → Actions → General → Workflow permissions → "Read and write.") After that the site serves at `https://gregfaletto.github.io/fetwfePackage/`.

⚠️ **Enable Pages before the next CRAN submission.** The new github.io URL is in `DESCRIPTION`; until the site is live it 404s. The local `R CMD check --as-cran` is clean (Status: OK), but CRAN's incoming-URL check runs at submission — so deploy the site first to avoid a "URL not reachable" NOTE then.

## Follow-ups (optional, cssr-style polish)

- A short "why FETWFE" narrative on the README home page.
- A hex logo (`man/figures/`).
- Rename the intro `vignette.Rmd` → `fetwfe.Rmd` for a proper navbar "Get started" slot.

Closes #283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
