### PR TITLE
docs: add a "why FETWFE" narrative to the README home page (#369)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 The `{fetwfe}` package implements *fused extended two-way fixed effects* (FETWFE), a methodology for estimating treatment effects in difference-in-differences with staggered adoptions.
 
+In staggered-adoption settings — where units become treated at different times — treatment effects typically vary across adoption cohorts and over time since treatment. The conventional two-way fixed effects (TWFE) estimator is biased when effects are heterogeneous like this, because it effectively uses already-treated units as controls for newly-treated ones, contaminating the estimate.
+
+FETWFE instead fits a *fully heterogeneous* model — a separate effect for every cohort and time period — and applies a **fusion penalty** that shrinks together effects which are similar across neighboring cohorts and periods. This pools the cohort-by-time effects in a data-driven way (collapsing them where they genuinely agree, keeping them distinct where they differ) and, unlike ad hoc model selection, comes with **asymptotically valid standard errors and confidence intervals** for the resulting estimates.
+
 * For a brief introduction to the methodology, as well as background on difference-in-differences with staggered adoptions and motivation for FETWFE, see this [blog post](https://gregoryfaletto.com/2023/12/13/new-paper-fused-extended-two-way-fixed-effects-for-difference-in-differences-with-staggered-adoptions/).
 * For more detailed slides on the methodology (but less detailed than the paper), see [here](https://gregoryfaletto.com/2024/02/11/presentation-on-fused-extended-two-way-fixed-effects/).
 * Check out the most recent draft of the full paper [here](https://arxiv.org/abs/2312.05985).

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -122,6 +122,7 @@ le
 len
 lexicographically
 Liang
+Lifecycle
 lim
 lme
 lmer


### PR DESCRIPTION
## Summary

Adds a short **"why FETWFE"** narrative to the README home page (Closes #369) — a cssr-style problem → solution intro before the install/example. Since the README is the pkgdown site's home page (#283/#368), this improves the landing experience for someone arriving at the site.

## Change

Two prose paragraphs, inserted after the one-sentence tagline and before the resource-link bullets:

- **The problem** — in staggered-adoption difference-in-differences, treatment effects vary across adoption cohorts and over time since treatment, and conventional two-way fixed effects (TWFE) is biased under that heterogeneity (it effectively uses already-treated units as controls for newly-treated ones).
- **The solution** — FETWFE fits a fully heterogeneous cohort-by-time model plus a **fusion penalty** that pools similar neighboring effects in a data-driven way, and comes with valid standard errors and confidence intervals for the resulting estimates.

Also adds `Lifecycle` to `inst/WORDLIST` — a latent spell-check miss from the lifecycle badge added in #368 (`README.md:6`), fixed here since this PR is already in the README.

## Verification

- `spelling::spell_check_package()` → **clean** (the narrative prose needed no new words; only the pre-existing `Lifecycle` badge word).
- `pkgdown::build_home()` → renders cleanly; the narrative appears on the home `index.html`.
- Post-exec review focused on the statistical accuracy of the claims (esp. the inference wording, given the package's care not to over-state validity).
- **README + WORDLIST prose only — no package code changed** (no version bump, no NEWS; `R CMD check` unaffected — no code, URL, or DESCRIPTION change).

Closes #369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
