### PR TITLE
refactor: rename debiasedATT se_method -> method to align with simultaneousCIs (#365)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.56.1
+Version: 1.56.2
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # NEWS
 
+## Version 1.56.2
+
+- Renamed `debiasedATT()`'s bootstrap-CI argument from `se_method` to `method`
+  (and its non-default value from `"wild_bootstrap"` to `"bootstrap"`) to match
+  the sibling `simultaneousCIs()`, whose argument is also `method` with values
+  `"analytic"` / `"bootstrap"`. This resolves the naming inconsistency between the
+  two inference functions before the 2.x release; `se_method` never appeared in a
+  CRAN release (#365).
+
 ## Version 1.56.1
 
 - Renamed the introductory vignette from `vignette.Rmd` to `fetwfe.Rmd` so it is

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -130,7 +130,7 @@
 #'     cluster approximation is poor and the interval can under-cover; a genuine
 #'     few-clusters correction (a restricted wild-cluster bootstrap-t or a
 #'     CR2-type analytic adjustment, #361) is future work. The
-#'     `se_method = "wild_bootstrap"` option does *not* remedy this (see its
+#'     `method = "bootstrap"` option does *not* remedy this (see its
 #'     documentation).
 #'   \item **Regularity / two regimes.** When `p < NT` (Theorem
 #'     `debiased.att.thm`) the full design Gram is nonsingular and the debiasing
@@ -177,9 +177,9 @@
 #'   construction is specific to the FETWFE transformed-coefficient space).
 #' @param alpha Numeric in `(0, 1)`; the confidence level is `1 - alpha`.
 #'   Defaults to the `alpha` stored on the fit.
-#' @param se_method How to form the confidence interval. `"analytic"` (default)
+#' @param method How to form the confidence interval. `"analytic"` (default)
 #'   uses the two-channel unit-clustered sandwich SE with a Gaussian critical
-#'   value. `"wild_bootstrap"` replaces the Gaussian critical value with a
+#'   value. `"bootstrap"` replaces the Gaussian critical value with a
 #'   studentized score / influence-function **wild cluster bootstrap** (#360),
 #'   **floored at the Gaussian quantile** so the interval is never narrower than
 #'   the analytic Wald interval. The point estimate and the reported `se` are
@@ -191,15 +191,14 @@
 #'   critical value (before the floor) falls *below* the Gaussian --- so under the
 #'   floor it reduces to the analytic interval exactly in the small-`N` regime; it
 #'   only ever *widens* the interval when cluster influence is near-homogeneous.
-#'   For a
-#'   genuine few-clusters correction the restricted bootstrap-t or a CR2-type
+#'   For a genuine few-clusters correction the restricted bootstrap-t or a CR2-type
 #'   analytic adjustment is required (tracked as future work, #361). Not supported
 #'   for `indep_counts` (two-sample) fits.
 #' @param B Integer; the number of wild-bootstrap replicates (default `1000`).
-#'   Ignored unless `se_method = "wild_bootstrap"`.
+#'   Ignored unless `method = "bootstrap"`.
 #' @param seed `NULL` (draw from the ambient RNG, the default) or a single
 #'   integer for a reproducible bootstrap (the RNG state is saved and restored).
-#'   Ignored unless `se_method = "wild_bootstrap"`.
+#'   Ignored unless `method = "bootstrap"`.
 #' @param multiplier The wild-bootstrap weight distribution: `"webb"` (default),
 #'   `"rademacher"`, or `"mammen"`. `"rademacher"` (`±1`) gives a constant
 #'   studentization denominator (a *percentile* bootstrap); `"webb"` and
@@ -207,7 +206,7 @@
 #'   floored at the Gaussian quantile, the multiplier only affects the
 #'   near-homogeneous case where the bootstrap widens above the floor; in the
 #'   small-`N` / heterogeneous regime the interval is the analytic one regardless
-#'   of the weight. Ignored unless `se_method = "wild_bootstrap"`.
+#'   of the weight. Ignored unless `method = "bootstrap"`.
 #' @param lambda_c The leading constant of the high-dimensional (`p >= NT`)
 #'   nodewise penalty `lambda_node = lambda_c * max(|a|) * sqrt(log(p) / N)` (`N` =
 #'   number of units). Either a single positive number (a fixed constant; default
@@ -230,8 +229,8 @@
 #'     \item{se}{Numeric scalar; the uniformly-valid standard error,
 #'       `sqrt(var_reg + var_weight)`.}
 #'     \item{ci_low, ci_high}{Numeric; the `1 - alpha` interval. With
-#'       `se_method = "analytic"` (default) this is the Wald interval
-#'       `att +/- qnorm(1 - alpha/2) * se`; with `se_method = "wild_bootstrap"`
+#'       `method = "analytic"` (default) this is the Wald interval
+#'       `att +/- qnorm(1 - alpha/2) * se`; with `method = "bootstrap"`
 #'       the critical value is the bootstrap `crit_value` (floored at
 #'       `qnorm(1 - alpha/2)`, so never narrower than the Wald interval) in place
 #'       of `qnorm(1 - alpha/2)`.}
@@ -255,8 +254,8 @@
 #'   per-grid feasibility flags and CV losses, and whether the theory-scale
 #'   fallback fired). These are absent for `p < NT` fits.
 #'
-#'   With `se_method = "wild_bootstrap"` the list additionally contains
-#'   `se_method`, `crit_value` (the studentized wild-bootstrap critical value,
+#'   With `method = "bootstrap"` the list additionally contains
+#'   `method`, `crit_value` (the studentized wild-bootstrap critical value,
 #'   floored at `qnorm(1 - alpha/2)`), `B`, `multiplier`, and `alpha`. The analytic
 #'   default adds none of these, so its `names()` are unchanged.
 #'
@@ -279,7 +278,7 @@
 debiasedATT <- function(
 	fit,
 	alpha = NULL,
-	se_method = c("analytic", "wild_bootstrap"),
+	method = c("analytic", "bootstrap"),
 	B = 1000L,
 	seed = NULL,
 	multiplier = c("webb", "rademacher", "mammen"),
@@ -287,7 +286,7 @@ debiasedATT <- function(
 	riesz_max_iter = 5000L,
 	riesz_tol = 1e-9
 ) {
-	se_method <- match.arg(se_method)
+	method <- match.arg(method)
 	multiplier <- match.arg(multiplier)
 	if (!inherits(fit, "fetwfe")) {
 		stop(
@@ -316,11 +315,11 @@ debiasedATT <- function(
 		)
 	}
 
-	if (se_method == "wild_bootstrap") {
+	if (method == "bootstrap") {
 		B <- .validate_boot_args(B, seed, "debiasedATT")
 		if (isTRUE(fit$indep_counts_used)) {
 			stop(
-				"debiasedATT(se_method = \"wild_bootstrap\") is not supported for ",
+				"debiasedATT(method = \"bootstrap\") is not supported for ",
 				"`indep_counts` (two-sample) fits: the cohort-weight variance ",
 				"channel is estimated from the separate count sample, so it has no ",
 				"per-unit influence-function decomposition over the main sample's ",
@@ -684,7 +683,7 @@ debiasedATT <- function(
 	# per-unit V1 (regression) influence summand; the per-unit V2 (cohort-weight)
 	# summands are built inside the helper. The analytic default leaves `out`
 	# byte-identical (no extra fields), preserving the `names()` contract.
-	if (se_method == "wild_bootstrap") {
+	if (method == "bootstrap") {
 		boot <- .debiased_att_wild_boot(
 			fit = fit,
 			psi1 = unit_scores,
@@ -701,7 +700,7 @@ debiasedATT <- function(
 		)
 		out$ci_low <- boot$ci_low
 		out$ci_high <- boot$ci_high
-		out$se_method <- "wild_bootstrap"
+		out$method <- "bootstrap"
 		out$crit_value <- boot$crit
 		out$B <- B
 		out$multiplier <- multiplier
@@ -857,14 +856,14 @@ debiasedATT <- function(
 #' @export
 print.debiased_att <- function(x, ...) {
 	highdim <- !is.null(x$lambda_node)
-	boot <- identical(x$se_method, "wild_bootstrap")
+	boot <- identical(x$method, "bootstrap")
 	cat(sprintf(
 		"Debiased overall ATT (%s regime)\n",
 		if (highdim) "high-dimensional" else "fixed-p"
 	))
 	# The wild-bootstrap CI half-width is `crit * se` with a bootstrap `crit`, so
 	# the nominal level cannot be read back off the Gaussian quantile -- use the
-	# stored `alpha`. The analytic path (no `se_method`) keeps its inference.
+	# stored `alpha`. The analytic path (no `method`) keeps its inference.
 	level <- if (boot) {
 		round(100 * (1 - x$alpha))
 	} else if (is.finite(x$se) && x$se > 0) {

--- a/R/simultaneous_bootstrap.R
+++ b/R/simultaneous_bootstrap.R
@@ -64,7 +64,7 @@
 #' @description Shared validation for the bootstrap replicate count `B` (a single
 #'   positive integer) and `seed` (`NULL` or a single integer) used by both
 #'   `simultaneousCIs(method = "bootstrap")` and
-#'   `debiasedATT(se_method = "wild_bootstrap")`, so the two cannot silently drift
+#'   `debiasedATT(method = "bootstrap")`, so the two cannot silently drift
 #'   on what they accept. `seed` must be integer-valued (a non-integer would be
 #'   silently truncated by `set.seed()`).
 #' @param B,seed The arguments to validate.

--- a/man/debiasedATT.Rd
+++ b/man/debiasedATT.Rd
@@ -7,7 +7,7 @@
 debiasedATT(
   fit,
   alpha = NULL,
-  se_method = c("analytic", "wild_bootstrap"),
+  method = c("analytic", "bootstrap"),
   B = 1000L,
   seed = NULL,
   multiplier = c("webb", "rademacher", "mammen"),
@@ -27,9 +27,9 @@ construction is specific to the FETWFE transformed-coefficient space).}
 \item{alpha}{Numeric in \verb{(0, 1)}; the confidence level is \code{1 - alpha}.
 Defaults to the \code{alpha} stored on the fit.}
 
-\item{se_method}{How to form the confidence interval. \code{"analytic"} (default)
+\item{method}{How to form the confidence interval. \code{"analytic"} (default)
 uses the two-channel unit-clustered sandwich SE with a Gaussian critical
-value. \code{"wild_bootstrap"} replaces the Gaussian critical value with a
+value. \code{"bootstrap"} replaces the Gaussian critical value with a
 studentized score / influence-function \strong{wild cluster bootstrap} (#360),
 \strong{floored at the Gaussian quantile} so the interval is never narrower than
 the analytic Wald interval. The point estimate and the reported \code{se} are
@@ -41,17 +41,16 @@ wild-cluster bootstrap-t, and under heterogeneous cluster influence its
 critical value (before the floor) falls \emph{below} the Gaussian --- so under the
 floor it reduces to the analytic interval exactly in the small-\code{N} regime; it
 only ever \emph{widens} the interval when cluster influence is near-homogeneous.
-For a
-genuine few-clusters correction the restricted bootstrap-t or a CR2-type
+For a genuine few-clusters correction the restricted bootstrap-t or a CR2-type
 analytic adjustment is required (tracked as future work, #361). Not supported
 for \code{indep_counts} (two-sample) fits.}
 
 \item{B}{Integer; the number of wild-bootstrap replicates (default \code{1000}).
-Ignored unless \code{se_method = "wild_bootstrap"}.}
+Ignored unless \code{method = "bootstrap"}.}
 
 \item{seed}{\code{NULL} (draw from the ambient RNG, the default) or a single
 integer for a reproducible bootstrap (the RNG state is saved and restored).
-Ignored unless \code{se_method = "wild_bootstrap"}.}
+Ignored unless \code{method = "bootstrap"}.}
 
 \item{multiplier}{The wild-bootstrap weight distribution: \code{"webb"} (default),
 \code{"rademacher"}, or \code{"mammen"}. \code{"rademacher"} (\verb{±1}) gives a constant
@@ -60,7 +59,7 @@ studentization denominator (a \emph{percentile} bootstrap); \code{"webb"} and
 floored at the Gaussian quantile, the multiplier only affects the
 near-homogeneous case where the bootstrap widens above the floor; in the
 small-\code{N} / heterogeneous regime the interval is the analytic one regardless
-of the weight. Ignored unless \code{se_method = "wild_bootstrap"}.}
+of the weight. Ignored unless \code{method = "bootstrap"}.}
 
 \item{lambda_c}{The leading constant of the high-dimensional (\code{p >= NT})
 nodewise penalty \verb{lambda_node = lambda_c * max(|a|) * sqrt(log(p) / N)} (\code{N} =
@@ -86,8 +85,8 @@ and a \code{tidy} method) with elements:
 \item{se}{Numeric scalar; the uniformly-valid standard error,
 \code{sqrt(var_reg + var_weight)}.}
 \item{ci_low, ci_high}{Numeric; the \code{1 - alpha} interval. With
-\code{se_method = "analytic"} (default) this is the Wald interval
-\verb{att +/- qnorm(1 - alpha/2) * se}; with \code{se_method = "wild_bootstrap"}
+\code{method = "analytic"} (default) this is the Wald interval
+\verb{att +/- qnorm(1 - alpha/2) * se}; with \code{method = "bootstrap"}
 the critical value is the bootstrap \code{crit_value} (floored at
 \code{qnorm(1 - alpha/2)}, so never narrower than the Wald interval) in place
 of \code{qnorm(1 - alpha/2)}.}
@@ -111,8 +110,8 @@ also contains \code{lambda_cv}, the cross-validation diagnostics (the grid, the
 per-grid feasibility flags and CV losses, and whether the theory-scale
 fallback fired). These are absent for \code{p < NT} fits.
 
-With \code{se_method = "wild_bootstrap"} the list additionally contains
-\code{se_method}, \code{crit_value} (the studentized wild-bootstrap critical value,
+With \code{method = "bootstrap"} the list additionally contains
+\code{method}, \code{crit_value} (the studentized wild-bootstrap critical value,
 floored at \code{qnorm(1 - alpha/2)}), \code{B}, \code{multiplier}, and \code{alpha}. The analytic
 default adds none of these, so its \code{names()} are unchanged.
 }
@@ -191,7 +190,7 @@ and cancels in the OLS-identity case.
 cluster approximation is poor and the interval can under-cover; a genuine
 few-clusters correction (a restricted wild-cluster bootstrap-t or a
 CR2-type analytic adjustment, #361) is future work. The
-\code{se_method = "wild_bootstrap"} option does \emph{not} remedy this (see its
+\code{method = "bootstrap"} option does \emph{not} remedy this (see its
 documentation).
 \item \strong{Regularity / two regimes.} When \code{p < NT} (Theorem
 \code{debiased.att.thm}) the full design Gram is nonsingular and the debiasing

--- a/tests/testthat/test-debiased-att-wild-bootstrap-360.R
+++ b/tests/testthat/test-debiased-att-wild-bootstrap-360.R
@@ -3,14 +3,14 @@ library(fetwfe)
 
 # ------------------------------------------------------------------------------
 # #360 / #363: the debiased overall ATT via a studentized score /
-# influence-function WILD CLUSTER BOOTSTRAP (se_method = "wild_bootstrap"),
+# influence-function WILD CLUSTER BOOTSTRAP (method = "bootstrap"),
 # re-signing the per-unit influence summands (V1 regression `unit_scores` + V2
 # cohort-weight, built from a_att_G = (catt - att_hat)/S) WITHOUT a refit per
 # replicate. Point estimate and reported `se` are unchanged; only the critical
 # value changes, and it is FLOORED at qnorm(1 - alpha/2) (#363) so the interval is
 # never narrower than the analytic Wald interval -- this is NOT a few-clusters
 # remedy (an unrestricted no-refit score bootstrap narrows below the Gaussian
-# under heterogeneous cluster influence). Default se_method = "analytic" is
+# under heterogeneous cluster influence). Default method = "analytic" is
 # byte-identical to the previous behavior.
 # ------------------------------------------------------------------------------
 
@@ -62,12 +62,12 @@ library(fetwfe)
 test_that("analytic default is unchanged and adds no bootstrap fields (#360)", {
 	for (fit in list(.wb_fixedp, .wb_highdim)) {
 		a0 <- debiasedATT(fit)
-		a1 <- debiasedATT(fit, se_method = "analytic")
-		# se_method = "analytic" is the default and is identical.
+		a1 <- debiasedATT(fit, method = "analytic")
+		# method = "analytic" is the default and is identical.
 		expect_identical(a0, a1)
 		# No bootstrap fields on the analytic object.
 		expect_false(any(
-			c("se_method", "crit_value", "B", "multiplier") %in% names(a0)
+			c("method", "crit_value", "B", "multiplier") %in% names(a0)
 		))
 	}
 	# fixed-p analytic keeps EXACTLY the documented names (the #326 contract).
@@ -80,10 +80,10 @@ test_that("analytic default is unchanged and adds no bootstrap fields (#360)", {
 test_that("wild bootstrap leaves att and se unchanged, only the CI changes (#360)", {
 	for (fit in list(.wb_fixedp, .wb_highdim)) {
 		a <- debiasedATT(fit)
-		w <- debiasedATT(fit, se_method = "wild_bootstrap", seed = 1)
+		w <- debiasedATT(fit, method = "bootstrap", seed = 1)
 		expect_equal(w$att, a$att)
 		expect_equal(w$se, a$se) # analytic sandwich SE is reused verbatim
-		expect_identical(w$se_method, "wild_bootstrap")
+		expect_identical(w$method, "bootstrap")
 		expect_true(all(
 			c("crit_value", "B", "multiplier", "alpha") %in% names(w)
 		))
@@ -120,22 +120,22 @@ test_that("the V2 cohort-weight influence function reproduces var_weight (the an
 
 test_that("wild bootstrap is reproducible with a seed and ambient without (#360)", {
 	fit <- .wb_fixedp
-	w1 <- debiasedATT(fit, se_method = "wild_bootstrap", seed = 42)
-	w2 <- debiasedATT(fit, se_method = "wild_bootstrap", seed = 42)
+	w1 <- debiasedATT(fit, method = "bootstrap", seed = 42)
+	w2 <- debiasedATT(fit, method = "bootstrap", seed = 42)
 	expect_identical(w1$crit_value, w2$crit_value)
 	expect_identical(w1$ci_low, w2$ci_low)
 	# A different seed (almost surely) gives a different critical value.
-	w3 <- debiasedATT(fit, se_method = "wild_bootstrap", seed = 7)
+	w3 <- debiasedATT(fit, method = "bootstrap", seed = 7)
 	expect_false(isTRUE(all.equal(w1$crit_value, w3$crit_value)))
 	# seed = NULL draws from the ambient stream and still returns a finite crit.
 	set.seed(1)
-	w_null <- debiasedATT(fit, se_method = "wild_bootstrap")
+	w_null <- debiasedATT(fit, method = "bootstrap")
 	expect_true(is.finite(w_null$crit_value) && w_null$crit_value > 0)
 	# Seeded draw does not disturb the ambient RNG stream (.with_preserved_rng).
 	set.seed(100)
 	u_before <- runif(1)
 	set.seed(100)
-	invisible(debiasedATT(fit, se_method = "wild_bootstrap", seed = 42))
+	invisible(debiasedATT(fit, method = "bootstrap", seed = 42))
 	u_after <- runif(1)
 	expect_identical(u_before, u_after)
 })
@@ -145,7 +145,7 @@ test_that("all three multiplier types produce finite critical values (#360)", {
 	for (m in c("rademacher", "mammen", "webb")) {
 		w <- debiasedATT(
 			fit,
-			se_method = "wild_bootstrap",
+			method = "bootstrap",
 			multiplier = m,
 			seed = 1
 		)
@@ -182,7 +182,7 @@ test_that("wild bootstrap errors on indep_counts (two-sample) fits (#360)", {
 	expect_s3_class(debiasedATT(fit_ic), "debiased_att")
 	# The wild bootstrap refuses, with an actionable message.
 	expect_error(
-		debiasedATT(fit_ic, se_method = "wild_bootstrap"),
+		debiasedATT(fit_ic, method = "bootstrap"),
 		"indep_counts"
 	)
 })
@@ -190,24 +190,24 @@ test_that("wild bootstrap errors on indep_counts (two-sample) fits (#360)", {
 test_that("wild bootstrap validates B and seed (#360)", {
 	fit <- .wb_fixedp
 	expect_error(
-		debiasedATT(fit, se_method = "wild_bootstrap", B = -1),
+		debiasedATT(fit, method = "bootstrap", B = -1),
 		"`B`"
 	)
 	expect_error(
-		debiasedATT(fit, se_method = "wild_bootstrap", B = 2.5),
+		debiasedATT(fit, method = "bootstrap", B = 2.5),
 		"`B`"
 	)
 	expect_error(
-		debiasedATT(fit, se_method = "wild_bootstrap", seed = c(1, 2)),
+		debiasedATT(fit, method = "bootstrap", seed = c(1, 2)),
 		"`seed`"
 	)
 	# A non-integer seed is rejected (it would be silently truncated by set.seed).
 	expect_error(
-		debiasedATT(fit, se_method = "wild_bootstrap", seed = 1.5),
+		debiasedATT(fit, method = "bootstrap", seed = 1.5),
 		"`seed`"
 	)
 	expect_error(
-		debiasedATT(fit, se_method = "wild_bootstrap", multiplier = "gaussian")
+		debiasedATT(fit, method = "bootstrap", multiplier = "gaussian")
 	)
 })
 
@@ -215,7 +215,7 @@ test_that("the default wild-bootstrap multiplier is webb (#360, review 1)", {
 	# Webb is kept as the default (a studentized statistic, vs rademacher's constant
 	# denominator); given the #363 floor the multiplier choice only matters in the
 	# near-homogeneous case where the bootstrap widens above the floor.
-	w <- debiasedATT(.wb_fixedp, se_method = "wild_bootstrap", seed = 1)
+	w <- debiasedATT(.wb_fixedp, method = "bootstrap", seed = 1)
 	expect_identical(w$multiplier, "webb")
 })
 
@@ -242,7 +242,7 @@ test_that("wild bootstrap handles a single-cohort fit, var_weight = 0 (#360, rev
 	)
 	a <- debiasedATT(fit)
 	expect_equal(a$var_weight, 0)
-	w <- debiasedATT(fit, se_method = "wild_bootstrap", seed = 1)
+	w <- debiasedATT(fit, method = "bootstrap", seed = 1)
 	expect_equal(w$se, a$se)
 	expect_true(is.finite(w$crit_value) && w$crit_value > 0)
 	expect_equal(w$ci_high - w$att, w$crit_value * w$se)
@@ -265,7 +265,7 @@ test_that("print.debiased_att surfaces the bootstrap method and level (#360)", {
 	fit <- .wb_fixedp
 	w <- debiasedATT(
 		fit,
-		se_method = "wild_bootstrap",
+		method = "bootstrap",
 		multiplier = "webb",
 		seed = 1
 	)
@@ -283,7 +283,7 @@ test_that("the wild-bootstrap crit is floored at the Gaussian quantile (#363)", 
 	z <- stats::qnorm(0.975)
 	# The (floored) crit is never below z on any fit.
 	for (fit in list(.wb_fixedp, .wb_highdim)) {
-		w <- debiasedATT(fit, se_method = "wild_bootstrap", seed = 1)
+		w <- debiasedATT(fit, method = "bootstrap", seed = 1)
 		expect_gte(w$crit_value, z)
 	}
 	# The floor BITES: on a heterogeneous few-cluster fit whose pre-floor crit is
@@ -311,7 +311,7 @@ test_that("the wild-bootstrap crit is floored at the Gaussian quantile (#363)", 
 	)
 	w_het <- debiasedATT(
 		fit_het,
-		se_method = "wild_bootstrap",
+		method = "bootstrap",
 		multiplier = "webb",
 		seed = 1,
 		B = 2000
@@ -326,7 +326,7 @@ test_that("the wild-bootstrap crit is floored at the Gaussian quantile (#363)", 
 	# here.
 	w_het_90 <- debiasedATT(
 		fit_het,
-		se_method = "wild_bootstrap",
+		method = "bootstrap",
 		multiplier = "webb",
 		seed = 1,
 		B = 2000,

--- a/vignettes/inference_vignette.Rmd
+++ b/vignettes/inference_vignette.Rmd
@@ -437,14 +437,14 @@ The fused interval under-covers because of the post-selection non-uniformity; th
 
 ## An asymptotic alternative: the wild bootstrap
 
-`se_method = "wild_bootstrap"` offers an alternative, asymptotically-valid reference distribution for the overall-ATT interval: a studentized score / influence-function **wild cluster bootstrap** that re-signs the per-unit influence summands (no refit per replicate), leaving the point estimate and the reported `se` unchanged and changing only the critical value. It is **floored at the Gaussian quantile**, so the interval is never narrower than the analytic Wald interval.
+`method = "bootstrap"` offers an alternative, asymptotically-valid reference distribution for the overall-ATT interval: a studentized score / influence-function **wild cluster bootstrap** that re-signs the per-unit influence summands (no refit per replicate), leaving the point estimate and the reported `se` unchanged and changing only the critical value. It is **floored at the Gaussian quantile**, so the interval is never narrower than the analytic Wald interval.
 
 **It is not a few-clusters remedy.** The analytic sandwich SE is downward-biased with few clusters, but this bootstrap does not fix that: as an *unrestricted, no-refit* score bootstrap it does not reproduce the tail inflation the *restricted* wild-cluster bootstrap-t uses for few-cluster coverage, and under heterogeneous cluster influence its critical value (before the floor) actually falls *below* the Gaussian --- so the floor reduces it to the analytic interval in exactly the small-`N` regime. Its only effect is to *widen* the interval when cluster influence is near-homogeneous. For genuine few-clusters inference a restricted bootstrap-t or a CR2-type analytic correction is required (future work).
 
 ```{r highdim-wild-boot, eval = FALSE}
 # `fit` must be a single-sample fetwfe() fit -- not an `indep_counts` fit, which
 # the worked example above (via fetwfeWithSimulatedData) happens to be.
-debiasedATT(fit, se_method = "wild_bootstrap", multiplier = "webb", seed = 1)
+debiasedATT(fit, method = "bootstrap", multiplier = "webb", seed = 1)
 ```
 
 The `multiplier` (`"webb"`, the default; `"rademacher"`; or `"mammen"`) only affects the near-homogeneous case where the bootstrap widens above the floor --- in the small-`N` / heterogeneous regime the interval is the analytic one regardless of the weight. The bootstrap is defined only for **single-sample** fits (real observational panels are single-sample), not `indep_counts` two-sample fits.


### PR DESCRIPTION
## Summary

Renames `debiasedATT()`'s inference-method argument `se_method` → `method` (and its non-default value `"wild_bootstrap"` → `"bootstrap"`) to match the sibling `simultaneousCIs(method = c("analytic", "bootstrap"))` (Closes #365). Per your call in the #363 discussion; done now because `se_method` never shipped to CRAN, so the rename is breaking-change-free — the clean window before 2.x.

## Why

The two inference functions drive the same shared bootstrap machinery but named the analytic-vs-bootstrap toggle inconsistently — `debiasedATT(se_method=…)` vs `simultaneousCIs(method=…)` — and `se_method` also collided with the estimators' existing `se_type` argument (the SE *flavor*). Aligning to `method` / `bootstrap` removes both frictions.

## Change

- **`debiasedATT()`**: `se_method = c("analytic", "wild_bootstrap")` → `method = c("analytic", "bootstrap")`; the returned object now stores `method` (was `se_method`); the roxygen, the `indep_counts` error message, and the `print.debiased_att` guard are updated. The method itself is still described as a **wild cluster bootstrap** (accurate) — only the argument name and value changed.
- **Tests + vignette**: every `se_method = "wild_bootstrap"` → `method = "bootstrap"`.
- **NEWS + version** `1.56.1 → 1.56.2`, documenting the rename.

## Verification

- **No `se_method` / `wild_bootstrap` remains** in code, tests, vignette, or `man/` (`document()` regenerated the `.Rd`).
- Full suite **FAIL 0**; `spell_check` clean; `R CMD check --as-cran`.
- Behavior is unchanged apart from the argument/value name — the analytic default path is byte-identical, and the bootstrap path is the same method (same shared machinery) under the new name.

## Note on NEWS

The three *historical* NEWS entries (1.36.0, 1.55.0, 1.56.0) still mention `se_method` — deliberately left as-is. The new 1.56.2 entry at the top documents the rename, so the changelog reads coherently top-to-bottom (dev builds used `se_method`; renamed to `method` in 1.56.2). Release-prep can harmonize the pre-release NEWS if a fully consistent release changelog is wanted.

Closes #365.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
