### PR TITLE
refactor: single-source the event-time point-estimate aggregation into `.true_event_time_effects()` (#389)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.56.8
+Version: 1.56.9
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 # NEWS
 
+## Version 1.56.9
+
+### Internal
+
+- Folded the previously-triplicated event-time point-estimate aggregation
+  (`tau_E(e) = sum_{g in V_e} w_g * cell(g, e)`) into the shared internal helper
+  `.true_event_time_effects()`; `eventStudy()` for `fetwfe`, `etwfe`, and
+  `betwfe` now computes its point estimates through that single source (#389).
+  `eventStudy()` output is byte-identical to before. Because the helper adopts
+  the estimator loops' exact summation form, `getTes()`'s `actual_event_time_tes`
+  may differ from prior versions by a floating-point rounding step (a small
+  multiple of `1e-16`, i.e. a few ULP) on some data-generating processes.
+
 ## Version 1.56.8
 
 ### Documentation

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -167,19 +167,20 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 	}
 }
 
-#' True per-event-time treatment effects from cohort-time cell effects
+#' True (or estimated) per-event-time treatment effects from cohort-time cells
 #'
-#' @description The point-estimate aggregation of `.event_study_fetwfe()` (the
-#'   `estimates[k]` loop) factored out for reuse by [getTes()]: given the
-#'   per-`(g, t)` treatment-effect cells and the cohort structure, returns the
-#'   event-time effects `tau_E(e) = sum_{g in V_e} w_g * cell(g, e)`, where `V_e`
-#'   is the set of cohorts still observed at event time `e`, `w_g` is cohort
-#'   `g`'s probability normalized within `V_e`, and
-#'   `cell(g, e) = cell_effects[first_inds[g] + e]`. Feeding a fit's estimated
-#'   cells reproduces `eventStudy(fit)$estimate` (verified to machine precision);
-#'   feeding a DGP's true cells (`coefs$beta[treat_inds]`) gives the true
-#'   event-time effects. An event time with no contributing cohort returns `NA`
-#'   (the truth is undefined there; the estimator reports `0`).
+#' @description The single source of truth for the event-time point-estimate
+#'   aggregation `tau_E(e) = sum_{g in V_e} w_g * cell(g, e)`, where `V_e` is the
+#'   set of cohorts still observed at event time `e`, `w_g` is cohort `g`'s
+#'   probability normalized within `V_e`, and
+#'   `cell(g, e) = cell_effects[first_inds[g] + e]`. Called by both estimator
+#'   event-study loops (`.event_study_fetwfe()` / `.event_study_etwfe_betwfe()`,
+#'   with `empty_value = 0`) and by [getTes()] (truth side, default
+#'   `empty_value = NA`); #389 folded the previously-triplicated aggregation
+#'   here. Feeding a fit's estimated cells reproduces `eventStudy(fit)$estimate`
+#'   bit-for-bit (the aggregation uses the same sparse-weight `crossprod` form
+#'   the loops use); feeding a DGP's true cells (`coefs$beta[treat_inds]`) gives
+#'   the true event-time effects.
 #' @param cell_effects Numeric length `num_treats`; per-`(g, t)` effects in
 #'   `treat_inds` order.
 #' @param first_inds Integer length `G`; index within `cell_effects` of each
@@ -189,8 +190,14 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 #' @param cohort_probs Numeric length `G`; cohort probabilities (any positive
 #'   scaling; normalized within `V_e`).
 #' @param T Integer; number of time periods. Event times run `0:(T - 2)`.
+#' @param empty_value Numeric scalar written at an event time no cohort reaches
+#'   (`length(V_e) == 0`) or where the within-`V_e` probability mass is
+#'   non-positive/non-finite. Defaults to `NA_real_` (the truth convention: the
+#'   effect is undefined there); the estimator loops pass `0` (they report a
+#'   zero pooled estimate for an empty event time).
 #' @return Named numeric length `T - 1`; the event-time effects with names
-#'   `as.character(0:(T - 2))`, `NA` where no cohort reaches that event time.
+#'   `as.character(0:(T - 2))`, `empty_value` where no cohort reaches that event
+#'   time.
 #' @keywords internal
 #' @noRd
 .true_event_time_effects <- function(
@@ -198,10 +205,12 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 	first_inds,
 	cohort_offsets_int,
 	cohort_probs,
-	T
+	T,
+	empty_value = NA_real_
 ) {
+	num_treats <- length(cell_effects)
 	event_times <- 0:(T - 2L)
-	out <- rep(NA_real_, length(event_times))
+	out <- rep(empty_value, length(event_times))
 	for (k in seq_along(event_times)) {
 		e <- event_times[k]
 		V_e <- which(cohort_offsets_int <= T - e)
@@ -214,7 +223,17 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 			next
 		}
 		weights_Ve <- probs_Ve / S_V
-		out[k] <- sum(weights_Ve * cell_effects[first_inds[V_e] + e])
+		# Same sparse-weight `crossprod` form the estimator loops in
+		# `.event_study_fetwfe()` / `.event_study_etwfe_betwfe()` use, so those
+		# loops -- which now call this helper -- reproduce `eventStudy()`'s
+		# estimand BIT-FOR-BIT. A length-|V_e| `sum(weights * cells)` diverges
+		# from the estimator `crossprod` by up to a couple of ULP on some DGPs
+		# (#389).
+		psi <- numeric(num_treats)
+		for (j in seq_along(V_e)) {
+			psi[first_inds[V_e[j]] + e] <- weights_Ve[j]
+		}
+		out[k] <- as.numeric(crossprod(psi, cell_effects))
 	}
 	names(out) <- as.character(event_times)
 	out
@@ -318,7 +337,19 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 
 	max_event <- T - 2L
 	event_times <- 0:max_event
-	estimates <- numeric(length(event_times))
+	# Point estimates: single-sourced through the shared aggregation helper
+	# (#389). `empty_value = 0` matches the loop's degenerate convention (a zero
+	# pooled estimate for an empty event time). The SE loop below recomputes
+	# `V_e` / `weights_Ve` (and, for etwfe/betwfe, `psi_e_tes`) for the variance
+	# terms; only the point estimate is factored out here.
+	estimates <- unname(.true_event_time_effects(
+		cell_effects = tes,
+		first_inds = first_inds,
+		cohort_offsets_int = cohort_offsets_int,
+		cohort_probs = cohort_probs_overall,
+		T = T,
+		empty_value = 0
+	))
 	ses <- numeric(length(event_times))
 	n_cohorts <- integer(length(event_times))
 
@@ -333,7 +364,6 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 		V_e <- which(cohort_offsets_int <= T - e)
 		n_cohorts[k] <- length(V_e)
 		if (length(V_e) == 0L) {
-			estimates[k] <- 0
 			ses[k] <- NA_real_
 			next
 		}
@@ -342,20 +372,18 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 		probs_Ve <- cohort_probs_overall[V_e]
 		S_V <- sum(probs_Ve)
 		if (S_V <= 0) {
-			estimates[k] <- 0
 			ses[k] <- NA_real_
 			next
 		}
 		weights_Ve <- probs_Ve / S_V
 
-		# psi_e_tes (length num_treats): weight at idx(g, e) for g in V_e, 0 elsewhere
+		# psi_e_tes (length num_treats): weight at idx(g, e) for g in V_e, 0
+		# elsewhere. Feeds the SE terms below; the point estimate is
+		# single-sourced through `.true_event_time_effects()` above (#389).
 		psi_e_tes <- numeric(num_treats)
 		for (j in seq_along(V_e)) {
 			psi_e_tes[first_inds[V_e[j]] + e] <- weights_Ve[j]
 		}
-
-		# Point estimate
-		estimates[k] <- as.numeric(crossprod(psi_e_tes, tes))
 
 		if (!calc_ses) {
 			ses[k] <- NA_real_
@@ -562,7 +590,19 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 
 	max_event <- T - 2L
 	event_times <- 0:max_event
-	estimates <- numeric(length(event_times))
+	# Point estimates: single-sourced through the shared aggregation helper
+	# (#389). `empty_value = 0` matches the loop's degenerate convention (a zero
+	# pooled estimate for an empty event time). The SE loop below recomputes
+	# `V_e` / `weights_Ve` (and, for etwfe/betwfe, `psi_e_tes`) for the variance
+	# terms; only the point estimate is factored out here.
+	estimates <- unname(.true_event_time_effects(
+		cell_effects = tes,
+		first_inds = first_inds,
+		cohort_offsets_int = cohort_offsets_int,
+		cohort_probs = cohort_probs_overall,
+		T = T,
+		empty_value = 0
+	))
 	ses <- numeric(length(event_times))
 	n_cohorts <- integer(length(event_times))
 
@@ -573,7 +613,6 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 		V_e <- which(cohort_offsets_int <= T - e)
 		n_cohorts[k] <- length(V_e)
 		if (length(V_e) == 0L) {
-			estimates[k] <- 0
 			ses[k] <- NA_real_
 			next
 		}
@@ -581,19 +620,10 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 		probs_Ve <- cohort_probs_overall[V_e]
 		S_V <- sum(probs_Ve)
 		if (S_V <= 0) {
-			estimates[k] <- 0
 			ses[k] <- NA_real_
 			next
 		}
 		weights_Ve <- probs_Ve / S_V
-
-		# Point estimate: weighted sum of per-cell tes (which already
-		# incorporates d_inv_treat times theta_hat under the FETWFE fit).
-		psi_e_tes <- numeric(num_treats)
-		for (j in seq_along(V_e)) {
-			psi_e_tes[first_inds[V_e[j]] + e] <- weights_Ve[j]
-		}
-		estimates[k] <- as.numeric(crossprod(psi_e_tes, tes))
 
 		if (!calc_ses) {
 			ses[k] <- NA_real_

--- a/tests/testthat/test-gettes-event-time.R
+++ b/tests/testthat/test-gettes-event-time.R
@@ -1,7 +1,10 @@
 # Tests for getTes()'s `actual_event_time_tes` accessor and the internal
 # `.true_event_time_effects()` helper (#388). The load-bearing test binds the
-# helper to the estimator's `eventStudy()` estimand; the aggregation is otherwise
-# duplicated (the estimator's inline loop is intentionally un-refactored).
+# helper to the estimator's `eventStudy()` estimand. As of #389 the two estimator
+# event-study loops (`.event_study_fetwfe()` / `.event_study_etwfe_betwfe()`) are
+# folded onto this helper (single source of truth); the byte-exact test below
+# locks that `eventStudy()`'s estimand IS the helper's output for all three
+# estimators.
 
 # Helper: the event-time effects the estimator targets, computed from a fit's
 # estimated cells + resolved cohort structure.
@@ -163,4 +166,79 @@ test_that(".true_event_time_effects returns NA at an event time no cohort reache
 	expect_false(is.na(res[["0"]]))
 	expect_true(is.na(res[["2"]]))
 	expect_true(is.na(res[["4"]]))
+})
+
+test_that(".true_event_time_effects() single-sources eventStudy()'s estimand byte-exactly (fetwfe/etwfe/betwfe, #389)", {
+	# After #389 both estimator loops compute their point estimates by calling
+	# `.true_event_time_effects()` (with `empty_value = 0`), using the SAME
+	# sparse-weight crossprod form, so `eventStudy(fit)$estimate` equals the
+	# helper's output BIT-FOR-BIT. Loop seeds 1-6: whether the old inline `sum`
+	# form diverged from `crossprod` is BLAS/DGP-dependent (e.g. betwfe seed 3
+	# does not diverge on some platforms), so a single pinned seed could make an
+	# estimator's assertion vacuous; looping guarantees the mutation-check bites.
+	for (seed in 1:6) {
+		coefs <- genCoefs(
+			G = 3,
+			T = 5,
+			d = 2,
+			density = 0.5,
+			eff_size = 2,
+			seed = seed
+		)
+		sim <- simulateData(
+			coefs,
+			N = 400,
+			sig_eps_sq = 1,
+			sig_eps_c_sq = 0.5,
+			seed = seed
+		)
+		fits <- list(
+			fetwfeWithSimulatedData(sim),
+			etwfeWithSimulatedData(sim),
+			betwfeWithSimulatedData(sim)
+		)
+		for (fit in fits) {
+			offs <- fetwfe:::.resolve_cohort_offsets_and_first_inds(
+				fit,
+				fit$G,
+				fit$T
+			)
+			est_via_helper <- unname(fetwfe:::.true_event_time_effects(
+				cell_effects = fit$beta_hat[fit$treat_inds],
+				first_inds = offs$first_inds,
+				cohort_offsets_int = offs$cohort_offsets_int,
+				cohort_probs = fit$cohort_probs_overall,
+				T = fit$T,
+				empty_value = 0
+			))
+			# expect_identical (not expect_equal): byte-for-byte is the point.
+			# unname() is load-bearing -- a named vector would flip the data
+			# frame's row.names, failing df-level identical().
+			expect_identical(est_via_helper, eventStudy(fit)$estimate)
+		}
+	}
+})
+
+test_that(".true_event_time_effects() `empty_value` controls the unreached-event-time fill (#389)", {
+	# Synthetic offsets 5,6 with T=6: event times 2,3,4 are reached by no cohort
+	# (V_e empty). The default fills NA (truth convention); the estimator loops
+	# pass empty_value = 0 (a zero pooled estimate). Reached rows are unaffected.
+	args <- list(
+		cell_effects = rep(1, 20),
+		first_inds = c(1L, 6L),
+		cohort_offsets_int = c(5L, 6L),
+		cohort_probs = c(0.5, 0.5),
+		T = 6L
+	)
+	res_na <- do.call(fetwfe:::.true_event_time_effects, args)
+	res_0 <- do.call(
+		fetwfe:::.true_event_time_effects,
+		c(args, list(empty_value = 0))
+	)
+	expect_true(is.na(res_na[["2"]]))
+	expect_true(is.na(res_na[["4"]]))
+	expect_identical(res_0[["2"]], 0)
+	expect_identical(res_0[["4"]], 0)
+	expect_false(is.na(res_0[["0"]]))
+	expect_identical(res_na[["0"]], res_0[["0"]])
 })


### PR DESCRIPTION

Folds the event-time point-estimate aggregation `tau_E(e) = sum_{g in V_e} w_g * cell(g, e)` — previously triplicated in `.event_study_fetwfe()`, `.event_study_etwfe_betwfe()`, and the `.true_event_time_effects()` helper — so both estimator loops now compute their point estimates by calling the helper (single source of truth). The helper gains an `empty_value` parameter (estimators pass `0`; `getTes()` keeps the default `NA`).

`eventStudy()` output is **byte-identical** before/after — proven with `identical()` on a 13-fit battery spanning fetwfe/etwfe/betwfe, the cluster-robust SE path, both `ci_type` bands, and a high-dimensional `gls = FALSE` fit. To achieve that, the helper adopts the estimator loops' exact `crossprod` summation form; the only numeric consequence is that `getTes()$actual_event_time_tes` may shift by a floating-point rounding step (at most a few times `1e-16`) on some DGPs — a truth quantity with no bit-exact contract. A new looped byte-exact test locks `eventStudy()`'s estimand to the helper across all three estimators (mutation-proven to bite at each refactored site); the `empty_value` contract gets its own unit test.

No behavior change, no new exports. Closes #389.

## Out of scope (deferred follow-ups)

- **Hardening the estimator loops' bare `S_V <= 0` SE guard against adversarial non-finite cohort probabilities** (plan-review R2) — **dropped (c)**: unreachable on real fits (`cohort_probs_overall` are finite positive sample proportions, so `S_V > 0` always), and out of scope for a byte-identity refactor. The helper's estimate branch already carries the stricter `!is.finite(S_V) || S_V <= 0` guard.
