### PR TITLE
fix: floor the K>=2 sup-t bootstrap critical value and its dual adjusted p-value at the pointwise value (#393)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.56.9
+Version: 1.56.10
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # NEWS
 
+## Version 1.56.10
+
+### Bug fixes
+
+- `simultaneousCIs(method = "bootstrap")` now floors the `K >= 2` sup-t critical
+  value **and** its dual single-step max-T adjusted p-value at the pointwise
+  Gaussian value (`qnorm(1 - alpha/2)` and `2 * pnorm(-|t|)`). Under strong
+  cross-effect correlation the raw Monte-Carlo estimate of either could dip below
+  the pointwise value, returning a "simultaneous" band strictly inside its own
+  pointwise band (or an adjusted p-value smaller than the pointwise p) ---
+  anti-conservative in the one quantity a simultaneous band exists to guarantee.
+  Flooring both restores "simultaneous never narrower / more significant than
+  pointwise" and keeps the band / adjusted-p duality exact. Mirrors the scalar
+  wild-bootstrap floor (#363) and the `K <= 1` branch. (#393)
+
 ## Version 1.56.9
 
 ### Internal

--- a/R/simultaneous_bootstrap.R
+++ b/R/simultaneous_bootstrap.R
@@ -549,6 +549,15 @@
 			names = FALSE,
 			type = 7
 		)
+		# Floor the Monte-Carlo sup-t quantile at the pointwise Gaussian value
+		# (#393). The true sup-t quantile is >= qnorm(1 - alpha/2) (a sup over
+		# K >= 1 standardized effects stochastically dominates a single |Z|), but
+		# the B-draw MC estimate can dip below it under strong cross-effect
+		# correlation, returning a "simultaneous" band strictly inside its own
+		# pointwise band. Mirrors the K <= 1 branch above and the scalar wild-
+		# bootstrap floor (`.debiased_att_wild_boot()`, #363). Free when the MC
+		# estimate is already >= z.
+		crit <- max(crit, stats::qnorm(1 - alpha / 2))
 	}
 
 	list(crit = crit, ses = ses, nondeg = nondeg, boot_max = boot_max)
@@ -845,6 +854,15 @@
 			numeric(1)
 		)
 	}
+	# Floor the adjusted p-values at the pointwise two-sided p (#393) -- the dual
+	# of the crit floor in `.simultaneous_bootstrap_crit()`. The single-step
+	# max-T p is population-level >= the pointwise p (the sup over K >= 1 effects
+	# dominates |Z|), but the MC estimate `mean(boot_max >= t)` can dip below it
+	# under strong cross-effect correlation. Flooring BOTH crit and the p keeps
+	# the documented duality "outside band iff adjusted p < alpha" exact at the
+	# boundary. No-op for the K <= 1 branch (already the pointwise value) and
+	# NA-preserving for degenerate effects (`t_stat` is NA there -> pmax(NA, NA)).
+	adjusted_p_values <- pmax(adjusted_p_values, 2 * stats::pnorm(-abs(t_stat)))
 
 	# Band center `estimates_used`: the bridge `estimates` in fixed-p, the debiased
 	# `estimates + colSums(F_mat)/(N*T)` in the high-dim regime (see the regime

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -206,6 +206,7 @@ tryCatch
 tunable
 TWFE
 twfeCovs
+ULP
 un
 uncentered
 unregularized

--- a/tests/testthat/test-bootstrap-supt-floor-393.R
+++ b/tests/testthat/test-bootstrap-supt-floor-393.R
@@ -1,0 +1,92 @@
+# Tests for #393: the K >= 2 sup-t multiplier-bootstrap critical value AND its
+# dual single-step max-T adjusted p-value are floored at the pointwise Gaussian
+# value, so `simultaneousCIs(method = "bootstrap")` is never anti-conservative
+# relative to its own pointwise band/p-values.
+#
+# Two floors, two failure modes (mutation-proven to bite separately):
+#   (1) band crit floor  -> `.simultaneous_bootstrap_crit()` (crit >= z);
+#   (2) adjusted-p floor -> the caller (adjusted_p >= pointwise two-sided p).
+# The raw Monte-Carlo estimate of each dips below the pointwise value under
+# strong cross-effect correlation (a sup over K >= 1 standardized effects
+# dominates a single |Z| in the population, but the B-draw estimate need not).
+
+test_that(".simultaneous_bootstrap_crit() floors the K>=2 sup-t crit at qnorm(1-alpha/2) (#393)", {
+	alpha <- 0.05
+	z <- stats::qnorm(1 - alpha / 2)
+	N <- 200L
+	# Three near-perfectly correlated IF columns (common base + tiny noise): the
+	# sup-t statistic collapses to ~|Z|, so its 1-alpha MC quantile fluctuates
+	# around z and dips below it on a sizeable fraction (~44%) of bootstrap draws.
+	set.seed(393)
+	v <- stats::rnorm(N)
+	F_mat <- sapply(1:3, function(k) v + 0.01 * stats::rnorm(N))
+	# Loop bootstrap seeds: which seeds dip is BLAS/RNG-dependent, so a single
+	# pinned seed is fragile; looping guarantees the floor is exercised (>= 1
+	# dipping seed) on any platform. Every returned crit must be >= z.
+	crits <- vapply(
+		1:8,
+		function(s) {
+			fetwfe:::.simultaneous_bootstrap_crit(
+				F_mat,
+				n = N,
+				alpha = alpha,
+				B = 1000,
+				multiplier = "rademacher",
+				seed = s
+			)$crit
+		},
+		numeric(1)
+	)
+	expect_true(all(crits >= z))
+})
+
+test_that("simultaneousCIs(method='bootstrap') is never anti-conservative vs pointwise (#393)", {
+	# A plain 2-cohort fit whose bootstrap adjusted p-values dip below the
+	# pointwise p on ~75% of seeds (the reachable-in-normal-use half of #393; the
+	# band crit itself rarely dips on real fits, so the crit assertion here is an
+	# invariant guard, and the direct test above is the crit floor's biting test).
+	coefs <- genCoefs(
+		G = 2,
+		T = 5,
+		d = 2,
+		density = 0.5,
+		eff_size = 2,
+		seed = 5
+	)
+	sim <- simulateData(
+		coefs,
+		N = 200,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 5
+	)
+	fit <- fetwfeWithSimulatedData(sim)
+	alpha <- fit$alpha
+	for (bs in 1:8) {
+		sc <- suppressWarnings(simultaneousCIs(
+			fit,
+			family = "cohort",
+			method = "bootstrap",
+			B = 1000,
+			seed = bs
+		))
+		est <- sc$ci$estimate
+		# Recover the per-effect SE exactly from the simultaneous half-width.
+		se <- (sc$ci$simultaneous_ci_high - est) / sc$critical_value
+		pw_p <- 2 * stats::pnorm(-abs(est / se))
+		# (1) Band: the simultaneous crit / band never inside the pointwise one.
+		expect_gte(sc$critical_value, sc$pointwise_critical_value)
+		expect_true(all(
+			sc$ci$simultaneous_ci_low <= sc$ci$pointwise_ci_low + 1e-10
+		))
+		expect_true(all(
+			sc$ci$simultaneous_ci_high >= sc$ci$pointwise_ci_high - 1e-10
+		))
+		# (2) p-value: the adjusted (simultaneous, family-wise) p never below the
+		# pointwise two-sided p. This is the assertion the p-value floor restores;
+		# it fails pre-fix on the dipping seeds.
+		ok <- is.na(sc$adjusted_p_values) |
+			(sc$adjusted_p_values >= pw_p - 1e-10)
+		expect_true(all(ok))
+	}
+})


### PR DESCRIPTION

`.simultaneous_bootstrap_crit()` took the raw Monte-Carlo sup-t quantile as the `K >= 2` critical value with no floor, so under strong cross-effect correlation the MC estimate could dip below `qnorm(1 - alpha/2)` and `simultaneousCIs(method = "bootstrap")` returned a "simultaneous" band strictly *inside* its own pointwise band. Fixed by flooring `crit` at the pointwise value — mirroring the `K <= 1` branch of the same function and the scalar wild-bootstrap floor (#363).

**Two floors, not one.** The issue proposed flooring only the band, but the `K >= 2` adjusted p-values are computed independently from the same bootstrap sample and carry the identical anti-conservatism — and flooring only the band would *break* the documented "outside band iff adjusted p < alpha" duality (`simultaneous_bootstrap.R:822`/`:852`). So this also floors the adjusted p-values at the pointwise `2 * pnorm(-|t|)`, restoring "simultaneous never narrower / more significant than pointwise" for both quantities and keeping the duality exact. Empirically the p-value is the more reachable half: the band crit does not dip on real fits, but the adjusted p dips on ~75% of bootstrap seeds of a plain 2-cohort fit (the band dip needs a near-collinear family).

New `test-bootstrap-supt-floor-393.R`: a direct-crit test (near-collinear family, looped seeds) guarding the band floor and a full-path test (2-cohort fit, looped seeds) guarding the p-value floor — each mutation-proven to bite its own floor. No behavior change except raising anti-conservative crit/p up to the pointwise value; byte-neutral wherever the MC estimate is already `>= z` (610 existing simultaneous/bootstrap assertions unchanged). Patch bump to 1.56.10. Closes #393.

## Out of scope

- The `event_study` family shows a residual ~`1e-7` adjusted-p offset (now also floored away, harmlessly) attributable to the cadjust/studentization asymmetry tracked separately by **#302** (cosmetic; unaffected by and distinct from this fix).
