### PR TITLE
fix: correct the Kronecker order in `genFullInvFusionTransformMat()` so `add_ridge` (d>=2) penalizes the intended coordinates (#394)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.56.10
+Version: 1.56.11
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # NEWS
 
+## Version 1.56.11
+
+### Bug fixes
+
+- `genFullInvFusionTransformMat()` --- the standalone full inverse-fusion basis
+  matrix --- built its three covariate-interaction blocks (cohort x X, time x X,
+  treatment x X) with the wrong Kronecker order (feature-major `I_d (x) block`
+  instead of the package's level-major `block (x) I_d`), so it disagreed with the
+  authoritative `untransformCoefImproved()` for `d >= 2`. The only estimator path
+  that consumes this builder is the ridge augmentation, so **`fetwfe(add_ridge =
+  TRUE)` with `d >= 2` covariates** was penalizing a coordinate-permuted
+  coefficient vector rather than the documented untransformed coefficients. Fixed;
+  affected fits shift by a small numeric amount (~`1e-7` at the default
+  `lambda_ridge`, growing with `lambda_ridge`). `add_ridge = FALSE` fits,
+  `debiasedATT()`, and the simultaneous-band paths are byte-identical. (#394)
+
 ## Version 1.56.10
 
 ### Bug fixes

--- a/R/fusion_transforms.R
+++ b/R/fusion_transforms.R
@@ -21,10 +21,10 @@
 #'       (D^{(1)}(G))^{-1},\;
 #'       (D^{(1)}(T-1))^{-1},\;
 #'       I_{d},\;
-#'       I_{d}\otimes(D^{(1)}(G))^{-1},\;
-#'       I_{d}\otimes(D^{(1)}(T-1))^{-1},\;
+#'       (D^{(1)}(G))^{-1}\otimes I_{d},\;
+#'       (D^{(1)}(T-1))^{-1}\otimes I_{d},\;
 #'       (D^{(2)}(\mathcal G))^{-1},\;
-#'       I_{d}\otimes(D^{(2)}(\mathcal G))^{-1}
+#'       (D^{(2)}(\mathcal G))^{-1}\otimes I_{d}
 #'     \bigr).
 #' }
 #' The result is a matrix ready for vanilla bridge regression (Lasso,
@@ -255,10 +255,10 @@ transformXintImproved <- function(
 #'        (D^{(1)}(G))^{-1},\;
 #'        (D^{(1)}(T\!-\!1))^{-1},\;
 #'        I_d,\;
-#'        I_d\!\otimes\!(D^{(1)}(G))^{-1},\;
-#'        I_d\!\otimes\!(D^{(1)}(T\!-\!1))^{-1},\;
+#'        (D^{(1)}(G))^{-1}\!\otimes\!I_d,\;
+#'        (D^{(1)}(T\!-\!1))^{-1}\!\otimes\!I_d,\;
 #'        (D^{(2)}(\mathcal G))^{-1},\;
-#'        I_d\!\otimes\!(D^{(2)}(\mathcal G))^{-1}
+#'        (D^{(2)}(\mathcal G))^{-1}\!\otimes\!I_d
 #'     \Bigr)
 #' }
 #' corresponds to seven consecutive blocks in the column ordering used by
@@ -282,10 +282,10 @@ transformXintImproved <- function(
 #' | cohort FE | `genBackwardsInvFusionTransformMat(G)` | \((D^{(1)}(G))^{-1}\) |
 #' | time FE | `genBackwardsInvFusionTransformMat(T-1)` | \((D^{(1)}(T-1))^{-1}\) |
 #' | covariate blocks | identity copy | \(I_d\) |
-#' | covariate x cohort | same helper, repeated for each feature | \(I_d\otimes(D^{(1)}(G))^{-1}\) |
-#' | covariate x time | idem with \(T-1\) | \(I_d\otimes(D^{(1)}(T-1))^{-1}\) |
+#' | covariate x cohort | same helper, one copy per feature (interleaved, level-major) | \((D^{(1)}(G))^{-1}\otimes I_d\) |
+#' | covariate x time | idem with \(T-1\) | \((D^{(1)}(T-1))^{-1}\otimes I_d\) |
 #' | base treatment | `genInvTwoWayFusionTransformMat()` | \((D^{(2)}(\mathcal G))^{-1}\) |
-#' | covariate x treatment | same two-way helper for each feature | \(I_d\otimes(D^{(2)}(\mathcal G))^{-1}\) |
+#' | covariate x treatment | same two-way helper per feature (interleaved, level-major) | \((D^{(2)}(\mathcal G))^{-1}\otimes I_d\) |
 #'
 #' @param beta_hat_mod Numeric vector (length \eqn{p}).
 #'   Estimated coefficients returned by a penalised fit on the transformed
@@ -601,7 +601,7 @@ genBackwardsInvFusionTransformMat <- function(n_vars) {
 	## -- self-test: D_inv %*% D  ==  I
 	D <- genBackwardsFusionTransformMat(n_vars)
 	tol <- 1e-12
-	if (!all.equal(D_inv %*% D, diag(n_vars), tolerance = tol)) {
+	if (!isTRUE(all.equal(D_inv %*% D, diag(n_vars), tolerance = tol))) {
 		stop(
 			"genBackwardsInvFusionTransformMat(): self-test failed - ",
 			"result is not the matrix inverse of D."
@@ -632,7 +632,7 @@ genBackwardsInvFusionTransformMat <- function(n_vars) {
 #' two-level fusion penalty on \eqn{\beta}.
 #'
 #' @details
-#' * The returned matrix is **upper-triangular with 1s** on and above the main
+#' * The returned matrix is **lower-triangular with 1s** on and below the main
 #'   diagonal and zeros elsewhere, except for extra 1s that implement the
 #'   cross-cohort link on the first effect of each cohort (see paper, Eq. (18)).
 #' * Its inverse contains only \{-1,0,1\} and recreates Eq. (17) of the paper.
@@ -1049,10 +1049,10 @@ genInvEventStudyFusionTransformMat <- function(n_vars, first_inds, G) {
 #'         (D^{(1)}(G))^{-1},                          # 1. cohort FEs
 #'         (D^{(1)}(T-1))^{-1},                        # 2. time  FEs
 #'         I_d,                                        # 3. X main effects
-#'         I_d ⊗ (D^{(1)}(G))^{-1},                   # 4. cohort × X
-#'         I_d ⊗ (D^{(1)}(T-1))^{-1},                 # 5. time   × X
+#'         (D^{(1)}(G))^{-1} ⊗ I_d,                   # 4. cohort × X
+#'         (D^{(1)}(T-1))^{-1} ⊗ I_d,                 # 5. time   × X
 #'         (D^{(2)}(G))^{-1},                         # 6. base τ_{g,t}
-#'         I_d ⊗ (D^{(2)}(G))^{-1} )                  # 7. τ_{g,t} × X
+#'         (D^{(2)}(G))^{-1} ⊗ I_d )                  # 7. τ_{g,t} × X
 #' }
 #'
 #' @section Block dimensions:
@@ -1069,7 +1069,7 @@ genInvEventStudyFusionTransformMat <- function(n_vars, first_inds, G) {
 #' @param first_inds Integer vector (length \code{G}).
 #'   `first_inds[g]` is the 1-based column index of the first base
 #'   treatment-effect parameter \(\tau_{g,0}\) for cohort \code{g}.
-#' @param T Integer. Total number of time periods \(\ge 3\).
+#' @param T Integer. Total number of time periods \(\ge 2\).
 #' @param G Integer. Number of treated cohorts (\(\ge 1\)).
 #'   The function stops if you accidentally pass \code{G = 0}.
 #' @param d Integer. Number of time-invariant covariates (can be 0).
@@ -1120,16 +1120,16 @@ genFullInvFusionTransformMat <- function(
 	##———— 3. Covariate main effects:      I_d ————————————————
 	block3 <- if (d > 0) diag(d) else NULL
 
-	##———— 4. Cohort × X interactions:     I_d ⊗ (D^{(1)}(G))^{-1} ——
+	##———— 4. Cohort × X interactions:     (D^{(1)}(G))^{-1} ⊗ I_d ——
 	block4 <- if (d > 0) {
-		kronecker(diag(d), genBackwardsInvFusionTransformMat(G))
+		kronecker(genBackwardsInvFusionTransformMat(G), diag(d))
 	} else {
 		NULL
 	}
 
-	##———— 5. Time × X interactions:       I_d ⊗ (D^{(1)}(T-1))^{-1} —
+	##———— 5. Time × X interactions:       (D^{(1)}(T-1))^{-1} ⊗ I_d —
 	block5 <- if (d > 0) {
-		kronecker(diag(d), genBackwardsInvFusionTransformMat(T - 1))
+		kronecker(genBackwardsInvFusionTransformMat(T - 1), diag(d))
 	} else {
 		NULL
 	}
@@ -1143,17 +1143,17 @@ genFullInvFusionTransformMat <- function(
 		d_inv_treat = d_inv_treat
 	)
 
-	##———— 7. Treatment × X interactions:  I_d ⊗ (D^{(2)}(G))^{-1} ——
+	##———— 7. Treatment × X interactions:  (D^{(2)}(G))^{-1} ⊗ I_d ——
 	block7 <- if (d > 0) {
 		kronecker(
-			diag(d),
 			.gen_inv_treat_block(
 				num_treats = num_treats,
 				first_inds = first_inds,
 				G = G,
 				fusion_structure = fusion_structure,
 				d_inv_treat = d_inv_treat
-			)
+			),
+			diag(d)
 		)
 	} else {
 		NULL

--- a/tests/testthat/test-fullinv-kronecker-394.R
+++ b/tests/testthat/test-fullinv-kronecker-394.R
@@ -1,0 +1,53 @@
+# Tests for #394: genFullInvFusionTransformMat() must agree with the
+# authoritative main-path untransformCoefImproved(). The builder is a standalone
+# block-diagonal D_N^{-1}; its three covariate-interaction blocks (cohort x X,
+# time x X, treatment x X) must use the package's LEVEL-major Kronecker order
+# `block %x% I_d`, not the feature-major `I_d %x% block`. The bug (feature-major)
+# made `fetwfe(add_ridge = TRUE)` with d >= 2 penalize coordinate-permuted
+# coefficients. This transform-agreement invariant is exactly what would have
+# caught it (it fails by O(1) under the wrong order).
+
+.check_fullinv_agrees <- function(G, T, d, fs, seed) {
+	nt <- fetwfe:::getNumTreats(G, T)
+	fi <- fetwfe:::getFirstInds(G, T)
+	p <- G + (T - 1L) + d + d * G + d * (T - 1L) + nt + d * nt
+	set.seed(seed)
+	theta <- stats::rnorm(p)
+	Dfull <- as.matrix(fetwfe:::genFullInvFusionTransformMat(
+		fi,
+		T,
+		G,
+		d,
+		nt,
+		fusion_structure = fs
+	))
+	via_D <- as.numeric(Dfull %*% theta)
+	via_fn <- as.numeric(fetwfe:::untransformCoefImproved(
+		theta,
+		T,
+		G,
+		p,
+		d,
+		nt,
+		first_inds = fi,
+		fusion_structure = fs
+	))
+	# Byte-exact on the dev platform (0/1 arithmetic); the 1e-12 tolerance guards
+	# cross-platform summation-order ULP. The bug is O(1), so it bites regardless.
+	expect_equal(via_D, via_fn, tolerance = 1e-12)
+}
+
+test_that("genFullInvFusionTransformMat() == untransformCoefImproved() for d>=2, both fusion structures (#394)", {
+	for (cfg in list(c(3L, 6L, 2L), c(2L, 4L, 3L), c(4L, 7L, 4L))) {
+		for (fs in c("cohort", "event_study")) {
+			.check_fullinv_agrees(cfg[1], cfg[2], cfg[3], fs, seed = 394)
+		}
+	}
+})
+
+test_that("genFullInvFusionTransformMat() agrees with untransform at d in {0,1} too (low-d guard) (#394)", {
+	# At d in {0,1} the two Kronecker orders coincide, so this passed pre-fix as
+	# well; it is an invariant guard against a future edit breaking the low-d path.
+	.check_fullinv_agrees(3L, 6L, 1L, "cohort", seed = 1)
+	.check_fullinv_agrees(3L, 6L, 0L, "cohort", seed = 1)
+})


### PR DESCRIPTION

`genFullInvFusionTransformMat()` built its three covariate-interaction blocks (cohort×X, time×X, treatment×X) as `kronecker(diag(d), block)` — the paper's feature-major form — but the package's design-matrix column order is level-major, so the correct form is `kronecker(block, diag(d))`. The buggy builder disagreed with the authoritative `untransformCoefImproved()` by O(1) for `d >= 2` (empirically exact after the swap). The only estimator path that consumes the builder is the ridge augmentation, so **`fetwfe(add_ridge = TRUE)` with `d >= 2`** was penalizing a coordinate-permuted coefficient vector rather than the documented untransformed coefficients.

**Blast radius (verified main-vs-branch):** `add_ridge = TRUE` d>=2 fits shift by ~1e-7 at the default `lambda_ridge` (the correction; grows with `lambda_ridge`). `add_ridge = FALSE` fits, `debiasedATT()`, and the simultaneous-band paths are byte-identical — those consumers touch only the treatment block, which is unchanged by the swap.

Same-file riders: harmonized the five feature-major `I_d ⊗ block` doc-notation sites to level-major `block ⊗ I_d` (including the `transformXintImproved` / `untransformCoefImproved` docstrings, whose correct level-major code was documented with the *wrong* notation — the exact confusion that caused the bug); fixed `!all.equal(...)` → `!isTRUE(all.equal(...))` in a self-test guard (`all.equal` returns a string on mismatch, so `!` errored instead of `stop()`ping — latent, since the exact 0/1 arithmetic always passes); corrected an "upper-triangular" → "lower-triangular" docstring and a `T >= 3` → `T >= 2` param doc.

New `test-fullinv-kronecker-394.R` pins the transform-agreement invariant (`D_full %*% theta == untransformCoefImproved(theta)`, d>=2, both fusion structures), mutation-proven to bite (O(1) failure under the wrong order). Patch bump to 1.56.11. Closes #394.

## Version note

Tagged **patch** (bug fix). It does change `add_ridge = TRUE` d>=2 output by ~1e-7 — flagging in case you'd prefer a minor bump for the user-visible (if tiny) shift; trivial to change.
