### PR TITLE
fix: give `getTes()` a `distribution` argument so the propensity-weighted truth integrates over the panel's actual covariate distribution (#398)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.56.10
+Version: 1.56.12
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # NEWS
 
+## Version 1.56.12
+
+### Bug fixes
+
+- `getTes()` gained a `distribution` argument (default `"gaussian"`) so the
+  propensity-weighted ground truth (`att_true`, `cohort_weights`, and
+  `actual_event_time_tes`) integrates `E[pi_g(X)]` over the covariate
+  distribution the panel was actually simulated from. Previously the integration
+  was always over a Gaussian X, so a `simulateData(distribution = "uniform")` panel
+  with covariate-dependent cohort assignment reported a truth integrated over the
+  wrong distribution (an ~0.7% ATT gap in that cell). Pass the same
+  `distribution` to `getTes()` that you passed to `simulateData()`; the default
+  preserves the previous (Gaussian) output for every existing call. (#398)
+
 ## Version 1.56.10
 
 ### Bug fixes

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -570,6 +570,12 @@ genCoefs <- function(
 #'
 #' @param coefs_obj An object of class \code{"FETWFE_coefs"} containing the coefficient vector
 #' and simulation parameters.
+#' @param distribution Character; the covariate distribution to integrate the
+#'   propensity-weighted truth over. Must match the \code{distribution} passed to
+#'   \code{\link{simulateData}} for the panel whose truth you want. One of
+#'   \code{"gaussian"} (default) or \code{"uniform"}. Only affects
+#'   covariate-dependent assignment (\code{assignment_type != "marginal"}); it is
+#'   ignored under marginal assignment, where the cohort weights are uniform.
 #'
 #' @return An object of class \code{"FETWFE_tes"}, which is a list with the
 #' following elements:
@@ -630,8 +636,9 @@ genCoefs <- function(
 #' weights under the marginal DGP, propensity weights otherwise).
 #'
 #' Under non-marginal DGPs, \eqn{E[\pi_g(X)]}{E[pi_g(X)]} is estimated by
-#' Monte Carlo integration over the X distribution (Gaussian by default) with
-#' \code{M = 10000} draws. The Monte Carlo seed is offset from the main
+#' Monte Carlo integration over the X distribution set by \code{distribution}
+#' (\code{"gaussian"} by default) with \code{M = 10000} draws. The Monte Carlo
+#' seed is offset from the main
 #' \code{coefs_obj$seed} by \code{+ 2L} per the documented seed-offset
 #' convention.
 #'
@@ -671,7 +678,7 @@ genCoefs <- function(
 #' }
 #'
 #' @export
-getTes <- function(coefs_obj) {
+getTes <- function(coefs_obj, distribution = "gaussian") {
 	if (!inherits(coefs_obj, "FETWFE_coefs")) {
 		stop(
 			"coefs_obj must be an object of class 'FETWFE_coefs'; got class: ",
@@ -679,6 +686,7 @@ getTes <- function(coefs_obj) {
 			call. = FALSE
 		)
 	}
+	distribution <- match.arg(distribution, c("gaussian", "uniform"))
 
 	# Unpack components from the coefs object
 	beta <- coefs_obj$beta
@@ -742,7 +750,7 @@ getTes <- function(coefs_obj) {
 			.expected_cohort_probs(
 				assignment_coefs = coefs_obj$assignment_coefs,
 				d = d,
-				distribution = "gaussian",
+				distribution = distribution,
 				M = 10000L,
 				seed = NULL
 			)

--- a/R/gen_data.R
+++ b/R/gen_data.R
@@ -25,7 +25,8 @@
 #'   random effects).
 #' @param distribution Character. Distribution to generate covariates.
 #'   Defaults to \code{"gaussian"}. If set to \code{"uniform"}, covariates are drawn uniformly
-#'   from \eqn{[-\sqrt{3}, \sqrt{3}]}.
+#'   from \eqn{[-\sqrt{3}, \sqrt{3}]}. To obtain a matching ground truth from
+#'   \code{\link{getTes}}, pass the same \code{distribution} value there.
 #' @param guarantee_rank_condition (Optional). Logical. If TRUE, the returned
 #' data set is guaranteed to have at least `d + 1` units per cohort, which is
 #' necessary for the final design matrix to have full column rank. Default is
@@ -280,7 +281,8 @@ simulateData <- function(
 #'   if \code{FALSE} (the default), generate a design matrix without any interaction terms.
 #' @param distribution Character. Distribution to generate covariates.
 #'   Defaults to \code{"gaussian"}. If set to \code{"uniform"}, covariates are drawn uniformly
-#'   from \eqn{[-\sqrt{3}, \sqrt{3}]}.
+#'   from \eqn{[-\sqrt{3}, \sqrt{3}]}. To obtain a matching ground truth from
+#'   \code{\link{getTes}}, pass the same \code{distribution} value there.
 #' @param guarantee_rank_condition (Optional). Logical. If TRUE, the returned
 #' data set is guaranteed to have at least `d + 1` units per cohort, which is
 #' necessary for the final design matrix to have full column rank. Default is

--- a/man/getTes.Rd
+++ b/man/getTes.Rd
@@ -4,11 +4,18 @@
 \alias{getTes}
 \title{Compute True Treatment Effects}
 \usage{
-getTes(coefs_obj)
+getTes(coefs_obj, distribution = "gaussian")
 }
 \arguments{
 \item{coefs_obj}{An object of class \code{"FETWFE_coefs"} containing the coefficient vector
 and simulation parameters.}
+
+\item{distribution}{Character; the covariate distribution to integrate the
+propensity-weighted truth over. Must match the \code{distribution} passed to
+\code{\link{simulateData}} for the panel whose truth you want. One of
+\code{"gaussian"} (default) or \code{"uniform"}. Only affects
+covariate-dependent assignment (\code{assignment_type != "marginal"}); it is
+ignored under marginal assignment, where the cohort weights are uniform.}
 }
 \value{
 An object of class \code{"FETWFE_tes"}, which is a list with the
@@ -82,8 +89,9 @@ is computed as a weighted average of the cohort-specific effects (uniform
 weights under the marginal DGP, propensity weights otherwise).
 
 Under non-marginal DGPs, \eqn{E[\pi_g(X)]}{E[pi_g(X)]} is estimated by
-Monte Carlo integration over the X distribution (Gaussian by default) with
-\code{M = 10000} draws. The Monte Carlo seed is offset from the main
+Monte Carlo integration over the X distribution set by \code{distribution}
+(\code{"gaussian"} by default) with \code{M = 10000} draws. The Monte Carlo
+seed is offset from the main
 \code{coefs_obj$seed} by \code{+ 2L} per the documented seed-offset
 convention.
 }

--- a/man/simulateData.Rd
+++ b/man/simulateData.Rd
@@ -28,7 +28,8 @@ random effects).}
 
 \item{distribution}{Character. Distribution to generate covariates.
 Defaults to \code{"gaussian"}. If set to \code{"uniform"}, covariates are drawn uniformly
-from \eqn{[-\sqrt{3}, \sqrt{3}]}.}
+from \eqn{[-\sqrt{3}, \sqrt{3}]}. To obtain a matching ground truth from
+\code{\link{getTes}}, pass the same \code{distribution} value there.}
 
 \item{guarantee_rank_condition}{(Optional). Logical. If TRUE, the returned
 data set is guaranteed to have at least \code{d + 1} units per cohort, which is

--- a/man/simulateDataCore.Rd
+++ b/man/simulateDataCore.Rd
@@ -55,7 +55,8 @@ if \code{FALSE} (the default), generate a design matrix without any interaction 
 
 \item{distribution}{Character. Distribution to generate covariates.
 Defaults to \code{"gaussian"}. If set to \code{"uniform"}, covariates are drawn uniformly
-from \eqn{[-\sqrt{3}, \sqrt{3}]}.}
+from \eqn{[-\sqrt{3}, \sqrt{3}]}. To obtain a matching ground truth from
+\code{\link{getTes}}, pass the same \code{distribution} value there.}
 
 \item{guarantee_rank_condition}{(Optional). Logical. If TRUE, the returned
 data set is guaranteed to have at least \code{d + 1} units per cohort, which is

--- a/tests/testthat/test-gettes-distribution-398.R
+++ b/tests/testthat/test-gettes-distribution-398.R
@@ -1,0 +1,73 @@
+# Tests for #398: getTes() integrates the propensity-weighted truth over the
+# covariate distribution given by its new `distribution` argument, instead of a
+# hardcoded Gaussian. Only bites covariate-dependent assignment (uniform vs
+# gaussian X give different E[pi_g(X)]); marginal assignment is unaffected.
+
+# A covariate-dependent (multinomial) DGP whose gaussian and uniform propensity
+# integrals differ; and a marginal DGP where they cannot.
+.cf_cov <- genCoefs(
+	G = 3,
+	T = 5,
+	d = 2,
+	density = 0.5,
+	eff_size = 2,
+	assignment_type = "multinomial",
+	assignment_strength = 2,
+	seed = 11
+)
+.cf_marg <- genCoefs(
+	G = 3,
+	T = 5,
+	d = 2,
+	density = 0.5,
+	eff_size = 2,
+	seed = 11
+)
+
+test_that("getTes() `distribution` arg contract: default back-compat, effect, marginal no-op, validation (#398)", {
+	# Default is byte-identical to the pre-#398 behavior (hardcoded gaussian).
+	expect_identical(getTes(.cf_cov), getTes(.cf_cov, "gaussian"))
+
+	# The argument has an effect under covariate-dependent assignment.
+	g <- getTes(.cf_cov, "gaussian")
+	u <- getTes(.cf_cov, "uniform")
+	expect_false(isTRUE(all.equal(u$cohort_weights, g$cohort_weights)))
+	expect_false(isTRUE(all.equal(u$att_true, g$att_true)))
+
+	# Under marginal assignment the truth does not integrate over X, so the
+	# argument is ignored (cohort weights are uniform 1/G either way).
+	expect_identical(getTes(.cf_marg, "uniform"), getTes(.cf_marg, "gaussian"))
+
+	# Unsupported values error at the front door (match.arg).
+	expect_error(getTes(.cf_cov, "poisson"))
+})
+
+test_that("getTes(distribution = 'uniform') matches the uniform-X sampling it claims to describe (#398)", {
+	# End-to-end: the propensity-weighted truth getTes() reports for a uniform
+	# panel must match the cohort frequencies a large uniform-X draw actually
+	# produces -- which the pre-#398 gaussian-integrated truth does NOT.
+	sim <- simulateData(
+		.cf_cov,
+		N = 30000,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		distribution = "uniform",
+		seed = 7
+	)
+	# sim$assignments is the length-(G+1) per-cohort count in the package's
+	# never-treated-first order: index 1 is the never-treated count (guarded
+	# below), indices 2..(G+1) are the treated cohorts. Use assignments[-1] --
+	# tie-proof, unlike matching on the count value.
+	expect_identical(sim$assignments[1], sim$N_UNTREATED)
+	emp_treated <- sim$assignments[-1] / sum(sim$assignments[-1])
+
+	wu <- getTes(.cf_cov, "uniform")$cohort_weights
+	wg <- getTes(.cf_cov, "gaussian")$cohort_weights
+	l1_u <- sum(abs(emp_treated - wu))
+	l1_g <- sum(abs(emp_treated - wg))
+
+	# The uniform truth is much closer to the uniform sampling than the gaussian
+	# truth is (~0.006 vs ~0.033 here), and matches within MC tolerance.
+	expect_lt(l1_u, l1_g)
+	expect_lt(l1_u, 0.02)
+})


### PR DESCRIPTION

`getTes()` computed the propensity-weighted ground truth (`att_true`, `cohort_weights`, `actual_event_time_tes`) by Monte-Carlo integrating `E[pi_g(X)]` over a **hardcoded** Gaussian X. But `simulateData(distribution = "uniform")` draws `U(-√3, √3)`, and its covariate-dependent cohort assignment uses those uniform X's — so for a uniform panel the *reported* truth integrated over the wrong distribution (a ~0.7% ATT gap in the covariate-dependent cell, the kind of silent fidelity gap a coverage study won't notice). The `FETWFE_coefs` object can't know the distribution (it's a `simulateData()` argument), so there was no way to override it.

Fix: `getTes(coefs_obj, distribution = "gaussian")` — validated with `match.arg(c("gaussian", "uniform"))` and threaded to the existing (already-correct) `.expected_cohort_probs()` integrator. The default `"gaussian"` keeps every existing call byte-identical; pass the same `distribution` you gave `simulateData()`. `simulateData()`'s roxygen now cross-references it. Only affects covariate-dependent assignment (marginal weights are uniform regardless).

New `test-gettes-distribution-398.R`: the argument contract (back-compat default, effect under covariate-dependent assignment, marginal no-op, `match.arg` validation) plus an end-to-end check that `getTes(cf, "uniform")` matches the cohort frequencies a large uniform-X draw actually produces (L1 ≈ 0.006 vs ≈ 0.033 for the gaussian truth) — mutation-proven to bite. Closes #398.

## Version note

Tagged **1.56.12** because the still-open **#405** already claims 1.56.11 — this assumes #405 merges first. If #398 merges first, renumber (trivial DESCRIPTION/NEWS edit). The two PRs share no source files, so there's no other conflict.
