### PR TITLE
fix: validate `alpha` on every CI accessor (eventStudy/plot no longer return inverted CIs) + order catt cohorts numerically (#396)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.56.10
+Version: 1.56.13
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,22 @@
 # NEWS
 
+## Version 1.56.13
+
+### Bug fixes
+
+- `eventStudy()` and `plot()` now reject an invalid `alpha` (outside `(0, 1)`,
+  `NA`, or non-scalar) instead of silently returning inverted confidence
+  intervals (`qnorm(1 - alpha/2)` is negative once `alpha >= 1`). A shared
+  internal guard now backs every confidence-interval accessor (`eventStudy()`,
+  `cohortTimeATTs()`, `debiasedATT()`, `simultaneousCIs()`, and `plot()`), so
+  they all reject a bad `alpha` with the same message. `simultaneousCIs()`
+  likewise now validates its `riesz_max_iter` / `riesz_tol` nodewise controls,
+  matching `debiasedATT()`.
+- `plot(type = "catt")` now orders the cohort axis numerically rather than
+  alphabetically. Previously, for panels whose adoption times cross a digit-width
+  boundary, cohorts `2, 3, ..., 10, 11` rendered in string order
+  (`10, 11, 2, ...`). (#396)
+
 ## Version 1.56.10
 
 ### Bug fixes

--- a/R/cohort_time_atts.R
+++ b/R/cohort_time_atts.R
@@ -150,18 +150,7 @@ cohortTimeATTs <- function(result, alpha = NULL) {
 	if (is.null(alpha)) {
 		alpha <- x$alpha
 	}
-	if (
-		!is.numeric(alpha) ||
-			length(alpha) != 1L ||
-			is.na(alpha) ||
-			alpha <= 0 ||
-			alpha >= 1
-	) {
-		stop(
-			"cohortTimeATTs(): `alpha` must be a single number in (0, 1).",
-			call. = FALSE
-		)
-	}
+	.validate_alpha_arg(alpha, "cohortTimeATTs")
 	z <- stats::qnorm(1 - alpha / 2)
 
 	# ---- Shared quantities ------------------------------------------------

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -314,18 +314,7 @@ debiasedATT <- function(
 	if (is.null(alpha)) {
 		alpha <- fit$alpha
 	}
-	if (
-		!is.numeric(alpha) ||
-			length(alpha) != 1L ||
-			is.na(alpha) ||
-			alpha <= 0 ||
-			alpha >= 1
-	) {
-		stop(
-			"debiasedATT(): `alpha` must be a single number in (0, 1).",
-			call. = FALSE
-		)
-	}
+	.validate_alpha_arg(alpha, "debiasedATT")
 
 	if (method == "bootstrap") {
 		B <- .validate_boot_args(B, seed, "debiasedATT")

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -252,6 +252,7 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 	if (is.null(alpha)) {
 		alpha <- x$alpha
 	}
+	.validate_alpha_arg(alpha, "eventStudy")
 	z <- stats::qnorm(1 - alpha / 2)
 	# Resolve the band type (#197): NULL inherits the fit's stored ci_type
 	# (pointwise for pre-1.16.0 objects); an explicit value overrides.
@@ -491,6 +492,7 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 	if (is.null(alpha)) {
 		alpha <- x$alpha
 	}
+	.validate_alpha_arg(alpha, "eventStudy")
 	z <- stats::qnorm(1 - alpha / 2)
 	# Resolve the band type (#197): NULL inherits the fit's stored ci_type
 	# (pointwise for pre-1.16.0 objects); an explicit value overrides.

--- a/R/plot.R
+++ b/R/plot.R
@@ -236,6 +236,7 @@ plot.twfeCovs <- function(x, ...) {
 	# estimate +/- qnorm(1 - alpha/2) * se. Otherwise use the CI columns
 	# already in catt_df (computed at fit time using the fit's alpha).
 	if (!is.null(alpha)) {
+		.validate_alpha_arg(alpha, "plot")
 		z <- stats::qnorm(1 - alpha / 2)
 		# Use unclass() so .subset2() / direct $-access can mutate the
 		# data.frame without triggering catt_df's helpful-error layer on
@@ -244,6 +245,16 @@ plot.twfeCovs <- function(x, ...) {
 		catt$ci_low <- catt$estimate - z * catt$se
 		catt$ci_high <- catt$estimate + z * catt$se
 	}
+	# Order the discrete x-axis numerically: cohorts are as.character(integer
+	# adoption time), so a bare character axis sorts "10" before "2" (#396).
+	# Reuse the numeric-first composite key from .truncate_catt().
+	catt$cohort <- factor(
+		catt$cohort,
+		levels = {
+			lv <- unique(catt$cohort)
+			lv[order(suppressWarnings(as.numeric(lv)), lv)]
+		}
+	)
 	p <- ggplot2::ggplot(
 		catt,
 		ggplot2::aes(x = cohort, y = estimate)

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -464,7 +464,7 @@ simultaneousCIs.twfeCovs <- function(
 	if (is.null(alpha)) {
 		alpha <- .alpha_of(x)
 	}
-	stopifnot(is.numeric(alpha), length(alpha) == 1L, alpha > 0, alpha < 1)
+	.validate_alpha_arg(alpha, "simultaneousCIs")
 	method <- match.arg(method, c("analytic", "bootstrap"))
 	# `lambda_c` is validated unconditionally (symmetric with debiasedATT()). It is
 	# only USED on the high-dim bootstrap path, but a malformed value should error
@@ -479,6 +479,32 @@ simultaneousCIs.twfeCovs <- function(
 		stop(
 			"simultaneousCIs(): `lambda_c` must be a single positive number ",
 			"or the string \"cv\".",
+			call. = FALSE
+		)
+	}
+	# `riesz_max_iter` / `riesz_tol` validated unconditionally, symmetric with
+	# debiasedATT() (#396): they only affect the high-dim bootstrap nodewise
+	# solve, but a malformed value should fail loudly rather than error cryptically
+	# inside `seq_len()` or silently yield a degenerate debiasing direction.
+	if (
+		!is.numeric(riesz_max_iter) ||
+			length(riesz_max_iter) != 1L ||
+			is.na(riesz_max_iter) ||
+			riesz_max_iter < 1
+	) {
+		stop(
+			"simultaneousCIs(): `riesz_max_iter` must be a single positive integer.",
+			call. = FALSE
+		)
+	}
+	if (
+		!is.numeric(riesz_tol) ||
+			length(riesz_tol) != 1L ||
+			is.na(riesz_tol) ||
+			riesz_tol <= 0
+	) {
+		stop(
+			"simultaneousCIs(): `riesz_tol` must be a single positive number.",
 			call. = FALSE
 		)
 	}

--- a/R/utility.R
+++ b/R/utility.R
@@ -2,6 +2,36 @@
 #' @importFrom Matrix bdiag
 #' @importFrom stats qnorm pnorm predict coef model.matrix setNames lm
 
+#' @title Validate an `alpha` significance-level argument
+#' @description Shared guard for the `alpha` argument of the CI accessors
+#'   (`eventStudy()`, `cohortTimeATTs()`, `debiasedATT()`, `simultaneousCIs()`,
+#'   and the `plot()` catt recompute). Errors unless `alpha` is a single number
+#'   strictly inside `(0, 1)`. Single-sources the previously-duplicated stanzas
+#'   and closes the event-study / plot paths, which formerly accepted an invalid
+#'   `alpha` and silently produced inverted intervals (`qnorm(1 - alpha/2) < 0`
+#'   when `alpha >= 1`).
+#' @param alpha The value to validate (already resolved from any `NULL` default).
+#' @param fn_name Character; the calling function's name, for the message.
+#' @return `invisible(alpha)`; errors via `stop()` on an invalid value.
+#' @keywords internal
+#' @noRd
+.validate_alpha_arg <- function(alpha, fn_name) {
+	if (
+		!is.numeric(alpha) ||
+			length(alpha) != 1L ||
+			is.na(alpha) ||
+			alpha <= 0 ||
+			alpha >= 1
+	) {
+		stop(
+			fn_name,
+			"(): `alpha` must be a single number in (0, 1).",
+			call. = FALSE
+		)
+	}
+	invisible(alpha)
+}
+
 #' @title Resolve the cohort-count argument (G canonical, R deprecated)
 #' @description Internal helper for the `R -> G` user-facing rename (#41).
 #'   Returns the canonical cohort count. If the deprecated `R` argument is

--- a/tests/testthat/test-validate-alpha-catt-396.R
+++ b/tests/testthat/test-validate-alpha-catt-396.R
@@ -1,0 +1,74 @@
+# Tests for #396: (1) every CI accessor rejects an invalid `alpha` via the shared
+# .validate_alpha_arg() guard -- eventStudy()/plot() formerly accepted it and
+# silently returned inverted intervals; (2) plot(type = "catt") orders cohorts
+# numerically, not alphabetically; (3) simultaneousCIs() validates its nodewise
+# (riesz) controls like debiasedATT() does.
+
+.fit_396 <- local({
+	cf <- genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = 2, seed = 1)
+	sim <- simulateData(
+		cf,
+		N = 200,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 1
+	)
+	fetwfeWithSimulatedData(sim)
+})
+
+test_that("every CI accessor rejects an invalid alpha with the shared (0, 1) message (#396)", {
+	msg <- "must be a single number in \\(0, 1\\)"
+	# The two formerly-unguarded bug sites: eventStudy() and plot() (both views).
+	expect_error(eventStudy(.fit_396, alpha = 1.5), msg)
+	expect_error(eventStudy(.fit_396, alpha = NA_real_), msg)
+	expect_error(plot(.fit_396, type = "catt", alpha = 1.5), msg)
+	expect_error(plot(.fit_396, type = "event_study", alpha = 1.5), msg)
+	# The three consolidated sites keep rejecting it (now via the shared helper).
+	expect_error(cohortTimeATTs(.fit_396, alpha = 1.5), msg)
+	expect_error(debiasedATT(.fit_396, alpha = 1.5), msg)
+	expect_error(simultaneousCIs(.fit_396, alpha = 1.5), msg)
+	# Boundary / type violations all rejected.
+	expect_error(eventStudy(.fit_396, alpha = 0), msg)
+	expect_error(eventStudy(.fit_396, alpha = 1), msg)
+	expect_error(eventStudy(.fit_396, alpha = c(0.05, 0.1)), msg)
+	# Valid alpha (default and explicit) is unaffected: the guards are no-ops.
+	expect_s3_class(eventStudy(.fit_396), "eventStudy")
+	expect_s3_class(eventStudy(.fit_396, alpha = 0.1), "eventStudy")
+	expect_s3_class(cohortTimeATTs(.fit_396, alpha = 0.1), "cohortTimeATTs")
+})
+
+test_that("plot(type = 'catt') orders the cohort axis numerically, not alphabetically (#396)", {
+	# >= 10 cohorts so the string order ("10" before "2") diverges from numeric.
+	cf <- genCoefs(G = 10, T = 12, d = 1, density = 0.5, eff_size = 2, seed = 2)
+	sim <- simulateData(
+		cf,
+		N = 600,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 2
+	)
+	fit <- fetwfeWithSimulatedData(sim)
+	p <- plot(fit, type = "catt")
+	xl <- ggplot2::ggplot_build(p)$layout$panel_params[[1]]$x$get_labels()
+	# Numeric order: "10"/"11" come AFTER "9", not after "1".
+	expect_identical(xl, as.character(sort(as.numeric(xl))))
+	expect_gt(match("10", xl), match("9", xl))
+})
+
+test_that("simultaneousCIs() validates its nodewise (riesz) controls (#396)", {
+	expect_error(
+		simultaneousCIs(.fit_396, riesz_max_iter = 0),
+		"riesz_max_iter"
+	)
+	expect_error(
+		simultaneousCIs(.fit_396, riesz_max_iter = c(1L, 2L)),
+		"riesz_max_iter"
+	)
+	expect_error(simultaneousCIs(.fit_396, riesz_tol = -1), "riesz_tol")
+	expect_error(simultaneousCIs(.fit_396, riesz_tol = NA_real_), "riesz_tol")
+	# Valid controls unaffected.
+	expect_s3_class(
+		simultaneousCIs(.fit_396, riesz_max_iter = 5000L, riesz_tol = 1e-9),
+		"simultaneous_cis"
+	)
+})


### PR DESCRIPTION

Three accessor-surface defects, one shared vehicle:

1. **`eventStudy()` and `plot()` silently accepted an invalid `alpha`.** With no guard before `qnorm(1 - alpha/2)`, `eventStudy(fit, alpha = 1.5)` returned `ci_low > ci_high` in every row (inverted intervals; `z = qnorm(0.25) < 0`), while every sibling accessor (`cohortTimeATTs`, `debiasedATT`, `simultaneousCIs`) errored cleanly. Extracted `.validate_alpha_arg(alpha, fn_name)` (consolidating the two near-verbatim stanzas + one bare `stopifnot`) and applied it at all six sites — including the two event-study workers and `.plot_catt` — so every accessor now rejects a bad `alpha` (out of `(0, 1)`, `NA`, non-scalar) with the same message.

2. **`plot(type = "catt")` ordered cohorts alphabetically.** A character `cohort` on a discrete axis renders `10, 11, 2, ...` for two-digit adoption times. Fixed by factoring `cohort` with the numeric-first level order already used by `.truncate_catt()` / the tidy methods — display-only, no `catt_df` value changes.

3. **`simultaneousCIs()` forwarded `riesz_max_iter` / `riesz_tol` unvalidated** while `debiasedATT()` validates them; mirrored that validation (a malformed value formerly errored cryptically inside `seq_len()` or silently yielded a degenerate direction).

New `test-validate-alpha-catt-396.R`: every accessor errors on a bad `alpha` (the eventStudy/plot cases mutation-proven to bite — they returned inverted CIs before); the catt axis is numeric-ordered on a 10-cohort fit (also mutation-proven); `simultaneousCIs()` rejects bad riesz controls. Valid input is unaffected — the guards are no-ops, and 846 existing accessor assertions are unchanged. Closes #396.

## Version note

Tagged **1.56.13** because the still-open **#405** (1.56.11) and **#406** (1.56.12) precede it — this assumes both merge first. No source-file overlap with either, so renumber trivially if they land out of order.
