### PR TITLE
fix: OLS guard rails — informative error on rank-deficient designs; don't misapply the d+1 gate to twfeCovs() (#395)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.56.13
+Version: 1.56.14
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,23 @@
 # NEWS
 
+## Version 1.56.14
+
+### Bug fixes
+
+- `etwfe()` and `twfeCovs()` now report an informative error when the design is
+  rank-deficient for a reason other than a small cohort (e.g. perfectly collinear
+  covariates, where `lm()` returns `NA` for the aliased column), instead of the
+  opaque `all(!is.na(beta_hat_slopes)) is not TRUE` assertion. The message names
+  the cause and points to dropping the redundant covariate(s) or setting
+  `add_ridge = TRUE`.
+- `twfeCovs()` no longer refuses fits with fewer than `d + 1` units in some
+  cohort. That `d + 1`-per-cohort rank condition is a requirement of the full
+  ETWFE design (its cohort-by-covariate interaction blocks), not of the collapsed
+  design `twfeCovs()` fits, so small-cohort covariate fits --- a core `twfeCovs()`
+  use case (e.g. single-state cohorts) --- now succeed, with valid standard
+  errors where the collapsed design is full rank. The gate is retained for
+  `etwfe()`, whose full design genuinely needs it. (#395)
+
 ## Version 1.56.13
 
 ### Bug fixes

--- a/R/etwfe_core.R
+++ b/R/etwfe_core.R
@@ -330,7 +330,26 @@ checkEtwfeInputs <- function(
 	beta_hat_slopes <- coef(fit) / scale_scale
 
 	stopifnot(length(beta_hat_slopes) == p_eff)
-	stopifnot(all(!is.na(beta_hat_slopes)))
+	# A rank-deficient design (perfectly collinear covariates -- e.g. one covariate
+	# a linear function of another -- or an otherwise singular design) makes `lm()`
+	# return NA coefficients for the aliased columns. Report the cause and the
+	# `add_ridge` escape hatch instead of the bare `all(!is.na(...))` assertion
+	# (#395). Column names are positional here, so they are not named. The
+	# small-cohort cause is caught earlier by `.check_cohort_rank_for_ols()` (for
+	# `etwfe()`); this covers every other rank-deficiency cause, for both estimators.
+	if (anyNA(beta_hat_slopes)) {
+		stop(
+			"The design matrix is rank-deficient: the ordinary-least-squares fit ",
+			"could not identify ",
+			sum(is.na(beta_hat_slopes)),
+			" coefficient(s) (aliased columns receive NA estimates). This happens ",
+			"when covariates are perfectly collinear or the design is otherwise ",
+			"singular; standard errors are unavailable. Drop the redundant ",
+			"covariate(s), or set `add_ridge = TRUE` to estimate treatment effects ",
+			"with a small amount of ridge regularization.",
+			call. = FALSE
+		)
+	}
 
 	# If using ridge regularization, multiply the "naive" estimated coefficients
 	# by 1 + lambda_ridge, similar to suggestion in original elastic net paper.

--- a/R/utility.R
+++ b/R/utility.R
@@ -2390,12 +2390,22 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 	treatment,
 	covs_orig
 ) {
-	.check_cohort_rank_for_ols(
-		in_sample_counts = prep$in_sample_counts,
-		G = prep$G,
-		d = prep$d,
-		add_ridge = add_ridge
-	)
+	# The d + 1 units-per-cohort condition is a rank requirement of the FULL ETWFE
+	# design (each cohort's cohort x covariate interaction block needs >= d + 1
+	# units). twfeCovs() fits the COLLAPSED design (cohort FE + time FE + covariate
+	# mains + pooled treatment dummies -- no cohort x covariate or treatment x
+	# covariate interactions), which does not need it. A genuinely singular
+	# collapsed design is caught downstream: getGramInv() degrades calc_ses to
+	# FALSE, and the OLS core errors informatively on NA coefficients. So the gate
+	# is etwfe-only (#395).
+	if (!identical(class_name, "twfeCovs")) {
+		.check_cohort_rank_for_ols(
+			in_sample_counts = prep$in_sample_counts,
+			G = prep$G,
+			d = prep$d,
+			add_ridge = add_ridge
+		)
+	}
 
 	res <- core_fn(
 		X_ints = prep$X_ints,

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -41,6 +41,7 @@ Chernozhukov
 Chetverikov
 CLT
 coef
+collinear
 compat
 counterintuitive
 covs

--- a/tests/testthat/test-ols-guardrails-395.R
+++ b/tests/testthat/test-ols-guardrails-395.R
@@ -1,0 +1,72 @@
+# Tests for #395: OLS-pair (etwfe/twfeCovs) guard rails.
+# (1) A rank-deficient design (e.g. perfectly collinear covariates) now errors
+#     informatively for BOTH OLS estimators, instead of the bare
+#     `all(!is.na(beta_hat_slopes)) is not TRUE` assertion.
+# (2) The d+1-per-cohort gate stays for etwfe() (its full design needs it) but is
+#     skipped for twfeCovs() (collapsed design). The twfeCovs-succeeds case is in
+#     test-twfeCovs.R Test 30; here we check the etwfe() gate still fires.
+
+.mk_panel_395 <- function(cohort_of_unit, T = 4L, collinear = FALSE, seed = 1) {
+	set.seed(seed)
+	rows <- list()
+	for (i in seq_along(cohort_of_unit)) {
+		g <- cohort_of_unit[i]
+		x1 <- stats::rnorm(1)
+		for (t in 1:T) {
+			treat <- as.integer(g > 0 & t >= g)
+			row <- data.frame(
+				unit = sprintf("u%02d", i),
+				year = t,
+				treat = treat,
+				x1 = x1
+			)
+			if (collinear) {
+				row$x2 <- 2 * x1
+			}
+			row$y <- 0.3 * t + 1.5 * treat + 0.5 * x1 + stats::rnorm(1, 0, 0.3)
+			rows[[length(rows) + 1L]] <- row
+		}
+	}
+	do.call(rbind, rows)
+}
+
+test_that("collinear covariates yield an informative rank-deficiency error, not a bare assertion (#395)", {
+	# Cohorts of 4 units (>= d + 1 = 3), so the d+1 gate does NOT pre-empt: the
+	# design reaches lm(), which aliases the collinear column -> the informative
+	# rank-deficiency error (defect 1), for both OLS estimators.
+	df <- .mk_panel_395(c(rep(0L, 4), rep(2L, 4), rep(3L, 4)), collinear = TRUE)
+	args <- list(
+		pdata = df,
+		time_var = "year",
+		unit_var = "unit",
+		treatment = "treat",
+		response = "y",
+		covs = c("x1", "x2"),
+		verbose = FALSE
+	)
+	# New message names the cause (+ the add_ridge escape hatch); it is NOT the
+	# bare `all(!is.na(beta_hat_slopes)) is not TRUE` assertion.
+	expect_error(do.call(etwfe, args), "rank-deficient")
+	expect_error(do.call(twfeCovs, args), "rank-deficient")
+	# The penalized estimator fits the identical collinear input fine (contract).
+	expect_s3_class(do.call(fetwfe, c(args, list(q = 0.5))), "fetwfe")
+})
+
+test_that("the d+1-per-cohort gate still fires for etwfe() (its full design needs it) (#395)", {
+	# A 1-unit cohort (d = 1): etwfe()'s full ETWFE design genuinely needs d + 1
+	# units per cohort, so the gate legitimately stops -- unchanged by #395 (only
+	# twfeCovs() skips it).
+	df <- .mk_panel_395(c(rep(0L, 4), rep(2L, 6), 3L), T = 4L, seed = 2)
+	expect_error(
+		etwfe(
+			pdata = df,
+			time_var = "year",
+			unit_var = "unit",
+			treatment = "treat",
+			response = "y",
+			covs = "x1",
+			verbose = FALSE
+		),
+		"fewer than d \\+ 1 units"
+	)
+})

--- a/tests/testthat/test-twfeCovs.R
+++ b/tests/testthat/test-twfeCovs.R
@@ -820,51 +820,42 @@ test_that("tibbles work as input to twfeCovs", {
 })
 
 # ------------------------------------------------------------------------------
-# Test 30: Error when a cohort contains fewer than d + 1 units
+# Test 30: a small-cohort covariate design fits (the d+1 gate is etwfe-only, #395)
 # ------------------------------------------------------------------------------
-test_that("twfeCovs throws error when a cohort contains fewer than d + 1 units", {
+test_that("twfeCovs fits a small-cohort covariate design without the d+1 gate (#395)", {
+	# R = 9 cohorts across N = 30 units includes cohort(s) with fewer than
+	# d + 1 (= 3) units. The d+1-per-cohort rank condition is a requirement of the
+	# FULL ETWFE design (each cohort's cohort x covariate interaction block);
+	# twfeCovs() fits the COLLAPSED design (no such blocks), which is full column
+	# rank here -- so the fit now SUCCEEDS where it previously hard-stopped (#395).
 	df <- generate_panel_data(N = 30, T = 10, R = 9, seed = 123)
-
-	expect_error(
-		twfeCovs(
-			pdata = df,
-			time_var = "time",
-			unit_var = "unit",
-			treatment = "treatment",
-			covs = c("cov1", "cov2"),
-			response = "y",
-			verbose = FALSE
-		),
-		"At least one cohort contains fewer than d \\+ 1 units\\. The design matrix is rank-deficient\\. Calculating standard errors will not be possible, and estimating treatment effects is only possible using add_ridge = TRUE\\."
-	)
-
-	expect_warning(
-		twfeCovs(
-			pdata = df,
-			time_var = "time",
-			unit_var = "unit",
-			treatment = "treatment",
-			covs = c("cov1", "cov2"),
-			response = "y",
-			verbose = FALSE,
-			add_ridge = TRUE
-		),
-		"At least one cohort contains fewer than d \\+ 1 units\\. The design matrix is rank-deficient\\. Calculating standard errors will not be possible, and estimating treatment effects is only possible using add_ridge = TRUE\\."
-	)
-
-	res <- suppressWarnings(twfeCovs(
+	args <- list(
 		pdata = df,
 		time_var = "time",
 		unit_var = "unit",
 		treatment = "treatment",
 		covs = c("cov1", "cov2"),
 		response = "y",
-		verbose = FALSE,
-		add_ridge = TRUE
-	))
+		verbose = FALSE
+	)
 
-	expect_true(!is.na(res$att_hat))
-	expect_true(res$att_hat != 0)
+	res <- do.call(twfeCovs, args)
+	expect_s3_class(res, "twfeCovs")
+	expect_true(is.finite(res$att_hat) && res$att_hat != 0)
+	# The collapsed design is full column rank, so standard errors are available.
+	expect_true(is.finite(res$att_se))
+
+	# add_ridge = TRUE still succeeds AND no longer emits the d+1 gate warning
+	# (that warning is now etwfe-only). Reverting the twfeCovs gate-skip would make
+	# the no-ridge fit error and re-introduce this warning.
+	w <- testthat::capture_warnings(
+		res_r <- do.call(
+			twfeCovs,
+			c(args, list(add_ridge = TRUE))
+		)
+	)
+	expect_false(any(grepl("fewer than d", w)))
+	expect_true(is.finite(res_r$att_hat) && res_r$att_hat != 0)
 })
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION

Two coupled guard-rail defects in the OLS estimator pair (`etwfe()` / `twfeCovs()`); the estimators' arithmetic is clean.

1. **Collinear designs crashed with a bare assertion.** `.ols_estimator_core()` (`R/etwfe_core.R`) fired the opaque `all(!is.na(beta_hat_slopes)) is not TRUE` on any rank-deficient design other than a small cohort — e.g. perfectly collinear covariates (`x2 = 2*x1`), where `lm()` returns `NA` for the aliased column. Now it errors informatively (names the cause + the `add_ridge` escape hatch). `fetwfe()`/`betwfe()` fit the identical input fine (penalized).

2. **The `d+1`-per-cohort gate was misapplied to `twfeCovs()`.** `.check_cohort_rank_for_ols()` `stop()`s when any cohort has `< d+1` units — a rank requirement of the **full ETWFE design** (its cohort×covariate interaction blocks). `twfeCovs()` fits the **collapsed** design (no such blocks), which doesn't need it, so small-cohort covariate fits — a core `twfeCovs()` use case (single-state cohorts in divorce/castle) — were wrongly refused. Now the gate is `etwfe()`-only; `twfeCovs()` fits succeed, with valid SEs where the collapsed design is full rank (verified: 1-unit-cohort fit is rank 9/9, `att_se` finite, point estimate matches `solve(X'X, X'y)` to 2.8e-15). A genuinely-singular collapsed design is caught downstream — `getGramInv()` degrades `calc_ses`, and defect 1 gives the informative point-estimate error.

They interact: fixing (2) alone would route genuinely-singular collapsed designs into (1)'s crash, so both ship together.

Rewrote `test-twfeCovs.R` Test 30 (its fixture has a `< d+1`-unit cohort, so it now asserts the fit *succeeds* with a finite SE, not the old refusal). New `test-ols-guardrails-395.R` covers the collinear-error path (both OLS estimators, `fetwfe()` still fits) and confirms the `etwfe()` gate still fires — both fixes mutation-proven to bite. Normal fits are byte-identical. Patch bump to 1.56.14. Closes #395.
