### PR TITLE
fix: converter/validator diagnostics — drop the always-false "treatment reversal" warning; accept Inf never-treated; name NA violations (#397)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.56.14
+Version: 1.56.15
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,23 @@
 # NEWS
 
+## Version 1.56.15
+
+### Bug fixes
+
+- `attgtToFetwfeDf()` / `etwfeToFetwfeDf()` no longer emit a spurious "unit(s)
+  switch from treated back to untreated" warning. The check measured only the
+  input data frame's row order (a treated-to-untreated reversal is impossible by
+  construction, since the first-treatment period is constant within a unit), so
+  it fired falsely on valid time-descending input; it has been removed. These
+  converters also now accept a first-treatment period of `Inf` (a common
+  never-treated encoding), mapping it to `0` instead of erroring with a
+  misleading "Missing values" message.
+- The estimator input validator now reports a named, actionable violation for a
+  missing (`NA`) value in the response or time column (previously an `NA`
+  response surfaced as a bare internal `all(!is.na(data)) is not TRUE`), and for
+  a mixed-`NA` `indep_counts` vector (previously "missing value where TRUE/FALSE
+  needed"). (#397)
+
 ## Version 1.56.14
 
 ### Bug fixes

--- a/R/convert_dfs.R
+++ b/R/convert_dfs.R
@@ -21,7 +21,8 @@
 #' @param idname Character scalar. Name of the unit identifier. Converted to
 #'   character and returned as `unit_var`.
 #' @param gname  Character scalar. Name of the *group* variable holding the
-#'   first period of treatment. Values must be 0 for never-treated, or a
+#'   first period of treatment. Values must be 0 (or `Inf`, a common
+#'   never-treated encoding, which is mapped to 0) for never-treated, or a
 #'   positive integer representing the first treated period.
 #' @param covars Character vector of additional covariate column names to carry
 #'   through (default `character(0)`). These columns are left untouched and
@@ -125,7 +126,7 @@ attgtToFetwfeDf <- function(
 #' @param idvar Character. Column name of the unit identifier (the variable you would
 #'   cluster on, or pass to `etwfe(..., ivar = idvar)` if you were using unit FEs).
 #' @param gvar Character. Column name of the "first treated" cohort variable passed to `etwfe()` as `gvar`.
-#'   Must be `0` for never-treated units, or the (strictly positive) first treated period.
+#'   Must be `0` (or `Inf`, which is mapped to `0`) for never-treated units, or the (strictly positive) first treated period.
 #' @param covars Character vector of *additional* covariate columns to keep (default `character(0)`).
 #' @param drop_first_period_treated Logical. Should units already treated in the very first
 #'   sample period be removed?  (`fetwfe()` will drop them internally anyway, but doing it
@@ -261,9 +262,11 @@ etwfeToFetwfeDf <- function(
 #'     (irreversible treatment).
 #'   \item `time` and `g` are coerced to `integer`; `unit` to `character`.
 #' }
-#' If any unit ever switches from treated back to untreated
-#' (`diff(treatment) < 0`), a warning is thrown because those units will be
-#' silently dropped by [fetwfe::fetwfe()].
+#' Because `g` is constant within a unit (rule 2) and the absorbing-state dummy
+#' is `1{g > 0 & t >= g}`, treatment is monotone within a unit by construction,
+#' so a treated-to-untreated reversal cannot occur and no reversal check is
+#' performed. A first-treatment period of `Inf` (a common never-treated encoding)
+#' is accepted and mapped to `0`.
 #'
 #' @keywords internal
 #' @noRd
@@ -308,6 +311,11 @@ etwfeToFetwfeDf <- function(
 	## ---------- enforce types --------------------------------------------------
 	df <- data[, unique(c(required, covars))]
 	df[[vars$t]] <- as.integer(df[[vars$t]])
+	# Several ecosystems (fect, staggered, some `did` paths) encode never-treated
+	# as `g = Inf`; the documented contract here is 0. Map Inf -> 0 before the
+	# integer coercion (as.integer(Inf) is NA, which would misleadingly trip the
+	# "Missing values" stop below). (#397)
+	df[[vars$g]][is.infinite(df[[vars$g]])] <- 0
 	df[[vars$g]] <- as.integer(df[[vars$g]])
 	df[[vars$id]] <- as.character(df[[vars$id]])
 
@@ -359,17 +367,11 @@ etwfeToFetwfeDf <- function(
 		1L,
 		0L
 	)
-	bad_units <- with(
-		df,
-		tapply(treat_dummy, df[[vars$id]], function(z) any(diff(z) < 0))
-	)
-	if (any(bad_units)) {
-		warning(
-			sum(bad_units),
-			" unit(s) switch from treated back to untreated. ",
-			"They will be dropped by `fetwfe()`."
-		)
-	}
+	# No treated-to-untreated reversal check: `g` is unit-constant (rule 2 in the
+	# @details), so `treat_dummy = 1{g > 0 & t >= g}` is monotone within a unit by
+	# construction -- a reversal is impossible. The previous `diff()` check ran in
+	# input row order (rows are not sorted until below), so it only measured the
+	# input's row order and fired falsely on time-descending input (#397).
 
 	## ---------- assemble tidy dataframe ---------------------------------------
 	res <- data.frame(

--- a/R/utility.R
+++ b/R/utility.R
@@ -522,6 +522,14 @@ idCohorts <- function(df, time_var, unit_var, treat_var) {
 				paste(class(pdata[[time_var]]), collapse = "/")
 			)
 		)
+	} else if (pdata_ok && anyNA(pdata[[time_var]])) {
+		violations <- c(
+			violations,
+			sprintf(
+				"the time_var column '%s' must not contain missing (NA) values",
+				time_var
+			)
+		)
 	}
 
 	# --- unit_var --------------------------------------------------------
@@ -676,6 +684,14 @@ idCohorts <- function(df, time_var, unit_var, treat_var) {
 				paste(class(pdata[[response]]), collapse = "/")
 			)
 		)
+	} else if (pdata_ok && anyNA(pdata[[response]])) {
+		violations <- c(
+			violations,
+			sprintf(
+				"the response column '%s' must not contain missing (NA) values",
+				response
+			)
+		)
 	}
 
 	# --- indep_counts ----------------------------------------------------
@@ -690,6 +706,11 @@ idCohorts <- function(df, time_var, unit_var, treat_var) {
 					"indep_counts must be an integer vector; got %s",
 					paste(class(indep_counts), collapse = "/")
 				)
+			)
+		} else if (anyNA(indep_counts)) {
+			violations <- c(
+				violations,
+				"indep_counts must not contain missing (NA) values"
 			)
 		} else if (any(indep_counts <= 0)) {
 			# Original message preserved verbatim (also surfaced in

--- a/man/attgtToFetwfeDf.Rd
+++ b/man/attgtToFetwfeDf.Rd
@@ -32,7 +32,8 @@ integer). This becomes \code{time_var} in the returned dataframe.}
 character and returned as \code{unit_var}.}
 
 \item{gname}{Character scalar. Name of the \emph{group} variable holding the
-first period of treatment. Values must be 0 for never-treated, or a
+first period of treatment. Values must be 0 (or \code{Inf}, a common
+never-treated encoding, which is mapped to 0) for never-treated, or a
 positive integer representing the first treated period.}
 
 \item{covars}{Character vector of additional covariate column names to carry

--- a/man/etwfeToFetwfeDf.Rd
+++ b/man/etwfeToFetwfeDf.Rd
@@ -29,7 +29,7 @@ etwfeToFetwfeDf(
 cluster on, or pass to \code{etwfe(..., ivar = idvar)} if you were using unit FEs).}
 
 \item{gvar}{Character. Column name of the "first treated" cohort variable passed to \code{etwfe()} as \code{gvar}.
-Must be \code{0} for never-treated units, or the (strictly positive) first treated period.}
+Must be \code{0} (or \code{Inf}, which is mapped to \code{0}) for never-treated units, or the (strictly positive) first treated period.}
 
 \item{covars}{Character vector of \emph{additional} covariate columns to keep (default \code{character(0)}).}
 

--- a/tests/testthat/test-converter-diagnostics-397.R
+++ b/tests/testthat/test-converter-diagnostics-397.R
@@ -1,0 +1,96 @@
+# Tests for #397: converter/validator input diagnostics.
+# (1) attgtToFetwfeDf() no longer emits the always-false "treatment reversal"
+#     warning (it measured input row order, not a real reversal, which is
+#     impossible by construction); output is row-order-invariant.
+# (2) Inf-coded never-treated (fect/staggered/some did) converts as never-treated
+#     (mapped to 0), instead of the misleading "Missing values" error.
+# (3)/(4) The estimator input validator names NA response / NA time / mixed-NA
+#     indep_counts violations instead of a bare internal assertion or a crash.
+
+.attgt_397 <- local({
+	set.seed(397)
+	data.frame(
+		unit = rep(1:6, each = 4),
+		period = rep(1:4, times = 6),
+		G = rep(c(0, 0, 2, 2, 3, 3), each = 4),
+		Y = stats::rnorm(24),
+		x1 = rep(stats::rnorm(6), each = 4)
+	)
+})
+.conv_397 <- function(d) {
+	attgtToFetwfeDf(
+		d,
+		yname = "Y",
+		tname = "period",
+		idname = "unit",
+		gname = "G",
+		covars = "x1"
+	)
+}
+
+test_that("attgtToFetwfeDf: no false 'reversal' warning; output is row-order-invariant; Inf accepted (#397)", {
+	asc <- .conv_397(.attgt_397[order(.attgt_397$period), ])
+
+	# Time-descending input previously tripped the (always-false) reversal
+	# warning; it must not now, and the converted output is identical regardless
+	# of input row order (the converter sorts internally).
+	w <- testthat::capture_warnings(
+		desc <- .conv_397(.attgt_397[order(-.attgt_397$period), ])
+	)
+	expect_false(any(grepl("switch from treated back", w)))
+	expect_identical(asc, desc)
+
+	# Inf-coded never-treated converts identically to the 0-coded panel (was:
+	# "Missing values in `G`." because as.integer(Inf) is NA).
+	attgt_inf <- .attgt_397
+	attgt_inf$G[attgt_inf$G == 0] <- Inf
+	expect_identical(.conv_397(.attgt_397), .conv_397(attgt_inf))
+})
+
+test_that("the estimator input validator names NA response / time / indep_counts violations (#397)", {
+	cf <- genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = 2, seed = 1)
+	sim <- simulateData(
+		cf,
+		N = 120,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 1
+	)
+	base <- list(
+		time_var = sim$time_var,
+		unit_var = sim$unit_var,
+		treatment = sim$treatment,
+		response = sim$response,
+		covs = sim$covs,
+		verbose = FALSE
+	)
+
+	# NA response: named violation, NOT the bare `all(!is.na(data)) is not TRUE`.
+	pd_resp <- sim$pdata
+	pd_resp[[sim$response]][1] <- NA
+	expect_error(
+		do.call(etwfe, c(list(pdata = pd_resp), base)),
+		"response column.*must not contain missing"
+	)
+
+	# NA time: named violation, not a confusing idCohorts() balance error.
+	pd_time <- sim$pdata
+	pd_time[[sim$time_var]][1] <- NA_integer_
+	expect_error(
+		do.call(etwfe, c(list(pdata = pd_time), base)),
+		"time_var column.*must not contain missing"
+	)
+
+	# Mixed-NA indep_counts: named violation, not "missing value where TRUE/FALSE
+	# needed" (the validator formerly crashed on `any(c(18, NA, 6) <= 0)` -> NA).
+	expect_error(
+		do.call(
+			etwfe,
+			c(list(pdata = sim$pdata, indep_counts = c(18L, NA, 6L)), base)
+		),
+		"indep_counts must not contain missing"
+	)
+
+	# A normal fit (no NA anywhere) is unaffected.
+	expect_s3_class(do.call(etwfe, c(list(pdata = sim$pdata), base)), "etwfe")
+})


### PR DESCRIPTION

Four converter/validator input-diagnostic defects (all loud-or-benign — converter output is `identical()` across row orders, no silent corruption — but one actively misleads and three give unhelpful errors):

1. **The "N unit(s) switch from treated back to untreated" warning was always a false positive.** Its `diff()` check ran in *input row order* (rows are sorted later), and treatment is monotone by construction (the first-treatment period is constant within a unit), so a real reversal is impossible — it fired only on valid time-descending input. Deleted.
2. **Inf-coded never-treated** (`first.treat = Inf`, common in fect/staggered/some `did` paths) now converts as never-treated (mapped to `0`) instead of erroring "Missing values in `G`" (from `as.integer(Inf) → NA`).
3. **An `NA` response / time value** now gives a named validator violation, instead of the bare internal `all(!is.na(data)) is not TRUE` (response) or a confusing `idCohorts()` balance error (time).
4. **A mixed-`NA` `indep_counts`** (`c(18L, NA, 6L)`) now gives a named violation, instead of crashing the validator with "missing value where TRUE/FALSE needed" (`any(c(18, NA, 6) <= 0)` is `NA`).

New `test-converter-diagnostics-397.R`: converter output is row-order-invariant with no reversal warning and `Inf ≡ 0`; the validator names all three NA violations. Additive fixes are mutation-proven to bite; 787 existing converter/estimator assertions are unchanged. The plan-review caught a stale `@details` orphan (the deleted warning was still documented in `.fetwfe_df_core`) — fixed — and the exported converters' `@param gname`/`@param gvar` now note the accepted `Inf` encoding. Patch bump to 1.56.15. Closes #397.
