### PR TITLE
cleanup: 2026-07 review sweep — dead locals/params, doc drift, message nits (#399)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.56.15
+Version: 1.56.16
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,22 @@
 # NEWS
 
+## Version 1.56.16
+
+### Bug fixes
+
+- `processFactors()` (used when a `fetwfe()` / `etwfe()` / `betwfe()` /
+  `twfeCovs()` fit includes factor covariates) now names the dummy columns with
+  the documented `factorVar_levelName` scheme (e.g. `group_B`), instead of
+  leaking the internal `model.matrix` term label (e.g. `group_pdata[[v]]B`).
+  This corrects the constructed design-matrix column names
+  (`colnames(fit$internal$X_ints)`); the returned coefficient vector is unnamed,
+  so `summary()` / `coef()` output is unchanged. (#399)
+- `genCoefs()` / `simulateData()` no longer advance the caller's ambient
+  random-number stream when they reject an invalid argument. Seeding is now
+  applied only after all argument validation succeeds, so a call that errors
+  (e.g. an invalid `T`, `G`, or `density`) leaves `.Random.seed` untouched.
+  (#399)
+
 ## Version 1.56.15
 
 ### Bug fixes

--- a/R/bridge_selection.R
+++ b/R/bridge_selection.R
@@ -207,7 +207,7 @@ getBetaBIC <- function(fit, N, T, p, X_mod, y, scale_center, scale_scale) {
 #'   \item{lambda_star_ind}{Integer; the index of the selected lambda in
 #'     `cv_fit$fit$lambda`.}
 #'   \item{lambda_star_model_size}{Integer; the number of non-zero
-#'     coefficients (including intercept) at the selected lambda.}
+#'     coefficients (excluding the intercept) at the selected lambda.}
 #' @keywords internal
 #' @noRd
 getBetaCV <- function(

--- a/R/cohort_assignment.R
+++ b/R/cohort_assignment.R
@@ -67,7 +67,7 @@
 #'   - `seed + 2L` -> Monte Carlo integration in `getTes()` for
 #'                    `E[pi_g(X)]`.
 #'
-#' @param G Integer >= 2. Number of treated cohorts.
+#' @param G Integer >= 1. Number of treated cohorts.
 #' @param d Integer >= 1. Number of covariates. Only called when
 #'   `type != "marginal"`, which requires `d >= 1`.
 #' @param type Character. One of `"multinomial"` or `"ordered"`. The
@@ -143,7 +143,6 @@
 	interaction_strength = NULL,
 	seed = NULL
 ) {
-	.apply_seed(seed)
 	.validate_strength_arg(strength, "assignment_strength")
 	if (!(type %in% c("multinomial", "ordered"))) {
 		stop(sprintf(
@@ -156,6 +155,7 @@
 			"Covariate-dependent cohort assignment requires d >= 1 (at least one covariate)"
 		)
 	}
+	.apply_seed(seed)
 	K <- if (is.null(interactions)) 0L else length(interactions)
 	effective_int_strength <- if (is.null(interaction_strength)) {
 		strength
@@ -580,23 +580,34 @@
 			break
 		}
 		if (attempt >= max_iters) {
+			if (guarantee_rank_condition) {
+				bar_desc <- "the rank condition (min count >= d + 1)"
+				suggestion <- paste0(
+					"Try a larger N, a smaller assignment_strength, or set ",
+					"guarantee_rank_condition = FALSE."
+				)
+			} else {
+				bar_desc <- "a non-empty count in every cohort (min count >= 1)"
+				suggestion <- "Try a larger N or a smaller assignment_strength."
+			}
 			msg <- sprintf(
 				paste0(
-					"Failed to draw %scohort assignments satisfying the rank condition ",
-					"(min count >= d + 1) after %d attempts at assignment_type = '%s', ",
+					"Failed to draw %scohort assignments satisfying %s ",
+					"after %d attempts at assignment_type = '%s', ",
 					"assignment_strength = %g, N = %d, G = %d, d = %d. ",
 					"Under covariate-dependent assignment with strong covariate-cohort ",
 					"coupling, the smallest treated cohorts can have arbitrarily small ",
-					"counts. Try a larger N, a smaller assignment_strength, or set ",
-					"guarantee_rank_condition = FALSE."
+					"counts. %s"
 				),
 				label,
+				bar_desc,
 				max_iters,
 				assignment_coefs$type,
 				assignment_coefs$strength,
 				N,
 				G,
-				d
+				d,
+				suggestion
 			)
 			# When interactions are present (K > 0L), .gen_assignment_coefs()
 			# stores the effective interaction strength on assignment_coefs.

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -425,7 +425,9 @@ debiasedATT <- function(
 			"debiasedATT() requires a fit computed with q < 1 (bridge selection) in ",
 			"the fixed-p (p < NT) regime when the design is GLS-whitened ",
 			"(`gls = TRUE`), so a valid debiased standard error exists. This fit has ",
-			"calc_ses = FALSE (q >= 1). Re-fit with q < 1 (e.g. q = 0.5), or with ",
+			"calc_ses = FALSE, either because q >= 1 (no bridge-selection SE is ",
+			"available) or because a q < 1 fit's selected-support Gram was singular. ",
+			"Re-fit with q < 1 (e.g. q = 0.5) on a well-conditioned support, or with ",
 			"`gls = FALSE` for the cluster-robust SE.",
 			call. = FALSE
 		)

--- a/R/design_matrix.R
+++ b/R/design_matrix.R
@@ -50,12 +50,21 @@ processFactors <- function(pdata, covs) {
 			# produces one dummy column per factor level and no intercept; we
 			# drop the first dummy below to serve as the baseline category.
 			dummies <- stats::model.matrix(~ pdata[[v]] - 1)
+			# Map columns to factor levels. `model.matrix(~ f - 1)` emits one
+			# column per `levels(f)` in order (empty levels included), so the
+			# retained columns correspond 1:1 to those level names. Naming from
+			# `levels()` (not `colnames(dummies)`, which leaks the
+			# `model.matrix` term label such as `pdata[[v]]B`) yields the
+			# documented `factorVar_levelName` scheme (#399).
+			lvls <- levels(pdata[[v]])
 			# If there is more than one level, drop the first column to use it as baseline.
 			if (ncol(dummies) > 1) {
 				dummies <- dummies[, -1, drop = FALSE]
+				kept_levels <- lvls[-1]
+			} else {
+				kept_levels <- lvls[1]
 			}
-			# Rename the dummy columns: for example, if v = "group", new names will be "group_level2", etc.
-			dummy_names <- paste(v, colnames(dummies), sep = "_")
+			dummy_names <- paste(v, kept_levels, sep = "_")
 			colnames(dummies) <- dummy_names
 			# Remove the original factor column from pdata
 			pdata[[v]] <- NULL
@@ -278,8 +287,6 @@ prepXints <- function(
 	y_mean <- ret$y_mean # mean of pre-centered response (preserved on output)
 	cohort_treat_names <- ret$cohort_treat_names # List of names of treatment
 	# dummies for each cohort
-	time_var_names <- ret$time_var_names # Names of time dummies
-	cohort_vars <- ret$cohort_vars # Names of cohort dummies
 	first_inds <- ret$first_inds # Among blocks of treatment variables, indices
 	# of first treatment effects corresponding to each cohort
 	cohort_var_mat <- ret$cohort_var_mat # Cohort dummies; G columns total

--- a/R/etwfe_core.R
+++ b/R/etwfe_core.R
@@ -251,7 +251,6 @@ checkEtwfeInputs <- function(
 
 	X_final_scaled <- res$X_final_scaled
 	y_final <- res$y_final
-	scale_center <- res$scale_center
 	scale_scale <- res$scale_scale
 	cohort_probs <- res$cohort_probs
 	cohort_probs_overall <- res$cohort_probs_overall

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -510,7 +510,6 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 	N <- x$N
 	T <- x$T
 	G <- x$G
-	d <- x$d
 	p <- x$p
 	sig_eps_sq <- x$sig_eps_sq
 	cohort_probs_overall <- x$cohort_probs_overall
@@ -671,7 +670,6 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 			d_inv_treat_sel = d_inv_treat_sel,
 			cohort_probs_overall = cohort_probs_overall,
 			first_inds = first_inds,
-			num_treats = num_treats,
 			N = N,
 			T = T,
 			G = G
@@ -734,7 +732,6 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 	d_inv_treat_sel,
 	cohort_probs_overall,
 	first_inds,
-	num_treats,
 	N,
 	T,
 	G

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -922,11 +922,11 @@ genCoefsCore <- function(
 
 	fusion_structure <- match.arg(fusion_structure)
 
-	# Defensive re-validation (genCoefsCore is exported and callable directly);
-	# pure checks, no RNG, before `.apply_seed` (#332).
+	# Defensive re-validation (genCoefsCore is exported and callable directly).
+	# All argument validation runs before `.apply_seed()` so an invalid-arg
+	# error does not advance the caller's ambient RNG (#399); the
+	# targeted-sparsity check in particular is a pure, RNG-free check (#332).
 	.validate_targeted_sparsity(n_signal_cohorts, treat_base_levels, G)
-
-	.apply_seed(seed)
 
 	# Check that T is a numeric scalar and at least 2.
 	if (!is.numeric(T) || length(T) != 1 || T < 2) {
@@ -968,6 +968,10 @@ genCoefsCore <- function(
 	stopifnot(G >= 1)
 	stopifnot(T >= 2)
 	stopifnot(G <= T - 1)
+
+	# Seed only after all argument validation, so an invalid-arg error does not
+	# advance the caller's ambient RNG (#399).
+	.apply_seed(seed)
 
 	num_treats <- getNumTreats(G = G, T = T)
 
@@ -1166,7 +1170,16 @@ genCoefsCore <- function(
 			coefs = beta,
 			num_treats = num_treats
 		)
-		if (all(catt_built == 0)) {
+		# Scale-relative degeneracy tolerance (#399): `catt_built` is a linear
+		# map of the treatment coefficients `beta[treat_inds]`, so a
+		# floating-point cancellation (e.g. equal-and-opposite
+		# `treat_base_levels`) lands many orders of magnitude below the
+		# coefficient scale, while a legitimately small `eff_size` DGP stays AT
+		# the coefficient scale. Comparing to `tol * max(1, scale)` (not exact
+		# `== 0`) rejects the former without false-rejecting the latter.
+		catt_tol <- sqrt(.Machine$double.eps) *
+			max(1, max(abs(beta[treat_inds])))
+		if (all(abs(catt_built) < catt_tol)) {
 			stop(
 				"genCoefs() targeted mode produced all-zero cohort effects ",
 				"(att == 0). Supply a nonzero `eff_size` (count mode) or a ",
@@ -1174,7 +1187,7 @@ genCoefsCore <- function(
 				call. = FALSE
 			)
 		}
-		if (length(unique(catt_built)) == 1L) {
+		if (max(catt_built) - min(catt_built) < catt_tol) {
 			stop(
 				"genCoefs() targeted mode produced homogeneous cohort effects ",
 				"(V2 == 0): all cohorts have the same effect, so there is no ",

--- a/R/gen_data.R
+++ b/R/gen_data.R
@@ -412,8 +412,6 @@ simulateDataCore <- function(
 	# directly.
 	G <- .resolve_cohort_count_arg(G, R, "simulateDataCore")
 
-	.apply_seed(seed)
-
 	# Normalize assignment_type defensively (backward-compat for callers
 	# that pass NULL directly).
 	if (is.null(assignment_type)) {
@@ -444,6 +442,10 @@ simulateDataCore <- function(
 	p_expected <- res$p_expected
 
 	rm(res)
+
+	# Seed only after all argument validation, so an invalid-arg error does not
+	# advance the caller's ambient RNG (#399).
+	.apply_seed(seed)
 
 	# Generate base effects and covariates. Marginal path keeps the
 	# pre-1.14.0 byte-identical behavior; covariate path samples per-unit

--- a/R/plot.R
+++ b/R/plot.R
@@ -238,10 +238,6 @@ plot.twfeCovs <- function(x, ...) {
 	if (!is.null(alpha)) {
 		.validate_alpha_arg(alpha, "plot")
 		z <- stats::qnorm(1 - alpha / 2)
-		# Use unclass() so .subset2() / direct $-access can mutate the
-		# data.frame without triggering catt_df's helpful-error layer on
-		# new column writes (which doesn't intercept these but is safer
-		# to avoid).
 		catt$ci_low <- catt$estimate - z * catt$se
 		catt$ci_high <- catt$estimate + z * catt$se
 	}

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -823,7 +823,6 @@ simultaneousCIs.twfeCovs <- function(
 				K = K,
 				G = G,
 				T = T_,
-				num_treats = num_treats,
 				cohort_offsets_int = cohort_offsets_int,
 				first_inds = first_inds,
 				cohort_probs_overall = cohort_probs_overall,
@@ -845,7 +844,6 @@ simultaneousCIs.twfeCovs <- function(
 				K = K,
 				G = G,
 				T = T_,
-				num_treats = num_treats,
 				cohort_offsets_int = cohort_offsets_int,
 				first_inds = first_inds,
 				cohort_probs_overall = cohort_probs_overall,
@@ -950,7 +948,6 @@ simultaneousCIs.twfeCovs <- function(
 		K = K,
 		G = G,
 		T = T_,
-		num_treats = num_treats,
 		cohort_offsets_int = cohort_offsets_int,
 		first_inds = first_inds,
 		cohort_probs_overall = cohort_probs_overall,
@@ -1385,7 +1382,7 @@ simultaneousCIs.twfeCovs <- function(
 #'   is anti-conservative (not conservative) for a contrast that pools across
 #'   cohorts in a probability-weighted way, which does carry cohort-probability
 #'   variance.
-#' @param family,K,G,T,num_treats,cohort_offsets_int,first_inds,cohort_probs_overall,d_inv_treat_sel
+#' @param family,K,G,T,cohort_offsets_int,first_inds,cohort_probs_overall,d_inv_treat_sel
 #'   See `.simultaneous_cis_impl()`.
 #' @return A length-K list of numeric matrices (each `G x ncol(d_inv_treat_sel)`).
 #' @keywords internal
@@ -1395,7 +1392,6 @@ simultaneousCIs.twfeCovs <- function(
 	K,
 	G,
 	T,
-	num_treats,
 	cohort_offsets_int,
 	first_inds,
 	cohort_probs_overall,

--- a/R/utility.R
+++ b/R/utility.R
@@ -352,14 +352,12 @@ idCohorts <- function(df, time_var, unit_var, treat_var) {
 		if (length(first_year_cohort_units) > 0) {
 			df <- df[!(df[, unit_var] %in% first_year_cohort_units), ]
 			units <- unique(df[, unit_var]) # Update units
-			if (length(first_year_cohort_units) > 0) {
-				# N is original N
-				warning(paste(
-					length(first_year_cohort_units),
-					"units were removed because they were treated in the first time period:",
-					paste(first_year_cohort_units, collapse = ", ")
-				))
-			}
+			# N is original N
+			warning(paste(
+				length(first_year_cohort_units),
+				"units were removed because they were treated in the first time period:",
+				paste(first_year_cohort_units, collapse = ", ")
+			))
 		}
 		cohorts[[first_time_val_char]] <- NULL # Remove this cohort entry
 	}

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -231,8 +231,9 @@ getSecondVarTermOLS <- function(
 
 	# Construct Jacobian matrix corresponding to the mapping from the
 	# individual cohort probabilities to the proportions calculated for the ATT.
-	# See the Proof of Theorem 6.1 (Consistency of FETWFE), paper_arxiv.tex:2678,
-	# for the explicit form (verified #325). Consolidated into `.build_jacobian()`
+	# See the Proof of Theorem 6.1 (Consistency of FETWFE) --- paper label
+	# `main.te.cons.thm` --- for the explicit form (verified #325).
+	# Consolidated into `.build_jacobian()`
 	# (#192, WORKFLOW_LESSONS §14 Class A); the OLS-family path (d_inv = NULL)
 	# returns the G x G column-indexed Jacobian byte-identically.
 	jacobian_mat <- .build_jacobian(
@@ -250,7 +251,7 @@ getSecondVarTermOLS <- function(
 	# Finally, calculate variance term for ATT from Sigma_pi_hat, Jacobian
 	# matrix, psi_mat, and beta_hat. This is the estimated-propensity variance
 	# term: see Theorem 6.4(b) (Asymptotic Confidence Intervals for FETWFE),
-	# eq. (v.n.r.t.att.rand) at paper_arxiv.tex:2876, for details (was a stale
+	# eq. `v.n.r.t.att.rand` (paper label), for details (was a stale
 	# "Theorem D.2" reference; corrected #325).
 
 	# Issue #127: floor `att_var_2` at zero, mirroring the `att_var_1`
@@ -377,7 +378,6 @@ getPsiGUnfused <- function(
 	stopifnot(nrow(X_S) == N * T)
 	stopifnot(length(residuals) == N * T)
 	X_S_centered <- scale(X_S, center = TRUE, scale = FALSE)
-	p_S <- ncol(X_S_centered)
 	# Issue #84 item 10: convert the LAPACK rank-deficiency error from
 	# `solve(crossprod(X_S_centered))` into the same user-facing message
 	# that `getGramInv()` emits, so a cluster-SE fit on a rank-deficient
@@ -988,7 +988,7 @@ getSecondVarTermDataApp <- function(
 	stopifnot(nrow(Sigma_pi_hat) == G)
 	stopifnot(ncol(Sigma_pi_hat) == G)
 
-	# Jacobian (paper Theorem 6.1 proof, paper_arxiv.tex:2678; was a stale
+	# Jacobian (paper Theorem 6.1 proof, label `main.te.cons.thm`; was a stale
 	# "Theorem 6.3 / 2577-2592" reference, corrected #325):
 	##
 	## J_{rs} =  (S-pi_g)/S^2      if g = s
@@ -1053,7 +1053,7 @@ getSecondVarTermDataApp <- function(
 #' the third copy triggers a refactor). All four sites implement the same
 #' delta-method gradient of \eqn{f_g(\pi)=\pi_g/\sum_k \pi_k}; the column-index
 #' off-diagonal coefficient \eqn{J_{rs}=-\pi_s/S^2} matches the explicit Jacobian
-#' in the proof of paper Theorem 6.1 (`paper_arxiv.tex:2678`; was a stale
+#' in the proof of paper Theorem 6.1 (label `main.te.cons.thm`; was a stale
 #' "Theorem 6.3 / 2577-2592" reference, corrected #325). Prior to v1.8.0 the
 #' off-diagonal used the outer-loop row index; see issue #46.
 #' @param cohort_probs_overall Numeric vector of length `G`; marginal cohort
@@ -1483,7 +1483,6 @@ getCohortATTsFinal <- function(
 	stopifnot(all(!is.na(tes)))
 
 	stopifnot(nrow(X_final) == N * T)
-	X_to_pass <- X_final
 
 	# Translate the OLS-caller `sel_feat_inds = NULL` sentinel to the value
 	# each downstream helper expects: `getGramInv()` uses NA as its "all
@@ -1498,7 +1497,7 @@ getCohortATTsFinal <- function(
 		res <- getGramInv(
 			N = N,
 			T = T,
-			X_final = X_to_pass,
+			X_final = X_final,
 			sel_feat_inds = gram_sel_feat,
 			treat_inds = treat_inds,
 			num_treats = num_treats,

--- a/tests/testthat/test-review-sweep-399.R
+++ b/tests/testthat/test-review-sweep-399.R
@@ -1,0 +1,117 @@
+# Behavior-visible items from the 2026-07 review sweep (#399).
+#
+# Item 10: an invalid-argument error on the data-generation entry points must
+#          NOT advance the caller's ambient RNG (the seed is applied only after
+#          all argument validation succeeds).
+# Item 11: processFactors() names factor dummies as `factorVar_levelName`
+#          (e.g. `group_B`), not the leaked `model.matrix` term label
+#          (`group_pdata[[v]]B`).
+# Item 12: the targeted-sparsity degeneracy guards compare against a
+#          scale-relative tolerance, so a floating-point-cancelling DGP is
+#          rejected while a legitimately small (but nonzero-variance) one is not.
+
+# ---- Item 11: processFactors clean dummy names -------------------------------
+
+test_that("processFactors() names factor dummies as factorVar_levelName (#399)", {
+	df <- data.frame(
+		y = 1:6,
+		group = factor(c("A", "B", "A", "C", "B", "C")),
+		x1 = 11:16
+	)
+	res <- processFactors(df, c("group", "x1"))
+
+	# Baseline level "A" is dropped; "B"/"C" are retained as group_B / group_C.
+	# The names must equal paste(factorVar, level, sep = "_") EXACTLY, not the
+	# leaked model.matrix term label (which produced e.g. `group_pdata[[v]]B`).
+	dummy_covs <- setdiff(res$covs, "x1")
+	expect_identical(sort(dummy_covs), c("group_B", "group_C"))
+	expect_true("x1" %in% res$covs)
+	expect_false("group" %in% res$covs)
+
+	# No leak of the internal `pdata[[v]]` term label into any covariate name.
+	expect_false(any(grepl("pdata", res$covs, fixed = TRUE)))
+	expect_false(any(grepl("[[", res$covs, fixed = TRUE)))
+
+	# The same clean names appear as columns of the returned data frame.
+	expect_true(all(c("group_B", "group_C") %in% colnames(res$pdata)))
+	expect_false("group" %in% colnames(res$pdata))
+})
+
+# ---- Item 10: invalid args do not advance the ambient RNG --------------------
+
+test_that("genCoefs() invalid-arg error leaves the ambient RNG untouched (#399)", {
+	# A non-NULL `seed` makes the pre-#399 bug observable: the old order applied
+	# set.seed(seed) BEFORE the scalar validations, so an invalid `T` reseeded
+	# (and thus perturbed) the caller's ambient .Random.seed on the error path.
+	set.seed(1)
+	before <- .Random.seed
+	expect_error(
+		genCoefs(G = 3, T = -1, d = 2, density = 0.5, eff_size = 1, seed = 123)
+	)
+	expect_identical(.Random.seed, before)
+
+	# Draw-based cross-check: the failed call must not shift the stream, so the
+	# next draw matches a fresh set.seed(1) draw.
+	set.seed(1)
+	expect_error(
+		genCoefs(G = 3, T = -1, d = 2, density = 0.5, eff_size = 1, seed = 123)
+	)
+	got <- runif(1)
+	set.seed(1)
+	expect_identical(got, runif(1))
+})
+
+test_that("simulateDataCore() invalid-arg error leaves the ambient RNG untouched (#399)", {
+	num_treats <- getNumTreats(G = 3, T = 4)
+	beta_ok <- rep(0.1, getP(G = 3, T = 4, d = 1, num_treats = num_treats))
+
+	set.seed(2)
+	before <- .Random.seed
+	expect_error(
+		simulateDataCore(
+			N = -5,
+			T = 4,
+			d = 1,
+			G = 3,
+			sig_eps_sq = 1,
+			sig_eps_c_sq = 1,
+			beta = beta_ok,
+			seed = 123,
+			distribution = "gaussian"
+		)
+	)
+	expect_identical(.Random.seed, before)
+})
+
+# ---- Item 12: scale-relative targeted-sparsity degeneracy guards -------------
+
+test_that("genCoefs() targeted degeneracy guards use a scale-relative tolerance (#399)", {
+	G <- 3
+	T <- 5
+	d <- 0
+	mk <- function(tbl) {
+		genCoefs(
+			G = G,
+			T = T,
+			d = d,
+			density = 0.5,
+			eff_size = 1,
+			treat_base_levels = tbl,
+			seed = 1
+		)
+	}
+
+	# Truly degenerate cases are still rejected.
+	expect_error(mk(rep(0, G)), "all-zero cohort effects") # att == 0 (guard 1)
+	expect_error(mk(c(1, 0, 0)), "homogeneous cohort effects") # V2 == 0 (guard 2)
+
+	# Near-homogeneous below tolerance: the cohort effects differ only at ~1e-9.
+	# The OLD exact `length(unique(catt_built)) == 1L` guard would have PASSED
+	# this (three distinct doubles); the scale-relative tolerance rejects it as
+	# numerically homogeneous (V2 ~ 0).
+	expect_error(mk(c(1, 1e-9, 0)))
+
+	# Legitimately small-but-nonzero heterogeneity must NOT be false-rejected.
+	expect_s3_class(mk(c(0, 0.01, 0.02)), "FETWFE_coefs")
+	expect_s3_class(mk(c(1, 1e-7, 0)), "FETWFE_coefs")
+})

--- a/tests/testthat/test-simultaneous-bootstrap-eventstudy-142.R
+++ b/tests/testthat/test-simultaneous-bootstrap-eventstudy-142.R
@@ -106,7 +106,6 @@
 		K = K,
 		G = G,
 		T = T_,
-		num_treats = num_treats,
 		cohort_offsets_int = cohort_offsets_int,
 		first_inds = first_inds,
 		cohort_probs_overall = cohort_probs_overall,

--- a/tests/testthat/test-simultaneous-bootstrap-fpi-desparsify-309.R
+++ b/tests/testthat/test-simultaneous-bootstrap-fpi-desparsify-309.R
@@ -86,7 +86,6 @@ hd309 <- .make_hd309_fit()
 		K = Tt - 1L,
 		G = G,
 		T = Tt,
-		num_treats = nt,
 		cohort_offsets_int = offs$cohort_offsets_int,
 		first_inds = offs$first_inds,
 		cohort_probs_overall = hd$cohort_probs_overall,


### PR DESCRIPTION

Behavior-neutral cleanup sweep from the 2026-07 periodic review (12 items, each verified before editing — `codetools` for the dead code, code-vs-doc reads for the drift). Two items are user-visible and get NEWS bullets.

**Dead code / vestigial params** (clears standing `codetools::checkUsagePackage()` noise): removed the unused `num_treats` parameter from `.event_study_var2_fetwfe()` and `.build_j_list_for_family()` (and their call sites); deleted five dead locals (`scale_center`, `p_S`, `d`, `time_var_names`, `cohort_vars`), inlined a single-use `X_to_pass` alias, and flattened an always-true nested `if` in `idCohorts()`.

**Doc drift** (doc-only): `getBetaCV()` `@return` (model size *excludes* the intercept, per #269); replaced stale `paper_arxiv.tex` line-number citations with paper `\label` names (`main.te.cons.thm`, `v.n.r.t.att.rand`) so this drift class ends; `.retry_until_rank_ok`'s exhaustion message now states the actual rank bar (`>= d + 1` vs `>= 1`, per `guarantee_rank_condition`); removed a stale `unclass()` comment in `.plot_catt()`; `debiasedATT()`'s fixed-p gate message now names both NA-SE causes (`q >= 1` *or* a singular selected-support Gram); softened a `G >= 2` doc that already accepts `G = 1`.

**Behavior-adjacent nits** (two → NEWS): `genCoefs()` / `simulateData()` / `.gen_assignment_coefs()` now seed only *after* argument validation, so an invalid-arg error no longer advances the caller's ambient RNG; `processFactors()` factor-dummy column names now follow the documented `factorVar_levelName` scheme (e.g. `group_B`) instead of leaking the `model.matrix` term label (`group_pdata[[v]]B`) — this changes coefficient names for fits with factor covariates; targeted-sparsity degeneracy guards use a scale-relative tolerance (rejecting floating-point cancellation without false-rejecting a legitimately small DGP).

New `test-review-sweep-399.R` pins the three behavior items (the tolerance guard mutation-verified); the dead-code/doc items are covered by the gate — `devtools::test()` 4438 pass, and all 7 targeted `codetools` warnings (5 locals + 2 params) cleared. No man/NAMESPACE change (all touched functions are internal). Patch bump to 1.56.16. Closes #399.

## Out of scope (deferred follow-up)

- `.expected_cohort_probs()` has a *milder, interleaved* variant of the seed-before-validation pattern (an invalid `distribution` string reseeds because the check is fused into the RNG branch) — outside the enumerated item-10 sites, and largely masked by `.with_preserved_rng` at its `getTes()` caller. Flagged as a possible follow-up (natural home: the #403 defense-in-depth batch); **dropped from this PR** to keep the sweep scoped.
