### PR TITLE
feat: align the two bootstrap accessors' contracts — lift the debiasedATT indep_counts gate; add cv_time_budget to simultaneousCIs (#402)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.56.16
+Version: 1.56.17
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # NEWS
 
+## Version 1.56.17
+
+### New features
+
+- `simultaneousCIs()` gains a `cv_time_budget` argument (default `Inf`) --- the same
+  wall-clock backstop `debiasedATT()` already offered (#384). Under `lambda_c = "cv"`
+  it caps the cross-validation that selects the high-dimensional (`p >= NT`) nodewise
+  penalty, falling back to the theory scale (`lambda_c = 1.0`) with a warning if the
+  budget fires, so an adversarial high-dimensional draw cannot spin indefinitely
+  through the band path. When `lambda_c = "cv"` the band object now also carries
+  `$lambda_cv` (the cross-validation diagnostics), matching `debiasedATT()`. (#402)
+
+- `debiasedATT(method = "bootstrap")` now supports `indep_counts` (two-sample) fits,
+  which it previously refused. The wild bootstrap perturbs the cohort-weight channel
+  on its own independent multiplier stream over the reconstructed count-sample units
+  (`sum(indep_counts) == N` is enforced), reproducing the two-sample propensity
+  variance --- the identical construction `simultaneousCIs()` already ran on such
+  fits. The default analytic SE is unchanged. (#402)
+
 ## Version 1.56.16
 
 ### Bug fixes

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -194,8 +194,11 @@
 #'   floor it reduces to the analytic interval exactly in the small-`N` regime; it
 #'   only ever *widens* the interval when cluster influence is near-homogeneous.
 #'   For a genuine few-clusters correction the restricted bootstrap-t or a CR2-type
-#'   analytic adjustment is required (tracked as future work, #361). Not supported
-#'   for `indep_counts` (two-sample) fits.
+#'   analytic adjustment is required (tracked as future work, #361). Supported for
+#'   both single-sample and `indep_counts` (two-sample) fits: for a two-sample fit
+#'   the cohort-weight channel is perturbed on its own independent multiplier stream
+#'   over the `N` count-sample units (`sum(indep_counts) == N` is enforced), yielding
+#'   the two-sample propensity variance.
 #' @param B Integer; the number of wild-bootstrap replicates (default `1000`).
 #'   Ignored unless `method = "bootstrap"`.
 #' @param seed `NULL` (draw from the ambient RNG, the default) or a single
@@ -318,18 +321,6 @@ debiasedATT <- function(
 
 	if (method == "bootstrap") {
 		B <- .validate_boot_args(B, seed, "debiasedATT")
-		if (isTRUE(fit$indep_counts_used)) {
-			stop(
-				"debiasedATT(method = \"bootstrap\") is not supported for ",
-				"`indep_counts` (two-sample) fits: the cohort-weight variance ",
-				"channel is estimated from the separate count sample, so it has no ",
-				"per-unit influence-function decomposition over the main sample's ",
-				"clusters. Use the analytic SE (the default) here, or refit without ",
-				"`indep_counts` -- a simulation-only feature -- to use the wild ",
-				"bootstrap (real single-sample panels are supported directly).",
-				call. = FALSE
-			)
-		}
 	}
 
 	# High-dimensional nodewise-solver controls. These only affect the p >= NT

--- a/R/simultaneous_bootstrap.R
+++ b/R/simultaneous_bootstrap.R
@@ -592,6 +592,7 @@
 	lambda_c,
 	riesz_max_iter,
 	riesz_tol,
+	cv_time_budget,
 	X_final,
 	y_final,
 	N,
@@ -628,6 +629,7 @@
 	# back to the post-selection `J_list %*% theta_sel` construction.
 	A_db <- NULL
 	cell_diag <- NULL
+	lambda_cv <- NULL
 	if (!is.null(targets)) {
 		# High-dim nuisance (#303): an internal q=1 fused lasso (NOT the q<1 bridge
 		# theta_hat), the SAME nuisance debiasedATT() uses -- its l1 rate is what
@@ -661,15 +663,17 @@
 		# and the per-fit feasibility warning (a #88 coverage consideration).
 		lambda_c_used <- lambda_c
 		if (identical(lambda_c, "cv")) {
-			lambda_c_used <- .cv_lambda_node(
+			lambda_cv <- .cv_lambda_node(
 				Sig_hd,
 				a_att,
 				X_final,
 				N,
 				T,
 				riesz_max_iter = riesz_max_iter,
-				riesz_tol = riesz_tol
-			)$lambda_c
+				riesz_tol = riesz_tol,
+				cv_time_budget = cv_time_budget
+			)
+			lambda_c_used <- lambda_cv$lambda_c
 		}
 		F_mat <- .build_regression_if_highdim(
 			X_final,
@@ -910,6 +914,19 @@
 			"cv"
 		} else {
 			"fixed"
+		}
+		# When lambda_c = "cv", surface the CV diagnostics (grid, per-grid
+		# feasibility / CV losses, and whether the theory-scale fallback fired),
+		# matching debiasedATT()'s `$lambda_cv` (one node, resolved on a_att; #402).
+		if (!is.null(lambda_cv)) {
+			out$lambda_cv <- lambda_cv[c(
+				"cv_loss",
+				"feasible",
+				"mult_grid",
+				"fallback",
+				"fallback_reason",
+				"bailed"
+			)]
 		}
 		# The high-dim event_study propensity channel desparsifies num_treats extra
 		# per-cohort-cell directions (#309); they also feed the band (via Sigma_2)

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -146,6 +146,14 @@ utils::globalVariables(c(
 #'   stays the fixed `1.0`; the family-wise coverage validated in Faletto (2025)
 #'   used the `"cv"` selector (`lambda_c` ~ 0.54, feasibility 1.0), the same
 #'   constant that serves the scalar `debiasedATT()` and every band effect.
+#' @param cv_time_budget Numeric; a wall-clock backstop (in seconds) for the
+#'   `lambda_c = "cv"` cross-validation (the same #384 backstop `debiasedATT()`
+#'   offers). `Inf` (the default) leaves selection fully deterministic /
+#'   reproducible; a finite value stops the CV early and falls back to the theory
+#'   scale (`lambda_c = 1.0`) with a warning, so an adversarial high-dimensional
+#'   draw cannot spin indefinitely (#384). Whether a finite budget fires depends
+#'   on machine speed, so the result can too. Ignored unless `lambda_c = "cv"` and
+#'   `p >= NT`.
 #' @return An object of S3 class `"simultaneous_cis"`: a list with
 #'   \describe{
 #'     \item{ci}{A data frame with columns `effect`, `estimate`,
@@ -176,7 +184,10 @@ utils::globalVariables(c(
 #'   `"high-dimensional"` fit additionally carries per-effect `feasibility`,
 #'   `converged`, and `lambda_node` (the nodewise-direction diagnostics), plus
 #'   `lambda_c` (the leading constant used) and `lambda_c_selection` (`"fixed"`
-#'   or `"cv"`).
+#'   or `"cv"`). When `lambda_c = "cv"` it also carries `lambda_cv`, the
+#'   cross-validation diagnostics (the grid, the per-grid feasibility flags and CV
+#'   losses, and whether the theory-scale fallback fired), matching
+#'   `debiasedATT()`'s `lambda_cv`.
 #' @details
 #' **Family resolution and `K`.** `"event_study"` resolves to one effect per
 #' post-treatment event time `e = 0, ..., T - 2` (`K = T - 1`); `"cohort"` to
@@ -268,7 +279,8 @@ simultaneousCIs <- function(
 	multiplier = c("rademacher", "mammen", "webb"),
 	lambda_c = 1.0,
 	riesz_max_iter = 5000L,
-	riesz_tol = 1e-9
+	riesz_tol = 1e-9,
+	cv_time_budget = Inf
 ) {
 	UseMethod("simultaneousCIs")
 }
@@ -295,7 +307,8 @@ simultaneousCIs.fetwfe <- function(
 	multiplier = c("rademacher", "mammen", "webb"),
 	lambda_c = 1.0,
 	riesz_max_iter = 5000L,
-	riesz_tol = 1e-9
+	riesz_tol = 1e-9,
+	cv_time_budget = Inf
 ) {
 	contract <- .check_for_simultaneous_cis(result)
 	family <- match.arg(family)
@@ -311,7 +324,8 @@ simultaneousCIs.fetwfe <- function(
 		multiplier = match.arg(multiplier),
 		lambda_c = lambda_c,
 		riesz_max_iter = riesz_max_iter,
-		riesz_tol = riesz_tol
+		riesz_tol = riesz_tol,
+		cv_time_budget = cv_time_budget
 	)
 }
 
@@ -327,7 +341,8 @@ simultaneousCIs.etwfe <- function(
 	multiplier = c("rademacher", "mammen", "webb"),
 	lambda_c = 1.0,
 	riesz_max_iter = 5000L,
-	riesz_tol = 1e-9
+	riesz_tol = 1e-9,
+	cv_time_budget = Inf
 ) {
 	contract <- .check_for_simultaneous_cis(result)
 	family <- match.arg(family)
@@ -343,7 +358,8 @@ simultaneousCIs.etwfe <- function(
 		multiplier = match.arg(multiplier),
 		lambda_c = lambda_c,
 		riesz_max_iter = riesz_max_iter,
-		riesz_tol = riesz_tol
+		riesz_tol = riesz_tol,
+		cv_time_budget = cv_time_budget
 	)
 }
 
@@ -359,7 +375,8 @@ simultaneousCIs.betwfe <- function(
 	multiplier = c("rademacher", "mammen", "webb"),
 	lambda_c = 1.0,
 	riesz_max_iter = 5000L,
-	riesz_tol = 1e-9
+	riesz_tol = 1e-9,
+	cv_time_budget = Inf
 ) {
 	contract <- .check_for_simultaneous_cis(result)
 	family <- match.arg(family)
@@ -375,7 +392,8 @@ simultaneousCIs.betwfe <- function(
 		multiplier = match.arg(multiplier),
 		lambda_c = lambda_c,
 		riesz_max_iter = riesz_max_iter,
-		riesz_tol = riesz_tol
+		riesz_tol = riesz_tol,
+		cv_time_budget = cv_time_budget
 	)
 }
 
@@ -400,7 +418,8 @@ simultaneousCIs.twfeCovs <- function(
 	multiplier = c("rademacher", "mammen", "webb"),
 	lambda_c = 1.0,
 	riesz_max_iter = 5000L,
-	riesz_tol = 1e-9
+	riesz_tol = 1e-9,
+	cv_time_budget = Inf
 ) {
 	contract <- .check_for_simultaneous_cis(result)
 	family <- match.arg(family)
@@ -416,7 +435,8 @@ simultaneousCIs.twfeCovs <- function(
 		multiplier = match.arg(multiplier),
 		lambda_c = lambda_c,
 		riesz_max_iter = riesz_max_iter,
-		riesz_tol = riesz_tol
+		riesz_tol = riesz_tol,
+		cv_time_budget = cv_time_budget
 	)
 }
 
@@ -449,6 +469,7 @@ simultaneousCIs.twfeCovs <- function(
 	lambda_c = 1.0,
 	riesz_max_iter = 5000L,
 	riesz_tol = 1e-9,
+	cv_time_budget = Inf,
 	# Severity of the high-dim (p >= NT) all-zero degenerate early-exit: a direct
 	# user accessor call warns (default); the silent fit-time band precompute
 	# (`.apply_simultaneous_catt_band()`, wrapped in suppressMessages()) passes
@@ -505,6 +526,18 @@ simultaneousCIs.twfeCovs <- function(
 	) {
 		stop(
 			"simultaneousCIs(): `riesz_tol` must be a single positive number.",
+			call. = FALSE
+		)
+	}
+	if (
+		!is.numeric(cv_time_budget) ||
+			length(cv_time_budget) != 1L ||
+			is.na(cv_time_budget) ||
+			cv_time_budget <= 0
+	) {
+		stop(
+			"simultaneousCIs(): `cv_time_budget` must be a single positive number ",
+			"(seconds) or `Inf`.",
 			call. = FALSE
 		)
 	}
@@ -861,6 +894,7 @@ simultaneousCIs.twfeCovs <- function(
 			lambda_c = lambda_c,
 			riesz_max_iter = riesz_max_iter,
 			riesz_tol = riesz_tol,
+			cv_time_budget = cv_time_budget,
 			X_final = X_final,
 			y_final = y_final,
 			N = N,

--- a/man/debiasedATT.Rd
+++ b/man/debiasedATT.Rd
@@ -43,8 +43,11 @@ critical value (before the floor) falls \emph{below} the Gaussian --- so under t
 floor it reduces to the analytic interval exactly in the small-\code{N} regime; it
 only ever \emph{widens} the interval when cluster influence is near-homogeneous.
 For a genuine few-clusters correction the restricted bootstrap-t or a CR2-type
-analytic adjustment is required (tracked as future work, #361). Not supported
-for \code{indep_counts} (two-sample) fits.}
+analytic adjustment is required (tracked as future work, #361). Supported for
+both single-sample and \code{indep_counts} (two-sample) fits: for a two-sample fit
+the cohort-weight channel is perturbed on its own independent multiplier stream
+over the \code{N} count-sample units (\code{sum(indep_counts) == N} is enforced), yielding
+the two-sample propensity variance.}
 
 \item{B}{Integer; the number of wild-bootstrap replicates (default \code{1000}).
 Ignored unless \code{method = "bootstrap"}.}

--- a/man/simultaneousCIs.Rd
+++ b/man/simultaneousCIs.Rd
@@ -16,7 +16,8 @@ simultaneousCIs(
   multiplier = c("rademacher", "mammen", "webb"),
   lambda_c = 1,
   riesz_max_iter = 5000L,
-  riesz_tol = 1e-09
+  riesz_tol = 1e-09,
+  cv_time_budget = Inf
 )
 }
 \arguments{
@@ -124,6 +125,15 @@ are unreliable).} Ignored when \code{p < NT} or \code{method = "analytic"}. The 
 stays the fixed \code{1.0}; the family-wise coverage validated in Faletto (2025)
 used the \code{"cv"} selector (\code{lambda_c} ~ 0.54, feasibility 1.0), the same
 constant that serves the scalar \code{debiasedATT()} and every band effect.}
+
+\item{cv_time_budget}{Numeric; a wall-clock backstop (in seconds) for the
+\code{lambda_c = "cv"} cross-validation (the same #384 backstop \code{debiasedATT()}
+offers). \code{Inf} (the default) leaves selection fully deterministic /
+reproducible; a finite value stops the CV early and falls back to the theory
+scale (\code{lambda_c = 1.0}) with a warning, so an adversarial high-dimensional
+draw cannot spin indefinitely (#384). Whether a finite budget fires depends
+on machine speed, so the result can too. Ignored unless \code{lambda_c = "cv"} and
+\code{p >= NT}.}
 }
 \value{
 An object of S3 class \code{"simultaneous_cis"}: a list with
@@ -156,7 +166,10 @@ the bootstrap band may differ from the analytic homoskedastic band). A
 \code{"high-dimensional"} fit additionally carries per-effect \code{feasibility},
 \code{converged}, and \code{lambda_node} (the nodewise-direction diagnostics), plus
 \code{lambda_c} (the leading constant used) and \code{lambda_c_selection} (\code{"fixed"}
-or \code{"cv"}).
+or \code{"cv"}). When \code{lambda_c = "cv"} it also carries \code{lambda_cv}, the
+cross-validation diagnostics (the grid, the per-grid feasibility flags and CV
+losses, and whether the theory-scale fallback fired), matching
+\code{debiasedATT()}'s \code{lambda_cv}.
 }
 \description{
 Computes simultaneous (family-wise) confidence intervals for a user-

--- a/tests/testthat/test-align-bootstrap-accessors-402.R
+++ b/tests/testthat/test-align-bootstrap-accessors-402.R
@@ -1,0 +1,187 @@
+# Tests for #402: align the two bootstrap accessors' contracts.
+#   Item 1 -- debiasedATT(method = "bootstrap") now supports indep_counts
+#             (two-sample) fits (the scalar gate was lifted; the band already ran
+#             the identical construction). The `debiasedATT` errors-on-indep test
+#             lived in test-debiased-att-wild-bootstrap-360.R and is now inverted
+#             there; the substantive correctness proof lives here.
+#   Item 2  -- simultaneousCIs() gains `cv_time_budget` (the #384 wall-clock
+#             backstop debiasedATT() already offered) and surfaces `$lambda_cv`.
+
+# ---- Fixtures (built once; the fetwfe fits are the expensive part) ---------
+
+# A two-sample fit: fetwfeWithSimulatedData() unconditionally forwards the
+# simulator's indep_counts, so every such fit is two-sample.
+.mk402_two_sample_fit <- function() {
+	cf <- genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = 2, seed = 3)
+	sim <- simulateData(
+		cf,
+		N = 80,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 3
+	)
+	fetwfeWithSimulatedData(sim, q = 0.5, verbose = FALSE)
+}
+
+# A single-sample high-dimensional fit: G=3, T=5, d=22 => full p = 390 > NT = 200
+# at N = 40, so the band takes the desparsified nodewise construction where
+# `lambda_c` / `cv_time_budget` are live (they are inert at p < NT).
+.mk402_highdim_fit <- function() {
+	cf <- genCoefs(G = 3, T = 5, d = 22, density = 0.5, eff_size = 2, seed = 1)
+	dat <- simulateData(
+		cf,
+		N = 40,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 1
+	)
+	dat$indep_counts <- NA
+	fetwfe(
+		pdata = dat$pdata,
+		time_var = dat$time_var,
+		unit_var = dat$unit_var,
+		treatment = dat$treatment,
+		response = dat$response,
+		covs = dat$covs,
+		q = 0.5,
+		verbose = FALSE,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5
+	)
+}
+
+ts_fit_402 <- .mk402_two_sample_fit()
+hd_fit_402 <- .mk402_highdim_fit()
+
+# ---- Item 1: two-sample wild bootstrap ------------------------------------
+
+test_that("debiasedATT(method='bootstrap') runs on two-sample (indep_counts) fits and returns valid two-sample inference (#402)", {
+	expect_true(isTRUE(ts_fit_402$indep_counts_used)) # guard: genuinely two-sample
+
+	alpha <- 0.05
+	# (i) Runs without error -- SUBSTANTIVE, not a smoke test: the internal V2
+	#     influence-function anchor stop()s unless the per-unit two-sample
+	#     propensity IF reproduces the two-sample `var_weight` to 1e-6, so success
+	#     PROVES the two-sample IF decomposition the lifted gate's message wrongly
+	#     claimed was impossible (empirically the anchor matches to ~1e-18).
+	res <- debiasedATT(
+		ts_fit_402,
+		method = "bootstrap",
+		seed = 1,
+		alpha = alpha
+	)
+	expect_s3_class(res, "debiased_att")
+	expect_identical(res$method, "bootstrap")
+
+	# (ii) The studentized bootstrap crit value honours the #363 Gaussian floor and
+	#      drives the interval; `se` is the two-channel two-sample SE.
+	expect_gte(res$crit_value, qnorm(1 - alpha / 2))
+	expect_equal(
+		res$ci_high - res$att,
+		res$crit_value * res$se,
+		tolerance = 1e-8
+	)
+	expect_equal(
+		res$att - res$ci_low,
+		res$crit_value * res$se,
+		tolerance = 1e-8
+	)
+	expect_true(is.finite(res$var_weight) && res$var_weight > 0)
+	expect_equal(res$se, sqrt(res$var_reg + res$var_weight), tolerance = 1e-10)
+
+	# (iii) Floored, so the bootstrap interval is never narrower than analytic Wald.
+	ana <- debiasedATT(ts_fit_402, method = "analytic", alpha = alpha)
+	expect_gte((res$ci_high - res$ci_low) - (ana$ci_high - ana$ci_low), -1e-9)
+
+	# (iv) Defense-in-depth, INDEPENDENT of the production runtime anchor: rebuild
+	#      the per-unit two-sample propensity IF from the fit's public slots (bridge
+	#      catt / att_hat, marginal cohort_probs_overall) and confirm sum(psi2^2)/n^2
+	#      reproduces the two-sample cohort-weight variance the bootstrap uses -- the
+	#      exact `.build_propensity_if()` construction the wild bootstrap runs. So even
+	#      if the internal anchor's tolerance were loosened, an IF mismatch is caught.
+	G <- ts_fit_402$G
+	cpo <- ts_fit_402$cohort_probs_overall
+	S <- sum(cpo[seq_len(G)])
+	a_att_G <- (ts_fit_402$catt_df$estimate - ts_fit_402$att_hat) / S
+	psi2 <- as.numeric(fetwfe:::.build_propensity_if(
+		cohort_probs_overall = cpo,
+		G = G,
+		N = ts_fit_402$N,
+		T = ts_fit_402$T,
+		A = matrix(a_att_G, nrow = G, ncol = 1L)
+	))
+	n <- ts_fit_402$N * ts_fit_402$T
+	expect_equal(sum(psi2^2) / n^2, res$var_weight, tolerance = 1e-6)
+})
+
+# ---- Item 2a: cv_time_budget validation + threading -----------------------
+
+test_that("simultaneousCIs() validates cv_time_budget (#402)", {
+	for (bad in list(-1, 0, NA_real_, c(1, 2), "x")) {
+		expect_error(
+			simultaneousCIs(ts_fit_402, cv_time_budget = bad),
+			"cv_time_budget"
+		)
+	}
+	# The default Inf and any positive number are accepted (validated even on the
+	# analytic path, where the budget is inert -- symmetric with debiasedATT()).
+	expect_s3_class(
+		simultaneousCIs(ts_fit_402, family = "cohort", cv_time_budget = Inf),
+		"simultaneous_cis"
+	)
+})
+
+test_that("cv_time_budget threads from simultaneousCIs() into the band's CV node, and $lambda_cv is surfaced (#402)", {
+	# A vanishing budget leaves the CV fold sweep incomplete -> theory-scale
+	# fallback with a warning. That the warning fires at all PROVES the budget
+	# threaded end-to-end (generic -> method -> impl -> bootstrap -> .cv_lambda_node);
+	# drop any link and no warning fires (mutation-checked).
+	ws <- character(0)
+	sc <- withCallingHandlers(
+		simultaneousCIs(
+			hd_fit_402,
+			family = "event_study",
+			method = "bootstrap",
+			lambda_c = "cv",
+			cv_time_budget = 1e-6,
+			seed = 1
+		),
+		warning = function(w) {
+			ws <<- c(ws, conditionMessage(w))
+			invokeRestart("muffleWarning")
+		}
+	)
+	expect_true(any(grepl("cv_time_budget", ws)))
+	expect_s3_class(sc, "simultaneous_cis")
+	expect_identical(sc$regime, "high-dimensional")
+
+	# Item 2b: with lambda_c = "cv" the band surfaces $lambda_cv (the CV diagnostics),
+	# matching debiasedATT(); the 1e-6 budget fired, so it records that fallback.
+	expect_true("lambda_cv" %in% names(sc))
+	expect_setequal(
+		names(sc$lambda_cv),
+		c(
+			"cv_loss",
+			"feasible",
+			"mult_grid",
+			"fallback",
+			"fallback_reason",
+			"bailed"
+		)
+	)
+	expect_true(isTRUE(sc$lambda_cv$fallback))
+	expect_identical(sc$lambda_cv$fallback_reason, "time")
+})
+
+# ---- Item 2b: $lambda_cv absent when no CV runs ---------------------------
+
+test_that("simultaneousCIs() omits $lambda_cv on a fixed-lambda_c band (#402)", {
+	sc_fixed <- simultaneousCIs(
+		hd_fit_402,
+		family = "event_study",
+		method = "bootstrap",
+		lambda_c = 1.0,
+		seed = 1
+	)
+	expect_false("lambda_cv" %in% names(sc_fixed))
+})

--- a/tests/testthat/test-debiased-att-wild-bootstrap-360.R
+++ b/tests/testthat/test-debiased-att-wild-bootstrap-360.R
@@ -165,9 +165,12 @@ test_that(".draw_multipliers webb has the right support and moments (#360)", {
 	expect_equal(mean(w^2), 1, tolerance = 0.02) # unit variance
 })
 
-test_that("wild bootstrap errors on indep_counts (two-sample) fits (#360)", {
-	# fetwfeWithSimulatedData() uses the simulator's indep_counts, so its fits are
-	# two-sample: the single-sample per-unit V2 IF cannot reproduce var_weight.
+test_that("wild bootstrap now supports indep_counts (two-sample) fits (#402)", {
+	# #360 originally REFUSED the bootstrap on two-sample fits; #402 lifted that
+	# gate after verifying the per-unit two-sample propensity IF reproduces the
+	# two-sample var_weight (the runtime V2 anchor enforces this to 1e-6). The
+	# comprehensive proof (IF reconstruction vs att_var_2) lives in
+	# test-align-bootstrap-accessors-402.R; here we pin that the call now succeeds.
 	cf <- genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = 2, seed = 3)
 	sim <- simulateData(
 		cf,
@@ -180,11 +183,10 @@ test_that("wild bootstrap errors on indep_counts (two-sample) fits (#360)", {
 	expect_true(isTRUE(fit_ic$indep_counts_used))
 	# Analytic still works on indep_counts fits.
 	expect_s3_class(debiasedATT(fit_ic), "debiased_att")
-	# The wild bootstrap refuses, with an actionable message.
-	expect_error(
-		debiasedATT(fit_ic, method = "bootstrap"),
-		"indep_counts"
-	)
+	# The wild bootstrap now runs (previously errored with "indep_counts").
+	res <- debiasedATT(fit_ic, method = "bootstrap", seed = 1)
+	expect_s3_class(res, "debiased_att")
+	expect_identical(res$method, "bootstrap")
 })
 
 test_that("wild bootstrap validates B and seed (#360)", {

--- a/vignettes/high_dimensional_vignette.Rmd
+++ b/vignettes/high_dimensional_vignette.Rmd
@@ -81,12 +81,12 @@ The fused interval under-covers because of the post-selection non-uniformity; th
 **It is not a few-clusters remedy.** The analytic sandwich SE is downward-biased with few clusters, but this bootstrap does not fix that: as an *unrestricted, no-refit* score bootstrap it does not reproduce the tail inflation the *restricted* wild-cluster bootstrap-t uses for few-cluster coverage, and under heterogeneous cluster influence its critical value (before the floor) actually falls *below* the Gaussian --- so the floor reduces it to the analytic interval in exactly the small-`N` regime. Its only effect is to *widen* the interval when cluster influence is near-homogeneous. For genuine few-clusters inference a restricted bootstrap-t or a CR2-type analytic correction is required (future work).
 
 ```{r highdim-wild-boot, eval = FALSE}
-# `fit` must be a single-sample fetwfe() fit -- not an `indep_counts` fit, which
-# the worked example above (via fetwfeWithSimulatedData) happens to be.
+# Works on both single-sample and two-sample (`indep_counts`) fits -- e.g. the
+# fetwfeWithSimulatedData() fit from the worked example above (a two-sample fit).
 debiasedATT(fit, method = "bootstrap", multiplier = "webb", seed = 1)
 ```
 
-The `multiplier` (`"webb"`, the default; `"rademacher"`; or `"mammen"`) only affects the near-homogeneous case where the bootstrap widens above the floor --- in the small-`N` / heterogeneous regime the interval is the analytic one regardless of the weight. The bootstrap is defined only for **single-sample** fits (real observational panels are single-sample), not `indep_counts` two-sample fits.
+The `multiplier` (`"webb"`, the default; `"rademacher"`; or `"mammen"`) only affects the near-homogeneous case where the bootstrap widens above the floor --- in the small-`N` / heterogeneous regime the interval is the analytic one regardless of the weight. The bootstrap supports both single-sample fits (real observational panels are single-sample) and `indep_counts` two-sample fits (the cohort-weight channel is perturbed on its own independent multiplier stream over the reconstructed count-sample units).
 
 ## Simultaneous bands at $p \geq NT$
 


### PR DESCRIPTION

Resolves the two `[Design]` contract asymmetries between `debiasedATT()` (scalar) and `simultaneousCIs()` (band) surfaced in the 2026-07-18 review. The numerics on both paths were already verified correct; this PR removes the inconsistencies, it does not change any correct number. Item 1's direction (lift vs. entrench the gate) was decided by the maintainer.

**Item 1 — `debiasedATT(method = "bootstrap")` now supports `indep_counts` (two-sample) fits.** The scalar accessor hard-errored on two-sample fits while `simultaneousCIs(method = "bootstrap", family = "event_study")` ran the *identical* construction on them silently and correctly. Both call the same `.build_propensity_if()` with their own independent propensity-multiplier stream, and `sum(indep_counts) == N` is enforced, so `round(N * pi_hat)` recovers the cohort counts exactly — the per-unit two-sample IF decomposition the gate's message claimed was impossible is in fact exact (the band's SEs matched the analytic two-sample band to 6.7e-16; the scalar's runtime V2 anchor matches to ~1e-18). Lifting the gate keeps that runtime anchor as the safety net; the default analytic SE is unchanged.

**Item 2 — `simultaneousCIs()` gains `cv_time_budget` (default `Inf`) and surfaces `$lambda_cv`.** The #384 wall-clock backstop `debiasedATT()` already offered was unreachable from the band path (`.cv_lambda_node()` was always called with `budget = Inf`). The argument is now threaded through the generic, all four S3 methods, `.simultaneous_cis_impl` (with the same validation `debiasedATT()` uses), and `.simultaneous_cis_bootstrap` into `.cv_lambda_node()`. Under `lambda_c = "cv"` the band also now carries `$lambda_cv` (the CV diagnostics), matching `debiasedATT()`. Both default to inert (`Inf` / `p < NT` = no CV), so every existing result is unchanged.

**Verification.** New `test-align-bootstrap-accessors-402.R` (mutation-checked: restoring the gate makes the item-1 test error; dropping the CV-node thread makes the threading test fail). The item-1 test proves correctness via the runtime anchor (success ⇒ the two-sample IF reproduces `var_weight`), the #363 floor, and the two-channel SE — not a tautological `se`-comparison. The pinning test in `test-debiased-att-wild-bootstrap-360.R` is inverted, and two now-false statements in `high_dimensional_vignette.Rmd` are reworded. `devtools::test()` FAIL 0 / WARN 0 / PASS 4458; `check --as-cran` clean (modulo the benign timestamp NOTE); spell clean; url 24/24. Patch bump to 1.56.17.

Closes #402.
