### PR TITLE
refactor: single-source the Gram-inverse + cluster-sandwich scaffold into .recompute_gram_and_sandwich() (Phase 2a of #400)

### DIFF
--- a/R/cohort_time_atts.R
+++ b/R/cohort_time_atts.R
@@ -233,41 +233,30 @@ cohortTimeATTs <- function(result, alpha = NULL) {
 		sel_treat_inds_shifted <- seq_len(num_treats)
 	}
 
-	# ---- Recompute the Gram inverse on the selected support ---------------
+	# ---- Recompute the Gram inverse (+ cluster sandwich) on the selected support;
+	#      single-sourced across the accessors (#400) -----------------------
 	calc_ses <- contract$has_valid_ses
 	gram_inv <- NULL
-	if (calc_ses && length(sel_treat_inds_shifted) > 0) {
-		res_gram <- getGramInv(
-			N = N,
-			T = T,
-			X_final = X_final,
-			sel_feat_inds = sel_feat_inds,
-			treat_inds = treat_inds,
-			num_treats = num_treats,
-			sel_treat_inds_shifted = sel_treat_inds_shifted,
-			calc_ses = TRUE
-		)
-		gram_inv <- res_gram$gram_inv
-		calc_ses <- res_gram$calc_ses
-	} else {
-		calc_ses <- FALSE
-	}
-
-	# ---- Optional cluster-robust sandwich ---------------------------------
 	sandwich_full <- NULL
 	treat_block_mask <- NULL
-	if (identical(se_type, "cluster") && calc_ses) {
-		sel_arg <- if (any(!is.na(sel_feat_inds))) sel_feat_inds else NULL
-		res <- .assemble_cluster_robust_sandwich(
+	if (calc_ses && length(sel_treat_inds_shifted) > 0) {
+		gs <- .recompute_gram_and_sandwich(
 			X_final = X_final,
 			y_final = y_final,
 			N = N,
 			T = T,
 			treat_inds = treat_inds,
-			sel_feat_inds = sel_arg
+			num_treats = num_treats,
+			sel_feat_inds = sel_feat_inds,
+			sel_treat_inds_shifted = sel_treat_inds_shifted,
+			se_type = se_type
 		)
-		sandwich_full <- res$sandwich_full
-		treat_block_mask <- res$treat_block_mask
+		gram_inv <- gs$gram_inv
+		calc_ses <- gs$calc_ses
+		sandwich_full <- gs$sandwich_full
+		treat_block_mask <- gs$treat_block_mask
+	} else {
+		calc_ses <- FALSE
 	}
 
 	# ---- Per-cell enumeration ---------------------------------------------

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -300,40 +300,30 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 		sel_treat_inds_shifted <- which(beta_hat[treat_inds] != 0)
 	}
 
+	# Recompute the Gram inverse (+ cluster sandwich if se_type = "cluster") on the
+	# selected support; single-sourced across the accessors (#400).
 	calc_ses <- contract$has_valid_ses
 	gram_inv <- NULL
-	if (calc_ses && length(sel_treat_inds_shifted) > 0) {
-		res_gram <- getGramInv(
-			N = N,
-			T = T,
-			X_final = X_final,
-			sel_feat_inds = sel_feat_inds,
-			treat_inds = treat_inds,
-			num_treats = num_treats,
-			sel_treat_inds_shifted = sel_treat_inds_shifted,
-			calc_ses = TRUE
-		)
-		gram_inv <- res_gram$gram_inv
-		calc_ses <- res_gram$calc_ses
-	} else {
-		calc_ses <- FALSE
-	}
-
-	# Cluster-robust sandwich (recomputed from existing slots)
 	sandwich_full <- NULL
 	treat_block_mask <- NULL
-	if (identical(se_type, "cluster") && calc_ses) {
-		sel_arg <- if (any(!is.na(sel_feat_inds))) sel_feat_inds else NULL
-		res <- .assemble_cluster_robust_sandwich(
+	if (calc_ses && length(sel_treat_inds_shifted) > 0) {
+		gs <- .recompute_gram_and_sandwich(
 			X_final = X_final,
 			y_final = y_final,
 			N = N,
 			T = T,
 			treat_inds = treat_inds,
-			sel_feat_inds = sel_arg
+			num_treats = num_treats,
+			sel_feat_inds = sel_feat_inds,
+			sel_treat_inds_shifted = sel_treat_inds_shifted,
+			se_type = se_type
 		)
-		sandwich_full <- res$sandwich_full
-		treat_block_mask <- res$treat_block_mask
+		gram_inv <- gs$gram_inv
+		calc_ses <- gs$calc_ses
+		sandwich_full <- gs$sandwich_full
+		treat_block_mask <- gs$treat_block_mask
+	} else {
+		calc_ses <- FALSE
 	}
 
 	max_event <- T - 2L
@@ -554,39 +544,30 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 		d_inv_treat_sel <- NULL
 	}
 
+	# Recompute the Gram inverse (+ cluster sandwich if se_type = "cluster") on the
+	# selected support; single-sourced across the accessors (#400).
 	calc_ses <- contract$has_valid_ses
 	gram_inv <- NULL
-	if (calc_ses && length(sel_treat_inds_shifted) > 0) {
-		res_gram <- getGramInv(
-			N = N,
-			T = T,
-			X_final = X_final,
-			sel_feat_inds = sel_feat_inds,
-			treat_inds = treat_inds,
-			num_treats = num_treats,
-			sel_treat_inds_shifted = sel_treat_inds_shifted,
-			calc_ses = TRUE
-		)
-		gram_inv <- res_gram$gram_inv
-		calc_ses <- res_gram$calc_ses
-	} else {
-		calc_ses <- FALSE
-	}
-
-	# Cluster-robust sandwich (recomputed in theta-space on the selected support)
 	sandwich_full <- NULL
 	treat_block_mask <- NULL
-	if (identical(se_type, "cluster") && calc_ses) {
-		res <- .assemble_cluster_robust_sandwich(
+	if (calc_ses && length(sel_treat_inds_shifted) > 0) {
+		gs <- .recompute_gram_and_sandwich(
 			X_final = X_final,
 			y_final = y_final,
 			N = N,
 			T = T,
 			treat_inds = treat_inds,
-			sel_feat_inds = sel_feat_inds
+			num_treats = num_treats,
+			sel_feat_inds = sel_feat_inds,
+			sel_treat_inds_shifted = sel_treat_inds_shifted,
+			se_type = se_type
 		)
-		sandwich_full <- res$sandwich_full
-		treat_block_mask <- res$treat_block_mask
+		gram_inv <- gs$gram_inv
+		calc_ses <- gs$calc_ses
+		sandwich_full <- gs$sandwich_full
+		treat_block_mask <- gs$treat_block_mask
+	} else {
+		calc_ses <- FALSE
 	}
 
 	max_event <- T - 2L

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -921,47 +921,31 @@ simultaneousCIs.twfeCovs <- function(
 
 	# --- 9. (analytic only) getGramInv() + (if cluster) the cluster-robust
 	#        sandwich, reusing the eventStudy machinery. ---
-	gram_sel_feat <- if (any(!is.na(sel_feat_inds))) sel_feat_inds else NA
-	gram_sel_treat <- if (any(!is.na(sel_feat_inds))) {
-		sel_treat_inds_shifted
-	} else {
-		NA
-	}
-	res_gram <- getGramInv(
+	# Single-sourced across the accessors (#400). simultaneousCIs STOPs on a
+	# singular selected-support Gram (the event-study / cohort-time accessors
+	# degrade to NA instead) -- the one genuine policy difference, carried by
+	# `on_singular`. The NA/`sel_treat_inds_shifted` sentinel mapping the inline
+	# form used only gated optional `stopifnot`s in getGramInv, never `gram_inv`.
+	gs <- .recompute_gram_and_sandwich(
+		X_final = X_final,
+		y_final = y_final,
 		N = N,
 		T = T_,
-		X_final = X_final,
-		sel_feat_inds = gram_sel_feat,
 		treat_inds = treat_inds,
 		num_treats = num_treats,
-		sel_treat_inds_shifted = gram_sel_treat,
-		calc_ses = TRUE
-	)
-	gram_inv <- res_gram$gram_inv
-	if (!isTRUE(res_gram$calc_ses)) {
-		stop(
+		sel_feat_inds = sel_feat_inds,
+		sel_treat_inds_shifted = sel_treat_inds_shifted,
+		se_type = se_type,
+		on_singular = "stop",
+		stop_message = paste0(
 			"simultaneousCIs(): the Gram matrix on the selected support is not ",
 			"invertible; the analytic method's assumptions are not satisfied. ",
-			"For a high-dimensional (p >= NT) design, use method = 'bootstrap'.",
-			call. = FALSE
+			"For a high-dimensional (p >= NT) design, use method = 'bootstrap'."
 		)
-	}
-
-	sandwich_full <- NULL
-	treat_block_mask <- NULL
-	if (identical(se_type, "cluster")) {
-		sel_arg <- if (any(!is.na(sel_feat_inds))) sel_feat_inds else NULL
-		res_cl <- .assemble_cluster_robust_sandwich(
-			X_final = X_final,
-			y_final = y_final,
-			N = N,
-			T = T_,
-			treat_inds = treat_inds,
-			sel_feat_inds = sel_arg
-		)
-		sandwich_full <- res_cl$sandwich_full
-		treat_block_mask <- res_cl$treat_block_mask
-	}
+	)
+	gram_inv <- gs$gram_inv
+	sandwich_full <- gs$sandwich_full
+	treat_block_mask <- gs$treat_block_mask
 
 	Sigma_1 <- .assemble_joint_cov_var1(
 		Psi = Psi,

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -478,6 +478,92 @@ getPsiGUnfused <- function(
 }
 
 
+#' @title Recompute the Gram inverse and optional cluster sandwich on a selected
+#'   support
+#' @description Single-sources the "recompute `getGramInv()` on the selected
+#'   support, then (if `se_type = "cluster"`) build the cluster-robust sandwich"
+#'   sequence that every access-time SE path shares (`eventStudy()`,
+#'   `cohortTimeATTs()`, `simultaneousCIs()`). These accessors MUST stay in
+#'   lockstep: a drift here would make them report inconsistent SEs for the same
+#'   fit (guarded by `test-cross-accessor-scaffold-guardrail-400.R`). This wraps
+#'   `getGramInv()` and `.assemble_cluster_robust_sandwich()` UNCHANGED (preserving
+#'   their exact numerics and the "all features" NA/NULL sentinel translation); it
+#'   only unifies the surrounding recompute.
+#'
+#'   The one genuine policy difference between callers is `on_singular`: when the
+#'   recomputed Gram is singular, `eventStudy()` / `cohortTimeATTs()` DEGRADE
+#'   (return `calc_ses = FALSE`, so their SEs become `NA`), whereas
+#'   `simultaneousCIs()` STOPs. That branch is defensive-only -- it is unreachable
+#'   through any public fit (a fit with valid SEs already inverted its Gram on this
+#'   support), so it is exercised only by the helper's direct unit test.
+#' @param X_final,y_final,N,T,treat_inds,num_treats Fit-design pieces, forwarded to
+#'   `getGramInv()` / `.assemble_cluster_robust_sandwich()`.
+#' @param sel_feat_inds Integer indices of the selected features, or the scalar
+#'   `NA` "all features" sentinel `getGramInv()` expects (translated to `NULL` for
+#'   the NULL-native sandwich).
+#' @param sel_treat_inds_shifted Integer indices of the selected treatment
+#'   coefficients within the treatment block.
+#' @param se_type `"cluster"` builds the sandwich; anything else skips it.
+#' @param on_singular `"degrade"` (default) returns `calc_ses = FALSE` on a
+#'   singular Gram; `"stop"` errors with `stop_message`.
+#' @param stop_message The exact error string for `on_singular = "stop"`.
+#' @return A list: `gram_inv`, `calc_ses` (logical), `sandwich_full` (or `NULL`),
+#'   `treat_block_mask` (or `NULL`).
+#' @keywords internal
+#' @noRd
+.recompute_gram_and_sandwich <- function(
+	X_final,
+	y_final,
+	N,
+	T,
+	treat_inds,
+	num_treats,
+	sel_feat_inds,
+	sel_treat_inds_shifted,
+	se_type,
+	on_singular = c("degrade", "stop"),
+	stop_message = NULL
+) {
+	on_singular <- match.arg(on_singular)
+	res_gram <- getGramInv(
+		N = N,
+		T = T,
+		X_final = X_final,
+		sel_feat_inds = sel_feat_inds,
+		treat_inds = treat_inds,
+		num_treats = num_treats,
+		sel_treat_inds_shifted = sel_treat_inds_shifted,
+		calc_ses = TRUE
+	)
+	gram_inv <- res_gram$gram_inv
+	calc_ses <- res_gram$calc_ses
+	if (!isTRUE(calc_ses) && on_singular == "stop") {
+		stop(stop_message, call. = FALSE)
+	}
+	sandwich_full <- NULL
+	treat_block_mask <- NULL
+	if (identical(se_type, "cluster") && isTRUE(calc_ses)) {
+		sel_arg <- if (any(!is.na(sel_feat_inds))) sel_feat_inds else NULL
+		res_cl <- .assemble_cluster_robust_sandwich(
+			X_final = X_final,
+			y_final = y_final,
+			N = N,
+			T = T,
+			treat_inds = treat_inds,
+			sel_feat_inds = sel_arg
+		)
+		sandwich_full <- res_cl$sandwich_full
+		treat_block_mask <- res_cl$treat_block_mask
+	}
+	list(
+		gram_inv = gram_inv,
+		calc_ses = calc_ses,
+		sandwich_full = sandwich_full,
+		treat_block_mask = treat_block_mask
+	)
+}
+
+
 # getTeResults2
 #' @title Calculate Overall ATT and its Standard Error (Version 2)
 #' @description Computes the overall Average Treatment Effect on the Treated

--- a/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
+++ b/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
@@ -1,0 +1,175 @@
+# Cross-accessor byte-identity guardrail for the shared access-time inference
+# scaffold (#400, Phase 1 -- the blocking prerequisite for the refactor).
+#
+# The "resolve selected support -> recompute Gram inverse -> cluster sandwich"
+# sequence is duplicated across eventStudy(), cohortTimeATTs(), and
+# simultaneousCIs() (R/event_study.R, R/cohort_time_atts.R, R/simultaneous_cis.R).
+# If any copy drifts, the accessors silently report INCONSISTENT SEs for the same
+# fit. This file pins the three cross-accessor SE/estimate anchors AND literal
+# pre-refactor values on a shared fit so the Phase 2 single-sourcing refactor must
+# reproduce byte-identical results. There was no unified cross-accessor fixture
+# before this (only pairwise checks in test-cohort_time_atts.R / test-simultaneous-cis.R).
+#
+# simultaneousCIs() exposes no `se` column; the pointwise SE is recovered from the
+# pointwise CI half-width. That recovery is algebraically alpha-invariant, so the
+# `alpha = fit$alpha` passed below is defensive (matches the fit), not load-bearing.
+
+.g400_dat <- local({
+	cf <- genCoefs(G = 4, T = 6, d = 2, density = 0.5, eff_size = 2, seed = 101)
+	simulateData(cf, N = 160, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 101)
+})
+
+# fetwfe (partial selection, 7/14 cells) + etwfe (no selection) + betwfe (13/14),
+# each at se_type default and cluster -> exercises the NA-sentinel, partial-support,
+# and cluster-sandwich branches of the scaffold. Built once at collection time.
+.g400_fits <- list(
+	"fetwfe/default" = fetwfeWithSimulatedData(
+		.g400_dat,
+		q = 0.5,
+		se_type = "default",
+		verbose = FALSE
+	),
+	"etwfe/default" = etwfeWithSimulatedData(
+		.g400_dat,
+		se_type = "default",
+		verbose = FALSE
+	),
+	"betwfe/default" = betwfeWithSimulatedData(
+		.g400_dat,
+		se_type = "default",
+		verbose = FALSE
+	),
+	"fetwfe/cluster" = fetwfeWithSimulatedData(
+		.g400_dat,
+		q = 0.5,
+		se_type = "cluster",
+		verbose = FALSE
+	),
+	"etwfe/cluster" = etwfeWithSimulatedData(
+		.g400_dat,
+		se_type = "cluster",
+		verbose = FALSE
+	),
+	"betwfe/cluster" = betwfeWithSimulatedData(
+		.g400_dat,
+		se_type = "cluster",
+		verbose = FALSE
+	)
+)
+
+# q = 1 -> has_valid_ses = FALSE: the reachable SE-unavailable path.
+.g400_fit_q1 <- fetwfeWithSimulatedData(.g400_dat, q = 1, verbose = FALSE)
+
+.g400_se_of_sci <- function(sci) {
+	(sci$ci$pointwise_ci_high - sci$ci$estimate) / sci$pointwise_critical_value
+}
+
+# --- Part 1: cross-accessor equality (the first-class regression guard) --------
+
+.g400_expect_anchors <- function(fit, label) {
+	a <- fit$alpha
+
+	# Anchor A -- per-(g, t) cell: cohortTimeATTs row <-> all_post_treatment effect.
+	# Estimates are the identical contrast (both `tes[idx]`), so exact.
+	cta <- cohortTimeATTs(fit)
+	ap <- simultaneousCIs(fit, family = "all_post_treatment", alpha = a)
+	expect_equal(
+		cta$estimate,
+		ap$ci$estimate,
+		tolerance = 1e-12,
+		info = paste(label, "Anchor A estimate")
+	)
+	expect_lt(max(abs(cta$se - .g400_se_of_sci(ap))), 1e-12)
+
+	# Anchor B -- per-event-time: eventStudy <-> event_study. Compare finite rows
+	# only (degenerate event times are NA in eventStudy).
+	es <- eventStudy(fit)
+	esr <- simultaneousCIs(fit, family = "event_study", alpha = a)
+	fin <- is.finite(es$se)
+	expect_true(any(fin), info = paste(label, "has a finite event-time SE"))
+	expect_equal(
+		es$estimate[fin],
+		esr$ci$estimate[fin],
+		tolerance = 1e-12,
+		info = paste(label, "Anchor B estimate")
+	)
+	expect_lt(max(abs(es$se[fin] - .g400_se_of_sci(esr)[fin])), 1e-12)
+
+	# Anchor C -- per-cohort: cohortStudy (the fit-time scaffold) <-> cohort family.
+	# The etwfe estimate side carries ~1e-15 mean-of-block rounding -> tolerance.
+	cs <- cohortStudy(fit)
+	co <- simultaneousCIs(fit, family = "cohort", alpha = a)
+	expect_equal(
+		cs$estimate,
+		co$ci$estimate,
+		tolerance = 1e-9,
+		info = paste(label, "Anchor C estimate")
+	)
+	expect_lt(max(abs(cs$se - .g400_se_of_sci(co))), 1e-12)
+}
+
+test_that("the shared scaffold yields cross-accessor-consistent SEs across classes and se_types (#400 guardrail)", {
+	for (label in names(.g400_fits)) {
+		.g400_expect_anchors(.g400_fits[[label]], label)
+	}
+})
+
+# --- Part 2: pre-refactor snapshot (the "AND to pre-refactor values" half) ------
+
+test_that("scaffold SEs match pinned pre-refactor values on the fetwfe/default fixture (#400 guardrail)", {
+	fit <- .g400_fits[["fetwfe/default"]]
+	expect_equal(
+		eventStudy(fit)$se,
+		c(0.1432551, 0.2040083, 0.2363452, 0.2494955, 0.2219078),
+		tolerance = 1e-6
+	)
+	expect_equal(
+		cohortStudy(fit)$se,
+		c(0.1738941, 0.1479012, 0.1596468, 0.1438447),
+		tolerance = 1e-6
+	)
+	expect_equal(
+		cohortTimeATTs(fit)$se,
+		c(
+			0.1817540,
+			0.1817540,
+			0.1817540,
+			0.2219078,
+			0.2219078,
+			0.1352874,
+			0.1840652,
+			0.1840652,
+			0.2448657,
+			0.1352874,
+			0.2071185,
+			0.2071185,
+			0.1352874,
+			0.2214705
+		),
+		tolerance = 1e-6
+	)
+})
+
+# --- Part 3: SE-unavailable fits degrade consistently ---------------------------
+
+test_that("an SE-unavailable fit degrades consistently: accessors -> NA, simultaneousCIs -> stop (#400 guardrail)", {
+	fq <- .g400_fit_q1
+	expect_false(isTRUE(fq$internal$calc_ses)) # guard: genuinely has_valid_ses = FALSE
+
+	es_se <- eventStudy(fq)$se
+	expect_true(length(es_se) > 0 && all(is.na(es_se)))
+	cta_se <- cohortTimeATTs(fq)$se
+	expect_true(length(cta_se) > 0 && all(is.na(cta_se)))
+
+	expect_error(simultaneousCIs(fq, family = "event_study"), "calc_ses")
+	expect_error(simultaneousCIs(fq, family = "all_post_treatment"), "calc_ses")
+
+	# NB: the *shared-scaffold* singular-Gram branch (recomputed selected-support
+	# Gram singular -> res_gram$calc_ses = FALSE; the two accessors degrade to NA
+	# while simultaneousCIs STOPs "not invertible") is defensive-only and
+	# UNREACHABLE through any public fit -- has_valid_ses = TRUE already implies the
+	# fit's own getGramInv() on that support succeeded. Phase 2 guards that
+	# on_singular = c("degrade", "stop") policy with a direct unit test of the
+	# extracted helper (feeding it a rank-deficient support), which is the only
+	# place the asymmetry can be exercised.
+})

--- a/tests/testthat/test-recompute-gram-sandwich-400.R
+++ b/tests/testthat/test-recompute-gram-sandwich-400.R
@@ -1,0 +1,89 @@
+# Direct unit test for the extracted scaffold helper .recompute_gram_and_sandwich()
+# (#400 Phase 2a). Its one genuine policy axis -- `on_singular` (degrade vs stop
+# on a singular recomputed Gram) -- is DEFENSIVE-ONLY and unreachable through any
+# public fit (a fit with valid SEs already inverted its Gram on this support; see
+# the note in test-cross-accessor-scaffold-guardrail-400.R). So the asymmetry can
+# only be exercised here, by feeding the helper a rank-deficient selected support.
+
+test_that(".recompute_gram_and_sandwich() degrades vs stops on a singular selected-support Gram (#400)", {
+	# Rank-deficient support: feature columns 1 and 2 are identical, so the centered
+	# Gram on the selected support {1,2,3} is singular (getGramInv's eigenvalue guard
+	# fires and warns).
+	N <- 4L
+	T <- 2L
+	n <- N * T
+	x1 <- as.double(seq_len(n))
+	X_sing <- cbind(x1, x1, rep(c(1, 0), n / 2))
+	y_final <- rep(0, n)
+	treat_inds <- c(1L, 2L)
+	num_treats <- 2L
+	sel_feat_inds <- c(1L, 2L, 3L)
+	sel_treat_inds_shifted <- c(1L, 2L)
+
+	# on_singular = "degrade" -> calc_ses = FALSE, no sandwich, no error.
+	gs <- suppressWarnings(fetwfe:::.recompute_gram_and_sandwich(
+		X_final = X_sing,
+		y_final = y_final,
+		N = N,
+		T = T,
+		treat_inds = treat_inds,
+		num_treats = num_treats,
+		sel_feat_inds = sel_feat_inds,
+		sel_treat_inds_shifted = sel_treat_inds_shifted,
+		se_type = "cluster",
+		on_singular = "degrade"
+	))
+	expect_false(isTRUE(gs$calc_ses))
+	expect_null(gs$sandwich_full)
+	expect_null(gs$treat_block_mask)
+
+	# on_singular = "stop" -> errors with EXACTLY the stop_message it is given
+	# (pins the helper's verbatim propagation). NB: the live call-site literal in
+	# .simultaneous_cis_impl() is a SEPARATE copy of this string, kept byte-identical
+	# by hand -- that singular-Gram path is unreachable through any public fit, so no
+	# integration test exercises it; edit one copy, edit both.
+	msg <- paste0(
+		"simultaneousCIs(): the Gram matrix on the selected support is not ",
+		"invertible; the analytic method's assumptions are not satisfied. ",
+		"For a high-dimensional (p >= NT) design, use method = 'bootstrap'."
+	)
+	err <- tryCatch(
+		suppressWarnings(fetwfe:::.recompute_gram_and_sandwich(
+			X_final = X_sing,
+			y_final = y_final,
+			N = N,
+			T = T,
+			treat_inds = treat_inds,
+			num_treats = num_treats,
+			sel_feat_inds = sel_feat_inds,
+			sel_treat_inds_shifted = sel_treat_inds_shifted,
+			se_type = "default",
+			on_singular = "stop",
+			stop_message = msg
+		)),
+		error = function(e) conditionMessage(e)
+	)
+	expect_identical(err, msg)
+
+	# Sanity: a well-conditioned support returns calc_ses = TRUE + a real gram_inv,
+	# and (cluster) a sandwich + mask -- so the degrade above is genuinely the
+	# singular branch, not a helper that always fails.
+	X_ok <- cbind(x1, x1^2, rep(c(1, 0), n / 2))
+	gs_ok <- fetwfe:::.recompute_gram_and_sandwich(
+		X_final = X_ok,
+		y_final = as.double(seq_len(n)),
+		N = N,
+		T = T,
+		treat_inds = treat_inds,
+		num_treats = num_treats,
+		sel_feat_inds = sel_feat_inds,
+		sel_treat_inds_shifted = sel_treat_inds_shifted,
+		se_type = "cluster",
+		on_singular = "stop",
+		stop_message = msg
+	)
+	expect_true(isTRUE(gs_ok$calc_ses))
+	expect_true(is.matrix(gs_ok$gram_inv))
+	expect_false(is.null(gs_ok$sandwich_full))
+	expect_length(gs_ok$treat_block_mask, length(sel_feat_inds))
+})


### PR DESCRIPTION

**Phase 2a of #400**, stacked on the Phase 1 guardrail (#412 — base branch). Single-sources the lockstep-critical "recompute the Gram inverse on the selected support → (if `se_type = "cluster"`) build the cluster-robust sandwich" block that was duplicated across the three access-time SE paths. **Byte-identical user-facing behavior** — no version bump.

**What moved.** New internal `.recompute_gram_and_sandwich()` (wraps `getGramInv()` + `.assemble_cluster_robust_sandwich()` unchanged) replaces the ~28-line inline block at four sites: `.event_study_etwfe_betwfe()`, `.event_study_fetwfe()`, `cohortTimeATTs()`, and `.simultaneous_cis_impl()`. The Gram block was byte-identical across the first three; `simultaneousCIs()` differed only by **policy** — it *stops* on a singular selected-support Gram where the others *degrade* to NA SEs. That one real difference is now the `on_singular = c("degrade", "stop")` argument; everything else (the NA↔NULL "all features" sentinel translation, the cluster guard, `T`) is unified. The fit-time original `getCohortATTsFinal()` and the support-resolution dispatch are intentionally out of scope (Phase 2b/2c).

**Byte-identity is proven, not assumed:**
- The #412 cross-accessor guardrail stays 50/50 green.
- A git-worktree **pre-vs-post `identical()` battery**: whole-object `identical()` is TRUE across 7 fixtures (fetwfe/etwfe/betwfe × default/cluster + the `q=1` degrade) × every deterministic accessor output (`eventStudy`, `cohortTimeATTs`, `cohortStudy`, and `simultaneousCIs` pointwise for all three families). Every observable is unchanged.
- The plan-review confirmed the one non-obvious equivalence — dropping `simultaneousCIs()`'s `gram_sel_treat <- NA` sentinel mapping is safe because `sel_treat_inds_shifted` only feeds optional `stopifnot`s inside `getGramInv()`, never `gram_inv` (verified statically and on real etwfe/twfeCovs fits).

**New unit test** (`test-recompute-gram-sandwich-400.R`): the `on_singular` degrade-vs-stop asymmetry is *defensive-only and unreachable through any public fit* (a fit with valid SEs already inverted its Gram on this support), so it can only be exercised by feeding the helper a rank-deficient support directly — which this test does, pinning the degrade path, the stop path (byte-equal to the `simultaneousCIs()` message), and a well-conditioned sanity case. Mutation-checked (disabling the stop makes it fail).

`devtools::test()` FAIL 0 / WARN 0; `check --as-cran` clean (modulo the benign timestamp NOTE); spell/url clean. No `man/`/NAMESPACE change (helper is `@noRd`).

Refs #400.
