### PR TITLE
refactor: single-source the selected-support class dispatch into .resolve_selected_support() (Phase 2b of #400)

### DIFF
--- a/R/cohort_time_atts.R
+++ b/R/cohort_time_atts.R
@@ -233,41 +233,30 @@ cohortTimeATTs <- function(result, alpha = NULL) {
 		sel_treat_inds_shifted <- seq_len(num_treats)
 	}
 
-	# ---- Recompute the Gram inverse on the selected support ---------------
+	# ---- Recompute the Gram inverse (+ cluster sandwich) on the selected support;
+	#      single-sourced across the accessors (#400) -----------------------
 	calc_ses <- contract$has_valid_ses
 	gram_inv <- NULL
-	if (calc_ses && length(sel_treat_inds_shifted) > 0) {
-		res_gram <- getGramInv(
-			N = N,
-			T = T,
-			X_final = X_final,
-			sel_feat_inds = sel_feat_inds,
-			treat_inds = treat_inds,
-			num_treats = num_treats,
-			sel_treat_inds_shifted = sel_treat_inds_shifted,
-			calc_ses = TRUE
-		)
-		gram_inv <- res_gram$gram_inv
-		calc_ses <- res_gram$calc_ses
-	} else {
-		calc_ses <- FALSE
-	}
-
-	# ---- Optional cluster-robust sandwich ---------------------------------
 	sandwich_full <- NULL
 	treat_block_mask <- NULL
-	if (identical(se_type, "cluster") && calc_ses) {
-		sel_arg <- if (any(!is.na(sel_feat_inds))) sel_feat_inds else NULL
-		res <- .assemble_cluster_robust_sandwich(
+	if (calc_ses && length(sel_treat_inds_shifted) > 0) {
+		gs <- .recompute_gram_and_sandwich(
 			X_final = X_final,
 			y_final = y_final,
 			N = N,
 			T = T,
 			treat_inds = treat_inds,
-			sel_feat_inds = sel_arg
+			num_treats = num_treats,
+			sel_feat_inds = sel_feat_inds,
+			sel_treat_inds_shifted = sel_treat_inds_shifted,
+			se_type = se_type
 		)
-		sandwich_full <- res$sandwich_full
-		treat_block_mask <- res$treat_block_mask
+		gram_inv <- gs$gram_inv
+		calc_ses <- gs$calc_ses
+		sandwich_full <- gs$sandwich_full
+		treat_block_mask <- gs$treat_block_mask
+	} else {
+		calc_ses <- FALSE
 	}
 
 	# ---- Per-cell enumeration ---------------------------------------------

--- a/R/cohort_time_atts.R
+++ b/R/cohort_time_atts.R
@@ -193,45 +193,23 @@ cohortTimeATTs <- function(result, alpha = NULL) {
 	# `selected` column (mirrors getCohortATTsFinal()'s include_selected).
 	do_selected <- is_fetwfe || is_betwfe
 
-	# For FETWFE the per-cell psi lives in the transformed (theta) coordinate
-	# space, mapped through the treatment block of the inverse fusion transform
-	# D^{-1}. For the OLS-family and BETWFE it is a unit selector in the
-	# original (beta) coordinate space.
-	d_inv_treat_sel <- NULL
-	if (is_fetwfe) {
-		X_final <- x$internal$X_final
-		y_final <- x$internal$y_final
-		p <- x$p
-		theta_hat_slopes <- x$internal$theta_hat[2:(p + 1)]
-		sel_feat_inds <- which(theta_hat_slopes != 0)
-		sel_treat_inds_shifted <- which(theta_hat_slopes[treat_inds] != 0)
-		# Treatment block of D^{-1}, threading any user-supplied fusion matrix
-		# (#236) so this accessor uses the SAME transform as the fit.
-		d_inv_treat <- .gen_inv_treat_block(
-			num_treats = num_treats,
-			first_inds = first_inds,
-			G = G,
-			fusion_structure = x$fusion_structure,
-			d_inv_treat = x$internal$d_inv_treat
-		)
-		if (length(sel_treat_inds_shifted) > 0) {
-			d_inv_treat_sel <- d_inv_treat[,
-				sel_treat_inds_shifted,
-				drop = FALSE
-			]
-		}
-	} else if (is_betwfe) {
-		X_final <- x$X_final
-		y_final <- x$y_final
-		sel_feat_inds <- which(beta_hat != 0)
-		sel_treat_inds_shifted <- which(beta_hat[treat_inds] != 0)
-	} else {
-		# etwfe: unpenalized OLS, no selection.
-		X_final <- x$X_final
-		y_final <- x$y_final
-		sel_feat_inds <- NA
-		sel_treat_inds_shifted <- seq_len(num_treats)
-	}
+	# X_final / y_final live on x$internal for FETWFE, on x$ for the OLS family.
+	X_final <- if (is_fetwfe) x$internal$X_final else x$X_final
+	y_final <- if (is_fetwfe) x$internal$y_final else x$y_final
+	# Selected support + treatment-block map, single-sourced across accessors
+	# (#400). cohortTimeATTs indexes per cell, so it ignores theta_sel.
+	sup <- .resolve_selected_support(
+		x,
+		treat_inds = treat_inds,
+		num_treats = num_treats,
+		first_inds = first_inds,
+		G = G,
+		beta_hat = beta_hat,
+		tes = tes
+	)
+	sel_feat_inds <- sup$sel_feat_inds
+	sel_treat_inds_shifted <- sup$sel_treat_inds_shifted
+	d_inv_treat_sel <- sup$d_inv_treat_sel
 
 	# ---- Recompute the Gram inverse (+ cluster sandwich) on the selected support;
 	#      single-sourced across the accessors (#400) -----------------------

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -290,15 +290,18 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 	first_inds <- offs$first_inds
 	tes <- beta_hat[treat_inds]
 
-	# Determine the selected support
-	if (inherits(x, "etwfe")) {
-		sel_feat_inds <- NA
-		sel_treat_inds_shifted <- seq_len(num_treats)
-	} else {
-		# betwfe: selection is in beta-space
-		sel_feat_inds <- which(beta_hat != 0)
-		sel_treat_inds_shifted <- which(beta_hat[treat_inds] != 0)
-	}
+	# Determine the selected support (single-sourced across accessors, #400).
+	sup <- .resolve_selected_support(
+		x,
+		treat_inds = treat_inds,
+		num_treats = num_treats,
+		first_inds = first_inds,
+		G = G,
+		beta_hat = beta_hat,
+		tes = tes
+	)
+	sel_feat_inds <- sup$sel_feat_inds
+	sel_treat_inds_shifted <- sup$sel_treat_inds_shifted
 
 	# Recompute the Gram inverse (+ cluster sandwich if se_type = "cluster") on the
 	# selected support; single-sourced across the accessors (#400).
@@ -500,12 +503,10 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 	N <- x$N
 	T <- x$T
 	G <- x$G
-	p <- x$p
 	sig_eps_sq <- x$sig_eps_sq
 	cohort_probs_overall <- x$cohort_probs_overall
 	X_final <- x$internal$X_final
 	y_final <- x$internal$y_final
-	theta_hat_full <- x$internal$theta_hat
 	se_type <- if (is.null(x$se_type)) "default" else x$se_type
 	is_indep <- isTRUE(x$indep_counts_used)
 	# v1.13.3 (#174): offset resolution lives in the shared helper
@@ -517,32 +518,20 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 	first_inds <- offs$first_inds
 	tes <- beta_hat[treat_inds]
 
-	# Selected support in theta-space (slopes only; drop intercept)
-	theta_hat_slopes <- theta_hat_full[2:(p + 1)]
-	sel_feat_inds <- which(theta_hat_slopes != 0)
-	sel_treat_inds_shifted <- which(theta_hat_slopes[treat_inds] != 0)
-	theta_hat_treat_sel <- theta_hat_slopes[treat_inds][sel_treat_inds_shifted]
-
-	# d_inv_treat: the treatment-block of D^{-1}, then restrict columns to selected.
-	# A user-supplied custom fusion matrix (#236), if any, is stored inverted on
-	# `x$internal$d_inv_treat`; pass it through so this accessor uses the SAME
-	# transform as the fit (otherwise it would fall back to the built-in dispatch
-	# and silently disagree with the fitted effects).
-	d_inv_treat <- .gen_inv_treat_block(
+	# Selected support + treatment-block map, single-sourced (#400).
+	sup <- .resolve_selected_support(
+		x,
+		treat_inds = treat_inds,
 		num_treats = num_treats,
 		first_inds = first_inds,
 		G = G,
-		fusion_structure = x$fusion_structure,
-		d_inv_treat = x$internal$d_inv_treat
+		beta_hat = beta_hat,
+		tes = tes
 	)
-	if (length(sel_treat_inds_shifted) > 0) {
-		d_inv_treat_sel <- d_inv_treat[,
-			sel_treat_inds_shifted,
-			drop = FALSE
-		]
-	} else {
-		d_inv_treat_sel <- NULL
-	}
+	sel_feat_inds <- sup$sel_feat_inds
+	sel_treat_inds_shifted <- sup$sel_treat_inds_shifted
+	theta_hat_treat_sel <- sup$theta_sel
+	d_inv_treat_sel <- sup$d_inv_treat_sel
 
 	# Recompute the Gram inverse (+ cluster sandwich if se_type = "cluster") on the
 	# selected support; single-sourced across the accessors (#400).

--- a/R/event_study.R
+++ b/R/event_study.R
@@ -300,40 +300,30 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 		sel_treat_inds_shifted <- which(beta_hat[treat_inds] != 0)
 	}
 
+	# Recompute the Gram inverse (+ cluster sandwich if se_type = "cluster") on the
+	# selected support; single-sourced across the accessors (#400).
 	calc_ses <- contract$has_valid_ses
 	gram_inv <- NULL
-	if (calc_ses && length(sel_treat_inds_shifted) > 0) {
-		res_gram <- getGramInv(
-			N = N,
-			T = T,
-			X_final = X_final,
-			sel_feat_inds = sel_feat_inds,
-			treat_inds = treat_inds,
-			num_treats = num_treats,
-			sel_treat_inds_shifted = sel_treat_inds_shifted,
-			calc_ses = TRUE
-		)
-		gram_inv <- res_gram$gram_inv
-		calc_ses <- res_gram$calc_ses
-	} else {
-		calc_ses <- FALSE
-	}
-
-	# Cluster-robust sandwich (recomputed from existing slots)
 	sandwich_full <- NULL
 	treat_block_mask <- NULL
-	if (identical(se_type, "cluster") && calc_ses) {
-		sel_arg <- if (any(!is.na(sel_feat_inds))) sel_feat_inds else NULL
-		res <- .assemble_cluster_robust_sandwich(
+	if (calc_ses && length(sel_treat_inds_shifted) > 0) {
+		gs <- .recompute_gram_and_sandwich(
 			X_final = X_final,
 			y_final = y_final,
 			N = N,
 			T = T,
 			treat_inds = treat_inds,
-			sel_feat_inds = sel_arg
+			num_treats = num_treats,
+			sel_feat_inds = sel_feat_inds,
+			sel_treat_inds_shifted = sel_treat_inds_shifted,
+			se_type = se_type
 		)
-		sandwich_full <- res$sandwich_full
-		treat_block_mask <- res$treat_block_mask
+		gram_inv <- gs$gram_inv
+		calc_ses <- gs$calc_ses
+		sandwich_full <- gs$sandwich_full
+		treat_block_mask <- gs$treat_block_mask
+	} else {
+		calc_ses <- FALSE
 	}
 
 	max_event <- T - 2L
@@ -554,39 +544,30 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 		d_inv_treat_sel <- NULL
 	}
 
+	# Recompute the Gram inverse (+ cluster sandwich if se_type = "cluster") on the
+	# selected support; single-sourced across the accessors (#400).
 	calc_ses <- contract$has_valid_ses
 	gram_inv <- NULL
-	if (calc_ses && length(sel_treat_inds_shifted) > 0) {
-		res_gram <- getGramInv(
-			N = N,
-			T = T,
-			X_final = X_final,
-			sel_feat_inds = sel_feat_inds,
-			treat_inds = treat_inds,
-			num_treats = num_treats,
-			sel_treat_inds_shifted = sel_treat_inds_shifted,
-			calc_ses = TRUE
-		)
-		gram_inv <- res_gram$gram_inv
-		calc_ses <- res_gram$calc_ses
-	} else {
-		calc_ses <- FALSE
-	}
-
-	# Cluster-robust sandwich (recomputed in theta-space on the selected support)
 	sandwich_full <- NULL
 	treat_block_mask <- NULL
-	if (identical(se_type, "cluster") && calc_ses) {
-		res <- .assemble_cluster_robust_sandwich(
+	if (calc_ses && length(sel_treat_inds_shifted) > 0) {
+		gs <- .recompute_gram_and_sandwich(
 			X_final = X_final,
 			y_final = y_final,
 			N = N,
 			T = T,
 			treat_inds = treat_inds,
-			sel_feat_inds = sel_feat_inds
+			num_treats = num_treats,
+			sel_feat_inds = sel_feat_inds,
+			sel_treat_inds_shifted = sel_treat_inds_shifted,
+			se_type = se_type
 		)
-		sandwich_full <- res$sandwich_full
-		treat_block_mask <- res$treat_block_mask
+		gram_inv <- gs$gram_inv
+		calc_ses <- gs$calc_ses
+		sandwich_full <- gs$sandwich_full
+		treat_block_mask <- gs$treat_block_mask
+	} else {
+		calc_ses <- FALSE
 	}
 
 	max_event <- T - 2L

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -921,47 +921,31 @@ simultaneousCIs.twfeCovs <- function(
 
 	# --- 9. (analytic only) getGramInv() + (if cluster) the cluster-robust
 	#        sandwich, reusing the eventStudy machinery. ---
-	gram_sel_feat <- if (any(!is.na(sel_feat_inds))) sel_feat_inds else NA
-	gram_sel_treat <- if (any(!is.na(sel_feat_inds))) {
-		sel_treat_inds_shifted
-	} else {
-		NA
-	}
-	res_gram <- getGramInv(
+	# Single-sourced across the accessors (#400). simultaneousCIs STOPs on a
+	# singular selected-support Gram (the event-study / cohort-time accessors
+	# degrade to NA instead) -- the one genuine policy difference, carried by
+	# `on_singular`. The NA/`sel_treat_inds_shifted` sentinel mapping the inline
+	# form used only gated optional `stopifnot`s in getGramInv, never `gram_inv`.
+	gs <- .recompute_gram_and_sandwich(
+		X_final = X_final,
+		y_final = y_final,
 		N = N,
 		T = T_,
-		X_final = X_final,
-		sel_feat_inds = gram_sel_feat,
 		treat_inds = treat_inds,
 		num_treats = num_treats,
-		sel_treat_inds_shifted = gram_sel_treat,
-		calc_ses = TRUE
-	)
-	gram_inv <- res_gram$gram_inv
-	if (!isTRUE(res_gram$calc_ses)) {
-		stop(
+		sel_feat_inds = sel_feat_inds,
+		sel_treat_inds_shifted = sel_treat_inds_shifted,
+		se_type = se_type,
+		on_singular = "stop",
+		stop_message = paste0(
 			"simultaneousCIs(): the Gram matrix on the selected support is not ",
 			"invertible; the analytic method's assumptions are not satisfied. ",
-			"For a high-dimensional (p >= NT) design, use method = 'bootstrap'.",
-			call. = FALSE
+			"For a high-dimensional (p >= NT) design, use method = 'bootstrap'."
 		)
-	}
-
-	sandwich_full <- NULL
-	treat_block_mask <- NULL
-	if (identical(se_type, "cluster")) {
-		sel_arg <- if (any(!is.na(sel_feat_inds))) sel_feat_inds else NULL
-		res_cl <- .assemble_cluster_robust_sandwich(
-			X_final = X_final,
-			y_final = y_final,
-			N = N,
-			T = T_,
-			treat_inds = treat_inds,
-			sel_feat_inds = sel_arg
-		)
-		sandwich_full <- res_cl$sandwich_full
-		treat_block_mask <- res_cl$treat_block_mask
-	}
+	)
+	gram_inv <- gs$gram_inv
+	sandwich_full <- gs$sandwich_full
+	treat_block_mask <- gs$treat_block_mask
 
 	Sigma_1 <- .assemble_joint_cov_var1(
 		Psi = Psi,

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -549,7 +549,6 @@ simultaneousCIs.twfeCovs <- function(
 	is_fetwfe <- inherits(x, "fetwfe")
 	X_final <- if (is_fetwfe) x$internal$X_final else x$X_final
 	y_final <- if (is_fetwfe) x$internal$y_final else x$y_final
-	theta_hat_full <- if (is_fetwfe) x$internal$theta_hat else NULL
 	beta_hat <- x$beta_hat
 	treat_inds <- x$treat_inds
 	num_treats <- length(treat_inds)
@@ -647,44 +646,21 @@ simultaneousCIs.twfeCovs <- function(
 	}
 
 	# --- 6. Determine the selected support (theta-space for FETWFE, beta-space
-	#        for the OLS family + BETWFE). Mirrors event_study.R. ---
-	if (is_fetwfe) {
-		theta_hat_slopes <- theta_hat_full[2:(p + 1)]
-		sel_feat_inds <- which(theta_hat_slopes != 0)
-		sel_treat_inds_shifted <- which(theta_hat_slopes[treat_inds] != 0)
-		theta_sel <- theta_hat_slopes[treat_inds][sel_treat_inds_shifted]
-		# #236: reuse the custom inverted block stored on the fit (NULL for
-		# non-custom fits -> byte-identical `fusion_structure` dispatch).
-		d_inv_treat <- .gen_inv_treat_block(
-			num_treats = num_treats,
-			first_inds = first_inds,
-			G = G,
-			fusion_structure = x$fusion_structure,
-			d_inv_treat = x$internal$d_inv_treat
-		)
-		d_inv_treat_sel <- if (length(sel_treat_inds_shifted) > 0) {
-			d_inv_treat[, sel_treat_inds_shifted, drop = FALSE]
-		} else {
-			NULL
-		}
-	} else if (inherits(x, "betwfe")) {
-		sel_feat_inds <- which(beta_hat != 0)
-		sel_treat_inds_shifted <- which(beta_hat[treat_inds] != 0)
-		# OLS-family unification: tes lives in beta-space, so the fusion-
-		# inverse map is the identity restricted to the selected cells.
-		theta_sel <- tes[sel_treat_inds_shifted]
-		d_inv_treat_sel <- if (length(sel_treat_inds_shifted) > 0) {
-			diag(num_treats)[, sel_treat_inds_shifted, drop = FALSE]
-		} else {
-			NULL
-		}
-	} else {
-		# etwfe / twfeCovs: pure OLS, all cells selected.
-		sel_feat_inds <- NA
-		sel_treat_inds_shifted <- seq_len(num_treats)
-		theta_sel <- tes
-		d_inv_treat_sel <- diag(num_treats)
-	}
+	#        for the OLS family + BETWFE); single-sourced via
+	#        .resolve_selected_support(). ---
+	sup <- .resolve_selected_support(
+		x,
+		treat_inds = treat_inds,
+		num_treats = num_treats,
+		first_inds = first_inds,
+		G = G,
+		beta_hat = beta_hat,
+		tes = tes
+	)
+	sel_feat_inds <- sup$sel_feat_inds
+	sel_treat_inds_shifted <- sup$sel_treat_inds_shifted
+	theta_sel <- sup$theta_sel
+	d_inv_treat_sel <- sup$d_inv_treat_sel
 
 	# --- 7. Degenerate support: the bridge zeroed every treatment effect. Normally
 	#        return a degenerate all-zero band. EXCEPT the high-dim (p >= NT) fetwfe

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -478,6 +478,89 @@ getPsiGUnfused <- function(
 }
 
 
+#' @title Resolve the selected treatment support across estimator classes
+#' @description Single-sources the class dispatch that every access-time SE path
+#'   shares (`eventStudy()`, `cohortTimeATTs()`, `simultaneousCIs()`): given a
+#'   fitted object, determine the selected support and the treatment-block map
+#'   used to build the per-effect psi vectors. FETWFE selects in theta (fused)
+#'   space and carries the treatment block of the inverse fusion transform
+#'   `D^{-1}`; BETWFE selects in beta space with the identity map restricted to
+#'   the selected cells; the OLS family (etwfe / twfeCovs) is unpenalized (all
+#'   cells selected, identity map). This returns the `simultaneousCIs()`
+#'   SUPERSET, so each caller takes the subset it needs (the event-study /
+#'   cohort-time paths ignore `theta_sel`; the beta-space paths that index cells
+#'   with a unit selector ignore `d_inv_treat_sel`, while `simultaneousCIs()`
+#'   consumes it for every class via the identity map). Returns only the SELECTION
+#'   fields -- callers keep their own `X_final` / `y_final` slot reads (those are
+#'   needed before `first_inds` is resolved, so folding them would reorder reads).
+#' @param x A validated fitted estimator object.
+#' @param treat_inds,num_treats,first_inds,G Design pieces already resolved by the
+#'   caller (`first_inds` / `G` feed `.gen_inv_treat_block()` for FETWFE).
+#' @param beta_hat,tes The fit's coefficient vector and treatment effects
+#'   (`tes = beta_hat[treat_inds]`), used by the beta-space (BETWFE / OLS) branches.
+#' @return A list: `sel_feat_inds` (integer indices, or the scalar `NA` "all
+#'   features" sentinel for the OLS family), `sel_treat_inds_shifted`, `theta_sel`
+#'   (selected treatment coefficients), and `d_inv_treat_sel` (the `drop = FALSE`
+#'   treatment-block map on the selected columns, or `NULL` when the support is
+#'   empty).
+#' @keywords internal
+#' @noRd
+.resolve_selected_support <- function(
+	x,
+	treat_inds,
+	num_treats,
+	first_inds,
+	G,
+	beta_hat,
+	tes
+) {
+	if (inherits(x, "fetwfe")) {
+		# Selected support in theta-space (slopes only; drop intercept).
+		theta_hat_slopes <- x$internal$theta_hat[2:(x$p + 1)]
+		sel_feat_inds <- which(theta_hat_slopes != 0)
+		sel_treat_inds_shifted <- which(theta_hat_slopes[treat_inds] != 0)
+		theta_sel <- theta_hat_slopes[treat_inds][sel_treat_inds_shifted]
+		# Treatment block of D^{-1}, threading any user-supplied fusion matrix
+		# (#236) so this accessor uses the SAME transform as the fit.
+		d_inv_treat <- .gen_inv_treat_block(
+			num_treats = num_treats,
+			first_inds = first_inds,
+			G = G,
+			fusion_structure = x$fusion_structure,
+			d_inv_treat = x$internal$d_inv_treat
+		)
+		d_inv_treat_sel <- if (length(sel_treat_inds_shifted) > 0) {
+			d_inv_treat[, sel_treat_inds_shifted, drop = FALSE]
+		} else {
+			NULL
+		}
+	} else if (inherits(x, "betwfe")) {
+		sel_feat_inds <- which(beta_hat != 0)
+		sel_treat_inds_shifted <- which(beta_hat[treat_inds] != 0)
+		# OLS-family unification: tes lives in beta-space, so the fusion-inverse
+		# map is the identity restricted to the selected cells.
+		theta_sel <- tes[sel_treat_inds_shifted]
+		d_inv_treat_sel <- if (length(sel_treat_inds_shifted) > 0) {
+			diag(num_treats)[, sel_treat_inds_shifted, drop = FALSE]
+		} else {
+			NULL
+		}
+	} else {
+		# etwfe / twfeCovs: pure OLS, all cells selected.
+		sel_feat_inds <- NA
+		sel_treat_inds_shifted <- seq_len(num_treats)
+		theta_sel <- tes
+		d_inv_treat_sel <- diag(num_treats)
+	}
+	list(
+		sel_feat_inds = sel_feat_inds,
+		sel_treat_inds_shifted = sel_treat_inds_shifted,
+		theta_sel = theta_sel,
+		d_inv_treat_sel = d_inv_treat_sel
+	)
+}
+
+
 #' @title Recompute the Gram inverse and optional cluster sandwich on a selected
 #'   support
 #' @description Single-sources the "recompute `getGramInv()` on the selected

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -478,6 +478,92 @@ getPsiGUnfused <- function(
 }
 
 
+#' @title Recompute the Gram inverse and optional cluster sandwich on a selected
+#'   support
+#' @description Single-sources the "recompute `getGramInv()` on the selected
+#'   support, then (if `se_type = "cluster"`) build the cluster-robust sandwich"
+#'   sequence that every access-time SE path shares (`eventStudy()`,
+#'   `cohortTimeATTs()`, `simultaneousCIs()`). These accessors MUST stay in
+#'   lockstep: a drift here would make them report inconsistent SEs for the same
+#'   fit (guarded by `test-cross-accessor-scaffold-guardrail-400.R`). This wraps
+#'   `getGramInv()` and `.assemble_cluster_robust_sandwich()` UNCHANGED (preserving
+#'   their exact numerics and the "all features" NA/NULL sentinel translation); it
+#'   only unifies the surrounding recompute.
+#'
+#'   The one genuine policy difference between callers is `on_singular`: when the
+#'   recomputed Gram is singular, `eventStudy()` / `cohortTimeATTs()` DEGRADE
+#'   (return `calc_ses = FALSE`, so their SEs become `NA`), whereas
+#'   `simultaneousCIs()` STOPs. That branch is defensive-only -- it is unreachable
+#'   through any public fit (a fit with valid SEs already inverted its Gram on this
+#'   support), so it is exercised only by the helper's direct unit test.
+#' @param X_final,y_final,N,T,treat_inds,num_treats Fit-design pieces, forwarded to
+#'   `getGramInv()` / `.assemble_cluster_robust_sandwich()`.
+#' @param sel_feat_inds Integer indices of the selected features, or the scalar
+#'   `NA` "all features" sentinel `getGramInv()` expects (translated to `NULL` for
+#'   the NULL-native sandwich).
+#' @param sel_treat_inds_shifted Integer indices of the selected treatment
+#'   coefficients within the treatment block.
+#' @param se_type `"cluster"` builds the sandwich; anything else skips it.
+#' @param on_singular `"degrade"` (default) returns `calc_ses = FALSE` on a
+#'   singular Gram; `"stop"` errors with `stop_message`.
+#' @param stop_message The exact error string for `on_singular = "stop"`.
+#' @return A list: `gram_inv`, `calc_ses` (logical), `sandwich_full` (or `NULL`),
+#'   `treat_block_mask` (or `NULL`).
+#' @keywords internal
+#' @noRd
+.recompute_gram_and_sandwich <- function(
+	X_final,
+	y_final,
+	N,
+	T,
+	treat_inds,
+	num_treats,
+	sel_feat_inds,
+	sel_treat_inds_shifted,
+	se_type,
+	on_singular = c("degrade", "stop"),
+	stop_message = NULL
+) {
+	on_singular <- match.arg(on_singular)
+	res_gram <- getGramInv(
+		N = N,
+		T = T,
+		X_final = X_final,
+		sel_feat_inds = sel_feat_inds,
+		treat_inds = treat_inds,
+		num_treats = num_treats,
+		sel_treat_inds_shifted = sel_treat_inds_shifted,
+		calc_ses = TRUE
+	)
+	gram_inv <- res_gram$gram_inv
+	calc_ses <- res_gram$calc_ses
+	if (!isTRUE(calc_ses) && on_singular == "stop") {
+		stop(stop_message, call. = FALSE)
+	}
+	sandwich_full <- NULL
+	treat_block_mask <- NULL
+	if (identical(se_type, "cluster") && isTRUE(calc_ses)) {
+		sel_arg <- if (any(!is.na(sel_feat_inds))) sel_feat_inds else NULL
+		res_cl <- .assemble_cluster_robust_sandwich(
+			X_final = X_final,
+			y_final = y_final,
+			N = N,
+			T = T,
+			treat_inds = treat_inds,
+			sel_feat_inds = sel_arg
+		)
+		sandwich_full <- res_cl$sandwich_full
+		treat_block_mask <- res_cl$treat_block_mask
+	}
+	list(
+		gram_inv = gram_inv,
+		calc_ses = calc_ses,
+		sandwich_full = sandwich_full,
+		treat_block_mask = treat_block_mask
+	)
+}
+
+
 # getTeResults2
 #' @title Calculate Overall ATT and its Standard Error (Version 2)
 #' @description Computes the overall Average Treatment Effect on the Treated

--- a/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
+++ b/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
@@ -1,0 +1,175 @@
+# Cross-accessor byte-identity guardrail for the shared access-time inference
+# scaffold (#400, Phase 1 -- the blocking prerequisite for the refactor).
+#
+# The "resolve selected support -> recompute Gram inverse -> cluster sandwich"
+# sequence is duplicated across eventStudy(), cohortTimeATTs(), and
+# simultaneousCIs() (R/event_study.R, R/cohort_time_atts.R, R/simultaneous_cis.R).
+# If any copy drifts, the accessors silently report INCONSISTENT SEs for the same
+# fit. This file pins the three cross-accessor SE/estimate anchors AND literal
+# pre-refactor values on a shared fit so the Phase 2 single-sourcing refactor must
+# reproduce byte-identical results. There was no unified cross-accessor fixture
+# before this (only pairwise checks in test-cohort_time_atts.R / test-simultaneous-cis.R).
+#
+# simultaneousCIs() exposes no `se` column; the pointwise SE is recovered from the
+# pointwise CI half-width. That recovery is algebraically alpha-invariant, so the
+# `alpha = fit$alpha` passed below is defensive (matches the fit), not load-bearing.
+
+.g400_dat <- local({
+	cf <- genCoefs(G = 4, T = 6, d = 2, density = 0.5, eff_size = 2, seed = 101)
+	simulateData(cf, N = 160, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 101)
+})
+
+# fetwfe (partial selection, 7/14 cells) + etwfe (no selection) + betwfe (13/14),
+# each at se_type default and cluster -> exercises the NA-sentinel, partial-support,
+# and cluster-sandwich branches of the scaffold. Built once at collection time.
+.g400_fits <- list(
+	"fetwfe/default" = fetwfeWithSimulatedData(
+		.g400_dat,
+		q = 0.5,
+		se_type = "default",
+		verbose = FALSE
+	),
+	"etwfe/default" = etwfeWithSimulatedData(
+		.g400_dat,
+		se_type = "default",
+		verbose = FALSE
+	),
+	"betwfe/default" = betwfeWithSimulatedData(
+		.g400_dat,
+		se_type = "default",
+		verbose = FALSE
+	),
+	"fetwfe/cluster" = fetwfeWithSimulatedData(
+		.g400_dat,
+		q = 0.5,
+		se_type = "cluster",
+		verbose = FALSE
+	),
+	"etwfe/cluster" = etwfeWithSimulatedData(
+		.g400_dat,
+		se_type = "cluster",
+		verbose = FALSE
+	),
+	"betwfe/cluster" = betwfeWithSimulatedData(
+		.g400_dat,
+		se_type = "cluster",
+		verbose = FALSE
+	)
+)
+
+# q = 1 -> has_valid_ses = FALSE: the reachable SE-unavailable path.
+.g400_fit_q1 <- fetwfeWithSimulatedData(.g400_dat, q = 1, verbose = FALSE)
+
+.g400_se_of_sci <- function(sci) {
+	(sci$ci$pointwise_ci_high - sci$ci$estimate) / sci$pointwise_critical_value
+}
+
+# --- Part 1: cross-accessor equality (the first-class regression guard) --------
+
+.g400_expect_anchors <- function(fit, label) {
+	a <- fit$alpha
+
+	# Anchor A -- per-(g, t) cell: cohortTimeATTs row <-> all_post_treatment effect.
+	# Estimates are the identical contrast (both `tes[idx]`), so exact.
+	cta <- cohortTimeATTs(fit)
+	ap <- simultaneousCIs(fit, family = "all_post_treatment", alpha = a)
+	expect_equal(
+		cta$estimate,
+		ap$ci$estimate,
+		tolerance = 1e-12,
+		info = paste(label, "Anchor A estimate")
+	)
+	expect_lt(max(abs(cta$se - .g400_se_of_sci(ap))), 1e-12)
+
+	# Anchor B -- per-event-time: eventStudy <-> event_study. Compare finite rows
+	# only (degenerate event times are NA in eventStudy).
+	es <- eventStudy(fit)
+	esr <- simultaneousCIs(fit, family = "event_study", alpha = a)
+	fin <- is.finite(es$se)
+	expect_true(any(fin), info = paste(label, "has a finite event-time SE"))
+	expect_equal(
+		es$estimate[fin],
+		esr$ci$estimate[fin],
+		tolerance = 1e-12,
+		info = paste(label, "Anchor B estimate")
+	)
+	expect_lt(max(abs(es$se[fin] - .g400_se_of_sci(esr)[fin])), 1e-12)
+
+	# Anchor C -- per-cohort: cohortStudy (the fit-time scaffold) <-> cohort family.
+	# The etwfe estimate side carries ~1e-15 mean-of-block rounding -> tolerance.
+	cs <- cohortStudy(fit)
+	co <- simultaneousCIs(fit, family = "cohort", alpha = a)
+	expect_equal(
+		cs$estimate,
+		co$ci$estimate,
+		tolerance = 1e-9,
+		info = paste(label, "Anchor C estimate")
+	)
+	expect_lt(max(abs(cs$se - .g400_se_of_sci(co))), 1e-12)
+}
+
+test_that("the shared scaffold yields cross-accessor-consistent SEs across classes and se_types (#400 guardrail)", {
+	for (label in names(.g400_fits)) {
+		.g400_expect_anchors(.g400_fits[[label]], label)
+	}
+})
+
+# --- Part 2: pre-refactor snapshot (the "AND to pre-refactor values" half) ------
+
+test_that("scaffold SEs match pinned pre-refactor values on the fetwfe/default fixture (#400 guardrail)", {
+	fit <- .g400_fits[["fetwfe/default"]]
+	expect_equal(
+		eventStudy(fit)$se,
+		c(0.1432551, 0.2040083, 0.2363452, 0.2494955, 0.2219078),
+		tolerance = 1e-6
+	)
+	expect_equal(
+		cohortStudy(fit)$se,
+		c(0.1738941, 0.1479012, 0.1596468, 0.1438447),
+		tolerance = 1e-6
+	)
+	expect_equal(
+		cohortTimeATTs(fit)$se,
+		c(
+			0.1817540,
+			0.1817540,
+			0.1817540,
+			0.2219078,
+			0.2219078,
+			0.1352874,
+			0.1840652,
+			0.1840652,
+			0.2448657,
+			0.1352874,
+			0.2071185,
+			0.2071185,
+			0.1352874,
+			0.2214705
+		),
+		tolerance = 1e-6
+	)
+})
+
+# --- Part 3: SE-unavailable fits degrade consistently ---------------------------
+
+test_that("an SE-unavailable fit degrades consistently: accessors -> NA, simultaneousCIs -> stop (#400 guardrail)", {
+	fq <- .g400_fit_q1
+	expect_false(isTRUE(fq$internal$calc_ses)) # guard: genuinely has_valid_ses = FALSE
+
+	es_se <- eventStudy(fq)$se
+	expect_true(length(es_se) > 0 && all(is.na(es_se)))
+	cta_se <- cohortTimeATTs(fq)$se
+	expect_true(length(cta_se) > 0 && all(is.na(cta_se)))
+
+	expect_error(simultaneousCIs(fq, family = "event_study"), "calc_ses")
+	expect_error(simultaneousCIs(fq, family = "all_post_treatment"), "calc_ses")
+
+	# NB: the *shared-scaffold* singular-Gram branch (recomputed selected-support
+	# Gram singular -> res_gram$calc_ses = FALSE; the two accessors degrade to NA
+	# while simultaneousCIs STOPs "not invertible") is defensive-only and
+	# UNREACHABLE through any public fit -- has_valid_ses = TRUE already implies the
+	# fit's own getGramInv() on that support succeeded. Phase 2 guards that
+	# on_singular = c("degrade", "stop") policy with a direct unit test of the
+	# extracted helper (feeding it a rank-deficient support), which is the only
+	# place the asymmetry can be exercised.
+})

--- a/tests/testthat/test-recompute-gram-sandwich-400.R
+++ b/tests/testthat/test-recompute-gram-sandwich-400.R
@@ -1,0 +1,89 @@
+# Direct unit test for the extracted scaffold helper .recompute_gram_and_sandwich()
+# (#400 Phase 2a). Its one genuine policy axis -- `on_singular` (degrade vs stop
+# on a singular recomputed Gram) -- is DEFENSIVE-ONLY and unreachable through any
+# public fit (a fit with valid SEs already inverted its Gram on this support; see
+# the note in test-cross-accessor-scaffold-guardrail-400.R). So the asymmetry can
+# only be exercised here, by feeding the helper a rank-deficient selected support.
+
+test_that(".recompute_gram_and_sandwich() degrades vs stops on a singular selected-support Gram (#400)", {
+	# Rank-deficient support: feature columns 1 and 2 are identical, so the centered
+	# Gram on the selected support {1,2,3} is singular (getGramInv's eigenvalue guard
+	# fires and warns).
+	N <- 4L
+	T <- 2L
+	n <- N * T
+	x1 <- as.double(seq_len(n))
+	X_sing <- cbind(x1, x1, rep(c(1, 0), n / 2))
+	y_final <- rep(0, n)
+	treat_inds <- c(1L, 2L)
+	num_treats <- 2L
+	sel_feat_inds <- c(1L, 2L, 3L)
+	sel_treat_inds_shifted <- c(1L, 2L)
+
+	# on_singular = "degrade" -> calc_ses = FALSE, no sandwich, no error.
+	gs <- suppressWarnings(fetwfe:::.recompute_gram_and_sandwich(
+		X_final = X_sing,
+		y_final = y_final,
+		N = N,
+		T = T,
+		treat_inds = treat_inds,
+		num_treats = num_treats,
+		sel_feat_inds = sel_feat_inds,
+		sel_treat_inds_shifted = sel_treat_inds_shifted,
+		se_type = "cluster",
+		on_singular = "degrade"
+	))
+	expect_false(isTRUE(gs$calc_ses))
+	expect_null(gs$sandwich_full)
+	expect_null(gs$treat_block_mask)
+
+	# on_singular = "stop" -> errors with EXACTLY the stop_message it is given
+	# (pins the helper's verbatim propagation). NB: the live call-site literal in
+	# .simultaneous_cis_impl() is a SEPARATE copy of this string, kept byte-identical
+	# by hand -- that singular-Gram path is unreachable through any public fit, so no
+	# integration test exercises it; edit one copy, edit both.
+	msg <- paste0(
+		"simultaneousCIs(): the Gram matrix on the selected support is not ",
+		"invertible; the analytic method's assumptions are not satisfied. ",
+		"For a high-dimensional (p >= NT) design, use method = 'bootstrap'."
+	)
+	err <- tryCatch(
+		suppressWarnings(fetwfe:::.recompute_gram_and_sandwich(
+			X_final = X_sing,
+			y_final = y_final,
+			N = N,
+			T = T,
+			treat_inds = treat_inds,
+			num_treats = num_treats,
+			sel_feat_inds = sel_feat_inds,
+			sel_treat_inds_shifted = sel_treat_inds_shifted,
+			se_type = "default",
+			on_singular = "stop",
+			stop_message = msg
+		)),
+		error = function(e) conditionMessage(e)
+	)
+	expect_identical(err, msg)
+
+	# Sanity: a well-conditioned support returns calc_ses = TRUE + a real gram_inv,
+	# and (cluster) a sandwich + mask -- so the degrade above is genuinely the
+	# singular branch, not a helper that always fails.
+	X_ok <- cbind(x1, x1^2, rep(c(1, 0), n / 2))
+	gs_ok <- fetwfe:::.recompute_gram_and_sandwich(
+		X_final = X_ok,
+		y_final = as.double(seq_len(n)),
+		N = N,
+		T = T,
+		treat_inds = treat_inds,
+		num_treats = num_treats,
+		sel_feat_inds = sel_feat_inds,
+		sel_treat_inds_shifted = sel_treat_inds_shifted,
+		se_type = "cluster",
+		on_singular = "stop",
+		stop_message = msg
+	)
+	expect_true(isTRUE(gs_ok$calc_ses))
+	expect_true(is.matrix(gs_ok$gram_inv))
+	expect_false(is.null(gs_ok$sandwich_full))
+	expect_length(gs_ok$treat_block_mask, length(sel_feat_inds))
+})


### PR DESCRIPTION

**Phase 2b of #400**, stacked on Phase 2a (#413). Completes the #400 "Proposed shape" by single-sourcing the SECOND scaffold half — the "resolve selected support" class dispatch — that was duplicated across the access-time SE paths. **Byte-identical user-facing behavior** — no version bump.

**What moved.** New internal `.resolve_selected_support()` (in `variance_machinery.R`, beside its 2a sibling) determines the selected treatment support and the treatment-block map `d_inv_treat_sel`: FETWFE selects in theta (fused) space and carries the inverse-fusion block; BETWFE selects in beta space with the identity restricted to selected cells; the OLS family (etwfe / twfeCovs) is unpenalized (all cells, identity map). It returns the `simultaneousCIs()` superset, so each of the four sites — `.event_study_etwfe_betwfe()`, `.event_study_fetwfe()`, `cohortTimeATTs()`, `.simultaneous_cis_impl()` — takes the subset it needs (the event-study / cohort-time paths ignore `theta_sel`; beta-space callers ignore `d_inv_treat_sel`). It returns only the *selection* fields; each site keeps its own trivial `X_final`/`y_final` slot read (those are needed before `first_inds` is resolved, so folding them would reorder reads). The now-dead `theta_hat_full` (both fetwfe functions) and `p` (event_study only — kept in `simultaneous_cis.R`, where the `p >= NT` gates still use it) are removed; `codetools` is clean.

**Byte-identity is proven, not assumed.** A git-worktree 2a-vs-2b `identical()` battery is whole-object TRUE across 7 fixtures (fetwfe/etwfe/betwfe × default/cluster + the `q=1` degrade) × every accessor output. Because the resolver *reconstructs* `d_inv_treat_sel` (which feeds the Jacobian → the off-diagonal `Sigma_2` → the simultaneous critical value), the battery was extended to also compare the seed-fixed qmvnorm critical value + simultaneous bounds — also `identical()` TRUE. So on- and off-diagonal `Sigma` are both unchanged. The #400 guardrail (#412) stays green.

**Why genuine DRY, not fake.** The selection dispatch (`which(theta≠0)` / `which(beta≠0)` / `NA`-seq, `theta_sel`, and the `drop = FALSE` / NULL-on-empty `d_inv_treat_sel` slice) is the error-prone, lockstep-relevant logic that was replicated near-identically at all four sites — exactly the kind #400 targets. It is distinct from the fetwfe/betwfe theta↔beta *core* mid-sections the package deliberately keeps as honest copy-paste (#401).

No dedicated unit test for the resolver: unlike the 2a helper's unreachable `on_singular` branch, this helper is fully reachable and exercised by the cross-accessor guardrail across all three classes (which the battery confirms byte-identical). The fit-time original `getCohortATTsFinal()` remains out of scope (possible Phase 2c).

`devtools::test()` FAIL 0 / WARN 0; `check --as-cran` clean (modulo the benign timestamp NOTE); spell/url clean. No `man/`/NAMESPACE change (helper is `@noRd`).

Refs #400.
