### PR TITLE
refactor: single-source the CV lambda.min selector and the C6/C8 class contract checks (#401, batch 1)

### DIFF
--- a/R/betwfe_class.R
+++ b/R/betwfe_class.R
@@ -162,25 +162,6 @@ print.summary.betwfe <- function(x, ...) {
 	.check_ci_band_width(x, cls)
 	.check_cohort_probs(x, cls)
 	.check_lambda_monotonicity(x, cls)
-	.assert_contract(
-		length(x$beta_hat) == x$p,
-		"C6 length(beta_hat) == p",
-		cls
-	)
-	.assert_contract(
-		length(x$y) == x$N * x$T,
-		"C6 length(y) == N * T",
-		cls
-	)
-	.assert_contract(
-		nrow(x$X_ints) == x$N * x$T,
-		"C6 nrow(X_ints) == N * T",
-		cls
-	)
-	.assert_contract(
-		is.logical(x$calc_ses) && length(x$calc_ses) == 1L,
-		"C8 calc_ses is length-1 logical",
-		cls
-	)
+	.check_c6_dims_toplevel(x, cls)
 	invisible(x)
 }

--- a/R/bridge_selection.R
+++ b/R/bridge_selection.R
@@ -260,13 +260,7 @@ getBetaCV <- function(
 		)
 	})
 
-	lambda_star <- cv_fit$lambda.min
-	lam_idx <- which(cv_fit$fit$lambda == lambda_star)
-	if (length(lam_idx) != 1L) {
-		# Fall back to nearest match in case of floating-point comparison drift.
-		lam_idx <- which.min(abs(cv_fit$fit$lambda - lambda_star))
-	}
-	stopifnot(length(lam_idx) == 1L)
+	lam_idx <- .cv_grpreg_at_min(cv_fit)
 	stopifnot(nrow(cv_fit$fit$beta) == p + 1L)
 
 	theta_hat_full <- cv_fit$fit$beta[, lam_idx]
@@ -349,13 +343,8 @@ getBetaCV <- function(
 			nfolds = cv_folds
 		)
 	})
-	lambda_star <- cv_fit$lambda.min
-	lam_idx <- which(cv_fit$fit$lambda == lambda_star)
-	if (length(lam_idx) != 1L) {
-		# Fall back to nearest match in case of floating-point comparison drift.
-		lam_idx <- which.min(abs(cv_fit$fit$lambda - lambda_star))
-	}
-	stopifnot(length(lam_idx) == 1L, nrow(cv_fit$fit$beta) == p + 1L)
+	lam_idx <- .cv_grpreg_at_min(cv_fit)
+	stopifnot(nrow(cv_fit$fit$beta) == p + 1L)
 	theta_scaled <- cv_fit$fit$beta[, lam_idx]
 	stopifnot(length(theta_scaled) == p + 1L, all(!is.na(theta_scaled)))
 	.untransform_scaled_theta(
@@ -364,4 +353,26 @@ getBetaCV <- function(
 		scale_center = scale_center,
 		scale_scale = scale_scale
 	)
+}
+
+#' @title Column index of cv.grpreg's lambda.min (exact match, float-drift fallback)
+#' @description The lockstep-critical step shared by the two cross-validation
+#'   call sites (`getBetaCV()` and `.fit_q1_nuisance()`): map `cv.grpreg()`'s
+#'   `lambda.min` to its column index in `cv_fit$fit$lambda`, falling back to the
+#'   nearest match under floating-point comparison drift. Single-sourced (#401)
+#'   because a fix applied to one copy would silently select the wrong lambda in
+#'   the other.
+#' @param cv_fit A `cv.grpreg` fit (with `$lambda.min` and `$fit$lambda`).
+#' @return The integer column index (guaranteed length 1).
+#' @keywords internal
+#' @noRd
+.cv_grpreg_at_min <- function(cv_fit) {
+	lambda_star <- cv_fit$lambda.min
+	lam_idx <- which(cv_fit$fit$lambda == lambda_star)
+	if (length(lam_idx) != 1L) {
+		# Fall back to nearest match in case of floating-point comparison drift.
+		lam_idx <- which.min(abs(cv_fit$fit$lambda - lambda_star))
+	}
+	stopifnot(length(lam_idx) == 1L)
+	lam_idx
 }

--- a/R/class_helpers.R
+++ b/R/class_helpers.R
@@ -368,6 +368,39 @@
 	)
 }
 
+#' @title Top-level C6 dimension + C8 calc_ses contract checks (class-invariant)
+#' @description The C6 (length / nrow) and C8 (`calc_ses`) top-level contract
+#'   checks shared byte-identically by the etwfe / betwfe / twfeCovs validators.
+#'   Single-sourced (#401) so a future C6 invariant added to one class cannot
+#'   silently skip the others. fetwfe's variant is nested and adds C11, so it
+#'   stays separate.
+#' @param x A fitted object.
+#' @param cls The object's class label, used in the assertion messages.
+#' @keywords internal
+#' @noRd
+.check_c6_dims_toplevel <- function(x, cls) {
+	.assert_contract(
+		length(x$beta_hat) == x$p,
+		"C6 length(beta_hat) == p",
+		cls
+	)
+	.assert_contract(
+		length(x$y) == x$N * x$T,
+		"C6 length(y) == N * T",
+		cls
+	)
+	.assert_contract(
+		nrow(x$X_ints) == x$N * x$T,
+		"C6 nrow(X_ints) == N * T",
+		cls
+	)
+	.assert_contract(
+		is.logical(x$calc_ses) && length(x$calc_ses) == 1L,
+		"C8 calc_ses is length-1 logical",
+		cls
+	)
+}
+
 #' @title C7 -- Lambda monotonicity (fetwfe / betwfe only)
 #' @description
 #' Larger lambda -> smaller model, so model-size direction is REVERSED from

--- a/R/etwfe_class.R
+++ b/R/etwfe_class.R
@@ -144,25 +144,6 @@ print.summary.etwfe <- function(x, ...) {
 	.check_catt_df_shape(x, cls)
 	.check_ci_band_width(x, cls)
 	.check_cohort_probs(x, cls)
-	.assert_contract(
-		length(x$beta_hat) == x$p,
-		"C6 length(beta_hat) == p",
-		cls
-	)
-	.assert_contract(
-		length(x$y) == x$N * x$T,
-		"C6 length(y) == N * T",
-		cls
-	)
-	.assert_contract(
-		nrow(x$X_ints) == x$N * x$T,
-		"C6 nrow(X_ints) == N * T",
-		cls
-	)
-	.assert_contract(
-		is.logical(x$calc_ses) && length(x$calc_ses) == 1L,
-		"C8 calc_ses is length-1 logical",
-		cls
-	)
+	.check_c6_dims_toplevel(x, cls)
 	invisible(x)
 }

--- a/R/twfeCovs_class.R
+++ b/R/twfeCovs_class.R
@@ -155,25 +155,6 @@ print.summary.twfeCovs <- function(x, ...) {
 	.check_catt_df_shape(x, cls)
 	.check_ci_band_width(x, cls)
 	.check_cohort_probs(x, cls)
-	.assert_contract(
-		length(x$beta_hat) == x$p,
-		"C6 length(beta_hat) == p",
-		cls
-	)
-	.assert_contract(
-		length(x$y) == x$N * x$T,
-		"C6 length(y) == N * T",
-		cls
-	)
-	.assert_contract(
-		nrow(x$X_ints) == x$N * x$T,
-		"C6 nrow(X_ints) == N * T",
-		cls
-	)
-	.assert_contract(
-		is.logical(x$calc_ses) && length(x$calc_ses) == 1L,
-		"C8 calc_ses is length-1 logical",
-		cls
-	)
+	.check_c6_dims_toplevel(x, cls)
 	invisible(x)
 }


### PR DESCRIPTION

First batch from the #401 consolidation backlog — two clean, independent "single-source a duplicated lockstep-critical block" refactors. **Byte-identical user-facing behavior** — no version bump.

- **`.cv_grpreg_at_min(cv_fit)`** (item 4, `bridge_selection.R`) folds the `lambda.min → which(lambda == lambda.min) → nearest-match float-fallback → stopifnot(length == 1)` logic that was duplicated across *both* cross-validation branches of `getBetaCV()`. The float-drift fallback is subtle — a fix applied to one copy would silently select the wrong lambda in the other. Each branch keeps its own `cv.grpreg()` call (the RNG-sensitive part, untouched) and its own `nrow`/extraction/`NA` checks.
- **`.check_c6_dims_toplevel(x, cls)`** (item 8, `class_helpers.R`) folds the byte-identical C6 (length/nrow) + C8 (`calc_ses`) `.assert_contract` block from `.validate_etwfe` / `.validate_betwfe` / `.validate_twfeCovs` (verified `diff`-identical across all three). A future C6 invariant added to one class can no longer silently skip the others. (fetwfe's validator is nested + carries C11, so it stays separate.)

**Byte-identity** is guaranteed by construction (the helpers reproduce the removed logic verbatim) and confirmed by the full suite staying green — the CV path is exercised by `test-lambda-selection-164.R` / `test-model-size-excludes-intercept-269.R`, the validators everywhere — plus `codetools` clean (no orphaned `lambda_star`, no unused params).

## Scope note

4 of #401's 9 items touch files the still-open #400 stack (#412/#413/#414) modified — the event-study tail, the `simultaneousCIs` method aliases, the result assembly, and the band-attach helpers. Those are **deferred** to a follow-up (off updated `main`, after #400 merges) to avoid conflicts. The remaining non-#400 items (genCoefs scalar validation; the core ATT-pair tail; the fusion treat-block index) are also left for follow-up batches — the last two are higher-risk (delicate cores / hot transform paths with byte-identity expectations) and warrant their own careful PRs.

`devtools::test()` FAIL 0 / WARN 0; `check --as-cran` clean (modulo the benign timestamp NOTE); spell/url clean. No `man/`/NAMESPACE change (both helpers are `@noRd`).

Refs #401.
