### PR TITLE
refactor: single-source the genCoefs scalar-argument validation (#401, batch 2)

### DIFF
--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -367,42 +367,15 @@ genCoefs <- function(
 	# consume no RNG). Both NULL => uniform-`density` mode, byte-identical.
 	.validate_targeted_sparsity(n_signal_cohorts, treat_base_levels, G)
 
-	# Check that T is a numeric scalar and at least 2.
-	if (!is.numeric(T) || length(T) != 1 || T < 2) {
-		stop("T must be a numeric value greater than or equal to 2")
-	}
-
-	# Check that G is a numeric scalar and at least 1.
-	if (!is.numeric(G) || length(G) != 1 || G < 1) {
-		stop(
-			"G must be a numeric value greater than or equal to 1 (at least one treated cohort)"
-		)
-	}
-
-	# Check that G does not exceed T - 1.
-	if (G > T - 1) {
-		stop("G must be less than or equal to T - 1")
-	}
-
-	# Check that d is a numeric scalar and is non-negative.
-	if (!is.numeric(d) || length(d) != 1 || d < 0) {
-		stop("d must be a non-negative numeric value")
-	}
-
-	# Check that density is a numeric scalar in (0, 1] (1 = fully dense, non-sparse).
-	if (
-		!is.numeric(density) ||
-			length(density) != 1 ||
-			density <= 0 ||
-			density > 1
-	) {
-		stop("density must be numeric, greater than 0 and at most 1")
-	}
-
-	# Check that eff_size is numeric.
-	if (!is.numeric(eff_size) || length(eff_size) != 1) {
-		stop("eff_size must be a numeric value")
-	}
+	# Validate the scalar arguments (single-sourced across genCoefs /
+	# genCoefsCore so the user-visible error text stays identical; #401).
+	.validate_gen_coefs_scalars(
+		T = T,
+		G = G,
+		d = d,
+		density = density,
+		eff_size = eff_size
+	)
 
 	fusion_structure <- match.arg(fusion_structure)
 	assignment_type <- match.arg(assignment_type)
@@ -928,42 +901,15 @@ genCoefsCore <- function(
 	# targeted-sparsity check in particular is a pure, RNG-free check (#332).
 	.validate_targeted_sparsity(n_signal_cohorts, treat_base_levels, G)
 
-	# Check that T is a numeric scalar and at least 2.
-	if (!is.numeric(T) || length(T) != 1 || T < 2) {
-		stop("T must be a numeric value greater than or equal to 2")
-	}
-
-	# Check that G is a numeric scalar and at least 1.
-	if (!is.numeric(G) || length(G) != 1 || G < 1) {
-		stop(
-			"G must be a numeric value greater than or equal to 1 (at least one treated cohort)"
-		)
-	}
-
-	# Check that G does not exceed T - 1.
-	if (G > T - 1) {
-		stop("G must be less than or equal to T - 1")
-	}
-
-	# Check that d is a numeric scalar and is non-negative.
-	if (!is.numeric(d) || length(d) != 1 || d < 0) {
-		stop("d must be a non-negative numeric value")
-	}
-
-	# Check that density is a numeric scalar in (0, 1] (1 = fully dense, non-sparse).
-	if (
-		!is.numeric(density) ||
-			length(density) != 1 ||
-			density <= 0 ||
-			density > 1
-	) {
-		stop("density must be numeric, greater than 0 and at most 1")
-	}
-
-	# Check that eff_size is numeric.
-	if (!is.numeric(eff_size) || length(eff_size) != 1) {
-		stop("eff_size must be a numeric value")
-	}
+	# Validate the scalar arguments (single-sourced across genCoefs /
+	# genCoefsCore so the user-visible error text stays identical; #401).
+	.validate_gen_coefs_scalars(
+		T = T,
+		G = G,
+		d = d,
+		density = density,
+		eff_size = eff_size
+	)
 
 	stopifnot(G >= 1)
 	stopifnot(T >= 2)
@@ -1243,4 +1189,52 @@ getActualCohortTes <- function(G, first_inds, treat_inds, coefs, num_treats) {
 	}
 
 	return(actual_cohort_tes)
+}
+
+#' @title Validate the scalar arguments shared by genCoefs() and genCoefsCore()
+#' @description Single-sources the user-visible error text for the `T` / `G` /
+#'   `d` / `density` / `eff_size` scalar checks (#401). Both entry points
+#'   re-validate defensively (`genCoefsCore()` is exported and callable
+#'   directly), so this keeps the messages identical across the two.
+#' @keywords internal
+#' @noRd
+.validate_gen_coefs_scalars <- function(T, G, d, density, eff_size) {
+	# Check that T is a numeric scalar and at least 2.
+	if (!is.numeric(T) || length(T) != 1 || T < 2) {
+		stop("T must be a numeric value greater than or equal to 2")
+	}
+
+	# Check that G is a numeric scalar and at least 1.
+	if (!is.numeric(G) || length(G) != 1 || G < 1) {
+		stop(
+			"G must be a numeric value greater than or equal to 1 (at least one treated cohort)"
+		)
+	}
+
+	# Check that G does not exceed T - 1.
+	if (G > T - 1) {
+		stop("G must be less than or equal to T - 1")
+	}
+
+	# Check that d is a numeric scalar and is non-negative.
+	if (!is.numeric(d) || length(d) != 1 || d < 0) {
+		stop("d must be a non-negative numeric value")
+	}
+
+	# Check that density is a numeric scalar in (0, 1] (1 = fully dense, non-sparse).
+	if (
+		!is.numeric(density) ||
+			length(density) != 1 ||
+			density <= 0 ||
+			density > 1
+	) {
+		stop("density must be numeric, greater than 0 and at most 1")
+	}
+
+	# Check that eff_size is numeric.
+	if (!is.numeric(eff_size) || length(eff_size) != 1) {
+		stop("eff_size must be a numeric value")
+	}
+
+	invisible()
 }


### PR DESCRIPTION

Small consolidation from the #401 backlog. The byte-identical scalar-argument checks (`T` / `G` / `G <= T - 1` / `d` / `density` / `eff_size`, with their `stop()` messages) that appeared inline in BOTH `genCoefs()` and `genCoefsCore()` are extracted into `.validate_gen_coefs_scalars(T, G, d, density, eff_size)`, called from both. **Byte-identical user-facing behavior** (same error strings) — no version bump.

The two inline blocks were `diff`-verified identical before folding; the extraction is confirmed byte-identical live (both entry points emit the same T / density / etc. messages, a valid call still succeeds) and `codetools` is clean. The defensive re-validation is preserved (`genCoefsCore()` is exported and callable directly) — this single-sources only the shared error *text* so the two can't drift.

Independent of batch 1 (#415) and the open #400 stack (different file). Remaining #401 items: the higher-risk core ATT-pair + fusion treat-block consolidations (separate careful PRs), and the four items touching #400-modified files (deferred until #400 merges).

Refs #401.
