### PR TITLE
refactor: single-source the core ATT-pair tail into `.compute_att_pair()` (#401, batch 3)

### DIFF
--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -1261,67 +1261,47 @@ betwfe_core <- function(
 	#
 
 	# Get overal estimated ATT!
-	in_sample_te_results <- getTeResultsOLS(
-		sig_eps_sq = sig_eps_sq,
-		N = N,
-		T = T,
-		G = G,
-		num_treats = num_treats,
-		cohort_tes = cohort_tes, # CATTs (point estimates)
-		cohort_probs = cohort_probs, # In-sample pi_g | treated
-		psi_mat = psi_mat,
-		gram_inv = gram_inv,
-		tes = tes[sel_treat_inds_shifted], # Untransformed treatment effect estimates beta_hat[treat_inds]
-		cohort_probs_overall = cohort_probs_overall, # In-sample pi_g (unconditional on treated)
-		calc_ses = calc_ses,
-		indep_probs = FALSE,
-		se_type = se_type,
-		sandwich_full = sandwich_full,
-		treat_block_mask = treat_block_mask
-	)
-
-	in_sample_att_hat <- in_sample_te_results$att_hat
-	in_sample_att_se <- in_sample_te_results$att_te_se
-	in_sample_att_se_no_prob <- in_sample_te_results$att_te_se_no_prob
-	in_sample_att_var_1 <- in_sample_te_results$att_var_1
-	in_sample_att_var_2 <- in_sample_te_results$att_var_2
-
-	if ((q < 1) & calc_ses) {
-		stopifnot(!is.na(in_sample_att_se))
-	}
-
-	if (indep_count_data_available) {
-		stopifnot(nrow(psi_mat) == length(tes[sel_treat_inds_shifted]))
-
-		indep_te_results <- getTeResultsOLS(
+	att_pair <- .compute_att_pair(
+		te_fn = getTeResultsOLS,
+		base_args = list(
 			sig_eps_sq = sig_eps_sq,
 			N = N,
 			T = T,
 			G = G,
 			num_treats = num_treats,
-			cohort_tes = cohort_tes,
-			cohort_probs = indep_cohort_probs, # indep pi_g | treated
+			cohort_tes = cohort_tes, # CATTs (point estimates)
 			psi_mat = psi_mat,
 			gram_inv = gram_inv,
-			tes = tes[sel_treat_inds_shifted],
-			cohort_probs_overall = indep_cohort_probs_overall, # indep pi_g (unconditional)
+			tes = tes[sel_treat_inds_shifted], # Untransformed treatment effect estimates beta_hat[treat_inds]
 			calc_ses = calc_ses,
-			indep_probs = TRUE,
 			se_type = se_type,
 			sandwich_full = sandwich_full,
 			treat_block_mask = treat_block_mask
-		)
+		),
+		in_sample_probs = list(
+			cohort_probs = cohort_probs, # In-sample pi_g | treated
+			cohort_probs_overall = cohort_probs_overall # In-sample pi_g (unconditional on treated)
+		),
+		indep_probs_args = list(
+			cohort_probs = indep_cohort_probs, # indep pi_g | treated
+			cohort_probs_overall = indep_cohort_probs_overall # indep pi_g (unconditional)
+		),
+		indep_count_data_available = indep_count_data_available,
+		assert_att_se = (q < 1) & calc_ses,
+		indep_precheck = function() {
+			stopifnot(nrow(psi_mat) == length(tes[sel_treat_inds_shifted]))
+		}
+	)
 
-		indep_att_hat <- indep_te_results$att_hat
-		indep_att_se <- indep_te_results$att_te_se
-		indep_att_var_1 <- indep_te_results$att_var_1
-		indep_att_var_2 <- indep_te_results$att_var_2
-	} else {
-		indep_att_hat <- NA
-		indep_att_se <- NA
-		indep_att_var_1 <- NA
-		indep_att_var_2 <- NA
-	}
+	in_sample_att_hat <- att_pair$in_sample_att_hat
+	in_sample_att_se <- att_pair$in_sample_att_se
+	in_sample_att_se_no_prob <- att_pair$in_sample_att_se_no_prob
+	in_sample_att_var_1 <- att_pair$in_sample_att_var_1
+	in_sample_att_var_2 <- att_pair$in_sample_att_var_2
+	indep_att_hat <- att_pair$indep_att_hat
+	indep_att_se <- att_pair$indep_att_se
+	indep_att_var_1 <- att_pair$indep_att_var_1
+	indep_att_var_2 <- att_pair$indep_att_var_2
 
 	return(list(
 		in_sample_att_hat = in_sample_att_hat,

--- a/R/etwfe_core.R
+++ b/R/etwfe_core.R
@@ -420,60 +420,43 @@ checkEtwfeInputs <- function(
 	stopifnot(length(tes) == num_treats_eff)
 	stopifnot(nrow(psi_mat) == length(tes))
 
-	in_sample_te_results <- getTeResultsOLS(
-		sig_eps_sq = sig_eps_sq,
-		N = N,
-		T = T,
-		G = G,
-		num_treats = num_treats_eff,
-		cohort_tes = cohort_tes, # CATTs (point estimates)
-		cohort_probs = cohort_probs, # In-sample pi_g | treated
-		psi_mat = psi_mat,
-		gram_inv = gram_inv,
-		tes = tes, # Untransformed treatment effect estimates beta_hat[treat_inds]
-		cohort_probs_overall = cohort_probs_overall, # In-sample pi_g (unconditional on treated)
-		calc_ses = calc_ses,
-		indep_probs = FALSE,
-		se_type = se_type,
-		sandwich_full = sandwich_full,
-		treat_block_mask = treat_block_mask
-	)
-
-	in_sample_att_hat <- in_sample_te_results$att_hat
-	in_sample_att_se <- in_sample_te_results$att_te_se
-	in_sample_att_se_no_prob <- in_sample_te_results$att_te_se_no_prob
-	in_sample_att_var_1 <- in_sample_te_results$att_var_1
-	in_sample_att_var_2 <- in_sample_te_results$att_var_2
-
-	if (indep_count_data_available) {
-		indep_te_results <- getTeResultsOLS(
+	att_pair <- .compute_att_pair(
+		te_fn = getTeResultsOLS,
+		base_args = list(
 			sig_eps_sq = sig_eps_sq,
 			N = N,
 			T = T,
 			G = G,
 			num_treats = num_treats_eff,
-			cohort_tes = cohort_tes,
-			cohort_probs = indep_cohort_probs, # indep pi_g | treated
+			cohort_tes = cohort_tes, # CATTs (point estimates)
 			psi_mat = psi_mat,
 			gram_inv = gram_inv,
-			tes = tes,
-			cohort_probs_overall = indep_cohort_probs_overall, # indep pi_g (unconditional)
+			tes = tes, # Untransformed treatment effect estimates beta_hat[treat_inds]
 			calc_ses = calc_ses,
-			indep_probs = TRUE,
 			se_type = se_type,
 			sandwich_full = sandwich_full,
 			treat_block_mask = treat_block_mask
-		)
-		indep_att_hat <- indep_te_results$att_hat
-		indep_att_se <- indep_te_results$att_te_se
-		indep_att_var_1 <- indep_te_results$att_var_1
-		indep_att_var_2 <- indep_te_results$att_var_2
-	} else {
-		indep_att_hat <- NA
-		indep_att_se <- NA
-		indep_att_var_1 <- NA
-		indep_att_var_2 <- NA
-	}
+		),
+		in_sample_probs = list(
+			cohort_probs = cohort_probs, # In-sample pi_g | treated
+			cohort_probs_overall = cohort_probs_overall # In-sample pi_g (unconditional on treated)
+		),
+		indep_probs_args = list(
+			cohort_probs = indep_cohort_probs, # indep pi_g | treated
+			cohort_probs_overall = indep_cohort_probs_overall # indep pi_g (unconditional)
+		),
+		indep_count_data_available = indep_count_data_available
+	)
+
+	in_sample_att_hat <- att_pair$in_sample_att_hat
+	in_sample_att_se <- att_pair$in_sample_att_se
+	in_sample_att_se_no_prob <- att_pair$in_sample_att_se_no_prob
+	in_sample_att_var_1 <- att_pair$in_sample_att_var_1
+	in_sample_att_var_2 <- att_pair$in_sample_att_var_2
+	indep_att_hat <- att_pair$indep_att_hat
+	indep_att_se <- att_pair$indep_att_se
+	indep_att_var_1 <- att_pair$indep_att_var_1
+	indep_att_var_2 <- att_pair$indep_att_var_2
 
 	return(list(
 		in_sample_att_hat = in_sample_att_hat,

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -820,70 +820,47 @@ fetwfe_core <- function(
 	# sel_treat_inds contains global indices of selected transformed features that are treatment effects
 	theta_hat_treat_sel_for_att <- theta_hat_slopes[sel_treat_inds]
 
-	in_sample_te_results <- getTeResults2(
-		sig_eps_sq = sig_eps_sq,
-		N = N,
-		T = T,
-		G = G,
-		num_treats = num_treats,
-		cohort_tes = cohort_tes, # CATTs (point estimates)
-		cohort_probs = cohort_probs, # In-sample pi_g | treated
-		psi_mat = psi_mat,
-		gram_inv = gram_inv,
-		sel_treat_inds_shifted = sel_treat_inds_shifted,
-		d_inv_treat_sel = d_inv_treat_sel,
-		cohort_probs_overall = cohort_probs_overall, # In-sample pi_g (unconditional on treated)
-		first_inds = first_inds,
-		theta_hat_treat_sel = theta_hat_treat_sel_for_att, # Selected non-zero transformed treat coefs
-		calc_ses = calc_ses,
-		indep_probs = FALSE,
-		se_type = se_type,
-		sandwich_full = sandwich_full,
-		treat_block_mask = treat_block_mask
-	)
-
-	in_sample_att_hat <- in_sample_te_results$att_hat
-	in_sample_att_se <- in_sample_te_results$att_te_se
-	in_sample_att_se_no_prob <- in_sample_te_results$att_te_se_no_prob
-	in_sample_att_var_1 <- in_sample_te_results$att_var_1
-	in_sample_att_var_2 <- in_sample_te_results$att_var_2
-
-	if ((q < 1) & calc_ses) {
-		stopifnot(!is.na(in_sample_att_se))
-	}
-
-	if (indep_count_data_available) {
-		indep_te_results <- getTeResults2(
+	att_pair <- .compute_att_pair(
+		te_fn = getTeResults2,
+		base_args = list(
 			sig_eps_sq = sig_eps_sq,
 			N = N,
 			T = T,
 			G = G,
 			num_treats = num_treats,
-			cohort_tes = cohort_tes,
-			cohort_probs = indep_cohort_probs, # indep pi_g | treated
+			cohort_tes = cohort_tes, # CATTs (point estimates)
 			psi_mat = psi_mat,
 			gram_inv = gram_inv,
 			sel_treat_inds_shifted = sel_treat_inds_shifted,
 			d_inv_treat_sel = d_inv_treat_sel,
-			cohort_probs_overall = indep_cohort_probs_overall, # indep pi_g (unconditional)
 			first_inds = first_inds,
-			theta_hat_treat_sel = theta_hat_treat_sel_for_att,
+			theta_hat_treat_sel = theta_hat_treat_sel_for_att, # Selected non-zero transformed treat coefs
 			calc_ses = calc_ses,
-			indep_probs = TRUE,
 			se_type = se_type,
 			sandwich_full = sandwich_full,
 			treat_block_mask = treat_block_mask
-		)
-		indep_att_hat <- indep_te_results$att_hat
-		indep_att_se <- indep_te_results$att_te_se
-		indep_att_var_1 <- indep_te_results$att_var_1
-		indep_att_var_2 <- indep_te_results$att_var_2
-	} else {
-		indep_att_hat <- NA
-		indep_att_se <- NA
-		indep_att_var_1 <- NA
-		indep_att_var_2 <- NA
-	}
+		),
+		in_sample_probs = list(
+			cohort_probs = cohort_probs, # In-sample pi_g | treated
+			cohort_probs_overall = cohort_probs_overall # In-sample pi_g (unconditional on treated)
+		),
+		indep_probs_args = list(
+			cohort_probs = indep_cohort_probs, # indep pi_g | treated
+			cohort_probs_overall = indep_cohort_probs_overall # indep pi_g (unconditional)
+		),
+		indep_count_data_available = indep_count_data_available,
+		assert_att_se = (q < 1) & calc_ses
+	)
+
+	in_sample_att_hat <- att_pair$in_sample_att_hat
+	in_sample_att_se <- att_pair$in_sample_att_se
+	in_sample_att_se_no_prob <- att_pair$in_sample_att_se_no_prob
+	in_sample_att_var_1 <- att_pair$in_sample_att_var_1
+	in_sample_att_var_2 <- att_pair$in_sample_att_var_2
+	indep_att_hat <- att_pair$indep_att_hat
+	indep_att_se <- att_pair$indep_att_se
+	indep_att_var_1 <- att_pair$indep_att_var_1
+	indep_att_var_2 <- att_pair$indep_att_var_2
 
 	return(list(
 		in_sample_att_hat = in_sample_att_hat,

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -678,6 +678,84 @@ getTeResults2 <- function(
 	))
 }
 
+#' @title Compute the in-sample / independent overall-ATT pair
+#' @description Single-sources the ATT-pair tail shared by the three estimator
+#'   cores (`fetwfe_core`, `betwfe_core`, `.ols_estimator_core`): call the
+#'   treatment-effect function once in-sample (`indep_probs = FALSE`), pull the
+#'   five in-sample ATT fields, then — when independent count data is available —
+#'   call it again with the independent cohort probabilities (`indep_probs =
+#'   TRUE`) for the four independent fields, else `NA`-fill them. The two cores
+#'   using `getTeResultsOLS()` and the one using `getTeResults2()` differ only in
+#'   the treatment-effect function and its per-function arguments, so the
+#'   function is passed as `te_fn` and its arguments are threaded through
+#'   `do.call()`.
+#' @param te_fn The treatment-effect function to call ([getTeResults2()] or
+#'   [getTeResultsOLS()]).
+#' @param base_args Named list of the arguments common to both calls (everything
+#'   except `cohort_probs`, `cohort_probs_overall`, and `indep_probs`).
+#' @param in_sample_probs Named list `list(cohort_probs = ..., cohort_probs_overall
+#'   = ...)` for the in-sample call.
+#' @param indep_probs_args Named list `list(cohort_probs = ..., cohort_probs_overall
+#'   = ...)` for the independent call.
+#' @param indep_count_data_available Logical; if `FALSE`, the four independent
+#'   fields are `NA` and `te_fn` is called only once.
+#' @param assert_att_se Logical; when `TRUE`, `stopifnot(!is.na(att_se))` after the
+#'   in-sample call (the `(q < 1) & calc_ses` guard the bridge cores apply).
+#' @param indep_precheck Optional zero-argument function run at the top of the
+#'   independent branch (betwfe's `psi_mat`/`tes` dimension check); `NULL` to skip.
+#' @return A named list with `in_sample_att_hat`, `in_sample_att_se`,
+#'   `in_sample_att_se_no_prob`, `in_sample_att_var_1`, `in_sample_att_var_2`,
+#'   `indep_att_hat`, `indep_att_se`, `indep_att_var_1`, `indep_att_var_2`.
+#' @keywords internal
+#' @noRd
+.compute_att_pair <- function(
+	te_fn,
+	base_args,
+	in_sample_probs,
+	indep_probs_args,
+	indep_count_data_available,
+	assert_att_se = FALSE,
+	indep_precheck = NULL
+) {
+	in_sample_te_results <- do.call(
+		te_fn,
+		c(base_args, in_sample_probs, list(indep_probs = FALSE))
+	)
+
+	out <- list(
+		in_sample_att_hat = in_sample_te_results$att_hat,
+		in_sample_att_se = in_sample_te_results$att_te_se,
+		in_sample_att_se_no_prob = in_sample_te_results$att_te_se_no_prob,
+		in_sample_att_var_1 = in_sample_te_results$att_var_1,
+		in_sample_att_var_2 = in_sample_te_results$att_var_2
+	)
+
+	if (assert_att_se) {
+		stopifnot(!is.na(out$in_sample_att_se))
+	}
+
+	if (indep_count_data_available) {
+		if (!is.null(indep_precheck)) {
+			indep_precheck()
+		}
+		indep_te_results <- do.call(
+			te_fn,
+			c(base_args, indep_probs_args, list(indep_probs = TRUE))
+		)
+		out$indep_att_hat <- indep_te_results$att_hat
+		out$indep_att_se <- indep_te_results$att_te_se
+		out$indep_att_var_1 <- indep_te_results$att_var_1
+		out$indep_att_var_2 <- indep_te_results$att_var_2
+	} else {
+		out$indep_att_hat <- NA
+		out$indep_att_se <- NA
+		out$indep_att_var_1 <- NA
+		out$indep_att_var_2 <- NA
+	}
+
+	out
+}
+
 #' @title Compute the first ATT variance term (theta-convergence)
 #' @description Shared by [getTeResultsOLS()] and [getTeResults2()]: the
 #'   `att_var_1` piece of the overall-ATT variance. The cluster branch floors the


### PR DESCRIPTION
Consolidation item 2 from the #401 backlog. The "call `getTeResults*()` in-sample, pull the five ATT fields, [assert the SE], then call it again for the independent probabilities (or `NA`-fill)" skeleton was duplicated across the three estimator cores:

- `fetwfe_core` (`getTeResults2`),
- `betwfe_core` (`getTeResultsOLS`, plus a `psi_mat`/`tes` dimension check at the top of the indep branch),
- `.ols_estimator_core` (`getTeResultsOLS`, shared by `etwfe()` + `twfeCovs()`).

The two treatment-effect functions differ only in signature, so the new `@noRd` `.compute_att_pair()` (in `R/variance_machinery.R`, next to the functions it dispatches to) takes the TE function as `te_fn` and threads its arguments through `do.call()`. The `(q < 1) & calc_ses` SE assertion and betwfe's indep-branch precheck are preserved as an `assert_att_se` flag and an optional `indep_precheck` thunk, so the **firing order is exactly preserved** (in-sample call → extract 5 → `assert_att_se` → indep branch: `indep_precheck` → indep call → extract 4). Each core keeps its per-core `return(list(...))` **byte-identical** (field order still pinned by `test-bridge-out-list-field-order-343.R` / `test-ols-out-list-field-order-270.R`) by unpacking the helper's nine fields back into the existing locals.

**Behavior-neutral** — no version bump. Verified by a pre-vs-post worktree `identical()` battery over 20 configs (all four estimators × indep-branch on/off × `q` ∈ {0.5, 1} × 2 seeds; 10 configs exercise the indep branch): `identical(pre, post) == TRUE`, and the battery was mutation-checked to bite (an injected field-swap flipped 8/20). `codetools` clean on the helper and all three cores; full suite green.

Independent of batch 1 (#415), batch 2 (#416), and the open #400 stack — the three core files are untouched by #400, and the helper lands after `getTeResults2` (line ~680), clear of #400's `variance_machinery.R` hunk at line 478, so there is no textual conflict at any merge order.

Remaining #401 items: the fusion treat-block index consolidation (item 9, next separate PR), and the four items touching #400-modified files (items 1/3/6/7, deferred until #400 merges).

Refs #401.
