### PR TITLE
refactor: single-source the treat-block layout formula into `.base_cols()` (#401, batch 4)

### DIFF
--- a/R/fusion_transforms.R
+++ b/R/fusion_transforms.R
@@ -163,9 +163,9 @@ transformXintImproved <- function(
 			X_mod[, feat_inds_j] <- X_int[, feat_inds_j] %*%
 				genBackwardsInvFusionTransformMat(T - 1)
 		}
-		stopifnot(all(!is.na(X_mod[, 1:(G + T - 1 + d + G * d + (T - 1) * d)])))
+		stopifnot(all(!is.na(X_mod[, 1:(.base_cols(G, T, d))])))
 		stopifnot(all(is.na(X_mod[,
-			(G + T - 1 + d + G * d + (T - 1) * d + 1):p
+			(.base_cols(G, T, d) + 1):p
 		])))
 	}
 
@@ -174,13 +174,7 @@ transformXintImproved <- function(
 	# treatment effect of this cohort to base of previous cohort. New function
 	# genTransformedMatTwoWayFusion does this.
 
-	feat_inds <- (G + T - 1 + d + G * d + (T - 1) * d + 1):(G +
-		T -
-		1 +
-		d +
-		G * d +
-		(T - 1) * d +
-		num_treats)
+	feat_inds <- (.base_cols(G, T, d) + 1):(.base_cols(G, T, d) + num_treats)
 
 	# Now ready to generate the appropriate transformed matrix
 	stopifnot(all(is.na(X_mod[, feat_inds])))
@@ -206,7 +200,7 @@ transformXintImproved <- function(
 			# j + 2*d, ..., j + (num_treats - 1)*d.
 			inds_j <- seq(j, j + (num_treats - 1) * d, by = d)
 			stopifnot(length(inds_j) == num_treats)
-			inds_j <- inds_j + G + T - 1 + d + G * d + (T - 1) * d + num_treats
+			inds_j <- inds_j + .base_cols(G, T, d) + num_treats
 
 			# Now ready to generate the appropriate transformed matrix
 			stopifnot(all(is.na(X_mod[, inds_j])))
@@ -428,22 +422,16 @@ untransformCoefImproved <- function(
 			stopifnot(all(!is.na(beta_hat[feat_inds_j])))
 		}
 		stopifnot(all(
-			!is.na(beta_hat[1:(G + T - 1 + d + G * d + (T - 1) * d)])
+			!is.na(beta_hat[1:(.base_cols(G, T, d))])
 		))
 		stopifnot(all(is.na(beta_hat[
-			(G + T - 1 + d + G * d + (T - 1) * d + 1):p
+			(.base_cols(G, T, d) + 1):p
 		])))
 	}
 
 	# Now base treatment effects.
 
-	feat_inds <- (G + T - 1 + d + G * d + (T - 1) * d + 1):(G +
-		T -
-		1 +
-		d +
-		G * d +
-		(T - 1) * d +
-		num_treats)
+	feat_inds <- (.base_cols(G, T, d) + 1):(.base_cols(G, T, d) + num_treats)
 
 	stopifnot(all(is.na(beta_hat[feat_inds])))
 
@@ -459,11 +447,11 @@ untransformCoefImproved <- function(
 	if (d > 0) {
 		stopifnot(all(
 			!is.na(beta_hat[
-				1:(G + T - 1 + d + G * d + (T - 1) * d + num_treats)
+				1:(.base_cols(G, T, d) + num_treats)
 			])
 		))
 		stopifnot(all(is.na(beta_hat[
-			(G + T - 1 + d + G * d + (T - 1) * d + num_treats + 1):p
+			(.base_cols(G, T, d) + num_treats + 1):p
 		])))
 		# Lastly, interactions between each treatment effect and each feature.
 		# Feature-wise, we can do this with untransformTwoWayFusionCoefs, in the same
@@ -476,7 +464,7 @@ untransformCoefImproved <- function(
 			# j + 2*d, ..., j + (num_treats - 1)*d.
 			inds_j <- seq(j, j + (num_treats - 1) * d, by = d)
 			stopifnot(length(inds_j) == num_treats)
-			inds_j <- inds_j + G + T - 1 + d + G * d + (T - 1) * d + num_treats
+			inds_j <- inds_j + .base_cols(G, T, d) + num_treats
 
 			# Now ready to untransform the estimated coefficients
 			stopifnot(all(is.na(beta_hat[inds_j])))

--- a/R/utility.R
+++ b/R/utility.R
@@ -963,6 +963,31 @@ getNumTreats <- function(G, T) {
 	return(as.integer(T * G - (G * (G + 1)) / 2))
 }
 
+# .base_cols
+#' @title Number of design-matrix columns before the treatment-effect block
+#' @description The FETWFE / ETWFE / BETWFE design matrix `X_ints` orders its
+#'   columns as cohort fixed effects (`G`) + time fixed effects (`T - 1`) +
+#'   covariate main effects (`d`) + cohort x covariate (`G * d`) + time x
+#'   covariate (`(T - 1) * d`), and THEN the `num_treats` base treatment effects
+#'   followed by the treatment x covariate interactions. This returns the count
+#'   of those preceding columns, i.e. the offset such that the base
+#'   treatment-effect block occupies columns `(.base_cols(G, T, d) + 1)` through
+#'   `(.base_cols(G, T, d) + num_treats)`. The `d`-terms vanish at `d == 0`, so
+#'   the single unbranched expression is correct for all `d >= 0`.
+#'
+#'   Single-sources the layout formula that MUST match the design matrix
+#'   everywhere; previously re-derived inline across `R/fusion_transforms.R` and
+#'   in `getTreatInds()` (issue #401 item 9).
+#' @param G Integer; the number of treated cohorts.
+#' @param T Integer; the number of time periods.
+#' @param d Integer; the number of time-invariant covariates.
+#' @return The number of pre-treatment columns (same numeric type as the inputs).
+#' @keywords internal
+#' @noRd
+.base_cols <- function(G, T, d) {
+	G + T - 1 + d + G * d + (T - 1) * d
+}
+
 # getTreatInds
 #' @title Get Indices of Base Treatment Effect Parameters
 #' @description Determines the column indices in the full design matrix `X_ints` (or
@@ -988,11 +1013,7 @@ getNumTreats <- function(G, T) {
 #' @keywords internal
 #' @noRd
 getTreatInds <- function(G, T, d, num_treats) {
-	base_cols <- if (d > 0) {
-		G + (T - 1) + d + d * G + d * (T - 1)
-	} else {
-		G + (T - 1)
-	}
+	base_cols <- .base_cols(G, T, d)
 
 	# #185 SB6: as.integer() so the indices honor the @return contract
 	# (`seq()` returns a double vector here).


### PR DESCRIPTION
Consolidation item 9 from the #401 backlog. The design-matrix layout constant `base_cols = G + T - 1 + d + G*d + (T-1)*d` — the number of columns before the base-treatment-effect block, which MUST match the design matrix everywhere it is used — was re-derived inline across the fusion transform paths. It is now single-sourced into a new `@noRd` helper `.base_cols(G, T, d)` in `R/utility.R` (next to `getTreatInds`):

- **`getTreatInds()`** (the treat-index owner the issue points at) now computes `base_cols <- .base_cols(G, T, d)` instead of its own branched `if (d > 0) ... else ...`. Byte-identical: the branched and unbranched forms agree for all `d >= 0` (the `d`-terms vanish at `d == 0`), and the result is still `as.integer(seq(...))`.
- **`R/fusion_transforms.R`** — all 10 inline occurrences (NA-layout checks, the two `feat_inds` treat-block ranges, the `1:(base_cols + num_treats)` / `(base_cols + num_treats + 1):p` bounds, and the `inds_j` offsets) now call `.base_cols(G, T, d)`.

Deliberately **left inline** (independent defensive cross-checks, not layout derivations): the two `stopifnot(max(treat_inds) == G + T - 1 + d + G*d + (T-1)*d + num_treats)` assertions in `getTreatInds()` and `.compute_treat_inds()`. Folding those onto the helper would make them tautological, so they stay as an independent re-derivation that verifies `.base_cols` — a property the mutation-check below relies on. The same formula in `R/gen_coefs.R` is out of item-9 scope (separate file) and left for a possible follow-up.

**Behavior-neutral** — no version bump. Verified by a pre-vs-post worktree `identical()` battery: 32 estimator fits (`fetwfe`/`betwfe`/`etwfe`/`twfeCovs` × `d ∈ {0, 2}` — both arms of the reduced formula, exercising the fusion transform on the `fetwfe` path — × indep on/off × 2 seeds) plus a 40-entry `getTreatInds` grid including `d == 0`: `identical(pre, post) == TRUE`. Mutation-checked to bite (dropping the `+ d` term made `getTreatInds`' retained cross-check throw). `codetools` clean; full suite green; `check --as-cran` Status OK.

Independent of batches 1 (#415), 2 (#416), 3 (#417) and the open #400 stack — batch 4 touches only `R/utility.R` and `R/fusion_transforms.R`, which none of them modify.

Remaining #401 items: the four touching #400-modified files (items 1/3/6/7), deferred until the #400 stack merges.

Refs #401.
