### PR TITLE
refactor: single-source the Group B simultaneous-CI / event-study twins (#401, items 1/3/6/7)

### DIFF
--- a/R/event_study.R
+++ b/R/event_study.R
@@ -450,25 +450,16 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 		))
 	}
 
-	# Simultaneous band (#197): when ci_type == "simultaneous" and SEs are
-	# available, override the pointwise bounds with the event-study-family
-	# simultaneous band (degrading to pointwise on any error, and preserving
-	# NA on degenerate rows). `calc_ses` here is the LOCAL value (FALSE if the
-	# Gram on the selected support was singular), which is the right gate.
-	sb <- if (identical(ci_type, "simultaneous") && calc_ses) {
-		.event_study_simultaneous_bounds(x, alpha, estimates, ses)
-	} else {
-		NULL
-	}
-	.assemble_event_study_df(
+	.finish_event_study(
+		x,
+		alpha,
+		ci_type,
+		calc_ses,
 		event_times,
 		n_cohorts,
 		estimates,
 		ses,
-		z,
-		ci_low = sb$ci_low,
-		ci_high = sb$ci_high,
-		p_value = sb$adjusted_p_values
+		z
 	)
 }
 
@@ -657,23 +648,16 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 		))
 	}
 
-	# Simultaneous band (#197): see the matching block in
-	# `.event_study_etwfe_betwfe()`. `calc_ses` is the LOCAL value (FALSE if
-	# the selected-support Gram was singular).
-	sb <- if (identical(ci_type, "simultaneous") && calc_ses) {
-		.event_study_simultaneous_bounds(x, alpha, estimates, ses)
-	} else {
-		NULL
-	}
-	.assemble_event_study_df(
+	.finish_event_study(
+		x,
+		alpha,
+		ci_type,
+		calc_ses,
 		event_times,
 		n_cohorts,
 		estimates,
 		ses,
-		z,
-		ci_low = sb$ci_low,
-		ci_high = sb$ci_high,
-		p_value = sb$adjusted_p_values
+		z
 	)
 }
 
@@ -802,6 +786,54 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 	out
 }
 
+#' Finish an event-study aggregation: attach the simultaneous band + assemble
+#'
+#' @description Shared tail of the two event-study workers
+#'   (`.event_study_etwfe_betwfe()` and `.event_study_fetwfe()`). When
+#'   `ci_type == "simultaneous"` and SEs are available (`calc_ses` -- the LOCAL
+#'   value, FALSE if the selected-support Gram was singular), overrides the
+#'   pointwise bounds with the event-study-family simultaneous band (degrading
+#'   to pointwise on any error, preserving `NA` on degenerate rows); then builds
+#'   the event-study data frame via `.assemble_event_study_df()`. Consolidated
+#'   from a byte-identical tail previously duplicated across the two workers
+#'   (#401 item 1).
+#' @param x A fully-classed `fetwfe`/`etwfe`/`betwfe` object.
+#' @param alpha Numeric significance level.
+#' @param ci_type `"simultaneous"` or `"pointwise"`.
+#' @param calc_ses Logical; the LOCAL SE-availability gate.
+#' @param event_times,n_cohorts,estimates,ses,z Assembled by the worker loop and
+#'   forwarded to `.assemble_event_study_df()`.
+#' @return The event-study data frame from `.assemble_event_study_df()`.
+#' @keywords internal
+#' @noRd
+.finish_event_study <- function(
+	x,
+	alpha,
+	ci_type,
+	calc_ses,
+	event_times,
+	n_cohorts,
+	estimates,
+	ses,
+	z
+) {
+	sb <- if (identical(ci_type, "simultaneous") && calc_ses) {
+		.event_study_simultaneous_bounds(x, alpha, estimates, ses)
+	} else {
+		NULL
+	}
+	.assemble_event_study_df(
+		event_times,
+		n_cohorts,
+		estimates,
+		ses,
+		z,
+		ci_low = sb$ci_low,
+		ci_high = sb$ci_high,
+		p_value = sb$adjusted_p_values
+	)
+}
+
 #' Compute event-study-family simultaneous CI bounds at fit time
 #'
 #' @description Internal helper for the `ci_type = "simultaneous"` default
@@ -834,35 +866,17 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 #' @keywords internal
 #' @noRd
 .event_study_simultaneous_bounds <- function(x, alpha, estimates, ses) {
-	sci <- tryCatch(
-		suppressMessages(
-			.simultaneous_cis_impl(
-				x = x,
-				family = "event_study",
-				alpha = alpha,
-				contrasts = NULL,
-				has_valid_ses = TRUE,
-				# Silent band-attach helper (like .apply_simultaneous_catt_band):
-				# keep the high-dim degenerate notice a message() rather than a
-				# warning(). The user gets the warning by calling simultaneousCIs()
-				# directly. (In practice an all-zeroed fit has all-NA event-time SEs
-				# so this path is skipped; FALSE keeps it silent defensively.) #304.
-				warn_degenerate_highdim = FALSE
-			)
-		),
-		error = function(e) NULL
-	)
-	if (is.null(sci)) {
-		return(NULL)
-	}
 	# Positional alignment: `.build_psi_tes_for_family(family = "event_study")`
 	# iterates over event_times 0:(T-2), the SAME order the eventStudy() loop
-	# produces. Assert the row count defensively before mapping.
-	if (nrow(sci$ci) != length(estimates)) {
+	# produces, so the worker's rows map to `estimates` by position.
+	# `.fit_band_for_family()` runs the worker silently (#304), degrades to NULL
+	# on error, and asserts the row count (`length(estimates)`) defensively.
+	band <- .fit_band_for_family(x, "event_study", alpha, length(estimates))
+	if (is.null(band)) {
 		return(NULL)
 	}
-	ci_low <- sci$ci$simultaneous_ci_low
-	ci_high <- sci$ci$simultaneous_ci_high
+	ci_low <- band$ci_low
+	ci_high <- band$ci_high
 	# BLOCKER FIX (#197 round 1): preserve NA on degenerate event-time rows.
 	# `eventStudy()`'s loop sets se = NA -> NA bounds for an empty/degenerate
 	# valid-cohort-set event time; the worker returns 0/0 there. Mapping the
@@ -873,7 +887,7 @@ eventStudy <- function(x, alpha = NULL, ci_type = NULL) {
 	# Single-step max-T adjusted p-values (#200) -- the dual of the band.
 	# Force NA on the same degenerate rows the bounds are NA'd on, mirroring
 	# `.compute_p_values()` (which returns NA wherever se is NA).
-	adjusted_p_values <- sci$adjusted_p_values
+	adjusted_p_values <- band$adjusted_p_values
 	adjusted_p_values[na_rows] <- NA_real_
 	list(
 		ci_low = ci_low,

--- a/R/simultaneous_bootstrap.R
+++ b/R/simultaneous_bootstrap.R
@@ -881,7 +881,7 @@
 		pointwise_ci_high = estimates_used + pointwise_crit * ses,
 		stringsAsFactors = FALSE
 	)
-	out <- list(
+	out <- .assemble_simultaneous_cis_result(
 		ci = ci,
 		adjusted_p_values = adjusted_p_values,
 		critical_value = crit,
@@ -890,15 +890,17 @@
 		family = family,
 		alpha = alpha,
 		K = K,
-		method = "bootstrap",
-		B = B,
-		seed = seed,
-		multiplier = multiplier,
-		regime = if (isTRUE(attr(F_mat, "highdim"))) {
-			"high-dimensional"
-		} else {
-			"fixed-p"
-		}
+		extras = list(
+			method = "bootstrap",
+			B = B,
+			seed = seed,
+			multiplier = multiplier,
+			regime = if (isTRUE(attr(F_mat, "highdim"))) {
+				"high-dimensional"
+			} else {
+				"fixed-p"
+			}
+		)
 	)
 	# High-dimensional fits append the per-effect nodewise-direction diagnostics
 	# (feasibility = ||Sig v - a||_inf, the KKT certificate; convergence flags;

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -329,73 +329,13 @@ simultaneousCIs.fetwfe <- function(
 	)
 }
 
+#' @method simultaneousCIs etwfe
 #' @export
-simultaneousCIs.etwfe <- function(
-	result,
-	family = c("event_study", "cohort", "all_post_treatment", "custom"),
-	alpha = NULL,
-	contrasts = NULL,
-	method = c("analytic", "bootstrap"),
-	B = 1000L,
-	seed = NULL,
-	multiplier = c("rademacher", "mammen", "webb"),
-	lambda_c = 1.0,
-	riesz_max_iter = 5000L,
-	riesz_tol = 1e-9,
-	cv_time_budget = Inf
-) {
-	contract <- .check_for_simultaneous_cis(result)
-	family <- match.arg(family)
-	.simultaneous_cis_impl(
-		x = result,
-		family = family,
-		alpha = alpha,
-		contrasts = contrasts,
-		has_valid_ses = contract$has_valid_ses,
-		method = match.arg(method),
-		B = B,
-		seed = seed,
-		multiplier = match.arg(multiplier),
-		lambda_c = lambda_c,
-		riesz_max_iter = riesz_max_iter,
-		riesz_tol = riesz_tol,
-		cv_time_budget = cv_time_budget
-	)
-}
+simultaneousCIs.etwfe <- simultaneousCIs.fetwfe
 
+#' @method simultaneousCIs betwfe
 #' @export
-simultaneousCIs.betwfe <- function(
-	result,
-	family = c("event_study", "cohort", "all_post_treatment", "custom"),
-	alpha = NULL,
-	contrasts = NULL,
-	method = c("analytic", "bootstrap"),
-	B = 1000L,
-	seed = NULL,
-	multiplier = c("rademacher", "mammen", "webb"),
-	lambda_c = 1.0,
-	riesz_max_iter = 5000L,
-	riesz_tol = 1e-9,
-	cv_time_budget = Inf
-) {
-	contract <- .check_for_simultaneous_cis(result)
-	family <- match.arg(family)
-	.simultaneous_cis_impl(
-		x = result,
-		family = family,
-		alpha = alpha,
-		contrasts = contrasts,
-		has_valid_ses = contract$has_valid_ses,
-		method = match.arg(method),
-		B = B,
-		seed = seed,
-		multiplier = match.arg(multiplier),
-		lambda_c = lambda_c,
-		riesz_max_iter = riesz_max_iter,
-		riesz_tol = riesz_tol,
-		cv_time_budget = cv_time_budget
-	)
-}
+simultaneousCIs.betwfe <- simultaneousCIs.fetwfe
 
 #' @note `twfeCovs` is documented as biased in its own roxygen header. The
 #'   simultaneous CIs returned here are still mathematically well-defined on
@@ -406,39 +346,9 @@ simultaneousCIs.betwfe <- function(
 #'   event-time structure), so only `family = "cohort"` and
 #'   `family = "custom"` are defined for it; `"event_study"` and
 #'   `"all_post_treatment"` raise an error.
+#' @method simultaneousCIs twfeCovs
 #' @export
-simultaneousCIs.twfeCovs <- function(
-	result,
-	family = c("event_study", "cohort", "all_post_treatment", "custom"),
-	alpha = NULL,
-	contrasts = NULL,
-	method = c("analytic", "bootstrap"),
-	B = 1000L,
-	seed = NULL,
-	multiplier = c("rademacher", "mammen", "webb"),
-	lambda_c = 1.0,
-	riesz_max_iter = 5000L,
-	riesz_tol = 1e-9,
-	cv_time_budget = Inf
-) {
-	contract <- .check_for_simultaneous_cis(result)
-	family <- match.arg(family)
-	.simultaneous_cis_impl(
-		x = result,
-		family = family,
-		alpha = alpha,
-		contrasts = contrasts,
-		has_valid_ses = contract$has_valid_ses,
-		method = match.arg(method),
-		B = B,
-		seed = seed,
-		multiplier = match.arg(multiplier),
-		lambda_c = lambda_c,
-		riesz_max_iter = riesz_max_iter,
-		riesz_tol = riesz_tol,
-		cv_time_budget = cv_time_budget
-	)
-}
+simultaneousCIs.twfeCovs <- simultaneousCIs.fetwfe
 
 #' @title Shared worker for simultaneousCIs()
 #' @description Reconstructs the K x K joint covariance from the fit's stored
@@ -706,7 +616,7 @@ simultaneousCIs.twfeCovs <- function(
 			pointwise_ci_high = estimates,
 			stringsAsFactors = FALSE
 		)
-		out <- list(
+		return(.assemble_simultaneous_cis_result(
 			ci = ci,
 			adjusted_p_values = rep(NA_real_, K),
 			critical_value = pointwise_crit,
@@ -715,9 +625,7 @@ simultaneousCIs.twfeCovs <- function(
 			family = family,
 			alpha = alpha,
 			K = K
-		)
-		class(out) <- "simultaneous_cis"
-		return(out)
+		))
 	}
 
 	# --- 8. Shape Psi (p_sel x K): map each effect's per-cell contrast into the
@@ -1086,7 +994,7 @@ simultaneousCIs.twfeCovs <- function(
 		stringsAsFactors = FALSE
 	)
 
-	out <- list(
+	.assemble_simultaneous_cis_result(
 		ci = ci,
 		adjusted_p_values = adjusted_p_values,
 		critical_value = crit,
@@ -1096,8 +1004,6 @@ simultaneousCIs.twfeCovs <- function(
 		alpha = alpha,
 		K = K
 	)
-	class(out) <- "simultaneous_cis"
-	out
 }
 
 # .maxt_adjusted_p_nd
@@ -1164,6 +1070,106 @@ simultaneousCIs.twfeCovs <- function(
 	sqrt(v1 + v2 + 2 * sqrt(v1 * v2))
 }
 
+#' @title Assemble a `simultaneous_cis` result object
+#' @description Single-sources the shared out-list schema of the three
+#'   `simultaneous_cis` assembly sites: the normal analytic return and the
+#'   degenerate all-zero early return in `.simultaneous_cis_impl()`, and the
+#'   bootstrap return in `R/simultaneous_bootstrap.R`. All three carry the same
+#'   eight core fields; the bootstrap path additionally passes `extras`
+#'   (`method`/`B`/`seed`/`multiplier`/`regime`) and appends its high-dim
+#'   diagnostics AFTER this call. Keeping the schema single-sourced keeps the
+#'   analytic and bootstrap objects aligned for `print`/`tidy`/`plot` (#401
+#'   item 6).
+#' @param ci The per-effect CI data frame.
+#' @param adjusted_p_values Numeric vector (length `K`) of adjusted p-values.
+#' @param critical_value,pointwise_critical_value,bonferroni_critical_value
+#'   Numeric scalars; the simultaneous, pointwise, and Bonferroni critical
+#'   values.
+#' @param family Character; the CI family.
+#' @param alpha Numeric; the significance level.
+#' @param K Integer; the number of effects.
+#' @param extras Named list of fields appended after the core eight (e.g. the
+#'   bootstrap `method`/`B`/`seed`/`multiplier`/`regime`). Default empty.
+#' @return A list with class `"simultaneous_cis"`.
+#' @keywords internal
+#' @noRd
+.assemble_simultaneous_cis_result <- function(
+	ci,
+	adjusted_p_values,
+	critical_value,
+	pointwise_critical_value,
+	bonferroni_critical_value,
+	family,
+	alpha,
+	K,
+	extras = list()
+) {
+	out <- c(
+		list(
+			ci = ci,
+			adjusted_p_values = adjusted_p_values,
+			critical_value = critical_value,
+			pointwise_critical_value = pointwise_critical_value,
+			bonferroni_critical_value = bonferroni_critical_value,
+			family = family,
+			alpha = alpha,
+			K = K
+		),
+		extras
+	)
+	class(out) <- "simultaneous_cis"
+	out
+}
+
+#' @title Fit a simultaneous band for one CI family (silent, fault-tolerant)
+#' @description Single-sources the band-attach skeleton shared by the two
+#'   fit-time band helpers: `.apply_simultaneous_catt_band()` (cohort family,
+#'   this file) and `.event_study_simultaneous_bounds()` (`R/event_study.R`,
+#'   event-study family). Calls the #192 worker under `suppressMessages()` and
+#'   a `tryCatch()` that degrades to `NULL`, then defensively checks the row
+#'   count. The `warn_degenerate_highdim = FALSE` silence policy (#304) -- keep
+#'   the high-dim degenerate notice a `message()` the user only gets by calling
+#'   `simultaneousCIs()` / `eventStudy()` directly -- is the lockstep concern
+#'   single-sourced here (#401 item 7). Each caller keeps its own specifics (the
+#'   cohort `has_valid_ses` guard; the event-study `NA`-masking on degenerate
+#'   rows).
+#' @param x A fully-classed estimator object.
+#' @param family Character; `"cohort"` or `"event_study"`.
+#' @param alpha Numeric; the significance level.
+#' @param expected_rows Integer; the row count `sci$ci` must have to be usable
+#'   (`nrow(x$catt_df)` for cohort, `length(estimates)` for event study); a
+#'   mismatch returns `NULL`.
+#' @return A list `list(ci_low, ci_high, adjusted_p_values)`, or `NULL` to fall
+#'   back to pointwise.
+#' @keywords internal
+#' @noRd
+.fit_band_for_family <- function(x, family, alpha, expected_rows) {
+	sci <- tryCatch(
+		suppressMessages(
+			.simultaneous_cis_impl(
+				x = x,
+				family = family,
+				alpha = alpha,
+				contrasts = NULL,
+				has_valid_ses = TRUE,
+				warn_degenerate_highdim = FALSE
+			)
+		),
+		error = function(e) NULL
+	)
+	if (is.null(sci)) {
+		return(NULL)
+	}
+	if (nrow(sci$ci) != expected_rows) {
+		return(NULL)
+	}
+	list(
+		ci_low = sci$ci$simultaneous_ci_low,
+		ci_high = sci$ci$simultaneous_ci_high,
+		adjusted_p_values = sci$adjusted_p_values
+	)
+}
+
 #' @title Recompute a fit's cohort-family CIs as simultaneous bands (fit-time)
 #' @description Internal helper for the `ci_type = "simultaneous"` default
 #'   (#197). Calls the #192 worker `.simultaneous_cis_impl()` for the cohort
@@ -1190,46 +1196,15 @@ simultaneousCIs.twfeCovs <- function(
 	if (!isTRUE(has_valid_ses)) {
 		return(NULL)
 	}
-	# Cohort family. Wrap in tryCatch: a rank-deficient or degenerate family
-	# should NOT abort the fit -> fall back to pointwise (NULL).
-	# suppressMessages(): under se_type = "conservative" the worker emits a
-	# Bonferroni-substitution message(); we do NOT want unprompted chatter on
-	# every conservative fit (verbose-gating convention). The user retains the
-	# note by calling simultaneousCIs() directly. See Decision Log "Q1 / R2".
-	sci <- tryCatch(
-		suppressMessages(
-			.simultaneous_cis_impl(
-				x = x,
-				family = "cohort",
-				alpha = alpha,
-				contrasts = NULL,
-				has_valid_ses = TRUE,
-				# Fit-time precompute stays silent: keep the high-dim degenerate
-				# notice a message() (swallowed by suppressMessages above) rather
-				# than a warning(). The user gets the warning by calling
-				# simultaneousCIs() / eventStudy() directly. See #304.
-				warn_degenerate_highdim = FALSE
-			)
-		),
-		error = function(e) NULL
-	)
-	if (is.null(sci)) {
-		return(NULL)
-	}
-	# Positional alignment: `.build_psi_tes_for_family(family = "cohort")`
-	# iterates g = 1:G in cohort-block order, the SAME order
-	# `getCohortATTsFinal()` builds `catt_df`. So `sci$ci` is already
-	# row-aligned to `catt_df`. The `effect` labels differ
-	# ("Cohort <offset>" vs `catt_df$cohort` = `c_names`), so rely on
-	# position, not labels; assert the row count defensively.
-	if (nrow(sci$ci) != nrow(x$catt_df)) {
-		return(NULL)
-	}
-	list(
-		ci_low = sci$ci$simultaneous_ci_low,
-		ci_high = sci$ci$simultaneous_ci_high,
-		adjusted_p_values = sci$adjusted_p_values
-	)
+	# Cohort family. Positional alignment: `.build_psi_tes_for_family(family =
+	# "cohort")` iterates g = 1:G in cohort-block order, the SAME order
+	# `getCohortATTsFinal()` builds `catt_df`, so the worker's `sci$ci` is
+	# already row-aligned to `catt_df` (the `effect` labels differ --
+	# "Cohort <offset>" vs `catt_df$cohort` = `c_names` -- so rely on position,
+	# not labels). `.fit_band_for_family()` runs the worker silently
+	# (suppressMessages + warn_degenerate_highdim = FALSE, #304), degrades to
+	# NULL on error, and asserts the row count defensively.
+	.fit_band_for_family(x, "cohort", alpha, nrow(x$catt_df))
 }
 
 #' @title Apply the fit's `ci_type` to its cohort-family bounds (fit-time)

--- a/tests/testthat/test-simultaneous-cis-schema-lockstep-401.R
+++ b/tests/testthat/test-simultaneous-cis-schema-lockstep-401.R
@@ -1,0 +1,82 @@
+library(testthat)
+library(fetwfe)
+
+# ------------------------------------------------------------------------------
+# #401 batch 5 -- forward lockstep guards for the Group B consolidations that
+# single-source drift-prone STRUCTURE (as opposed to behavior, which the
+# pre/post identical() battery + the existing eventStudy/simultaneousCIs suite
+# already cover). These assert the invariants the consolidations exist to
+# protect, so a future edit that re-introduces the duplication -- or drifts one
+# copy -- breaks loudly here.
+#   - item 3: the four simultaneousCIs.<class> S3 methods are ONE implementation.
+#   - item 6: the analytic and bootstrap `simultaneous_cis` objects (assembled by
+#             `.assemble_simultaneous_cis_result()`) share the same core schema.
+# ------------------------------------------------------------------------------
+
+test_that("simultaneousCIs.<class> methods are aliases of one implementation (#401 item 3)", {
+	# The #351 (riesz_tol), #402, and #400 edits each had to touch all four
+	# method signatures in lockstep. Aliasing three to `.fetwfe` makes that
+	# impossible to drift; if a future change re-expands one method into its own
+	# body, these expectations fail.
+	fe <- getS3method("simultaneousCIs", "fetwfe")
+	expect_identical(getS3method("simultaneousCIs", "etwfe"), fe)
+	expect_identical(getS3method("simultaneousCIs", "betwfe"), fe)
+	expect_identical(getS3method("simultaneousCIs", "twfeCovs"), fe)
+})
+
+test_that("analytic and bootstrap simultaneous_cis share the same core schema (#401 item 6)", {
+	# print()/tidy()/plot() for `simultaneous_cis` read these fields positionally
+	# and by name; the analytic path, the analytic degenerate early-return, and
+	# the bootstrap path must stay aligned. `.assemble_simultaneous_cis_result()`
+	# single-sources them -- this pins the contract so a field added to one path
+	# but not another fails here.
+	core <- c(
+		"ci",
+		"adjusted_p_values",
+		"critical_value",
+		"pointwise_critical_value",
+		"bonferroni_critical_value",
+		"family",
+		"alpha",
+		"K"
+	)
+	cf <- genCoefs(G = 4, T = 5, d = 2, density = 0.5, eff_size = 2, seed = 270)
+	sim <- simulateData(
+		cf,
+		N = 160,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 270
+	)
+	fit <- fetwfe(
+		pdata = sim$pdata,
+		time_var = sim$time_var,
+		unit_var = sim$unit_var,
+		treatment = sim$treatment,
+		response = sim$response,
+		covs = sim$covs,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		verbose = FALSE
+	)
+	an <- simultaneousCIs(fit, family = "cohort", method = "analytic")
+	bo <- simultaneousCIs(
+		fit,
+		family = "cohort",
+		method = "bootstrap",
+		B = 100L,
+		seed = 1L
+	)
+	expect_s3_class(an, "simultaneous_cis")
+	expect_s3_class(bo, "simultaneous_cis")
+	# Analytic carries EXACTLY the core fields, in order.
+	expect_identical(names(an), core)
+	# Bootstrap carries the SAME core fields first, in the same order, then its
+	# method/B/seed/multiplier/regime extras.
+	expect_identical(names(bo)[seq_along(core)], core)
+	expect_true(all(
+		c("method", "B", "seed", "multiplier", "regime") %in% names(bo)
+	))
+	# The per-effect `ci` data frame column schema is shared (what tidy/plot read).
+	expect_identical(names(an$ci), names(bo$ci))
+})


### PR DESCRIPTION
The final four consolidations from the #401 backlog (Group B), unblocked now that the #400 scaffold stack has merged. Re-mapped against current code (the issue's line numbers predate #400). All behavior-neutral; `@noRd`/alias; **no version bump**.

- **Item 3** — the four `simultaneousCIs.<class>` methods had byte-identical bodies. `.fetwfe` stays canonical; `.etwfe`/`.betwfe`/`.twfeCovs` become `simultaneousCIs.X <- simultaneousCIs.fetwfe` aliases (explicit `@method`/`@export`; `.twfeCovs` keeps its `@note`). Drift-proofs the recurring signature-touch pain (#351/#402/#400 each had to edit all four in lockstep). NAMESPACE unchanged.
- **Item 1** — the two event-study workers ended with a byte-identical band+assemble tail → `.finish_event_study()`. (Gram/sandwich third already single-sourced in #400 Phase 2a; the SE loops stay separate — a full merge is hook-soup, explicitly rejected upstream.)
- **Item 7** — `.apply_simultaneous_catt_band` (cohort) and `.event_study_simultaneous_bounds` (event-study) shared the `tryCatch(suppressMessages(.simultaneous_cis_impl(..., warn_degenerate_highdim = FALSE)))` + null / row-count skeleton (the #304 silence policy is the lockstep concern) → `.fit_band_for_family(x, family, alpha, expected_rows)`. The cohort `has_valid_ses` guard and the event-study `NA`-masking stay in their wrappers.
- **Item 6** — the analytic return, the analytic **degenerate early-return** (a *third* site the issue's 2-site list missed), and the bootstrap return all build a `simultaneous_cis` out-list with the same 8 core fields → `.assemble_simultaneous_cis_result(<core>, extras = list())`. The bootstrap passes its `method`/`B`/`seed`/`multiplier`/`regime` as `extras` and still appends its high-dim diagnostics after. Keeps the analytic/bootstrap schema aligned for `print`/`tidy`/`plot`.

## Tests

Adds `tests/testthat/test-simultaneous-cis-schema-lockstep-401.R` — a **forward lockstep guard** (not a bug regression: these are no-op refactors, so there is no red-before/green-after). It pins the two invariants the consolidations exist to protect: the four methods are one implementation (item 3), and the analytic/bootstrap `simultaneous_cis` objects share the same core field + `ci`-column schema (item 6). Both assertions were **mutation-checked to bite** (re-expanding an alias → 1 failure; renaming a core field in the assembler → 2 failures).

## Verification

Behavior-neutral, proven by a pre-vs-post worktree `identical()` battery over **77 configs** — `simultaneousCIs()` across 4 classes × families {event_study, cohort, all_post_treatment} × method {analytic, bootstrap}, `eventStudy()` on all 4, fits with `ci_type = "simultaneous"`, and a high-dim fetwfe bootstrap (exercising item 6's high-dim diagnostics extras): `identical(pre, post) == TRUE`, mutation-checked to bite (44/77 flipped on a field reorder). `codetools` clean; `document()` NAMESPACE byte-identical; full suite green; `check --as-cran` Status OK.

Independent of the merged #400/#401 work; touches only `event_study.R`, `simultaneous_cis.R`, `simultaneous_bootstrap.R`. Completes #401's consolidation backlog (bar the optional `gen_coefs.R` `base_cols` follow-up noted on item 9).

Refs #401.
