### PR TITLE
refactor: fold gen_coefs.R's inline base_cols onto `.base_cols()` (#401 item-9 follow-up)

### DIFF
--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -1035,8 +1035,8 @@ genCoefsCore <- function(
 				theta[inds_j]
 		}
 
-		stopifnot(all(!is.na(beta[1:(G + T - 1 + d + G * d + (T - 1) * d)])))
-		stopifnot(all(is.na(beta[(G + T - 1 + d + G * d + (T - 1) * d + 1):p])))
+		stopifnot(all(!is.na(beta[1:(.base_cols(G, T, d))])))
+		stopifnot(all(is.na(beta[(.base_cols(G, T, d) + 1):p])))
 	}
 
 	# Base treatment effects: need to identify indices of first treatment
@@ -1056,23 +1056,18 @@ genCoefsCore <- function(
 		theta[treat_inds]
 
 	stopifnot(all(
-		!is.na(beta[1:(G + T - 1 + d + G * d + (T - 1) * d + num_treats)])
+		!is.na(beta[1:(.base_cols(G, T, d) + num_treats)])
 	))
 
 	if (d > 0) {
 		stopifnot(all(is.na(beta[
-			(G + T - 1 + d + G * d + (T - 1) * d + num_treats + 1):p
+			(.base_cols(G, T, d) + num_treats + 1):p
 		])))
 
 		# Treatment effect-X interactions
 		for (j in 1:d) {
-			first_ind_j <- G + T - 1 + d + G * d + (T - 1) * d + num_treats + j
-			last_ind_j <- G +
-				T -
-				1 +
-				d +
-				G * d +
-				(T - 1) * d +
+			first_ind_j <- .base_cols(G, T, d) + num_treats + j
+			last_ind_j <- .base_cols(G, T, d) +
 				num_treats +
 				(num_treats - 1) * d +
 				j


### PR DESCRIPTION
The optional follow-up noted on #401 item 9: `R/gen_coefs.R` (`genCoefsCore`) re-derived the design-matrix pre-treatment column count `base_cols = G + T - 1 + d + G*d + (T-1)*d` inline in six spots. Item 9 (PR #418) introduced the `@noRd` `.base_cols(G, T, d)` helper (in `utility.R`) and used it in `getTreatInds()` + `fusion_transforms.R`; this finishes the single-source by routing `genCoefsCore`'s six through it too.

Five sites were single-line (the NA-layout `stopifnot`s and the `first_ind_j` derivation); one was the multi-line `last_ind_j <- G + T - 1 + d + G*d + (T-1)*d + num_treats + (num_treats-1)*d + j`.

Deliberately **left untouched** (different quantities — the same over-replacement trap the item-9 review flagged): the partial offsets `(G + T - 1 + 1):(G + T - 1 + d)` (covariate main effects) and `1:(G + T - 1 + d + G * d)` (through cohort-covariate, without the `(T-1)*d` term). A full-string replace can't reach those shorter forms.

**Behavior-neutral** — no version bump. Verified by a pre-vs-post worktree `identical()` battery over 90 `genCoefs()` + downstream `simulateData()` configs (`d = 0` exercising the layout `stopifnot`s, `d > 0` exercising all six including the multi-line treatment×covariate loop, across several `G`/`T`/seed): `identical(pre, post) == TRUE`, mutation-checked to bite (dropping the `+ j` from the multi-line site flipped 84/90). `codetools` clean; `document()` produces no man/NAMESPACE change; full suite green; `check --as-cran` Status OK.

No new test: this is a mechanical replacement onto an existing helper (like the item-9 `fusion_transforms.R` sites), and the layout invariant is already single-sourced and independently cross-checked by `getTreatInds()`'s `stopifnot`s and the existing `genCoefs` suite.

Completes #401's `base_cols` single-sourcing. Refs #401.
