### PR TITLE
refactor: fold the fit-time getCohortATTsFinal scaffold onto .recompute_gram_and_sandwich() (#400)

### DIFF
--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -1731,60 +1731,58 @@ getCohortATTsFinal <- function(
 
 	stopifnot(nrow(X_final) == N * T)
 
-	# Translate the OLS-caller `sel_feat_inds = NULL` sentinel to the value
-	# each downstream helper expects: `getGramInv()` uses NA as its "all
-	# features" sentinel, while `.assemble_cluster_robust_sandwich()` uses
-	# NULL. See #118 round-1 plan review for the empirical equivalence
-	# verification.
+	# Translate the OLS-caller `sel_feat_inds = NULL` sentinel to the NA "all
+	# features" value `getGramInv()` expects; `.recompute_gram_and_sandwich()`
+	# maps NA back to NULL for the NULL-native cluster sandwich. See #118 round-1
+	# plan review for the empirical equivalence verification.
 	gram_sel_feat <- if (is.null(sel_feat_inds)) NA else sel_feat_inds
 	gram_sel_treat <- if (is.null(sel_feat_inds)) NA else sel_treat_inds_shifted
 
-	# Start by getting Gram matrix needed for standard errors
-	if (calc_ses) {
-		res <- getGramInv(
-			N = N,
-			T = T,
-			X_final = X_final,
-			sel_feat_inds = gram_sel_feat,
-			treat_inds = treat_inds,
-			num_treats = num_treats,
-			sel_treat_inds_shifted = gram_sel_treat,
-			calc_ses = calc_ses
-		)
-
-		gram_inv <- res$gram_inv
-		calc_ses <- res$calc_ses
-	} else {
-		gram_inv <- NA
-	}
-
-	# Cluster-robust sandwich (computed once outside the cohort loop and
-	# reused for the overall ATT in getTeResults2() / getTeResultsOLS()).
+	# Cluster-robust sandwich is computed once here (outside the cohort loop) and
+	# reused for the overall ATT in getTeResults2() / getTeResultsOLS().
 	sandwich_full <- NULL
 	treat_block_mask <- NULL
-
-	if (identical(se_type, "cluster") && calc_ses) {
-		stopifnot(!is.null(y_final))
-		stopifnot(length(y_final) >= N * T)
-		res <- .assemble_cluster_robust_sandwich(
+	if (calc_ses) {
+		# Cluster inputs are defensive-only (y_final is always supplied when a
+		# cluster fit has calc_ses = TRUE); validate before the sandwich uses it.
+		if (identical(se_type, "cluster")) {
+			stopifnot(!is.null(y_final))
+			stopifnot(length(y_final) >= N * T)
+		}
+		# Single-source the "recompute the Gram inverse on the selected support,
+		# then (for cluster) build the sandwich" scaffold shared with the
+		# access-time accessors (#400). Fit-time DEGRADES on a singular Gram
+		# (calc_ses -> FALSE); the access-time simultaneousCIs() path is the only
+		# one that stops.
+		scaffold <- .recompute_gram_and_sandwich(
 			X_final = X_final,
 			y_final = y_final,
 			N = N,
 			T = T,
 			treat_inds = treat_inds,
-			sel_feat_inds = sel_feat_inds
+			num_treats = num_treats,
+			sel_feat_inds = gram_sel_feat,
+			sel_treat_inds_shifted = gram_sel_treat,
+			se_type = se_type,
+			on_singular = "degrade"
 		)
-		sandwich_full <- res$sandwich_full
-		treat_block_mask <- res$treat_block_mask
-		# Branch-aware mask-length check: in the OLS-caller path the mask
-		# spans ncol(X_final); in the bridge path it spans length(sel_feat_inds).
-		expected_mask_len <- if (is.null(sel_feat_inds)) {
-			ncol(X_final)
-		} else {
-			length(sel_feat_inds)
+		gram_inv <- scaffold$gram_inv
+		calc_ses <- scaffold$calc_ses
+		sandwich_full <- scaffold$sandwich_full
+		treat_block_mask <- scaffold$treat_block_mask
+		if (identical(se_type, "cluster") && calc_ses) {
+			# Branch-aware mask-length check: the OLS-caller mask spans
+			# ncol(X_final); the bridge mask spans length(sel_feat_inds).
+			expected_mask_len <- if (is.null(sel_feat_inds)) {
+				ncol(X_final)
+			} else {
+				length(sel_feat_inds)
+			}
+			stopifnot(length(treat_block_mask) == expected_mask_len)
+			stopifnot(sum(treat_block_mask) == length(sel_treat_inds_shifted))
 		}
-		stopifnot(length(treat_block_mask) == expected_mask_len)
-		stopifnot(sum(treat_block_mask) == length(sel_treat_inds_shifted))
+	} else {
+		gram_inv <- NA
 	}
 
 	## We need the tau sub-matrix of D^{-1} ONLY if we are in fused workflow

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -565,8 +565,9 @@ getPsiGUnfused <- function(
 #'   support
 #' @description Single-sources the "recompute `getGramInv()` on the selected
 #'   support, then (if `se_type = "cluster"`) build the cluster-robust sandwich"
-#'   sequence that every access-time SE path shares (`eventStudy()`,
-#'   `cohortTimeATTs()`, `simultaneousCIs()`). These accessors MUST stay in
+#'   sequence shared by the fit-time path (`getCohortATTsFinal()`, which is where
+#'   the sequence originates) and every access-time SE path (`eventStudy()`,
+#'   `cohortTimeATTs()`, `simultaneousCIs()`). These MUST stay in
 #'   lockstep: a drift here would make them report inconsistent SEs for the same
 #'   fit (guarded by `test-cross-accessor-scaffold-guardrail-400.R`). This wraps
 #'   `getGramInv()` and `.assemble_cluster_robust_sandwich()` UNCHANGED (preserving
@@ -574,11 +575,26 @@ getPsiGUnfused <- function(
 #'   only unifies the surrounding recompute.
 #'
 #'   The one genuine policy difference between callers is `on_singular`: when the
-#'   recomputed Gram is singular, `eventStudy()` / `cohortTimeATTs()` DEGRADE
-#'   (return `calc_ses = FALSE`, so their SEs become `NA`), whereas
-#'   `simultaneousCIs()` STOPs. That branch is defensive-only -- it is unreachable
-#'   through any public fit (a fit with valid SEs already inverted its Gram on this
-#'   support), so it is exercised only by the helper's direct unit test.
+#'   recomputed Gram is singular, `getCohortATTsFinal()` / `eventStudy()` /
+#'   `cohortTimeATTs()` DEGRADE (return `calc_ses = FALSE`, so their SEs become
+#'   `NA`), whereas `simultaneousCIs()` STOPs. That branch is defensive-only, but
+#'   the reason differs by caller and only the access-time reason is airtight:
+#'
+#'   - **Access-time** callers cannot reach it. `has_valid_ses = TRUE` already
+#'     implies the fit's own `getGramInv()` succeeded on this exact support, so
+#'     the recompute is re-inverting a matrix known to be invertible.
+#'   - **Fit time** (`getCohortATTsFinal()`) performs the FIRST inversion, so the
+#'     argument above does not apply to it. Its unreachability rests instead on
+#'     the upstream `#395` rank guards intercepting a rank-deficient support
+#'     earlier. That is NOT proven: attempts to reach it (an `etwfe()` fit with
+#'     `p` near `NT`, and a `fetwfe()` fit on `bacondecomp::divorce` with an
+#'     exactly-collinear duplicated covariate) were each intercepted by those
+#'     guards, which is consistent with unreachable but does not establish it.
+#'     Per `PROFILE.md` § 12.1 a singular Gram is this package's signature
+#'     failure mode -- if you find a public fit that reaches this branch, that is
+#'     a real finding, not a curiosity.
+#'
+#'   Either way the branch is exercised only by the helper's direct unit test.
 #' @param X_final,y_final,N,T,treat_inds,num_treats Fit-design pieces, forwarded to
 #'   `getGramInv()` / `.assemble_cluster_robust_sandwich()`.
 #' @param sel_feat_inds Integer indices of the selected features, or the scalar

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -597,8 +597,13 @@ getPsiGUnfused <- function(
 #'     collinear at `1e-6` land between the two: `lm()` identifies every
 #'     coefficient, the centered Gram does not invert, and `etwfe()` returns
 #'     `att_se = NA` with `calc_ses = FALSE` plus the standard warning. Tighten the
-#'     collinearity to `1e-8` and `#395` errors first instead; an exact duplicate
-#'     is always caught by `#395`. Regression test:
+#'     collinearity to `1e-8` and `#395` errors first instead. An exact duplicate
+#'     is always caught by `#395` **in the OLS cores only**: the
+#'     `anyNA(beta_hat_slopes)` gate lives in `R/etwfe_core.R`, so `etwfe()` and
+#'     `twfeCovs()` error on an exactly duplicated covariate while the bridge
+#'     estimators `fetwfe()` and `betwfe()` fit it without complaint and report
+#'     `calc_ses = TRUE` with finite SEs (verified for both
+#'     `se_type = "default"` and `"cluster"`). Regression test:
 #'     `test-fit-time-singular-gram-degrade-400.R`.
 #' @param X_final,y_final,N,T,treat_inds,num_treats Fit-design pieces, forwarded to
 #'   `getGramInv()` / `.assemble_cluster_robust_sandwich()`.
@@ -1771,7 +1776,12 @@ getCohortATTsFinal <- function(
 	treat_block_mask <- NULL
 	if (calc_ses) {
 		# Cluster inputs are defensive-only (y_final is always supplied when a
-		# cluster fit has calc_ses = TRUE); validate before the sandwich uses it.
+		# cluster fit has calc_ses = TRUE). Note what moved in #400: this
+		# validation now runs BEFORE the Gram recompute, whereas pre-#400 it sat
+		# after getGramInv(), so a singular-Gram degrade (calc_ses -> FALSE)
+		# would skip it. That relocation is the single semantic difference the
+		# fold introduces, and it is inert precisely because calc_ses = TRUE
+		# always supplies a full-length y_final.
 		if (identical(se_type, "cluster")) {
 			stopifnot(!is.null(y_final))
 			stopifnot(length(y_final) >= N * T)

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -577,24 +577,29 @@ getPsiGUnfused <- function(
 #'   The one genuine policy difference between callers is `on_singular`: when the
 #'   recomputed Gram is singular, `getCohortATTsFinal()` / `eventStudy()` /
 #'   `cohortTimeATTs()` DEGRADE (return `calc_ses = FALSE`, so their SEs become
-#'   `NA`), whereas `simultaneousCIs()` STOPs. That branch is defensive-only, but
-#'   the reason differs by caller and only the access-time reason is airtight:
+#'   `NA`), whereas `simultaneousCIs()` STOPs. The two kinds of caller reach that
+#'   branch very differently, and only one of them cannot:
 #'
 #'   - **Access-time** callers cannot reach it. `has_valid_ses = TRUE` already
 #'     implies the fit's own `getGramInv()` succeeded on this exact support, so
-#'     the recompute is re-inverting a matrix known to be invertible.
-#'   - **Fit time** (`getCohortATTsFinal()`) performs the FIRST inversion, so the
-#'     argument above does not apply to it. Its unreachability rests instead on
-#'     the upstream `#395` rank guards intercepting a rank-deficient support
-#'     earlier. That is NOT proven: attempts to reach it (an `etwfe()` fit with
-#'     `p` near `NT`, and a `fetwfe()` fit on `bacondecomp::divorce` with an
-#'     exactly-collinear duplicated covariate) were each intercepted by those
-#'     guards, which is consistent with unreachable but does not establish it.
-#'     Per `PROFILE.md` § 12.1 a singular Gram is this package's signature
-#'     failure mode -- if you find a public fit that reaches this branch, that is
-#'     a real finding, not a curiosity.
-#'
-#'   Either way the branch is exercised only by the helper's direct unit test.
+#'     the recompute is re-inverting a matrix known to be invertible. For them
+#'     the branch is genuinely defensive, and is exercised only by the helper's
+#'     direct unit test.
+#'   - **Fit time** (`getCohortATTsFinal()`) performs the FIRST inversion, and its
+#'     degrade branch IS REACHABLE through an ordinary public fit -- it is the
+#'     designed backstop, not a defensive nicety. `R/utility.R`'s `#395` note says
+#'     so outright: "A genuinely singular collapsed design is caught downstream:
+#'     getGramInv() degrades calc_ses to FALSE." The gap the `#395` gate leaves is
+#'     a tolerance gap, not an oversight: that gate runs
+#'     `anyNA(coef(lm(y ~ . + 0, df)))` on the UNCENTERED, column-scaled design at
+#'     `lm.fit`'s `1e-7` QR tolerance, while `getGramInv()` tests the CENTERED Gram
+#'     at `max(dim) * .Machine$double.eps` relative (~9e-15 here). Two covariates
+#'     collinear at `1e-6` land between the two: `lm()` identifies every
+#'     coefficient, the centered Gram does not invert, and `etwfe()` returns
+#'     `att_se = NA` with `calc_ses = FALSE` plus the standard warning. Tighten the
+#'     collinearity to `1e-8` and `#395` errors first instead; an exact duplicate
+#'     is always caught by `#395`. Regression test:
+#'     `test-fit-time-singular-gram-degrade-400.R`.
 #' @param X_final,y_final,N,T,treat_inds,num_treats Fit-design pieces, forwarded to
 #'   `getGramInv()` / `.assemble_cluster_robust_sandwich()`.
 #' @param sel_feat_inds Integer indices of the selected features, or the scalar
@@ -642,6 +647,12 @@ getPsiGUnfused <- function(
 	sandwich_full <- NULL
 	treat_block_mask <- NULL
 	if (identical(se_type, "cluster") && isTRUE(calc_ses)) {
+		# The "all features" sentinel is a scalar NA (or NULL); an EMPTY support
+		# would fall through this test to `NULL` and be read as "all features" --
+		# the exact inverse. Unreachable today (both bridge cores assert
+		# `length(sel_feat_inds) > 0` immediately before calling, and the OLS core
+		# passes NULL), so this asserts rather than handles it.
+		stopifnot(is.null(sel_feat_inds) || length(sel_feat_inds) > 0L)
 		sel_arg <- if (any(!is.na(sel_feat_inds))) sel_feat_inds else NULL
 		res_cl <- .assemble_cluster_robust_sandwich(
 			X_final = X_final,

--- a/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
+++ b/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
@@ -150,6 +150,58 @@ test_that("scaffold SEs match pinned pre-refactor values on the fetwfe/default f
 	)
 })
 
+# The cluster fixture needs its own ABSOLUTE pins, and the reason is structural.
+# Anchor C (Part 1) cross-checks fit-time cohortStudy() against access-time
+# simultaneousCIs(). Before the #400 fold those were two independent
+# implementations, so that comparison detected drift in either. After the fold
+# BOTH sides call .recompute_gram_and_sandwich(), so Anchor C compares the helper
+# against itself and a change inside the helper moves both sides together. Proven
+# by mutation: perturbing sandwich_full by 5% inside the helper fails Anchor C on
+# pre-fold code (3 failures) and passes it entirely on post-fold code.
+#
+# The general lesson, worth remembering beyond this file: a cross-implementation
+# parity test loses ALL of its power the moment the two implementations it
+# compares are consolidated. Absolute pins do not have that failure mode.
+#
+# Part 2 above pins only fetwfe/default, leaving no absolute cluster-sandwich
+# value anywhere -- and the one other test that catches such a mutation
+# (test-getCohortATTsFinal-unification.R) covers only the OLS branch
+# (sel_feat_inds = NULL), so the BRIDGE cluster path had no check at all. Values
+# below were computed on this branch and verified byte-identical on origin/main.
+test_that("scaffold SEs match pinned pre-refactor values on the fetwfe/cluster fixture (#400 guardrail)", {
+	fit <- .g400_fits[["fetwfe/cluster"]]
+	expect_equal(
+		cohortStudy(fit)$se,
+		c(0.1853167, 0.1275883, 0.1469086, 0.1456402),
+		tolerance = 1e-6
+	)
+	expect_equal(
+		eventStudy(fit)$se,
+		c(0.1466590, 0.2003153, 0.2334116, 0.2379342, 0.2090416),
+		tolerance = 1e-6
+	)
+	expect_equal(
+		cohortTimeATTs(fit)$se,
+		c(
+			0.1985337,
+			0.1985337,
+			0.1985337,
+			0.2090416,
+			0.2090416,
+			0.1382049,
+			0.1764362,
+			0.1764362,
+			0.2351856,
+			0.1382049,
+			0.1930629,
+			0.1930629,
+			0.1382049,
+			0.2308755
+		),
+		tolerance = 1e-6
+	)
+})
+
 # --- Part 3: SE-unavailable fits degrade consistently ---------------------------
 
 test_that("an SE-unavailable fit degrades consistently: accessors -> NA, simultaneousCIs -> stop (#400 guardrail)", {
@@ -166,12 +218,12 @@ test_that("an SE-unavailable fit degrades consistently: accessors -> NA, simulta
 
 	# NB: the *shared-scaffold* singular-Gram branch (recomputed selected-support
 	# Gram singular -> res_gram$calc_ses = FALSE; the two accessors degrade to NA
-	# while simultaneousCIs STOPs "not invertible") is defensive-only. From the
-	# ACCESS-TIME callers exercised here it is UNREACHABLE -- has_valid_ses = TRUE
-	# already implies the fit's own getGramInv() on that support succeeded. That
-	# argument does NOT extend to the fit-time caller getCohortATTsFinal(), which
-	# performs the first inversion; see the roxygen on
-	# .recompute_gram_and_sandwich() in R/variance_machinery.R. Phase 2 guards the
+	# while simultaneousCIs STOPs "not invertible") is UNREACHABLE from the
+	# ACCESS-TIME callers exercised here -- has_valid_ses = TRUE already implies
+	# the fit's own getGramInv() on that support succeeded. It is reachable from
+	# the fit-time caller getCohortATTsFinal(); see the roxygen on
+	# .recompute_gram_and_sandwich() in R/variance_machinery.R and
+	# test-fit-time-singular-gram-degrade-400.R. Phase 2 guards the
 	# on_singular = c("degrade", "stop") policy with a direct unit test of the
 	# extracted helper (feeding it a rank-deficient support), which is the only
 	# place the asymmetry can be exercised.

--- a/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
+++ b/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
@@ -166,9 +166,12 @@ test_that("an SE-unavailable fit degrades consistently: accessors -> NA, simulta
 
 	# NB: the *shared-scaffold* singular-Gram branch (recomputed selected-support
 	# Gram singular -> res_gram$calc_ses = FALSE; the two accessors degrade to NA
-	# while simultaneousCIs STOPs "not invertible") is defensive-only and
-	# UNREACHABLE through any public fit -- has_valid_ses = TRUE already implies the
-	# fit's own getGramInv() on that support succeeded. Phase 2 guards that
+	# while simultaneousCIs STOPs "not invertible") is defensive-only. From the
+	# ACCESS-TIME callers exercised here it is UNREACHABLE -- has_valid_ses = TRUE
+	# already implies the fit's own getGramInv() on that support succeeded. That
+	# argument does NOT extend to the fit-time caller getCohortATTsFinal(), which
+	# performs the first inversion; see the roxygen on
+	# .recompute_gram_and_sandwich() in R/variance_machinery.R. Phase 2 guards the
 	# on_singular = c("degrade", "stop") policy with a direct unit test of the
 	# extracted helper (feeding it a rank-deficient support), which is the only
 	# place the asymmetry can be exercised.

--- a/tests/testthat/test-fit-time-singular-gram-degrade-400.R
+++ b/tests/testthat/test-fit-time-singular-gram-degrade-400.R
@@ -1,0 +1,76 @@
+library(testthat)
+library(fetwfe)
+
+# The FIT-TIME singular-Gram degrade in getCohortATTsFinal() (via
+# .recompute_gram_and_sandwich(), #400) is REACHABLE through an ordinary public
+# fit. It is the backstop R/utility.R's #395 note relies on: "A genuinely
+# singular collapsed design is caught downstream: getGramInv() degrades calc_ses
+# to FALSE."
+#
+# The reachable window exists because the two rank tests disagree. The #395 gate
+# runs anyNA(coef(lm(y ~ . + 0, df))) on the UNCENTERED, column-scaled design at
+# lm.fit's 1e-7 QR tolerance; getGramInv() tests the CENTERED Gram at
+# max(dim) * .Machine$double.eps relative. Covariates collinear at 1e-6 sit
+# between them.
+#
+# This test exists because the roxygen on .recompute_gram_and_sandwich() twice
+# asserted the opposite (that the branch was defensive-only / unreachable). An
+# untested claim about reachability rots; this one pins it.
+
+.singular_gram_panel <- function(near_dup) {
+	set.seed(3)
+	N <- 40L
+	T <- 5L
+	cohorts <- sample(c(0, 3, 4, 5), N, replace = TRUE)
+	df <- expand.grid(t = seq_len(T), id = seq_len(N))
+	df$cohort <- cohorts[df$id]
+	df$id <- as.character(df$id)
+	df$changed <- as.integer(df$cohort > 0 & df$t >= df$cohort)
+	df$x1 <- stats::rnorm(nrow(df))
+	# Near-collinear, NOT lm()-aliased at near_dup = 1e-6.
+	df$x2 <- df$x1 + near_dup * stats::rnorm(nrow(df))
+	df$y <- 0.5 * df$x1 + 0.3 * df$changed + stats::rnorm(nrow(df), sd = 0.4)
+	df
+}
+
+test_that("a public etwfe() fit reaches the fit-time singular-Gram degrade (#400)", {
+	df <- .singular_gram_panel(1e-6)
+
+	expect_warning(
+		fit <- etwfe(
+			pdata = df,
+			time_var = "t",
+			unit_var = "id",
+			treatment = "changed",
+			covs = c("x1", "x2"),
+			response = "y",
+			se_type = "cluster"
+		),
+		"not invertible"
+	)
+
+	# The point estimate survives; only inference degrades.
+	expect_false(fit$calc_ses)
+	expect_true(is.na(fit$att_se))
+	expect_true(is.finite(fit$att_hat))
+})
+
+test_that("tighter collinearity is intercepted by the #395 rank gate instead (#400)", {
+	# The complement of the case above: at 1e-8 the design IS lm()-aliased, so
+	# #395 errors before the Gram is ever formed. Pins the ordering of the two
+	# tolerances -- a future change to either threshold moves this boundary, and
+	# without this nothing would notice.
+	df <- .singular_gram_panel(1e-8)
+
+	expect_error(
+		etwfe(
+			pdata = df,
+			time_var = "t",
+			unit_var = "id",
+			treatment = "changed",
+			covs = c("x1", "x2"),
+			response = "y",
+			se_type = "cluster"
+		)
+	)
+})

--- a/tests/testthat/test-fit-time-singular-gram-degrade-400.R
+++ b/tests/testthat/test-fit-time-singular-gram-degrade-400.R
@@ -34,6 +34,13 @@ library(fetwfe)
 }
 
 test_that("a public etwfe() fit reaches the fit-time singular-Gram degrade (#400)", {
+	# The fixture straddles a ~1-decade window between the two rank tolerances,
+	# and getGramInv()'s side of it compares a Gram eigenvalue against
+	# max(dim) * .Machine$double.eps. That margin is BLAS/LAPACK-dependent, and
+	# the package has no CI, so a cross-platform shift would first surface as a
+	# CRAN failure. Keep the assertions strict, but only run them locally.
+	skip_on_cran()
+
 	df <- .singular_gram_panel(1e-6)
 
 	expect_warning(
@@ -60,6 +67,11 @@ test_that("tighter collinearity is intercepted by the #395 rank gate instead (#4
 	# #395 errors before the Gram is ever formed. Pins the ordering of the two
 	# tolerances -- a future change to either threshold moves this boundary, and
 	# without this nothing would notice.
+	#
+	# Same BLAS/no-CI caveat as above: the boundary this pins is only meaningful
+	# on the eigenvalue margin this machine's LAPACK produces.
+	skip_on_cran()
+
 	df <- .singular_gram_panel(1e-8)
 
 	expect_error(
@@ -71,6 +83,12 @@ test_that("tighter collinearity is intercepted by the #395 rank gate instead (#4
 			covs = c("x1", "x2"),
 			response = "y",
 			se_type = "cluster"
-		)
+		),
+		# Must be the #395 gate specifically. R/utility.R's
+		# .check_cohort_rank_for_ols() message also says "rank-deficient", so
+		# match the phrase unique to #395's anyNA(beta_hat_slopes) branch in
+		# R/etwfe_core.R. A bare expect_error() here would accept ANY failure
+		# and so would pin nothing.
+		regexp = "rank-deficient.*aliased columns receive NA estimates"
 	)
 })

--- a/tests/testthat/test-recompute-gram-sandwich-400.R
+++ b/tests/testthat/test-recompute-gram-sandwich-400.R
@@ -1,9 +1,13 @@
 # Direct unit test for the extracted scaffold helper .recompute_gram_and_sandwich()
 # (#400 Phase 2a). Its one genuine policy axis -- `on_singular` (degrade vs stop
-# on a singular recomputed Gram) -- is DEFENSIVE-ONLY and unreachable through any
-# public fit (a fit with valid SEs already inverted its Gram on this support; see
-# the note in test-cross-accessor-scaffold-guardrail-400.R). So the asymmetry can
-# only be exercised here, by feeding the helper a rank-deficient selected support.
+# on a singular recomputed Gram) -- is DEFENSIVE-ONLY. For the ACCESS-TIME callers
+# it is unreachable through any public fit (a fit with valid SEs already inverted
+# its Gram on this support). The FIT-TIME caller getCohortATTsFinal() performs the
+# first inversion, so that argument does not cover it; its unreachability rests on
+# the upstream #395 rank guards instead, and is not proven. See the roxygen on
+# .recompute_gram_and_sandwich() in R/variance_machinery.R. Either way the
+# asymmetry can only be exercised here, by feeding the helper a rank-deficient
+# selected support.
 
 test_that(".recompute_gram_and_sandwich() degrades vs stops on a singular selected-support Gram (#400)", {
 	# Rank-deficient support: feature columns 1 and 2 are identical, so the centered

--- a/tests/testthat/test-recompute-gram-sandwich-400.R
+++ b/tests/testthat/test-recompute-gram-sandwich-400.R
@@ -1,13 +1,14 @@
 # Direct unit test for the extracted scaffold helper .recompute_gram_and_sandwich()
-# (#400 Phase 2a). Its one genuine policy axis -- `on_singular` (degrade vs stop
-# on a singular recomputed Gram) -- is DEFENSIVE-ONLY. For the ACCESS-TIME callers
-# it is unreachable through any public fit (a fit with valid SEs already inverted
-# its Gram on this support). The FIT-TIME caller getCohortATTsFinal() performs the
-# first inversion, so that argument does not cover it; its unreachability rests on
-# the upstream #395 rank guards instead, and is not proven. See the roxygen on
-# .recompute_gram_and_sandwich() in R/variance_machinery.R. Either way the
-# asymmetry can only be exercised here, by feeding the helper a rank-deficient
-# selected support.
+# (#400 Phase 2a). Its one genuine policy axis is `on_singular` (degrade vs stop
+# on a singular recomputed Gram). For the ACCESS-TIME callers that branch is
+# defensive-only and unreachable through any public fit (a fit with valid SEs
+# already inverted its Gram on this support). It is NOT defensive-only for the
+# fit-time caller getCohortATTsFinal(), which performs the first inversion and
+# where the degrade IS reachable -- see the roxygen on
+# .recompute_gram_and_sandwich() in R/variance_machinery.R and the end-to-end
+# regression test in test-fit-time-singular-gram-degrade-400.R. The degrade/stop
+# ASYMMETRY, though, can still only be exercised here, by feeding the helper a
+# rank-deficient selected support directly.
 
 test_that(".recompute_gram_and_sandwich() degrades vs stops on a singular selected-support Gram (#400)", {
 	# Rank-deficient support: feature columns 1 and 2 are identical, so the centered


### PR DESCRIPTION
Completes #400. The four **access-time** copies of the "recompute the Gram inverse on the selected support, then (for `se_type = "cluster"`) build the cluster-robust sandwich" scaffold were single-sourced into `.recompute_gram_and_sandwich()` in #413; the **fit-time** original in `getCohortATTsFinal()` was left as honest copy-paste. On a closer look it folds cleanly, so this routes it through the same helper — the whole scaffold is now single-sourced.

The earlier "not a clean fold" concern (the `gram_inv <- NA` sentinel) doesn't actually block it: the helper already maps `getGramInv()`'s `NA` all-features sentinel back to `NULL` for the NULL-native sandwich (`sel_arg <- if (any(!is.na(sel_feat_inds))) sel_feat_inds else NULL`). The three genuinely fit-time-specific pieces stay at the call site:
1. the outer `if (calc_ses) { … } else { gram_inv <- NA }` gate (a fit may skip SEs entirely);
2. the `NULL → NA` sentinel translation (fit-time passes `sel_feat_inds = NULL` for the OLS all-features case; accessors use `NA`);
3. the fit-time `stopifnot`s (`y_final` validation for cluster; the branch-aware `treat_block_mask`-length checks).

Fit-time keeps its `on_singular = "degrade"` policy (only the access-time `simultaneousCIs()` path stops on a singular Gram).

**Behavior-neutral** — no version bump. Verified by a pre-vs-post worktree `identical()` battery over 64 configs (4 estimators × `se_type ∈ {default, cluster}` — cluster confirmed to exercise the sandwich — × fit object + `eventStudy` + `cohortTimeATTs` + `cohortStudy` × 2 seeds): `identical(pre, post) == TRUE`, mutation-checked to bite (nulling the sandwich flipped 60/64). `codetools` clean; `document()` no man/NAMESPACE change; full suite green; `check --as-cran` Status OK. The cross-accessor guardrail (`test-cross-accessor-scaffold-guardrail-400.R`) and the resolver contract test (#421) both continue to pass.

Note: the one reachable-state subtlety — the `y_final` cluster `stopifnot` now validates *before* the helper call (on the incoming `calc_ses`) rather than after the Gram recompute — is inert: a fit with `calc_ses = TRUE` always supplies a valid `y_final`, so the defensive check never fires in either version, and the fold does NOT newly validate `y_final` on a `calc_ses = FALSE` cluster fit.

Closes #400.
