### PR TITLE
hardening: defense-in-depth batch (BIC log(0), Gram drop=FALSE, singular-Gram bootstrap error, propensity count guard, augment covs slot, cohort-prob reseed) (#403)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.56.17
+Version: 1.56.18
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,32 @@
 # NEWS
 
+## Version 1.56.18
+
+### Bug fixes
+
+- Defense-in-depth hardening (#403). Seven latent robustness fixes --- none
+  reachable as a live bug through the shipped entry points, but each a trap for
+  future changes or unusual-but-legal inputs:
+  - `getBetaBIC()` (the `lambda_selection = "bic"` path) now floors the residual
+    MSE at `.Machine$double.eps` and warns when a lambda interpolates the
+    response (residual MSE ~ 0), instead of producing `BIC = -Inf` (which would
+    win the selection unconditionally, ignoring model size). Reachable only in
+    the `p >= NT` / `gls = FALSE` corner.
+  - `getGramInv()` no longer drops its selected-treatment Gram sub-matrix to a
+    scalar when a single treatment feature is selected, so its dimension
+    assertions actually check that degenerate case.
+  - `simultaneousCIs(method = "bootstrap")` now reports an actionable
+    "not invertible" error (instead of a bare LAPACK error) when the centered
+    Gram on the selected support is singular, and its internal event-study
+    cohort-count guard now actually rejects a non-integral
+    `N * cohort_probs_overall`.
+  - `augment()` no longer requires the unused `covs` slot, so a `d = 0`
+    (covariate-free) or legacy fit with `covs = NULL` is accepted.
+  - The internal expected-cohort-probability helper validates its `distribution`
+    argument before seeding, so an invalid `distribution` combined with a
+    non-`NULL` seed no longer advances the caller's random-number stream before
+    erroring (the counterpart of the #399 seed-before-validation fix).
+
 ## Version 1.56.17
 
 ### New features

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,9 +4,10 @@
 
 ### Defensive improvements
 
-- Defense-in-depth hardening (#403). Six latent robustness fixes (plus one
-  documented acceptance) --- none reachable as a live bug through the shipped
-  entry points, but each a trap for future changes or unusual-but-legal inputs:
+- Defense-in-depth hardening (#403). Six latent robustness fixes, one per bullet
+  below, plus one documented acceptance that needed no code change --- none
+  reachable as a live bug through the shipped entry points, but each a trap for
+  future changes or unusual-but-legal inputs:
   - `getBetaBIC()` (the `lambda_selection = "bic"` path) now floors the residual
     MSE at `.Machine$double.eps * var(y)` and warns when a lambda interpolates
     the response, instead of producing `BIC = -Inf` (which would win the
@@ -17,9 +18,13 @@
     assertions actually check that degenerate case.
   - `simultaneousCIs(method = "bootstrap")` now reports an actionable
     "not invertible" error (instead of a bare LAPACK error) when the centered
-    Gram on the selected support is singular, and its internal event-study
-    cohort-count guard now actually rejects a non-integral
-    `N * cohort_probs_overall`.
+    Gram on the selected support is singular, and carries the underlying error
+    text along with it.
+  - The internal propensity influence-function helper's cohort-count guard now
+    actually rejects a non-integral `N * cohort_probs_overall` (the previous
+    condition was a tautology and never fired). The helper is shared by
+    `simultaneousCIs(method = "bootstrap")` and `debiasedATT(method =
+    "bootstrap")`, and its error now names whichever of the two you called.
   - `augment()` no longer requires the unused `covs` slot, so a hand-built or
     legacy fit carrying `covs = NULL` is accepted. (A covariate-free `d = 0`
     fit from the shipped entry points stores `character(0)` and was already

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 ### Defensive improvements
 
 - Defense-in-depth hardening (#403). Six latent robustness fixes, one per bullet
-  below, plus one documented acceptance that needed no code change --- none
+  below, plus one documented acceptance that needed no behavior change --- none
   reachable as a live bug through the shipped entry points, but each a trap for
   future changes or unusual-but-legal inputs:
   - `getBetaBIC()` (the `lambda_selection = "bic"` path) now floors the residual
@@ -32,7 +32,10 @@
   - The internal expected-cohort-probability helper validates its `distribution`
     argument before seeding, so an invalid `distribution` combined with a
     non-`NULL` seed no longer advances the caller's random-number stream before
-    erroring (the counterpart of the #399 seed-before-validation fix).
+    erroring (the counterpart of the #399 seed-before-validation fix). The
+    validation now goes through `match.arg()` (the package idiom), so the
+    argument also accepts unambiguous partial matches --- `"gauss"` resolves to
+    `"gaussian"` --- where it previously required an exact string.
 
 ## Version 1.56.17
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,16 +2,16 @@
 
 ## Version 1.56.18
 
-### Bug fixes
+### Defensive improvements
 
-- Defense-in-depth hardening (#403). Seven latent robustness fixes --- none
-  reachable as a live bug through the shipped entry points, but each a trap for
-  future changes or unusual-but-legal inputs:
+- Defense-in-depth hardening (#403). Six latent robustness fixes (plus one
+  documented acceptance) --- none reachable as a live bug through the shipped
+  entry points, but each a trap for future changes or unusual-but-legal inputs:
   - `getBetaBIC()` (the `lambda_selection = "bic"` path) now floors the residual
-    MSE at `.Machine$double.eps` and warns when a lambda interpolates the
-    response (residual MSE ~ 0), instead of producing `BIC = -Inf` (which would
-    win the selection unconditionally, ignoring model size). Reachable only in
-    the `p >= NT` / `gls = FALSE` corner.
+    MSE at `.Machine$double.eps * var(y)` and warns when a lambda interpolates
+    the response, instead of producing `BIC = -Inf` (which would win the
+    selection unconditionally, ignoring model size). The floor is relative to
+    the response's own scale, so it is invariant to the units of `y`.
   - `getGramInv()` no longer drops its selected-treatment Gram sub-matrix to a
     scalar when a single treatment feature is selected, so its dimension
     assertions actually check that degenerate case.
@@ -20,8 +20,10 @@
     Gram on the selected support is singular, and its internal event-study
     cohort-count guard now actually rejects a non-integral
     `N * cohort_probs_overall`.
-  - `augment()` no longer requires the unused `covs` slot, so a `d = 0`
-    (covariate-free) or legacy fit with `covs = NULL` is accepted.
+  - `augment()` no longer requires the unused `covs` slot, so a hand-built or
+    legacy fit carrying `covs = NULL` is accepted. (A covariate-free `d = 0`
+    fit from the shipped entry points stores `character(0)` and was already
+    accepted.)
   - The internal expected-cohort-probability helper validates its `distribution`
     argument before seeding, so an invalid `distribution` combined with a
     non-`NULL` seed no longer advances the caller's random-number stream before

--- a/R/bridge_selection.R
+++ b/R/bridge_selection.R
@@ -87,6 +87,9 @@
 #'   4. It computes the BIC value: `N*T*log(SSE/(N*T)) + s*log(N*T)`, where `s`
 #'      is the number of non-zero coefficients (excluding the always-present
 #'      intercept; a constant offset that does not affect which lambda minimizes BIC).
+#'      `SSE/(N*T)` is floored at `.Machine$double.eps * var(y)` (a
+#'      response-scale-relative floor) so that an interpolating lambda gives a
+#'      finite BIC instead of `-Inf` (#403).
 #'   The set of coefficients corresponding to the minimum BIC is chosen. If multiple
 #'   lambdas yield the same minimum BIC, the one resulting in the smallest model
 #'   size (fewest non-zero coefficients) is selected.
@@ -140,17 +143,40 @@ getBetaBIC <- function(fit, N, T, p, X_mod, y, scale_center, scale_scale) {
 	# non-interpolating lambda can now win where -Inf always picked the
 	# interpolator -- but a near-zero MSE may still not be overcome by the size
 	# penalty, so the warning flags that the selected lambda may over-fit. (#403)
-	if (any(mse_hat <= .Machine$double.eps)) {
+	#
+	# The floor is RELATIVE to the response's own scale. `mse_hat` is in the raw
+	# (unstandardized) units of `y`, so a fixed absolute cut is not
+	# scale-equivariant: rescaling `y` by c rescales every mse_hat by c^2, and an
+	# absolute .Machine$double.eps threshold would fire on a merely small-scale
+	# response (a change of units) while leaving the fit itself untouched --
+	# warning about "interpolation" on, and re-ranking the lambdas of, a fit that
+	# is nowhere near interpolating. Scaling by var(y) makes the criterion
+	# "residual MSE is zero to double precision relative to the variation being
+	# explained" (R^2 >= 1 - eps), which is invariant to the units of `y`.
+	# `.Machine$double.xmin` keeps the floor strictly positive (hence log() finite)
+	# for a constant or vanishingly-dispersed response.
+	var_y <- mean((y - mean(y))^2)
+	mse_floor <- max(.Machine$double.eps * var_y, .Machine$double.xmin)
+	# `var_y` overflows to Inf once max|y - mean(y)| exceeds ~1.3e154. An
+	# infinite floor would floor EVERY lambda to the same value, collapsing the
+	# whole BIC ranking onto the smallest-model tie-break below -- strictly worse
+	# than the absolute floor this replaced. Fall back to the smallest positive
+	# double: it floors nothing, and log() stays finite. (#403)
+	if (!is.finite(mse_floor)) {
+		mse_floor <- .Machine$double.xmin
+	}
+	if (any(mse_hat <= mse_floor)) {
 		warning(
 			"getBetaBIC(): at least one lambda interpolates the response ",
-			"(residual MSE ~ 0), which would make its BIC -Inf; flooring MSE at ",
-			".Machine$double.eps. This occurs in the p >= NT / gls = FALSE ",
-			"corner; the BIC-selected lambda may over-fit.",
+			"(residual MSE is zero to double precision relative to var(y)), ",
+			"which would make its BIC -Inf; flooring MSE at ",
+			".Machine$double.eps * var(y). This most often arises in the ",
+			"p >= NT / gls = FALSE corner; the BIC-selected lambda may over-fit.",
 			call. = FALSE
 		)
 	}
 	BICs <- nt_double *
-		log(pmax(mse_hat, .Machine$double.eps)) +
+		log(pmax(mse_hat, mse_floor)) +
 		model_sizes * log(nt_double)
 
 	lambda_star_ind <- which(BICs == min(BICs))

--- a/R/bridge_selection.R
+++ b/R/bridge_selection.R
@@ -133,7 +133,25 @@ getBetaBIC <- function(fit, N, T, p, X_mod, y, scale_center, scale_scale) {
 	# coercion here. No regression test: the bug fires only at panel
 	# sizes too large to construct in CI (#178).
 	nt_double <- as.numeric(N) * as.numeric(T)
-	BICs <- nt_double * log(mse_hat) + model_sizes * log(nt_double)
+	# Floor mse_hat (and warn): an interpolating lambda (mse_hat == 0, which
+	# sse_bridge()'s `>= 0` allows in the p >= NT / gls = FALSE corner) would give
+	# log(0) = -Inf and win the argmin unconditionally, ignoring model size. The
+	# floor keeps BICs finite/comparable -- so a sufficiently sparse
+	# non-interpolating lambda can now win where -Inf always picked the
+	# interpolator -- but a near-zero MSE may still not be overcome by the size
+	# penalty, so the warning flags that the selected lambda may over-fit. (#403)
+	if (any(mse_hat <= .Machine$double.eps)) {
+		warning(
+			"getBetaBIC(): at least one lambda interpolates the response ",
+			"(residual MSE ~ 0), which would make its BIC -Inf; flooring MSE at ",
+			".Machine$double.eps. This occurs in the p >= NT / gls = FALSE ",
+			"corner; the BIC-selected lambda may over-fit.",
+			call. = FALSE
+		)
+	}
+	BICs <- nt_double *
+		log(pmax(mse_hat, .Machine$double.eps)) +
+		model_sizes * log(nt_double)
 
 	lambda_star_ind <- which(BICs == min(BICs))
 	if (length(lambda_star_ind) == 1) {
@@ -250,6 +268,15 @@ getBetaCV <- function(
 	# (issue #177 — without this, every default-path fetwfe() / betwfe()
 	# call would silently mutate the user's seed, a v1.13.0 regression
 	# vs the v1.12.x BIC default).
+	#
+	# NOTE (#403): when add_ridge = TRUE, X_final_scaled already carries the p
+	# appended sqrt(lambda_ridge)-scale ridge pseudo-rows (response 0), so they
+	# participate in cv.grpreg()'s fold assignment and CV error. Accepted as-is:
+	# at the default lambda_ridge (~1e-5 scale) the contamination is numerically
+	# negligible. Excluding them (CV on the first N*T rows, then refit at the
+	# selected lambda on the augmented design) would change the selected lambda,
+	# so it is a separate behavior-changing enhancement, not a behavior-neutral
+	# hardening fix.
 	cv_fit <- .with_preserved_rng(cv_seed, {
 		grpreg::cv.grpreg(
 			X = X_final_scaled,

--- a/R/broom_methods.R
+++ b/R/broom_methods.R
@@ -258,9 +258,12 @@ NULL
 
 	X <- .get_X_ints(x)
 
-	# The four metadata slots are needed both for auto-trim (idCohorts) and
-	# for sorting `data` into X_ints' row order. Validate them up front.
-	needed_slots <- c("time_var", "unit_var", "treatment", "covs")
+	# These metadata slots are needed both for auto-trim (idCohorts) and for
+	# sorting `data` into X_ints' row order. Validate them up front. `covs` is
+	# NOT required: the body never consumes it, and the C8 validator allows
+	# `covs = NULL` (a d = 0 fit), which this list would otherwise reject
+	# spuriously (#403).
+	needed_slots <- c("time_var", "unit_var", "treatment")
 	missing_slots <- needed_slots[
 		vapply(needed_slots, function(s) is.null(x[[s]]), logical(1))
 	]

--- a/R/broom_methods.R
+++ b/R/broom_methods.R
@@ -261,8 +261,10 @@ NULL
 	# These metadata slots are needed both for auto-trim (idCohorts) and for
 	# sorting `data` into X_ints' row order. Validate them up front. `covs` is
 	# NOT required: the body never consumes it, and the C8 validator allows
-	# `covs = NULL` (a d = 0 fit), which this list would otherwise reject
-	# spuriously (#403).
+	# `covs = NULL`, which this list would otherwise reject spuriously. Note a
+	# covariate-free (d = 0) fit from the shipped entry points stores
+	# `character(0)`, not `NULL`, so it was already accepted; the slot only goes
+	# `NULL` on a hand-built or legacy object. (#403)
 	needed_slots <- c("time_var", "unit_var", "treatment")
 	missing_slots <- needed_slots[
 		vapply(needed_slots, function(s) is.null(x[[s]]), logical(1))

--- a/R/broom_methods.R
+++ b/R/broom_methods.R
@@ -220,7 +220,7 @@ NULL
 #' `.resid = data[[x$response_col_name]] - .fitted`, then column-binds to
 #' the (possibly auto-trimmed) panel. If `nrow(data) != nrow(X_ints)`, the
 #' method calls the package's internal cohort-identification routine on
-#' `data` using the `time_var` / `unit_var` / `treatment` / `covs` slots
+#' `data` using the `time_var` / `unit_var` / `treatment` slots
 #' stashed at fit time, which drops units treated in the first time
 #' period (their treatment effect is unidentifiable). The returned data
 #' frame therefore corresponds to the panel the estimator actually fit

--- a/R/class_helpers.R
+++ b/R/class_helpers.R
@@ -497,7 +497,8 @@
 			cls
 		)
 	}
-	# covs is NULL when d == 0, character otherwise.
+	# A d == 0 fit from the shipped entry points stores character(0), NOT NULL;
+	# NULL is allowed here only for hand-built or legacy objects. (#403)
 	.assert_contract(
 		is.null(x$covs) || is.character(x$covs),
 		"C8 covs is NULL or character",

--- a/R/cohort_assignment.R
+++ b/R/cohort_assignment.R
@@ -448,17 +448,18 @@
 	M = 10000L,
 	seed = NULL
 ) {
+	# Validate `distribution` BEFORE seeding: `.apply_seed()` mutates the ambient
+	# RNG, so validating after it (the old `else stop()`) would advance the
+	# caller's stream on a bad `distribution` + non-NULL `seed` before erroring
+	# (the #399 seed-before-validation anti-pattern's doubly-masked sibling; #403).
+	distribution <- match.arg(distribution, c("gaussian", "uniform"))
 	.apply_seed(seed)
 	X_mc <- if (distribution == "gaussian") {
 		matrix(rnorm(M * d), nrow = M, ncol = d)
-	} else if (distribution == "uniform") {
+	} else {
+		# "uniform" (validated above)
 		a <- sqrt(3)
 		matrix(stats::runif(M * d, min = -a, max = a), nrow = M, ncol = d)
-	} else {
-		stop(sprintf(
-			"Unsupported distribution '%s'. Choose 'gaussian' or 'uniform'.",
-			distribution
-		))
 	}
 	probs <- .compute_cohort_prob_matrix(X_mc, assignment_coefs)
 	colMeans(probs)

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -795,7 +795,8 @@ debiasedATT <- function(
 		G = G,
 		N = N,
 		T = T,
-		A = matrix(a_att_G, nrow = G, ncol = 1L)
+		A = matrix(a_att_G, nrow = G, ncol = 1L),
+		caller = "debiasedATT()"
 	))
 	# Anchor: the per-unit V2 IF must reproduce the analytic cohort-weight
 	# variance. A mismatch means the V2 gradient / probabilities are inconsistent

--- a/R/gls_machinery.R
+++ b/R/gls_machinery.R
@@ -360,7 +360,11 @@ getGramInv <- function(
 
 	stopifnot(all(!is.na(gram_inv)))
 
-	gram_inv <- gram_inv[sel_treat_inds, sel_treat_inds]
+	# `drop = FALSE`: with a single selected treatment feature the subset would
+	# otherwise degrade to a scalar, so the nrow()/ncol() dimension guards below
+	# would compare against NULL and pass vacuously in exactly the degenerate
+	# case they exist to catch (#403).
+	gram_inv <- gram_inv[sel_treat_inds, sel_treat_inds, drop = FALSE]
 
 	stopifnot(nrow(gram_inv) <= num_treats)
 	stopifnot(nrow(gram_inv) == ncol(gram_inv))

--- a/R/simultaneous_bootstrap.R
+++ b/R/simultaneous_bootstrap.R
@@ -132,9 +132,23 @@
 	Sig <- crossprod(X_sel_c) / n
 	K <- ncol(Psi_full)
 	V <- matrix(0, ncol(X_sel_c), K)
-	for (k in seq_len(K)) {
-		V[, k] <- solve(Sig, Psi_full[, k])
-	}
+	# Route a singular centered Gram through an actionable message rather than
+	# solve()'s bare LAPACK "system is computationally singular" error, matching
+	# the analytic path's getGramInv() "not invertible" handling (#403).
+	tryCatch(
+		for (k in seq_len(K)) {
+			V[, k] <- solve(Sig, Psi_full[, k])
+		},
+		error = function(e) {
+			stop(
+				"simultaneousCIs(method = \"bootstrap\"): the centered Gram ",
+				"matrix on the selected support is not invertible, so the ",
+				"regression influence function cannot be formed (the selected ",
+				"support is rank-deficient, e.g. collinear selected columns).",
+				call. = FALSE
+			)
+		}
+	)
 	F_mat <- XEps %*% V
 	attr(F_mat, "highdim") <- FALSE
 	F_mat
@@ -417,7 +431,15 @@
 	c0 <- as.numeric(crossprod(pi_hat, A))
 	n_g <- round(N * pi_hat)
 	n_never <- N - sum(n_g)
-	if (n_never < 0L || sum(n_g) + n_never != N) {
+	# `N * pi_hat` must actually be (near-)integral: a corrupted
+	# `cohort_probs_overall` with non-integral `N * pi_hat` would otherwise round
+	# and silently absorb the residual into the never-treated row. The old
+	# `sum(n_g) + n_never != N` check was identically FALSE (n_never = N -
+	# sum(n_g)) and never bit; `abs(N * pi_hat - n_g)` does (#403).
+	if (
+		n_never < 0L ||
+			any(abs(N * pi_hat - n_g) > sqrt(.Machine$double.eps))
+	) {
 		stop(
 			"simultaneousCIs(): could not recover integer cohort counts from ",
 			"`cohort_probs_overall` for the event_study propensity influence ",

--- a/R/simultaneous_bootstrap.R
+++ b/R/simultaneous_bootstrap.R
@@ -140,11 +140,17 @@
 			V[, k] <- solve(Sig, Psi_full[, k])
 		},
 		error = function(e) {
+			# Carry the original message: this handler catches EVERY error from
+			# the loop, not only rank deficiency (a non-finite entry in
+			# `Psi_full` raises "NA/NaN/Inf in foreign function call"), and
+			# relabelling that as a rank problem would misdirect the diagnosis.
 			stop(
 				"simultaneousCIs(method = \"bootstrap\"): the centered Gram ",
 				"matrix on the selected support is not invertible, so the ",
 				"regression influence function cannot be formed (the selected ",
-				"support is rank-deficient, e.g. collinear selected columns).",
+				"support is rank-deficient, e.g. collinear selected columns). ",
+				"Original error: ",
+				conditionMessage(e),
 				call. = FALSE
 			)
 		}
@@ -402,7 +408,8 @@
 	G,
 	N,
 	T,
-	A = NULL
+	A = NULL,
+	caller = "simultaneousCIs()"
 ) {
 	pi_hat <- cohort_probs_overall[seq_len(G)]
 	# A = [a_1 ... a_K] (G x K). Fixed-p / post-selection builds it as
@@ -436,14 +443,22 @@
 	# and silently absorb the residual into the never-treated row. The old
 	# `sum(n_g) + n_never != N` check was identically FALSE (n_never = N -
 	# sum(n_g)) and never bit; `abs(N * pi_hat - n_g)` does (#403).
+	#
+	# The tolerance scales with N. `pi_hat` reaches here as `n_g / N`, so the
+	# round-trip `N * (n_g / N) - n_g` carries O(N * eps) float error, while
+	# genuine corruption produces an O(1) deviation. A fixed absolute cut would
+	# be dimensionally an absolute constant compared against a count, and would
+	# start false-positiving at N ~ 6.7e7. (#403)
 	if (
 		n_never < 0L ||
-			any(abs(N * pi_hat - n_g) > sqrt(.Machine$double.eps))
+			any(
+				abs(N * pi_hat - n_g) > sqrt(.Machine$double.eps) * max(1, N)
+			)
 	) {
 		stop(
-			"simultaneousCIs(): could not recover integer cohort counts from ",
-			"`cohort_probs_overall` for the event_study propensity influence ",
-			"function.",
+			caller,
+			": could not recover integer cohort counts from ",
+			"`cohort_probs_overall` for the propensity influence function.",
 			call. = FALSE
 		)
 	}

--- a/R/simultaneous_bootstrap.R
+++ b/R/simultaneous_bootstrap.R
@@ -141,9 +141,12 @@
 		},
 		error = function(e) {
 			# Carry the original message: this handler catches EVERY error from
-			# the loop, not only rank deficiency (a non-finite entry in
-			# `Psi_full` raises "NA/NaN/Inf in foreign function call"), and
-			# relabelling that as a rank problem would misdirect the diagnosis.
+			# the loop, not only rank deficiency (a `Psi_full` whose row count
+			# does not match the selected support raises "'b' (m x 1) must be
+			# compatible with 'a' (p x p)"), and relabelling that as a rank
+			# problem would misdirect the diagnosis. (Note: a NON-FINITE entry in
+			# `Psi_full` does NOT error here -- `solve()` propagates NA/NaN
+			# silently -- so it is not an example of this, #403 review round 4.)
 			stop(
 				"simultaneousCIs(method = \"bootstrap\"): the centered Gram ",
 				"matrix on the selected support is not invertible, so the ",
@@ -398,6 +401,11 @@
 #'   supplied (the high-dim `event_study` path, #309) it is the DEBIASED cohort
 #'   effect matrix and `J_list` / `theta_sel` are ignored; when `NULL` (fixed-p) it
 #'   is built from `J_list %*% theta_sel` (post-selection, byte-identical to before).
+#' @param caller Character scalar; the user-facing entry point on whose behalf
+#'   this helper runs, prefixed to the cohort-count guard's error message so the
+#'   user sees the function they actually called. The helper is shared by
+#'   `simultaneousCIs(method = "bootstrap")` (the default) and
+#'   `debiasedATT(method = "bootstrap")`; it affects the error text only.
 #' @return `F_pi`, an `N x K` numeric matrix (`K = ncol(A)`).
 #' @keywords internal
 #' @noRd
@@ -444,17 +452,30 @@
 	# `sum(n_g) + n_never != N` check was identically FALSE (n_never = N -
 	# sum(n_g)) and never bit; `abs(N * pi_hat - n_g)` does (#403).
 	#
-	# The tolerance scales with N. `pi_hat` reaches here as `n_g / N`, so the
-	# round-trip `N * (n_g / N) - n_g` carries O(N * eps) float error, while
-	# genuine corruption produces an O(1) deviation. A fixed absolute cut would
-	# be dimensionally an absolute constant compared against a count, and would
-	# start false-positiving at N ~ 6.7e7. (#403)
-	if (
-		n_never < 0L ||
-			any(
-				abs(N * pi_hat - n_g) > sqrt(.Machine$double.eps) * max(1, N)
-			)
-	) {
+	# The tolerance needs BOTH a floor and a CEILING, and the ceiling is the
+	# load-bearing half:
+	#   Ceiling (0.25). `n_g = round(N * pi_hat)`, so `abs(N * pi_hat - n_g)` is
+	#     <= 0.5 BY CONSTRUCTION. Any tolerance that reaches 0.5 therefore makes
+	#     this condition identically FALSE -- the same dead-guard defect the
+	#     check replaced, just at the other end of the range. A bare
+	#     `sqrt(.Machine$double.eps) * N` reaches 0.5 at N = 2^25 = 33,554,432,
+	#     so it silently stopped guarding large panels; `min(0.25, .)` cannot.
+	#   Body (`8 * N * eps`). `pi_hat` always arrives as `n_g / N` (see
+	#     `.compute_cohort_probs()`), so the only LEGITIMATE deviation is the
+	#     `N * (n_g / N) - n_g` round-trip error, bounded by `n_g * eps <= N *
+	#     eps`. Measured: exactly 0 on real fits; exhaustively over every
+	#     `(N <= 5000, n_g <= N)` the worst case is 4.5e-13, and sampling up to
+	#     N = 1e12 leaves >= 16x headroom under `8 * N * eps`.
+	#   Floor (`sqrt(.Machine$double.eps)`). Dominates for N < 2^23 = 8,388,608,
+	#     preserving the pre-existing small-N behavior so this cannot introduce a
+	#     NEW false positive on any panel size seen in practice.
+	# Genuine corruption produces an O(1) deviation, orders of magnitude above
+	# either end. (#403)
+	tol <- min(
+		0.25,
+		max(sqrt(.Machine$double.eps), 8 * N * .Machine$double.eps)
+	)
+	if (n_never < 0L || any(abs(N * pi_hat - n_g) > tol)) {
 		stop(
 			caller,
 			": could not recover integer cohort counts from ",

--- a/tests/testthat/test-hardening-403.R
+++ b/tests/testthat/test-hardening-403.R
@@ -1,0 +1,170 @@
+library(testthat)
+library(fetwfe)
+
+# ------------------------------------------------------------------------------
+# #403 defense-in-depth hardening batch. Each test reproduces a latent trap that
+# is NOT reachable as a live bug through today's shipped entry points, so it
+# drives the internal function directly with a constructed edge input. Each is
+# red-green: it FAILS on the pre-fix line and PASSES after (mutation-checked
+# during development). Item 2 (CV ridge pseudo-rows) is resolved by documenting
+# the acceptance -> behavior-neutral, no test.
+# ------------------------------------------------------------------------------
+
+# --- Item 1: getBetaBIC() warns + floors on an interpolating lambda -----------
+test_that("getBetaBIC() warns and floors when a lambda interpolates (mse ~ 0) (#403)", {
+	N <- 10L
+	T <- 2L
+	p <- 3L
+	set.seed(403)
+	X_mod <- matrix(stats::rnorm(N * T * p), nrow = N * T, ncol = p)
+	beta_true <- c(1.5, -0.5, 2)
+	y <- as.numeric(X_mod %*% beta_true) # exact fit -> one lambda interpolates
+	# fit$beta is (p + 1) x n_lambda: col 1 interpolates (eta = 0, beta_true);
+	# col 2 is the null model (eta = mean(y), zero slopes).
+	fit <- list(beta = cbind(c(0, beta_true), c(mean(y), 0, 0, 0)))
+	expect_warning(
+		getBetaBIC(
+			fit,
+			N = N,
+			T = T,
+			p = p,
+			X_mod = X_mod,
+			y = y,
+			scale_center = rep(0, p),
+			scale_scale = rep(1, p)
+		),
+		"interpolates"
+	)
+})
+
+# --- Item 3: getGramInv() keeps a 1x1 matrix with one selected treat feature ---
+test_that("getGramInv() returns a matrix (not a scalar) with one selected treatment feature (#403)", {
+	N <- 40L
+	T <- 2L
+	set.seed(403)
+	# Well-conditioned 3-column design so getGramInv succeeds (calc_ses = TRUE).
+	X_final <- matrix(stats::rnorm(N * T * 3), nrow = N * T, ncol = 3)
+	res <- getGramInv(
+		N = N,
+		T = T,
+		X_final = X_final,
+		treat_inds = 1L, # column 1 is the single treatment feature
+		num_treats = 1L,
+		calc_ses = TRUE
+	)
+	expect_true(res$calc_ses)
+	# Pre-fix: gram_inv[TRUE-once, TRUE-once] drops to a scalar (is.matrix FALSE),
+	# so the following nrow()/ncol() guards compare NULL and pass vacuously.
+	expect_true(is.matrix(res$gram_inv))
+	expect_identical(dim(res$gram_inv), c(1L, 1L))
+})
+
+# --- Item 4: .build_regression_if() gives an actionable singular-Gram error ----
+test_that(".build_regression_if() routes a singular centered Gram to an actionable error (#403)", {
+	N <- 20L
+	T <- 2L
+	n <- N * T
+	set.seed(403)
+	z <- stats::rnorm(n)
+	X_sel <- cbind(z, z, stats::rnorm(n)) # duplicated column -> singular Sig
+	y <- stats::rnorm(n)
+	Psi_full <- matrix(stats::rnorm(3 * 2), nrow = 3, ncol = 2)
+	# Pre-fix: bare LAPACK "system is computationally singular" (does not match).
+	expect_error(
+		.build_regression_if(
+			X_sel = X_sel,
+			y = y,
+			N = N,
+			T = T,
+			Psi_full = Psi_full
+		),
+		"not invertible"
+	)
+})
+
+# --- Item 5: .build_propensity_if() count guard actually bites -----------------
+test_that(".build_propensity_if() rejects non-integral N * cohort_probs (#403)", {
+	G <- 3L
+	N <- 100L
+	T <- 5L
+	K <- 2L
+	set.seed(403)
+	A <- matrix(stats::rnorm(G * K), nrow = G, ncol = K)
+	# Non-integral N * pi_hat: N * 0.234 = 23.4. Pre-fix the tautological
+	# `sum(n_g) + n_never != N` never fires; the integrality check does.
+	bad <- c(0.234, 0.3, 0.4)
+	expect_error(
+		.build_propensity_if(
+			cohort_probs_overall = bad,
+			G = G,
+			N = N,
+			T = T,
+			A = A
+		),
+		"could not recover integer cohort counts"
+	)
+	# Control: integral N * pi_hat must NOT trip the guard.
+	good <- c(0.2, 0.3, 0.4)
+	expect_error(
+		.build_propensity_if(
+			cohort_probs_overall = good,
+			G = G,
+			N = N,
+			T = T,
+			A = A
+		),
+		NA
+	)
+})
+
+# --- Item 6: augment() accepts a fit whose covs slot is NULL (d = 0 / legacy) --
+test_that("augment() does not require the unused covs slot (#403)", {
+	cf <- genCoefs(G = 3, T = 4, d = 0, density = 0.5, eff_size = 2, seed = 403)
+	sim <- simulateData(
+		cf,
+		N = 120,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		seed = 403
+	)
+	fit <- fetwfe(
+		pdata = sim$pdata,
+		time_var = sim$time_var,
+		unit_var = sim$unit_var,
+		treatment = sim$treatment,
+		response = sim$response,
+		covs = sim$covs,
+		sig_eps_sq = 1,
+		sig_eps_c_sq = 0.5,
+		verbose = FALSE
+	)
+	# A d = 0 fit stores covs = character(0); a hand-built / legacy object can
+	# legitimately carry covs = NULL (the C8 validator allows it). Use
+	# `fit["covs"] <- list(NULL)` so the slot stays PRESENT with a NULL value
+	# (`fit$covs <- NULL` would delete the slot and trip the class validator).
+	fit["covs"] <- list(NULL)
+	stopifnot(is.null(fit$covs), "covs" %in% names(fit))
+	# Pre-fix: augment() errors "missing slots covs ... earlier dev build".
+	au <- augment(fit, data = sim$pdata)
+	expect_s3_class(au, "data.frame")
+	expect_true(all(c(".fitted", ".resid") %in% names(au)))
+})
+
+# --- Item 7: .expected_cohort_probs() validates distribution before seeding ----
+test_that(".expected_cohort_probs() does not touch the RNG on an invalid distribution (#403)", {
+	assignment_coefs <- matrix(0, nrow = 3, ncol = 4) # unused before the error
+	set.seed(999)
+	before <- .Random.seed
+	# Pre-fix: .apply_seed(seed = 1) runs BEFORE the distribution is validated, so
+	# the ambient RNG is advanced before the error. Post-fix: match.arg() errors
+	# first, leaving .Random.seed untouched.
+	expect_error(
+		.expected_cohort_probs(
+			assignment_coefs = assignment_coefs,
+			d = 2L,
+			distribution = "not_a_distribution",
+			seed = 1L
+		)
+	)
+	expect_identical(.Random.seed, before)
+})

--- a/tests/testthat/test-hardening-403.R
+++ b/tests/testthat/test-hardening-403.R
@@ -217,6 +217,45 @@ test_that(".build_regression_if() routes a singular centered Gram to an actionab
 		),
 		"not invertible"
 	)
+	# The handler must CARRY the underlying error text, not swallow it. Without
+	# the `conditionMessage(e)` append the message stops at "collinear selected
+	# columns)." and the two assertions below both go red, while the
+	# "not invertible" match above passes either way.
+	msg <- tryCatch(
+		.build_regression_if(
+			X_sel = X_sel,
+			y = y,
+			N = N,
+			T = T,
+			Psi_full = Psi_full
+		),
+		error = conditionMessage
+	)
+	expect_match(msg, "Original error: ", fixed = TRUE)
+	expect_match(msg, "singular")
+
+	# The handler wraps EVERY error from the solve loop, not only rank
+	# deficiency, which is the whole reason the original text has to survive: a
+	# `Psi_full` whose row count does not match the selected support raises a
+	# dimension error from `solve()`, and reporting only "rank-deficient" would
+	# misdirect the diagnosis. (`Sig` here is well conditioned, so rank is not
+	# the problem.) NOTE: a NON-FINITE `Psi_full` is NOT such a case --
+	# `solve()` propagates NA/NaN silently rather than erroring -- so it cannot
+	# be tested here.
+	X_ok <- matrix(stats::rnorm(n * 3), nrow = n, ncol = 3) # full rank
+	expect_gt(rcond(crossprod(scale(X_ok, TRUE, FALSE)) / n), 1e-6)
+	msg_dim <- tryCatch(
+		.build_regression_if(
+			X_sel = X_ok,
+			y = y,
+			N = N,
+			T = T,
+			Psi_full = matrix(1, nrow = 2, ncol = 1) # 2 rows vs 3 columns
+		),
+		error = conditionMessage
+	)
+	expect_match(msg_dim, "not invertible")
+	expect_match(msg_dim, "must be compatible with", fixed = TRUE)
 })
 
 # --- Item 5: .build_propensity_if() count guard actually bites -----------------
@@ -282,6 +321,60 @@ test_that(".build_propensity_if() rejects non-integral N * cohort_probs (#403)",
 		),
 		"^debiasedATT\\(\\): could not recover integer cohort counts"
 	)
+})
+
+# The cases above pin the TIGHT end of the cohort-count tolerance (it must not
+# false-positive on a legitimate n_g / N). This pins the LOOSE end, which is the
+# end that silently dies: `n_g = round(N * pi_hat)` bounds `abs(N * pi_hat -
+# n_g)` by 0.5 BY CONSTRUCTION, so any tolerance reaching 0.5 makes the guard
+# identically FALSE. An `N`-proportional `sqrt(.Machine$double.eps) * N` reaches
+# 0.5 at N = 2^25 = 33,554,432, so it stopped guarding above that -- red on the
+# pre-fix line (no error at all: the helper happily builds a 3.4e7-row matrix),
+# green under the `min(0.25, .)` ceiling. Kept cheap because the guard fires
+# before any allocation. (#403)
+test_that(".build_propensity_if() count guard survives a large N (#403)", {
+	G <- 3L
+	# Just past the N = 2^25 crossover where an `sqrt(eps) * N` tolerance
+	# reaches the 0.5 construction bound and the guard goes vacuous.
+	N <- 34000000L
+	expect_gt(N, 2^25)
+	T <- 5L
+	A <- matrix(c(1, -1, 0.5), nrow = G, ncol = 1L)
+	# 34e6 * 0.23456781 = 7975305.54 -- genuinely non-integral, and its deviation
+	# from the nearest integer (0.46) sits ABOVE the 0.25 ceiling, so this case
+	# must be rejected no matter how large N grows. Guard against the trap of a
+	# "corrupted" probability that happens to be exact: 34e6 * 0.3 is an integer
+	# and would test nothing.
+	bad <- c(0.23456781, 0.3, 0.4)
+	expect_false(isTRUE(all.equal(N * bad[1], round(N * bad[1]))))
+	expect_gt(abs(N * bad[1] - round(N * bad[1])), 0.25)
+	expect_error(
+		.build_propensity_if(
+			cohort_probs_overall = bad,
+			G = G,
+			N = N,
+			T = T,
+			A = A
+		),
+		"could not recover integer cohort counts"
+	)
+	# Control on the tight end, with a probability whose round-trip error is
+	# genuinely NON-ZERO. (N, n_g) = (4099, 4065) is the exhaustive worst case
+	# over every N <= 6000: `4099 * (4065 / 4099) - 4065` = 4.5e-13, so a future
+	# change that tightened the tolerance toward 0 would go red here. The
+	# control cannot be run at the large N above: the helper allocates N rows,
+	# and it only stays cheap there because the guard fires first.
+	N_rt <- 4099L
+	pi_rt <- 4065L / N_rt
+	expect_gt(abs(N_rt * pi_rt - round(N_rt * pi_rt)), 0)
+	F_pi <- .build_propensity_if(
+		cohort_probs_overall = pi_rt,
+		G = 1L,
+		N = N_rt,
+		T = T,
+		A = matrix(1, nrow = 1L, ncol = 1L)
+	)
+	expect_identical(dim(F_pi), c(N_rt, 1L))
 })
 
 # --- Item 6: augment() accepts a fit whose covs slot is NULL (d = 0 / legacy) --

--- a/tests/testthat/test-hardening-403.R
+++ b/tests/testthat/test-hardening-403.R
@@ -86,6 +86,42 @@ test_that("getBetaBIC() lambda selection is invariant to rescaling y (#403)", {
 	)
 })
 
+# The floor must not bite a merely EXCELLENT fit. The rescaling test above pins
+# the scale axis; this pins the tightness axis. Nothing else in the suite would
+# notice a future change from `.Machine$double.eps * var(y)` to, say,
+# `1e-8 * var(y)` -- which would keep every existing test green while warning
+# about "interpolation" on, and re-ranking the lambdas of, well-fit panels. (#403)
+test_that("getBetaBIC() floor does not fire on a near-deterministic fit (#403)", {
+	N <- 10L
+	T <- 2L
+	p <- 3L
+	set.seed(4033)
+	X_mod <- matrix(stats::rnorm(N * T * p), nrow = N * T, ncol = p)
+	beta_true <- c(1.5, -0.5, 2)
+	signal <- as.numeric(X_mod %*% beta_true)
+	# R^2 = 1 - 1e-9: far tighter than any real panel, and still ~7 orders of
+	# magnitude above the .Machine$double.eps floor.
+	resid_sd <- sqrt(1e-9 * mean((signal - mean(signal))^2))
+	y <- signal + resid_sd * stats::rnorm(N * T)
+	fit <- list(beta = cbind(c(0, beta_true), c(mean(y), 0, 0, 0)))
+
+	res <- expect_silent(
+		getBetaBIC(
+			fit,
+			N = N,
+			T = T,
+			p = p,
+			X_mod = X_mod,
+			y = y,
+			scale_center = rep(0, p),
+			scale_scale = rep(1, p)
+		)
+	)
+	# The excellent fit must still win on BIC, not be flattened onto the floor.
+	expect_identical(res$lambda_star_ind, 1L)
+	expect_identical(res$lambda_star_model_size, 3L)
+})
+
 # The two degenerate-var(y) branches of the relative floor. Neither is reachable
 # from a shipped entry point, but both are exactly the branches a future
 # "simplify to eps * var(y)" refactor would delete, and neither is covered by the
@@ -215,6 +251,36 @@ test_that(".build_propensity_if() rejects non-integral N * cohort_probs (#403)",
 			A = A
 		),
 		NA
+	)
+	# Control 2: the guard must survive a probability vector whose N * pi_hat
+	# round-trip carries real float error. `pi_hat` always arrives as n_g / N, so
+	# this is the shape of every legitimate input; an absolute tolerance that a
+	# future change tightened toward 0 would break every real event-study
+	# bootstrap while leaving the `bad` case above green.
+	n_g_real <- c(19L, 27L, 24L)
+	N_real <- 90L
+	expect_error(
+		.build_propensity_if(
+			cohort_probs_overall = n_g_real / N_real,
+			G = G,
+			N = N_real,
+			T = T,
+			A = A
+		),
+		NA
+	)
+	# The helper is shared by simultaneousCIs() and debiasedATT(); the error must
+	# name whichever one the user actually called, not a hardcoded default.
+	expect_error(
+		.build_propensity_if(
+			cohort_probs_overall = bad,
+			G = G,
+			N = N,
+			T = T,
+			A = A,
+			caller = "debiasedATT()"
+		),
+		"^debiasedATT\\(\\): could not recover integer cohort counts"
 	)
 })
 

--- a/tests/testthat/test-hardening-403.R
+++ b/tests/testthat/test-hardening-403.R
@@ -37,6 +37,107 @@ test_that("getBetaBIC() warns and floors when a lambda interpolates (mse ~ 0) (#
 	)
 })
 
+# The item-1 floor must be RELATIVE to the response scale. `mse_hat` carries the
+# raw units of `y`, so an absolute floor turns a pure change of units into a
+# spurious "interpolates" warning AND a different selected lambda -- on a fit
+# that is identical up to scale. Here rescaling by 1e-10 drops every mse_hat
+# below an absolute .Machine$double.eps, which floors ALL of them to the same
+# value and hands the argmin to the smallest model. Red on an absolute floor
+# (warning fires; lambda_star_ind flips 1 -> 2), green on the var(y)-relative
+# floor. (#403)
+test_that("getBetaBIC() lambda selection is invariant to rescaling y (#403)", {
+	N <- 10L
+	T <- 2L
+	p <- 3L
+	set.seed(4031)
+	X_mod <- matrix(stats::rnorm(N * T * p), nrow = N * T, ncol = p)
+	beta_true <- c(1.5, -0.5, 2)
+	# Noise -> no lambda interpolates, so neither call should warn at all.
+	y <- as.numeric(X_mod %*% beta_true) + stats::rnorm(N * T)
+	# Col 1: the (non-exact) 3-feature fit. Col 2: the null model.
+	fit <- list(beta = cbind(c(0, beta_true), c(mean(y), 0, 0, 0)))
+
+	call_bic <- function(fit, y) {
+		getBetaBIC(
+			fit,
+			N = N,
+			T = T,
+			p = p,
+			X_mod = X_mod,
+			y = y,
+			scale_center = rep(0, p),
+			scale_scale = rep(1, p)
+		)
+	}
+
+	# Scaling y by c and the coefficients by c is the same fit in new units: it
+	# multiplies every mse_hat by c^2, which shifts every BIC by the constant
+	# N * T * 2 * log(c) and so cannot change the argmin.
+	scale_c <- 1e-10
+	fit_scaled <- list(beta = fit$beta * scale_c)
+
+	res <- expect_silent(call_bic(fit, y))
+	res_scaled <- expect_silent(call_bic(fit_scaled, y * scale_c))
+
+	expect_identical(res_scaled$lambda_star_ind, res$lambda_star_ind)
+	expect_identical(
+		res_scaled$lambda_star_model_size,
+		res$lambda_star_model_size
+	)
+})
+
+# The two degenerate-var(y) branches of the relative floor. Neither is reachable
+# from a shipped entry point, but both are exactly the branches a future
+# "simplify to eps * var(y)" refactor would delete, and neither is covered by the
+# rescaling test above. (#403)
+test_that("getBetaBIC() floor survives a degenerate var(y) (#403)", {
+	N <- 10L
+	T <- 2L
+	p <- 2L
+	set.seed(4032)
+	X_mod <- matrix(stats::rnorm(N * T * p), nrow = N * T, ncol = p)
+
+	call_bic <- function(fit, y) {
+		getBetaBIC(
+			fit,
+			N = N,
+			T = T,
+			p = p,
+			X_mod = X_mod,
+			y = y,
+			scale_center = rep(0, p),
+			scale_scale = rep(1, p)
+		)
+	}
+
+	# (a) var(y) == 0 (constant response): the floor falls back to
+	# .Machine$double.xmin, so the interpolating lambda's BIC stays finite
+	# instead of going -Inf and winning unconditionally.
+	y_const <- rep(4.2, N * T)
+	fit_const <- list(
+		beta = cbind(c(4.2, 0, 0), c(0, 0, 0)) # col 1 interpolates exactly
+	)
+	res_const <- expect_warning(call_bic(fit_const, y_const), "interpolates")
+	expect_true(all(is.finite(res_const$theta_hat)))
+	expect_identical(res_const$lambda_star_ind, 1L)
+
+	# (b) var(y) == Inf (|y| beyond ~1.3e154): an Inf floor would floor EVERY
+	# lambda alike and hand the choice to the smallest-model tie-break. The
+	# lambdas below have finite, distinct MSEs differing by ~100x, so the
+	# larger/better-fitting model must win on BIC.
+	y_huge <- 1e155 * X_mod[, 1]
+	fit_huge <- list(
+		beta = cbind(
+			c(0, 1e155 - 1e152, 0), # size 1, residual ~1e152 * x1
+			c(0, 1e155 - 1e151, 1e-300) # size 2, residual ~1e151 * x1
+		)
+	)
+	expect_true(is.infinite(mean((y_huge - mean(y_huge))^2)))
+	res_huge <- expect_silent(call_bic(fit_huge, y_huge))
+	expect_identical(res_huge$lambda_star_ind, 2L)
+	expect_identical(res_huge$lambda_star_model_size, 2L)
+})
+
 # --- Item 3: getGramInv() keeps a 1x1 matrix with one selected treat feature ---
 test_that("getGramInv() returns a matrix (not a scalar) with one selected treatment feature (#403)", {
 	N <- 40L


### PR DESCRIPTION
The #403 hardening batch. Each item is a latent trap — none is reachable as a live bug through today's shipped entry points (verified, and re-verified independently across three adversarial review rounds), but each is a trap for future changes or unusual-but-legal inputs. Unlike a pure refactor these fixes DO change behavior in edge cases (guards / floors / clean errors). The batch is **behavior-neutral on every reachable path**: `identical()` on a 108-cell parameter grid and a 40-cell option matrix against `main`, plus the existing suite green.

**On the tests.** Every code fix below is covered, but not all coverage is the same kind, and the difference matters:

- **Red-green** (fails against the code state it targets, passes here): items 1, 3, 4, 5, 6, 7. Note the baselines differ — most are red against `main`, but the BIC rescaling-invariance test is red against **this branch's own first commit**, since the defect it pins was introduced by the original floor and fixed in a later commit.
- **Pins** (green on every ref; they exist to fail on a *future* change, not a past one): the "floor must not fire on a near-deterministic fit" test, the tight-end and loose-end tolerance controls. Verified by mutation rather than by baseline — e.g. loosening the floor to `1e-8 * var(y)` turns the first one red.

---

1. **BIC `log(0)`** (`bridge_selection.R`, `getBetaBIC`): an interpolating lambda (`mse_hat == 0`, which `sse_bridge()`'s `>= 0` allows in the `p >= NT` / `gls = FALSE` corner) gave `log(0) = -Inf`, winning the BIC argmin unconditionally. Now warns and floors at **`.Machine$double.eps * var(y)`** — relative to the response's own scale, not absolute. That matters: `mse_hat` carries the raw units of `y`, so an absolute cut fired on a merely small-scale response, warning about "interpolation" on a fit nowhere near it and re-ranking the lambdas (rescaling `y` by `1e-10` flipped the selection from 3 features to the null model). Since `sse_bridge()`'s divisor and `var(y)`'s agree exactly, the criterion is precisely `R² >= 1 - eps`. `var(y) = Inf` falls back to `.Machine$double.xmin`, because an infinite floor would flatten every lambda onto the smallest-model tie-break.
2. **CV ridge pseudo-rows** (`bridge_selection.R`, `getBetaCV`): under `lambda_selection = "cv"` + `add_ridge = TRUE` the appended ridge rows join `cv.grpreg` fold-assignment/CV. **Documented as accepted** (negligible at the default `lambda_ridge` ~1e-5). The real fix — CV on the first `N*T` rows then refit on the augmented design — *changes the selected lambda*, so it is a separate behavior-changing enhancement, out of scope here. No behavior change; the acceptance ships as a code comment.
3. **`getGramInv` `drop = FALSE`** (`gls_machinery.R`): `gram_inv[sel_treat_inds, sel_treat_inds]` degraded to a scalar with one selected treatment feature, so the following `nrow()`/`ncol()` guards compared `NULL` and passed vacuously in exactly the degenerate case they exist to catch. The degenerate case *is* reachable (T = 2 ⇒ one selected treatment feature on a real fit); what was broken was only the assertions, and no number changes.
4. **Fixed-p bootstrap singular Gram** (`simultaneous_bootstrap.R`, `.build_regression_if`): `solve(Sig, ...)` threw a bare LAPACK error; now routed through an actionable "not invertible" message, **carrying the original error text**, since the handler wraps the whole loop and catches more than rank deficiency (a `Psi_full` whose row count disagrees with the selected support, for instance). Non-singular results are byte-identical — the `solve` loop is unchanged, only wrapped.
5. **Tautological count guard** (`simultaneous_bootstrap.R`, `.build_propensity_if`): `sum(n_g) + n_never != N` (with `n_never <- N - sum(n_g)`) is identically FALSE and never bit. Replaced with a tolerance test on `abs(N * pi_hat - n_g)` that has **both a floor and a ceiling**:
   `tol <- min(0.25, max(sqrt(.Machine$double.eps), 8 * N * .Machine$double.eps))`.
   The ceiling is load-bearing: `n_g = round(N * pi_hat)` bounds the deviation at 0.5 by construction, so any tolerance reaching 0.5 recreates the dead-guard defect at the other end of the range — a bare `sqrt(eps) * N` does exactly that from `N = 2^25` upward. The body tracks the only legitimate deviation (the `n_g / N` round-trip, bounded by `N * eps`; measured 0 on real fits, worst case 4.5e-13 exhaustively under N = 5000). The floor preserves small-`N` behavior so the change cannot introduce a new false positive.
   The helper is shared by `simultaneousCIs(method = "bootstrap")` and `debiasedATT(method = "bootstrap")`, so its error now names whichever the user actually called instead of hardcoding one.
6. **`augment()` unused `covs` slot** (`broom_methods.R`): `needed_slots` required `covs`, which the body never uses and the C8 validator allows to be `NULL` — so a hand-built or legacy object carrying `covs = NULL` was spuriously rejected. Dropped `"covs"`. (A covariate-free `d = 0` fit from the shipped entry points stores `character(0)`, not `NULL`, and was already accepted — an earlier draft of this description and of NEWS claimed otherwise.)
7. **`.expected_cohort_probs` reseed-before-validate** (`cohort_assignment.R`): `.apply_seed(seed)` ran before the `distribution` value was validated, so a non-NULL seed + bad distribution advanced the caller's ambient RNG before erroring (the #399 anti-pattern's doubly-masked sibling). Now `match.arg(distribution, ...)` runs first. Side effect, per `match.arg` convention: partial matches such as `"gauss"` are now accepted where they previously errored.

---

`document()` no `man/`/`NAMESPACE` change; full suite green; `check --as-cran` Status OK (0/0/0); `spell_check()` clean. `urlchecker` could not run in the dev environment (no egress to CRAN.R-project.org) — the diff adds no URLs, but the gate item is unverified and wants a networked run before submission.

Patch version bump + NEWS, consistent with the #399 sibling fix's release. The `x.y.z.9000` development cycle opens with the *next* PR, per `.workflow/PROFILE.md` § 4.

Closes #403.
