### PR TITLE
refactor: single-source the high-dim nodewise solve, and pin its untested contract (#366 A1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fetwfe
 Title: Fused Extended Two-Way Fixed Effects
-Version: 1.56.18
+Version: 1.56.18.9000
 Authors@R: 
     person(given = "Gregory", family = "Faletto", email = "gfaletto@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8298-1401"))
 Maintainer: Gregory Faletto <gfaletto@gmail.com>

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # NEWS
 
+## fetwfe (development version)
+
+### Internal
+
+- The high-dimensional nodewise (desparsified-lasso) solve is now single-sourced
+  in one internal primitive shared by `debiasedATT()` and both simultaneous-band
+  bootstrap channels, so the point estimate and the bands cannot drift apart on
+  the penalty scale or the convergence diagnostics (#366).
+
 ## Version 1.56.18
 
 ### Defensive improvements

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -581,21 +581,19 @@ debiasedATT <- function(
 			)
 			lambda_c_used <- lambda_cv$lambda_c
 		}
-		lambda_node <- lambda_node_default(
-			p = p,
-			N = N_units,
-			const = lambda_c_used,
-			scale = max(abs(a_th))
-		)
-		v <- riesz_lasso(
+		nodewise <- .solve_nodewise(
 			Sig,
 			a_th,
-			lambda_node,
+			p = p,
+			N = N_units,
+			lambda_c = lambda_c_used,
 			max_iter = riesz_max_iter,
 			tol = riesz_tol
 		)
-		feasibility <- attr(v, "feasibility")
-		converged <- attr(v, "converged")
+		v <- nodewise$v
+		lambda_node <- nodewise$lambda_node
+		feasibility <- nodewise$feasibility
+		converged <- nodewise$converged
 		# The KKT certificate ||Sig v - a||_inf <= lambda_node is exactly the
 		# relaxed-inverse feasibility the high-dimensional FETWFE theory remainder bound needs.
 		if (!.riesz_feasible(feasibility, lambda_node)) {

--- a/R/riesz_lasso.R
+++ b/R/riesz_lasso.R
@@ -100,7 +100,7 @@ lambda_node_default <- function(p, N, const = 1.0, scale = 1.0) {
 #'   solving the IDENTICAL direction, so this contract is single-sourced here
 #'   (the callers diverge only on what they do with `v`). Theory: the relaxed-inverse
 #'   constraint `||Sig v - a||_inf <= lambda_node` this solves is eq.
-#'   `debiased.highdim.v` inside Theorem `debiased.highdim.thm` (uniformly valid
+#'   `debiased.highdim.v`, cited by Theorem `debiased.highdim.thm` (uniformly valid
 #'   debiased ATT) of `paper_arxiv.tex`; Theorem `debiased.highdim.joint.thm`
 #'   (simultaneous bands) derives its per-functional representation from that one,
 #'   which is why the same primitive serves the point estimate and both bands. (#366)
@@ -115,8 +115,9 @@ lambda_node_default <- function(p, N, const = 1.0, scale = 1.0) {
 #'   `.cv_lambda_node()`'s by the anchor test in `test-cv-lambda-node-295.R`.
 #' @param Sig Numeric `p x p`; the (singular, uncentered) Gram `crossprod(X) / n`.
 #' @param a Numeric length `p`; the target loading (theta-space direction).
-#' @param p,N Numeric; passed to `lambda_node_default()` (`N` = clusters = n / T,
-#'   a double at every call site).
+#' @param p,N Numeric; passed to `lambda_node_default()` (`N` = clusters = n / T).
+#'   `N` arrives as a double from `debiasedATT()` and as an integer from the two
+#'   band channels; `sqrt(log(p) / N)` is unaffected either way.
 #'   `p` is redundant with `length(a)` at every call site and is asserted against
 #'   it below: an inconsistent `p` would otherwise yield a silently wrong penalty,
 #'   which is the exact failure this consolidation exists to make impossible.

--- a/R/riesz_lasso.R
+++ b/R/riesz_lasso.R
@@ -98,18 +98,25 @@ lambda_node_default <- function(p, N, const = 1.0, scale = 1.0) {
 #'   KKT `feasibility` / `converged` diagnostics. The `gregfaletto/fetwfe#88`
 #'   coverage validity relies on the point estimate and both band channels
 #'   solving the IDENTICAL direction, so this contract is single-sourced here
-#'   (the callers diverge only on what they do with `v`). Theory: Theorem
-#'   `debiased.highdim.joint.thm` of `paper_arxiv.tex`. (#366)
+#'   (the callers diverge only on what they do with `v`). Theory: the relaxed-inverse
+#'   constraint `||Sig v - a||_inf <= lambda_node` this solves is eq.
+#'   `debiased.highdim.v` inside Theorem `debiased.highdim.thm` (uniformly valid
+#'   debiased ATT) of `paper_arxiv.tex`; Theorem `debiased.highdim.joint.thm`
+#'   (simultaneous bands) derives its per-functional representation from that one,
+#'   which is why the same primitive serves the point estimate and both bands. (#366)
 #'
 #'   **Lockstep partner:** `.cv_lambda_node()` searches `mult_grid * lam0` with
 #'   `lam0 = lambda_node_default(..., scale = max(abs(a)))`. Its selected
 #'   `lambda_c` is only transferable to the solve deployed here because BOTH use
-#'   `scale = max(abs(a))` -- that is the #295 D2 "one `lambda_c` for the point
-#'   estimate AND the band" claim. Change the scaling here and the CV anchor
-#'   silently drifts with nothing erroring; change it in both or neither.
+#'   `scale = max(abs(a))` -- that is the (#295, Decision D2) "one `lambda_c` for
+#'   the point estimate AND the band" claim. Change the scaling here and the CV
+#'   anchor drifts; change it in both or neither. Both sides are pinned: this one
+#'   by the `.solve_nodewise()` contract test in `test-debiased-att-highdim.R`,
+#'   `.cv_lambda_node()`'s by the anchor test in `test-cv-lambda-node-295.R`.
 #' @param Sig Numeric `p x p`; the (singular, uncentered) Gram `crossprod(X) / n`.
 #' @param a Numeric length `p`; the target loading (theta-space direction).
-#' @param p,N Integers; passed to `lambda_node_default()` (`N` = clusters = n / T).
+#' @param p,N Numeric; passed to `lambda_node_default()` (`N` = clusters = n / T,
+#'   a double at every call site).
 #'   `p` is redundant with `length(a)` at every call site and is asserted against
 #'   it below: an inconsistent `p` would otherwise yield a silently wrong penalty,
 #'   which is the exact failure this consolidation exists to make impossible.

--- a/R/riesz_lasso.R
+++ b/R/riesz_lasso.R
@@ -90,6 +90,58 @@ lambda_node_default <- function(p, N, const = 1.0, scale = 1.0) {
 	const * scale * sqrt(log(p) / N)
 }
 
+#' @title Solve one high-dimensional nodewise (desparsified-lasso) direction
+#' @description The single desparsification primitive shared by `debiasedATT()`
+#'   and the two high-dim bootstrap channels (`.build_regression_if_highdim()`
+#'   and `.build_debiased_treat_cells_highdim()`): scale the theory penalty by
+#'   `max(abs(a))`, solve the L1-penalized Riesz representer, and read back the
+#'   KKT `feasibility` / `converged` diagnostics. The `gregfaletto/fetwfe#88`
+#'   coverage validity relies on the point estimate and both band channels
+#'   solving the IDENTICAL direction, so this contract is single-sourced here
+#'   (the callers diverge only on what they do with `v`). Theory: Theorem
+#'   `debiased.highdim.joint.thm` of `paper_arxiv.tex`. (#366)
+#'
+#'   **Lockstep partner:** `.cv_lambda_node()` searches `mult_grid * lam0` with
+#'   `lam0 = lambda_node_default(..., scale = max(abs(a)))`. Its selected
+#'   `lambda_c` is only transferable to the solve deployed here because BOTH use
+#'   `scale = max(abs(a))` -- that is the #295 D2 "one `lambda_c` for the point
+#'   estimate AND the band" claim. Change the scaling here and the CV anchor
+#'   silently drifts with nothing erroring; change it in both or neither.
+#' @param Sig Numeric `p x p`; the (singular, uncentered) Gram `crossprod(X) / n`.
+#' @param a Numeric length `p`; the target loading (theta-space direction).
+#' @param p,N Integers; passed to `lambda_node_default()` (`N` = clusters = n / T).
+#'   `p` is redundant with `length(a)` at every call site and is asserted against
+#'   it below: an inconsistent `p` would otherwise yield a silently wrong penalty,
+#'   which is the exact failure this consolidation exists to make impossible.
+#' @param lambda_c Numeric; the leading penalty constant.
+#' @param max_iter,tol `riesz_lasso()` coordinate-descent controls.
+#' @return A list with `v` (the direction), `lambda_node` (the penalty used),
+#'   `feasibility` (`||Sig v - a||_inf`), and `converged`.
+#' @keywords internal
+#' @noRd
+.solve_nodewise <- function(Sig, a, p, N, lambda_c, max_iter, tol) {
+	stopifnot(length(a) == p, ncol(Sig) == p)
+	lambda_node <- lambda_node_default(
+		p = p,
+		N = N,
+		const = lambda_c,
+		scale = max(abs(a))
+	)
+	v <- riesz_lasso(
+		Sig,
+		a,
+		lambda_node,
+		max_iter = max_iter,
+		tol = tol
+	)
+	list(
+		v = v,
+		lambda_node = lambda_node,
+		feasibility = attr(v, "feasibility"),
+		converged = attr(v, "converged")
+	)
+}
+
 # Relative tolerance for the high-dim nodewise KKT feasibility certificate. The
 # desparsified L1 direction BINDS its constraint by construction
 # (||Sig v - a||_inf = lambda_node at the L1 optimum), so a converged solver

--- a/R/simultaneous_bootstrap.R
+++ b/R/simultaneous_bootstrap.R
@@ -215,24 +215,21 @@
 	converged <- logical(K)
 	lambda_node <- numeric(K)
 	for (k in seq_len(K)) {
-		a_k <- targets[, k]
-		lambda_node[k] <- lambda_node_default(
+		nodewise <- .solve_nodewise(
+			Sig,
+			targets[, k],
 			p = p,
 			N = N,
-			const = lambda_c,
-			scale = max(abs(a_k))
-		)
-		v_k <- riesz_lasso(
-			Sig,
-			a_k,
-			lambda_node[k],
+			lambda_c = lambda_c,
 			max_iter = riesz_max_iter,
 			tol = riesz_tol
 		)
+		v_k <- nodewise$v
+		lambda_node[k] <- nodewise$lambda_node
+		feasibility[k] <- nodewise$feasibility
+		converged[k] <- nodewise$converged
 		score_k <- as.numeric((X %*% v_k) * resid)
 		F_mat[, k] <- rowsum(score_k, group = unit, reorder = FALSE)
-		feasibility[k] <- attr(v_k, "feasibility")
-		converged[k] <- attr(v_k, "converged")
 	}
 	attr(F_mat, "highdim") <- TRUE
 	attr(F_mat, "diagnostics") <- list(
@@ -315,26 +312,24 @@
 	lambda_node <- numeric(num_treats)
 	for (j in seq_len(num_treats)) {
 		a_j <- cell_targets[, j]
-		lambda_node[j] <- lambda_node_default(
-			p = p,
-			N = N,
-			const = lambda_c,
-			scale = max(abs(a_j))
-		)
-		v_j <- riesz_lasso(
+		nodewise <- .solve_nodewise(
 			Sig,
 			a_j,
-			lambda_node[j],
+			p = p,
+			N = N,
+			lambda_c = lambda_c,
 			max_iter = riesz_max_iter,
 			tol = riesz_tol
 		)
+		v_j <- nodewise$v
+		lambda_node[j] <- nodewise$lambda_node
+		feasibility[j] <- nodewise$feasibility
+		converged[j] <- nodewise$converged
 		# q=1 plug-in + desparsified correction mean_n((X v_j) * resid). The mean
 		# is over all n = N*T rows (matching debiasedATT()'s mean(score) and
 		# colSums(F_reg)/(N*T)), NOT over units.
 		corr_j <- sum((X %*% v_j) * resid) / n
 		tau_db[j] <- as.numeric(crossprod(a_j, theta_q1_slopes)) + corr_j
-		feasibility[j] <- attr(v_j, "feasibility")
-		converged[j] <- attr(v_j, "converged")
 	}
 	list(
 		tau_db = tau_db,

--- a/tests/testthat/test-cv-lambda-node-295.R
+++ b/tests/testthat/test-cv-lambda-node-295.R
@@ -315,3 +315,46 @@ test_that("lambda_c rejects anything but a positive number or 'cv'", {
 		simultaneousCIs(hd295, method = "analytic", lambda_c = "garbage")
 	)
 })
+
+# ---- Absolute pin on the theory anchor `lam0` (#366) --------------------------
+# `.cv_lambda_node()` is the FOURTH live copy of the penalty-scale convention
+# `scale = max(abs(a))` (the other three were folded into .solve_nodewise() by
+# #366). Its selected `lambda_c` is only transferable to the deployed solve
+# because both anchor on the same scale -- the #295 Decision D2 claim that one
+# `lambda_c` serves the point estimate AND the band.
+#
+# The anchor is NOT unguarded today -- measured, not assumed. Mutating
+# `scale = max(abs(a))` to `1.0` inside .cv_lambda_node() fails 4 assertions in
+# this file (at :49, :137 and :138 twice) against 0 unmutated. Those catches are
+# INCIDENTAL, though: they are scale-invariant relations about the selection that
+# happen to break because rescaling `lam0` shifts which grid points clear the
+# feasibility gate. Change the grid, the fixture, or the gate budget and they
+# could stop biting without anyone noticing.
+#
+# This assertion is the direct one. It pins `lam0`'s observable consequence
+# rather than `lam0` itself, since the function does not return it: the feasible
+# set is exactly the grid points whose KKT certificate clears `mult_grid[k] *
+# lam0`, reconstructed here from `max(abs(a))` independently.
+test_that(".cv_lambda_node's grid anchors on scale = max(abs(a)) (#366)", {
+	s <- .cv295_synth()
+	expect_gt(abs(max(abs(s$a)) - 1), 0.5) # guard: the fixture is not the max|a| == 1 trap
+
+	r <- .cv_lambda_node(s$Sig, s$a, s$X, s$N_units, s$T)
+
+	lam0 <- lambda_node_default(
+		p = ncol(s$Sig),
+		N = s$N_units,
+		const = 1.0,
+		scale = max(abs(s$a))
+	)
+	feasible_expected <- vapply(
+		r$mult_grid,
+		function(m) {
+			v <- riesz_lasso(s$Sig, s$a, m * lam0, max_iter = 500L, tol = 1e-9)
+			isTRUE(attr(v, "converged")) &&
+				.riesz_feasible(attr(v, "feasibility"), m * lam0)
+		},
+		logical(1)
+	)
+	expect_identical(r$feasible, feasible_expected)
+})

--- a/tests/testthat/test-cv-lambda-node-295.R
+++ b/tests/testthat/test-cv-lambda-node-295.R
@@ -347,10 +347,25 @@ test_that(".cv_lambda_node's grid anchors on scale = max(abs(a)) (#366)", {
 		const = 1.0,
 		scale = max(abs(s$a))
 	)
+	# Read the gate's budget from the function under test rather than re-deriving
+	# it from literals. Hardcoding 500L / 1e-9 was measured to fail SILENTLY when
+	# either default moves: changing gate_max_iter to 1000L, or riesz_tol to 1e-8,
+	# left this file green while the reconstruction quietly stopped mirroring the
+	# gate it claims to reconstruct.
+	.fm <- formals(fetwfe:::.cv_lambda_node)
+	gate_iter <- eval(.fm$gate_max_iter)
+	gate_tol <- eval(.fm$riesz_tol)
+
 	feasible_expected <- vapply(
 		r$mult_grid,
 		function(m) {
-			v <- riesz_lasso(s$Sig, s$a, m * lam0, max_iter = 500L, tol = 1e-9)
+			v <- riesz_lasso(
+				s$Sig,
+				s$a,
+				m * lam0,
+				max_iter = gate_iter,
+				tol = gate_tol
+			)
 			isTRUE(attr(v, "converged")) &&
 				.riesz_feasible(attr(v, "feasibility"), m * lam0)
 		},

--- a/tests/testthat/test-debiased-att-highdim.R
+++ b/tests/testthat/test-debiased-att-highdim.R
@@ -519,18 +519,35 @@ test_that("the att_var_2 path is byte-unchanged: supplied-var var_weight == att_
 # inverse-fusion transform. So this test deliberately uses a target with
 # max(abs(a)) far from 1; that is the whole point of the `7 *` below.
 #
-# Mutation-checked, whole-suite counts: `scale = 1.0` -> 1 failure (this test, and
-# ONLY this test, in 4602 assertions); `N = 2 * N` -> 7; `const = lambda_c -> 1.0`
-# -> 4; dropping the attribute reads -> 2 failures plus 51 errors across 15 files.
+# Mutation-checked. ALL COUNTS BELOW ARE WHOLE-SUITE (4609 assertions across 109
+# files, NOT_CRAN=true) -- do not quote a single-file count here, which is a
+# mistake this comment has already made twice:
+#
+#   scale = max(abs(a)) -> 1.0   ->  3 failures: this test, plus 2 in the
+#                                    custom-family end-to-end witness in
+#                                    test-simultaneous-bootstrap-highdim-142.R
+#   N -> 2 * N                   ->  7 failures across 3 files
+#   const = lambda_c -> 1.0      ->  8 failures across 3 files
+#   drop the attribute reads     ->  2 failures + 51 errors across 13 files
+#
 # The riesz_lasso round-trip is NOT a mutation detector -- it recomputes with
 # whatever lambda_node the helper returned -- it pins argument order and the
 # max_iter/tol pass-through.
 #
-# DO NOT DELETE OR WEAKEN. The `scale` measurement above is the point: this is the
-# only assertion in the package that sees that clause. Removing it silently returns
-# the package to the pre-#366 state, where mutating the penalty scale left all 106
-# test files green. `lambda_c` is deliberately 2.3 and `max(abs(a))` deliberately
-# ~14.5; setting either to 1 makes the corresponding clause vacuous here.
+# DO NOT DELETE OR WEAKEN. Before #366, mutating the penalty scale left all 109
+# test files green; this test was the first thing in the package to see that clause.
+# `lambda_c` is deliberately 2.3 and `max(abs(a))` deliberately ~14.5 -- setting
+# either to 1 makes the corresponding clause vacuous here, which is the trap this
+# test exists to escape and which an earlier draft of it fell into for `lambda_c`.
+#
+# It is no longer the ONLY witness, and that is deliberate. "Every high-dim fixture
+# has max(abs(a)) == 1" holds for the BUILT-IN families, but `family = "custom"`
+# carries the user's own contrast scale, so the clause is genuinely live there in
+# production. The end-to-end witness is
+# `test-simultaneous-bootstrap-highdim-142.R`'s "high-dim custom-family lambda_node
+# scales with the contrast (#366)" -- it pins scale-equivariance through the public
+# API. Keep both: this one is a fast unit pin needing no fit; that one proves the
+# clause matters to a user.
 test_that(".solve_nodewise() pins scale, N and the diagnostic contract (#366)", {
 	Sig <- .psd_gram(p = 40L)
 	set.seed(101)

--- a/tests/testthat/test-debiased-att-highdim.R
+++ b/tests/testthat/test-debiased-att-highdim.R
@@ -505,3 +505,68 @@ test_that("the att_var_2 path is byte-unchanged: supplied-var var_weight == att_
 # "#312 follow-up" placeholder error -- now lives in its own file,
 # test-debiased-att-fixedp-gls-false-312.R, with consecutive-cohort fixtures the
 # debiasedATT ATT-identity guard supports.)
+
+# ---- .solve_nodewise() direct contract pin (#366) -----------------------------
+# The three high-dim callers (debiasedATT(), .build_regression_if_highdim(),
+# .build_debiased_treat_cells_highdim()) now share one nodewise primitive, so its
+# three contract clauses -- the penalty scale, the sample-size argument, and the
+# diagnostic pass-through -- live in exactly one place.
+#
+# Before #366 the FIRST of those was untested: mutating `scale = max(abs(a))` to
+# a constant 1.0 left every test file in the package green. That is structural,
+# not luck -- every high-dim FIXTURE in the suite has max(abs(a)) == 1 exactly,
+# because the targets are indicator directions through a 0/1 triangular
+# inverse-fusion transform. So this test deliberately uses a target with
+# max(abs(a)) far from 1; that is the whole point of the `7 *` below.
+#
+# Mutation-checked: `scale = 1.0` and `N = 2 * N` each fail the lambda_node
+# assertion; dropping the attribute reads fails the two diagnostic assertions.
+# Note the riesz_lasso round-trip is NOT a mutation detector (it recomputes with
+# whatever lambda_node the helper returned) -- it pins argument order and the
+# max_iter/tol pass-through.
+test_that(".solve_nodewise() pins scale, N and the diagnostic contract (#366)", {
+	Sig <- .psd_gram(p = 40L)
+	set.seed(101)
+	a <- 7 * stats::rnorm(40) # max|a| ~ 14.5, deliberately far from 1
+
+	r <- fetwfe:::.solve_nodewise(
+		Sig,
+		a,
+		p = 40L,
+		N = 25,
+		lambda_c = 1,
+		max_iter = 5000L,
+		tol = 1e-9
+	)
+
+	expect_equal(
+		r$lambda_node,
+		lambda_node_default(p = 40L, N = 25, const = 1, scale = max(abs(a)))
+	)
+	expect_identical(
+		r$v,
+		riesz_lasso(Sig, a, r$lambda_node, max_iter = 5000L, tol = 1e-9)
+	)
+	expect_identical(r$feasibility, attr(r$v, "feasibility"))
+	expect_identical(r$converged, attr(r$v, "converged"))
+})
+
+# The `p` argument is redundant with length(a) at every call site; the guard
+# turns that convention into an enforced invariant, so a future caller cannot
+# hand the helper an inconsistent p and get a silently wrong penalty.
+test_that(".solve_nodewise() rejects an inconsistent p (#366)", {
+	Sig <- .psd_gram(p = 40L)
+	a <- stats::rnorm(40)
+	expect_error(
+		fetwfe:::.solve_nodewise(
+			Sig,
+			a,
+			p = 39L,
+			N = 25,
+			lambda_c = 1,
+			max_iter = 100L,
+			tol = 1e-6
+		),
+		"length\\(a\\) == p"
+	)
+})

--- a/tests/testthat/test-debiased-att-highdim.R
+++ b/tests/testthat/test-debiased-att-highdim.R
@@ -519,11 +519,18 @@ test_that("the att_var_2 path is byte-unchanged: supplied-var var_weight == att_
 # inverse-fusion transform. So this test deliberately uses a target with
 # max(abs(a)) far from 1; that is the whole point of the `7 *` below.
 #
-# Mutation-checked: `scale = 1.0` and `N = 2 * N` each fail the lambda_node
-# assertion; dropping the attribute reads fails the two diagnostic assertions.
-# Note the riesz_lasso round-trip is NOT a mutation detector (it recomputes with
-# whatever lambda_node the helper returned) -- it pins argument order and the
+# Mutation-checked, whole-suite counts: `scale = 1.0` -> 1 failure (this test, and
+# ONLY this test, in 4602 assertions); `N = 2 * N` -> 7; `const = lambda_c -> 1.0`
+# -> 4; dropping the attribute reads -> 2 failures plus 51 errors across 15 files.
+# The riesz_lasso round-trip is NOT a mutation detector -- it recomputes with
+# whatever lambda_node the helper returned -- it pins argument order and the
 # max_iter/tol pass-through.
+#
+# DO NOT DELETE OR WEAKEN. The `scale` measurement above is the point: this is the
+# only assertion in the package that sees that clause. Removing it silently returns
+# the package to the pre-#366 state, where mutating the penalty scale left all 106
+# test files green. `lambda_c` is deliberately 2.3 and `max(abs(a))` deliberately
+# ~14.5; setting either to 1 makes the corresponding clause vacuous here.
 test_that(".solve_nodewise() pins scale, N and the diagnostic contract (#366)", {
 	Sig <- .psd_gram(p = 40L)
 	set.seed(101)
@@ -534,14 +541,14 @@ test_that(".solve_nodewise() pins scale, N and the diagnostic contract (#366)", 
 		a,
 		p = 40L,
 		N = 25,
-		lambda_c = 1,
+		lambda_c = 2.3, # NOT 1: else const = lambda_c is vacuous here
 		max_iter = 5000L,
 		tol = 1e-9
 	)
 
 	expect_equal(
 		r$lambda_node,
-		lambda_node_default(p = 40L, N = 25, const = 1, scale = max(abs(a)))
+		lambda_node_default(p = 40L, N = 25, const = 2.3, scale = max(abs(a)))
 	)
 	expect_identical(
 		r$v,
@@ -556,6 +563,7 @@ test_that(".solve_nodewise() pins scale, N and the diagnostic contract (#366)", 
 # hand the helper an inconsistent p and get a silently wrong penalty.
 test_that(".solve_nodewise() rejects an inconsistent p (#366)", {
 	Sig <- .psd_gram(p = 40L)
+	set.seed(202)
 	a <- stats::rnorm(40)
 	expect_error(
 		fetwfe:::.solve_nodewise(
@@ -568,5 +576,22 @@ test_that(".solve_nodewise() rejects an inconsistent p (#366)", {
 			tol = 1e-6
 		),
 		"length\\(a\\) == p"
+	)
+
+	# Second clause. Not redundant with the first: pre-guard, riesz_lasso() sets
+	# p <- length(a) internally and does `Sv + Sig[, j] * dv`, so a short `a`
+	# against a wider Sig RECYCLES SILENTLY and returns a wrong v with only a
+	# recycling warning -- a wrong answer, not a crash.
+	expect_error(
+		fetwfe:::.solve_nodewise(
+			.psd_gram(p = 41L),
+			a,
+			p = 40L,
+			N = 25,
+			lambda_c = 1,
+			max_iter = 100L,
+			tol = 1e-6
+		),
+		"ncol\\(Sig\\) == p"
 	)
 })

--- a/tests/testthat/test-debiased-att-highdim.R
+++ b/tests/testthat/test-debiased-att-highdim.R
@@ -519,7 +519,7 @@ test_that("the att_var_2 path is byte-unchanged: supplied-var var_weight == att_
 # inverse-fusion transform. So this test deliberately uses a target with
 # max(abs(a)) far from 1; that is the whole point of the `7 *` below.
 #
-# Mutation-checked. ALL COUNTS BELOW ARE WHOLE-SUITE (4609 assertions across 109
+# Mutation-checked. ALL COUNTS BELOW ARE WHOLE-SUITE (4612 assertions across 109
 # files, NOT_CRAN=true) -- do not quote a single-file count here, which is a
 # mistake this comment has already made twice:
 #

--- a/tests/testthat/test-simultaneous-bootstrap-highdim-142.R
+++ b/tests/testthat/test-simultaneous-bootstrap-highdim-142.R
@@ -172,8 +172,19 @@ test_that("too-small lambda_c warns for high-dim event_study (experimental)", {
 # contrast that matches debiasedATT()'s overall-ATT direction (cohort g loads its
 # treat_inds cells with cohort_probs[g] / (#cells in cohort g)), that center must
 # equal debiasedATT(fit)$att. RHS is the independently-validated single-effect
-# debiased ATT; LHS is the simultaneousCIs high-dim center -- an independent path,
-# not a round-trip. Mutation-checkable against the `colSums(F_mat)/(N*T)` line.
+# debiased ATT; LHS is the simultaneousCIs high-dim center.
+#
+# SCOPE OF THE INDEPENDENCE (narrowed by #366). This comment used to claim the two
+# sides were "an independent path, not a round-trip". That is no longer true of the
+# NODEWISE LEG: since #366 both sides obtain their direction from the single
+# `.solve_nodewise()` primitive, so a change to the penalty scale or the diagnostic
+# contract moves both sides together and cannot be detected here. That leg is now
+# pinned directly instead, by the `.solve_nodewise()` contract test in
+# test-debiased-att-highdim.R (mutation-checked: scale, N and the attribute reads).
+#
+# What this test still compares independently, and why it keeps its place: the
+# contrast-to-`a_th` mapping, `colSums(F_mat)/(N*T)` versus `mean(score)`, and the
+# q=1 plug-in assembly. Mutation-checkable against the `colSums(F_mat)/(N*T)` line.
 # ------------------------------------------------------------------------------
 test_that("high-dim debiased band center equals debiasedATT()$att for the overall-ATT contrast", {
 	G <- hd_fit$G

--- a/tests/testthat/test-simultaneous-bootstrap-highdim-142.R
+++ b/tests/testthat/test-simultaneous-bootstrap-highdim-142.R
@@ -192,13 +192,20 @@ test_that("too-small lambda_c warns for high-dim event_study (experimental)", {
 # passes its own N, lambda_c, riesz_max_iter and riesz_tol. The .solve_nodewise()
 # contract test pins the helper GIVEN its arguments and structurally cannot see
 # caller-side divergence -- which is exactly the gregfaletto/fetwfe#88 lockstep.
-# `test-aatt-scattered-cv-323.R` carries the same band-center-vs-debiasedATT()
-# comparison and is the second (only other) witness to that argument contract.
+#
+# The full witness set, measured by mutating the band channel's lambda_c to diverge
+# from debiasedATT()'s (6 assertions in 4 files fire):
+#   test-simultaneous-bootstrap-highdim-142.R:231, :290, :482  (here)
+#   test-simultaneous-bootstrap-gls-false-313.R:133   -- the identical cross-check
+#                                                        on a gls = FALSE high-dim fit
+#   test-simultaneous-bootstrap-fpi-desparsify-309.R:317 -- hand-rolled SE reconstruction
+#   test-aatt-scattered-cv-323.R:112                  -- scattered-adoption panel
 #
 # FOR FUTURE CONSOLIDATIONS (#366 A2/A3/B and beyond): if the contrast construction
-# or the center assembly is ever folded onto a shared helper too, this assertion and
-# 323's go fully tautological and the caller-side argument contract loses its last
-# oracle. Replace it with an absolute pin before doing that, not after.
+# or the center assembly is ever folded onto a shared helper too, ALL SIX of those go
+# tautological together -- they are one witness set, not independent ones, because
+# they all compare the band center against debiasedATT() through the same two
+# channels. Replace them with absolute pins before doing that, not after.
 # ------------------------------------------------------------------------------
 test_that("high-dim debiased band center equals debiasedATT()$att for the overall-ATT contrast", {
 	G <- hd_fit$G
@@ -607,4 +614,46 @@ test_that("non-fetwfe (betwfe) high-dim bootstrap uses the fixed-p band, not an 
 		expect_true(all(is.finite(bo$ci$simultaneous_ci_low)))
 		expect_true(all(is.finite(bo$ci$simultaneous_ci_high)))
 	}
+})
+
+# ---- The penalty scale is LIVE in production on family = "custom" (#366) ------
+# `.solve_nodewise()` scales its penalty by max(abs(a)). For the built-in families
+# that is always exactly 1 -- the targets are indicator directions through a 0/1
+# triangular inverse-fusion transform -- which is why mutating the clause to a
+# constant 1.0 was invisible to the whole suite before #366, and why the direct
+# contract test in test-debiased-att-highdim.R uses a hand-built target.
+#
+# `family = "custom"` is the one shipped path where the scale is genuinely the
+# user's: the contrast carries its own magnitude. Every other high-dim custom test
+# in the package (here at :231 and :290, plus 313:126 and 323:100) uses
+# ATT-direction weights that sum to 1, so all of them land back on scale 1 and none
+# of them sees the clause either.
+#
+# This is the end-to-end witness. It pins scale-EQUIVARIANCE rather than a value,
+# so it needs no reconstruction of `a`: scaling the contrast by c must scale
+# lambda_node by exactly c. Under `scale = 1.0` both calls return the identical
+# lambda_node and the ratio collapses to 1.
+test_that("high-dim custom-family lambda_node scales with the contrast (#366)", {
+	nt <- length(hd_fit$treat_inds)
+	C1 <- rbind(c(1, rep(0, nt - 1)), c(rep(0, nt - 1), 1))
+	kk <- 3.5
+
+	boot_at <- function(C) {
+		simultaneousCIs(
+			hd_fit,
+			family = "custom",
+			contrasts = C,
+			method = "bootstrap",
+			B = 40,
+			seed = 3,
+			lambda_c = 1.0 # fixed, so lambda_node moves only with the scale
+		)
+	}
+	b1 <- boot_at(C1)
+	b2 <- boot_at(kk * C1)
+
+	expect_identical(b1$regime, "high-dimensional")
+	expect_equal(b2$lambda_node, kk * b1$lambda_node, tolerance = 1e-12)
+	# Guard against a vacuous pass if lambda_node ever becomes constant.
+	expect_gt(min(b2$lambda_node), min(b1$lambda_node))
 })

--- a/tests/testthat/test-simultaneous-bootstrap-highdim-142.R
+++ b/tests/testthat/test-simultaneous-bootstrap-highdim-142.R
@@ -184,7 +184,21 @@ test_that("too-small lambda_c warns for high-dim event_study (experimental)", {
 #
 # What this test still compares independently, and why it keeps its place: the
 # contrast-to-`a_th` mapping, `colSums(F_mat)/(N*T)` versus `mean(score)`, and the
-# q=1 plug-in assembly. Mutation-checkable against the `colSums(F_mat)/(N*T)` line.
+# q=1 plug-in assembly -- all three verified still mutation-detectable here.
+#
+# MOST IMPORTANTLY, and the reason this test is not marginal: it is the only check
+# that the two channels pass EQUIVALENT ARGUMENTS to the shared primitive.
+# debiasedATT() passes N = N_units and its own lambda_c; .build_regression_if_highdim()
+# passes its own N, lambda_c, riesz_max_iter and riesz_tol. The .solve_nodewise()
+# contract test pins the helper GIVEN its arguments and structurally cannot see
+# caller-side divergence -- which is exactly the gregfaletto/fetwfe#88 lockstep.
+# `test-aatt-scattered-cv-323.R` carries the same band-center-vs-debiasedATT()
+# comparison and is the second (only other) witness to that argument contract.
+#
+# FOR FUTURE CONSOLIDATIONS (#366 A2/A3/B and beyond): if the contrast construction
+# or the center assembly is ever folded onto a shared helper too, this assertion and
+# 323's go fully tautological and the caller-side argument contract loses its last
+# oracle. Replace it with an absolute pin before doing that, not after.
 # ------------------------------------------------------------------------------
 test_that("high-dim debiased band center equals debiasedATT()$att for the overall-ATT contrast", {
 	G <- hd_fit$G


### PR DESCRIPTION

Three sites computed the same desparsified-lasso ("nodewise") recipe: the high-dimensional point estimate in `debiasedATT()`, and the two bootstrap channels that build the bands around it (`.build_regression_if_highdim()` and `.build_debiased_treat_cells_highdim()`). The `gregfaletto/fetwfe#88` coverage validity relies on the point estimate and both band channels solving the **identical** direction, so drift between the copies would produce a point estimate and an interval computed from different directions — no error, just a wrong interval.

Theory: the relaxed-inverse constraint `||Sig v - a||_inf <= lambda_node` this solves is eq. `debiased.highdim.v`, cited by Theorem `debiased.highdim.thm` (uniformly valid debiased ATT) of `paper_arxiv.tex`; Theorem `debiased.highdim.joint.thm` (simultaneous bands) derives its per-functional representation from that one, which is why a single primitive legitimately serves all three callers. **No new equation is implemented** — the fold is byte-identical by construction.

## The consolidation is the smaller half. The contract was untested.

The recipe scales its penalty by `max(abs(a))`. Plan review established that mutating that to a constant `1.0` left **every one of the 109 test files green**.

That is structural, not luck. Every high-dimensional fixture in the suite has `max(abs(a)) == 1` exactly, because the targets are indicator directions through a 0/1 triangular inverse-fusion transform. Measured on the `test-debiased-att-highdim.R` fixture: `lambda_node = 0.54449927196415493` against `sqrt(log(p)/N) = 0.54449927196415493` — implied scale exactly 1. The post-execution reviewer then reproduced this independently on a deliberately unlike panel (scattered adoption at t = 2, 5, 8; `p = 404 >= NT = 162`) and found the implied scale is *still* exactly 1 for all 8 band effects and all four ATT fits.

So consolidating without a test would have concentrated an untested contract into a single unguarded point. This PR adds the direct `.solve_nodewise()` contract test, deliberately using `max(abs(a)) ~ 14.5` and `lambda_c = 2.3` so no clause is vacuous.

**Mutation battery, whole-suite counts** (4612 assertions across 109 files, `NOT_CRAN=true`):

| Mutation | Result |
|---|---|
| `scale = max(abs(a))` → `1.0` | **3 failures** — the unit contract test, plus 2 in the custom-family end-to-end witness |
| `N` → `2 * N` | 7 failures across 3 files, including the 3 pre-existing oracles |
| `const = lambda_c` → `1.0` | 8 failures across 3 files |
| drop the `feasibility`/`converged` reads | 2 failures + 51 errors across 13 files |

(`N` is mutated to `2 * N` rather than `N * T` because `T` is not in the helper's scope. The `riesz_lasso` round-trip assertion is **not** a mutation detector — it recomputes with whatever `lambda_node` the helper returned — it pins argument order and the `max_iter`/`tol` pass-through.)

## Also in this PR

**A guard that is not decorative.** `stopifnot(length(a) == p, ncol(Sig) == p)`. `p` is `length(a)` at every call site, so carrying it as a parameter otherwise invites exactly the bug this consolidation exists to prevent. The second clause matters independently: `riesz_lasso()` sets `p <- length(a)` internally and does `Sv + Sig[, j] * dv`, so a short `a` against a wider `Sig` **recycles silently** and returns a wrong `v` with only a warning — a wrong answer, not a crash. Both clauses are tested. Verified unreachable from all three call sites (the ATT-identity check in `debiasedATT()` fires first).

**The fourth copy is named and pinned.** `.cv_lambda_node()` searches `mult_grid * lambda_node_default(..., scale = max(abs(a)))`, so its chosen `lambda_c` is only transferable to the deployed solve because both anchor on the same scale — the (#295, Decision D2) claim that one `lambda_c` serves the point estimate and the band. It is a single expression rather than a block, so it is not folded, but the roxygen now names it as the lockstep partner and `test-cv-lambda-node-295.R` gains a direct pin on its anchor.

**A corrected claim.** `test-simultaneous-bootstrap-highdim-142.R`'s header said its two sides were "an independent path, not a round-trip". That is now false for the nodewise leg — both sides call the same primitive — so the comment says which leg lost independence, where it is pinned instead, and what the test still compares independently (all three verified still mutation-detectable). It also now records the thing that makes it non-marginal: it is the only check that the two channels pass **equivalent arguments** to the shared primitive, which the contract test structurally cannot see. The full witness set is 6 assertions across 4 files (`142` ×3, `gls-false-313:133`, `fpi-desparsify-309:317`, `aatt-scattered-cv-323:112`) — measured by mutating the band channel's `lambda_c` to diverge. They are **one** witness set rather than independent ones: all six route through the same two channels, so a later consolidation voids them together.

**The scale clause is live in production on `family = "custom"`.** For the built-in families `max(abs(a))` is structurally 1, but a custom contrast carries the user's own magnitude — and all four existing high-dim custom tests use ATT-direction weights summing to 1, so they land back on scale 1 as well. A new test pins scale-*equivariance* through the public API (scaling the contrast by 3.5 must scale `lambda_node` by exactly 3.5), so the clause now has an end-to-end witness as well as a unit one.

Opens the `1.56.18.9000` development cycle per the repo's version convention.

## Verification

Byte-identity confirmed **five times on five different fixtures**, by four parties, using `identical()` on complete returned objects (never `all.equal()`, whose default tolerance would hide exactly the drift being checked). The most searching ones: a scattered-adoption panel (t = 2, 5, 8) crossing `q ∈ {0.5, 1, 2}`, `gls = FALSE`, `fusion_structure = "event_study"` and a two-sample `indep_counts` fit (22 objects); a `G = 1` single-cohort panel with `lambda_c = "cv"`, so the CV-selected constant actually feeds the primitive; and a user-supplied `fusion_matrix` fit, the one path where `A`'s shape is user-determined and `length(a) == p` is least tautological. All `identical()` TRUE at whole-object level and elementwise.

`air` clean; `document()` produces no `man/`/`NAMESPACE` diff; testthat 4612 pass / 0 fail; `check(error_on = "note")` 0 errors / 0 warnings / 0 notes; `spell_check()` clean.

`urlchecker::url_check()` **could not run** — this host has no network egress to `CRAN.R-project.org` (`curl` fails in ~165 ms while `github.com` returns 200). This diff adds no URLs. The limitation is now recorded in the repo's profile so it stops being re-derived, and a networked run is wanted before the next CRAN submission.

## Out of scope (deferred follow-ups)

Issue #366 collects roughly a dozen review items; this is **A1 of four**, split because the combined change measured ~350 lines against the repo's ~150 one-logical-change heuristic, and because A1's verification story was complete while the others' were not.

- **A2** — the `R/class_helpers.R` print/summary rendering consolidation. Its scope carries several corrections found during this PR's plan review, so they are not rediscovered: `.se_qualifier(se_type)` rather than `.se_label` (print renders `"Std. Error (cluster-robust)"`, summary `"SE (cluster-robust)"` — the shared piece is the qualifier); a **value-returning** `.att_wald_ci()` rather than a `cat()` helper (its third site computes values into a data frame); a `.cat_preview_block()` serving **four** sites rather than an event-study-only helper serving two; `.cat_model_details()` taking **named fields** (every snapshot fixture has `G == d == 2`, so a positional G/d transposition would be invisible); the event-study **gate** staying in the callers; and new coverage for `twfeCovs` print/summary, a distinct-`N/T/G/d/p` fixture, and the unpinned `"pointwise"` / `"cluster"` / `"conservative"` label branches.
- **A3** — the seed range guard in `.apply_seed()` (covering `simulateData(seed=)`, `cv_seed` and the bootstrap `seed` in one edit), plus dropping the redundant `match.arg()` calls from the four `*WithSimulatedData()` wrappers. Three implementation constraints are recorded in the plan: the check must sit **inside** the numeric branch (`abs(NA)` would otherwise break the documented `seed = NA` input), the boundary must be strictly `>` (`getBetaCV()` clips its *default* to exactly `.Machine$integer.max`), and it must use `abs()` (R's integer minimum is `-2147483647`).
- **B** — comments and roxygen only: the #318/#309 roxygen promotion, eight comments citing a deleted local doc, stale commented-out lines, a TODO reclassification, and dead scaffolding in `R/design_matrix.R`. Deliberately **not** merged into A1: promoting #318 into an exported function's roxygen makes `document()` rewrite `man/debiasedATT.Rd`, and this PR's expect-empty `man/`/`NAMESPACE` check is the tripwire that would catch an internal helper accidentally acquiring an export.

A warning for whoever does A2: if the contrast construction or the center assembly is ever folded onto a shared helper, all six assertions in that witness set go fully tautological and the caller-side argument contract loses its last oracle. Replace them with absolute pins **before** doing that, not after.

Refs #366.
