### PR TITLE
fix: guard out-of-range seeds at every door, and drop nine redundant match.arg() calls (#440)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,9 +21,14 @@
   `debiasedATT(method = "bootstrap")`. An out-of-range `B` previously became
   `NA_integer_` and surfaced several frames later as the cryptic `vector size
   cannot be NA`. The boundary is strict, so exactly `.Machine$integer.max` is
-  still accepted, and `NULL` / `NA` / `NaN` still mean "draw from the ambient
-  generator". This is a **range** check only --- a non-integral seed such as
-  `1.5` is still truncated silently by `set.seed()`, as before.
+  still accepted. On the four data-generation doors, `NULL` / `NA` / `NaN` still
+  mean "draw from the ambient generator", and this is a **range** check only ---
+  a non-integral seed such as `1.5` is still truncated silently by `set.seed()`,
+  as before; `cv_seed` and the bootstrap `B` / `seed` reject those values as
+  they always have. The one input that used to work and no longer does is a
+  non-integral magnitude between `.Machine$integer.max` and `2147483648`
+  (`2147483647.9`, say), which previously truncated to `2147483647L` and drew
+  from a different seed than the one supplied.
 
 ### Internal
 
@@ -37,6 +42,12 @@
   `.format_int_max_range()`, so the boundary cannot later be tightened in one
   copy only and the value-formatting guards cannot be applied to some sites but
   not others (#440).
+
+- `simultaneousCIs()` and `debiasedATT()` now report the `B` error ahead of the
+  `seed` error when both arguments are invalid, because the new `B` range check
+  precedes the pre-existing whole-number check on `seed`. Previously a call with
+  an out-of-range `B` and a non-integral `seed` reported the `seed` message
+  (#440).
 
 - The four `*WithSimulatedData()` wrappers no longer repeat the `match.arg()`
   calls their estimator cores already perform --- nine deletions across

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,12 +2,49 @@
 
 ## fetwfe (development version)
 
+### Defensive improvements
+
+- An out-of-range seed now fails with the package's own message, at every door
+  (#440). `set.seed()` can represent only a 32-bit signed integer, so a larger
+  magnitude previously produced base R's `NAs introduced by coercion to integer
+  range` warning followed by an opaque `supplied seed is not a valid integer`
+  error --- neither of which names the offending argument or states the limit.
+  Every argument that carries a seed into the random-number generator is now
+  range-checked against `+/- .Machine$integer.max` and reports, for example,
+  `seed must be within +/- .Machine$integer.max (2147483647); got 3000000000`.
+  The covered arguments are `seed` on `simulateData()`, `simulateDataCore()`,
+  `genCoefs()`, and `genCoefsCore()`; `cv_seed` on `fetwfe()` and `betwfe()`
+  (and their `*WithSimulatedData()` wrappers), which now fails during input
+  validation alongside any other bad argument in the same call instead of
+  part-way through the fit at the cross-validation fold seeding; and `B` and
+  `seed` on `simultaneousCIs(method = "bootstrap")` and
+  `debiasedATT(method = "bootstrap")`. An out-of-range `B` previously became
+  `NA_integer_` and surfaced several frames later as the cryptic `vector size
+  cannot be NA`. The boundary is strict, so exactly `.Machine$integer.max` is
+  still accepted, and `NULL` / `NA` / `NaN` still mean "draw from the ambient
+  generator". This is a **range** check only --- a non-integral seed such as
+  `1.5` is still truncated silently by `set.seed()`, as before.
+
 ### Internal
 
 - The high-dimensional nodewise (desparsified-lasso) solve is now single-sourced
   in one internal primitive shared by `debiasedATT()` and both simultaneous-band
   bootstrap channels, so the point estimate and the bands cannot drift apart on
   the penalty scale or the convergence diagnostics (#366).
+
+- The range rule above and its error wording are single-sourced in two new
+  internal helpers in `R/utility.R`, `.exceeds_integer_max()` and
+  `.format_int_max_range()`, so the boundary cannot later be tightened in one
+  copy only and the value-formatting guards cannot be applied to some sites but
+  not others (#440).
+
+- The four `*WithSimulatedData()` wrappers no longer repeat the `match.arg()`
+  calls their estimator cores already perform --- nine deletions across
+  `se_type`, `ci_type`, and `fusion_structure` --- so each of those arguments is
+  validated in exactly one place. Abbreviations still resolve
+  (`se_type = "conserv"` still yields `"conservative"`). One user-visible
+  consequence: when both `simulated_obj` and `se_type` are invalid, the reported
+  error is now the `simulated_obj` one rather than the `se_type` one (#440).
 
 ## Version 1.56.18
 

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -772,8 +772,8 @@ betwfeWithSimulatedData <- function(
 	cv_seed = NULL,
 	ci_type = c("simultaneous", "pointwise")
 ) {
-	# `se_type` and `ci_type` are deliberately forwarded UNRESOLVED: `betwfe()`
-	# runs the same `match.arg()` calls on them, so repeating them here would
+	# `se_type` and `ci_type` are deliberately forwarded without `match.arg()`:
+	# `betwfe()` runs the same calls on them, so repeating them here would
 	# validate each argument twice. Partial matches ("conserv", "point") and the
 	# untouched length-2 `ci_type` default both resolve identically downstream,
 	# because the callee's formal defaults are byte-identical to this wrapper's.

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -136,7 +136,8 @@
 #' @param cv_folds Integer; number of folds for the CV path. Ignored when
 #'   `lambda_selection = "bic"`. Default is 10.
 #' @param cv_seed Integer or `NULL`; the seed passed to `set.seed()`
-#'   immediately before the `cv.grpreg()` call. If `NULL` (the default),
+#'   immediately before the `cv.grpreg()` call. If supplied, must be
+#'   within `+/- .Machine$integer.max`. If `NULL` (the default),
 #'   the seed defaults internally to `as.integer(N * T)`. Ignored when
 #'   `lambda_selection = "bic"`.
 #' @param ci_type Character; one of `"simultaneous"` (default) or
@@ -576,7 +577,8 @@ betwfe <- function(
 #' @param cv_folds Integer; number of folds for the CV path. Ignored when
 #'   `lambda_selection = "bic"`. Default is 10.
 #' @param cv_seed Integer or `NULL`; the seed passed to `set.seed()`
-#'   immediately before the `cv.grpreg()` call. If `NULL` (the default),
+#'   immediately before the `cv.grpreg()` call. If supplied, must be
+#'   within `+/- .Machine$integer.max`. If `NULL` (the default),
 #'   the seed defaults internally to `as.integer(N * T)`. Ignored when
 #'   `lambda_selection = "bic"`.
 #' @param ci_type Character; one of `"simultaneous"` (default) or
@@ -770,13 +772,13 @@ betwfeWithSimulatedData <- function(
 	cv_seed = NULL,
 	ci_type = c("simultaneous", "pointwise")
 ) {
-	se_type <- match.arg(
-		se_type,
-		c("default", "conservative", "cluster")
-	)
-	ci_type <- match.arg(ci_type)
-	# `lambda_selection` validated downstream by `checkFetwfeInputs()`
-	# (collect-all-violations pattern).
+	# `se_type` and `ci_type` are deliberately forwarded UNRESOLVED: `betwfe()`
+	# runs the same `match.arg()` calls on them, so repeating them here would
+	# validate each argument twice. Partial matches ("conserv", "point") and the
+	# untouched length-2 `ci_type` default both resolve identically downstream,
+	# because the callee's formal defaults are byte-identical to this wrapper's.
+	# Do not restore them (#440). `lambda_selection` is likewise validated
+	# downstream by `checkFetwfeInputs()` (collect-all-violations pattern).
 
 	sim <- .unpack_simulated_obj(simulated_obj)
 

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -200,8 +200,8 @@
 #'   over the `N` count-sample units (`sum(indep_counts) == N` is enforced), yielding
 #'   the two-sample propensity variance.
 #' @param B Integer; the number of wild-bootstrap replicates (default `1000`).
-#'   Must be within `+/- .Machine$integer.max`. Ignored unless
-#'   `method = "bootstrap"`.
+#'   Must be a positive integer no greater than `.Machine$integer.max`. Ignored
+#'   unless `method = "bootstrap"`.
 #' @param seed `NULL` (draw from the ambient RNG, the default) or a single
 #'   integer within `+/- .Machine$integer.max` for a reproducible bootstrap
 #'   (the RNG state is saved and restored).

--- a/R/debiased_att.R
+++ b/R/debiased_att.R
@@ -200,9 +200,11 @@
 #'   over the `N` count-sample units (`sum(indep_counts) == N` is enforced), yielding
 #'   the two-sample propensity variance.
 #' @param B Integer; the number of wild-bootstrap replicates (default `1000`).
-#'   Ignored unless `method = "bootstrap"`.
+#'   Must be within `+/- .Machine$integer.max`. Ignored unless
+#'   `method = "bootstrap"`.
 #' @param seed `NULL` (draw from the ambient RNG, the default) or a single
-#'   integer for a reproducible bootstrap (the RNG state is saved and restored).
+#'   integer within `+/- .Machine$integer.max` for a reproducible bootstrap
+#'   (the RNG state is saved and restored).
 #'   Ignored unless `method = "bootstrap"`.
 #' @param multiplier The wild-bootstrap weight distribution: `"webb"` (default),
 #'   `"rademacher"`, or `"mammen"`. `"rademacher"` (`±1`) gives a constant

--- a/R/etwfe.R
+++ b/R/etwfe.R
@@ -533,8 +533,8 @@ etwfeWithSimulatedData <- function(
 	se_type = "default",
 	ci_type = c("simultaneous", "pointwise")
 ) {
-	# `se_type` and `ci_type` are deliberately forwarded UNRESOLVED: `etwfe()`
-	# runs the same `match.arg()` calls on them, so repeating them here would
+	# `se_type` and `ci_type` are deliberately forwarded without `match.arg()`:
+	# `etwfe()` runs the same calls on them, so repeating them here would
 	# validate each argument twice. Partial matches ("conserv", "point") and the
 	# untouched length-2 `ci_type` default both resolve identically downstream,
 	# because the callee's formal defaults are byte-identical to this wrapper's.

--- a/R/etwfe.R
+++ b/R/etwfe.R
@@ -533,11 +533,12 @@ etwfeWithSimulatedData <- function(
 	se_type = "default",
 	ci_type = c("simultaneous", "pointwise")
 ) {
-	se_type <- match.arg(
-		se_type,
-		c("default", "conservative", "cluster")
-	)
-	ci_type <- match.arg(ci_type)
+	# `se_type` and `ci_type` are deliberately forwarded UNRESOLVED: `etwfe()`
+	# runs the same `match.arg()` calls on them, so repeating them here would
+	# validate each argument twice. Partial matches ("conserv", "point") and the
+	# untouched length-2 `ci_type` default both resolve identically downstream,
+	# because the callee's formal defaults are byte-identical to this wrapper's.
+	# Do not restore them (#440).
 
 	sim <- .unpack_simulated_obj(simulated_obj)
 

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -834,7 +834,7 @@ fetwfeWithSimulatedData <- function(
 	gls = TRUE
 ) {
 	# `se_type`, `ci_type` and `fusion_structure` are deliberately forwarded
-	# UNRESOLVED: `fetwfe()` runs the same `match.arg()` calls on them, so
+	# without `match.arg()`: `fetwfe()` runs the same calls on them, so
 	# repeating them here would validate each argument twice. Partial matches
 	# ("conserv", "point", "event") and the untouched length-2 defaults both
 	# resolve identically downstream, because the callee's formal defaults are

--- a/R/fetwfe.R
+++ b/R/fetwfe.R
@@ -158,7 +158,8 @@
 #'   `lambda_selection = "bic"`. Default is 10.
 #' @param cv_seed Integer or `NULL`; the seed passed to `set.seed()`
 #'   immediately before the `cv.grpreg()` call, controlling fold
-#'   assignment. If `NULL` (the default), the seed defaults internally to
+#'   assignment. If supplied, must be within `+/- .Machine$integer.max`.
+#'   If `NULL` (the default), the seed defaults internally to
 #'   `as.integer(N * T)` so consecutive calls on the same dataset are
 #'   reproducible without the user having to specify a seed. The seed
 #'   actually used is stored on the returned object as `cv_seed`.
@@ -661,7 +662,8 @@ fetwfe <- function(
 #'   `lambda_selection = "bic"`. Default is 10.
 #' @param cv_seed Integer or `NULL`; the seed passed to `set.seed()`
 #'   immediately before the `cv.grpreg()` call, controlling fold
-#'   assignment. If `NULL` (the default), the seed defaults internally to
+#'   assignment. If supplied, must be within `+/- .Machine$integer.max`.
+#'   If `NULL` (the default), the seed defaults internally to
 #'   `as.integer(N * T)` so consecutive calls on the same dataset are
 #'   reproducible without the user having to specify a seed. The seed
 #'   actually used is stored on the returned object as `cv_seed`.
@@ -831,14 +833,14 @@ fetwfeWithSimulatedData <- function(
 	fusion_matrix = NULL,
 	gls = TRUE
 ) {
-	se_type <- match.arg(
-		se_type,
-		c("default", "conservative", "cluster")
-	)
-	ci_type <- match.arg(ci_type)
-	fusion_structure <- match.arg(fusion_structure)
-	# `lambda_selection` validated downstream by `checkFetwfeInputs()`
-	# (collect-all-violations pattern).
+	# `se_type`, `ci_type` and `fusion_structure` are deliberately forwarded
+	# UNRESOLVED: `fetwfe()` runs the same `match.arg()` calls on them, so
+	# repeating them here would validate each argument twice. Partial matches
+	# ("conserv", "point", "event") and the untouched length-2 defaults both
+	# resolve identically downstream, because the callee's formal defaults are
+	# byte-identical to this wrapper's. Do not restore them (#440).
+	# `lambda_selection` is likewise validated downstream by
+	# `checkFetwfeInputs()` (collect-all-violations pattern).
 
 	sim <- .unpack_simulated_obj(simulated_obj)
 

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -31,9 +31,10 @@
 #'   = "cv"`. Default `10L`.
 #' @param cv_seed Integer or NULL; the seed to pass to `set.seed()`
 #'   before calling `grpreg::cv.grpreg()` so CV fold assignment is
-#'   reproducible. `NULL` defaults to `as.integer(N * T)` (clipped to
-#'   `.Machine$integer.max` with a warning on overflow). Default
-#'   `NULL`.
+#'   reproducible. If supplied, must be within
+#'   `+/- .Machine$integer.max`. `NULL` defaults to `as.integer(N * T)`
+#'   (clipped to `.Machine$integer.max` with a warning on overflow).
+#'   Default `NULL`.
 #' @return A list with two elements:
 #'   - `pdata`: the (possibly tibble-coerced) panel data frame.
 #'   - `indep_count_data_available`: logical; `TRUE` if a valid
@@ -243,6 +244,19 @@ checkFetwfeInputs <- function(
 					"cv_seed must be an integer (or NULL); got %s",
 					format(cv_seed)
 				)
+			)
+		} else if (.exceeds_integer_max(cv_seed)) {
+			# Catches an explicitly supplied cv_seed at input validation, so it
+			# fails alongside every other bad argument in the same call rather
+			# than part-way through the fit at the CV fold seeding. Note the
+			# deliberate asymmetry with getBetaCV(), which *clips with a
+			# warning* when the package's own `N * T` default overflows: user
+			# input is rejected, a package-computed default is not. Composed
+			# with paste() (no trailing period) to match its siblings above.
+			# (#440)
+			violations <- c(
+				violations,
+				paste("cv_seed", .format_int_max_range(cv_seed))
 			)
 		}
 	}

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -252,11 +252,11 @@ checkFetwfeInputs <- function(
 			# deliberate asymmetry with getBetaCV(), which *clips with a
 			# warning* when the package's own `N * T` default overflows: user
 			# input is rejected, a package-computed default is not. Composed
-			# with paste() (no trailing period) to match its siblings above.
+			# with sprintf() and no trailing period to match its siblings above.
 			# (#440)
 			violations <- c(
 				violations,
-				paste("cv_seed", .format_int_max_range(cv_seed))
+				sprintf("cv_seed %s", .format_int_max_range(cv_seed))
 			)
 		}
 	}

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -203,7 +203,9 @@
 #'   all-zero or constant-effect specification is rejected. Defaults to
 #'   \code{NULL}. Mutually exclusive with \code{n_signal_cohorts}.
 #' @param seed (Optional) Integer. Seed for reproducibility. If supplied, must
-#'   be within \code{+/- .Machine$integer.max}. Three
+#'   be within \code{+/- .Machine$integer.max} --- and because the two offsets
+#'   below are derived from it, the usable maximum here is
+#'   \code{.Machine$integer.max - 2}. Three
 #'   deterministic offsets share this seed: the main coefficient draw uses
 #'   \code{seed}; the assignment coefficients use \code{seed + 1L}; the
 #'   Monte Carlo integration in \code{getTes()} uses \code{seed + 2L}.

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -202,7 +202,8 @@
 #'   map. The result must be non-degenerate and heterogeneous (\eqn{V_2 > 0}); an
 #'   all-zero or constant-effect specification is rejected. Defaults to
 #'   \code{NULL}. Mutually exclusive with \code{n_signal_cohorts}.
-#' @param seed (Optional) Integer. Seed for reproducibility. Three
+#' @param seed (Optional) Integer. Seed for reproducibility. If supplied, must
+#'   be within \code{+/- .Machine$integer.max}. Three
 #'   deterministic offsets share this seed: the main coefficient draw uses
 #'   \code{seed}; the assignment coefficients use \code{seed + 1L}; the
 #'   Monte Carlo integration in \code{getTes()} uses \code{seed + 2L}.
@@ -807,7 +808,8 @@ getTes <- function(coefs_obj, distribution = "gaussian") {
 #' deterministically on the per-cohort fused base levels for a sparse,
 #' non-degenerate, heterogeneous high-dimensional DGP. See \code{genCoefs()} for
 #' the full description; the two are mutually exclusive.
-#' @param seed (Optional) Integer. Seed for reproducibility. \code{NA} (or
+#' @param seed (Optional) Integer. Seed for reproducibility. If supplied, must
+#' be within \code{+/- .Machine$integer.max}. \code{NA} (or
 #' \code{NULL}) means "draw from the ambient random-number generator" --- no
 #' \code{set.seed()} is called.
 #' @param R Deprecated. The former name for \code{G}; still accepted with a

--- a/R/gen_data.R
+++ b/R/gen_data.R
@@ -38,7 +38,8 @@
 #' @param seed (Optional) Controls the random-number generator for the simulated
 #'   panel. As of fetwfe 1.24.0 the default is \code{NULL}, which draws from the
 #'   ambient random-number generator (respecting any preceding \code{set.seed()})
-#'   and emits a warning; pass an integer for a reproducible panel, or \code{NA}
+#'   and emits a warning; pass an integer within
+#'   \code{+/- .Machine$integer.max} for a reproducible panel, or \code{NA}
 #'   to draw from the ambient generator silently. \code{simulateData()} no longer
 #'   reuses \code{coefs_obj$seed} (the seed \code{genCoefs()} used to build the
 #'   coefficients). Default \code{NULL}.
@@ -276,7 +277,8 @@ simulateData <- function(
 #'     \item If \code{gen_ints = FALSE}, the expected length is
 #'       \eqn{p = G + (T-1) + d + num\_treats}.
 #'   }
-#' @param seed (Optional) Integer. Seed for reproducibility.
+#' @param seed (Optional) Integer. Seed for reproducibility. If supplied, must
+#'   be within \code{+/- .Machine$integer.max}.
 #' @param gen_ints Logical. If \code{TRUE}, generate the full design matrix with interactions;
 #'   if \code{FALSE} (the default), generate a design matrix without any interaction terms.
 #' @param distribution Character. Distribution to generate covariates.

--- a/R/simultaneous_bootstrap.R
+++ b/R/simultaneous_bootstrap.R
@@ -66,7 +66,10 @@
 #'   `simultaneousCIs(method = "bootstrap")` and
 #'   `debiasedATT(method = "bootstrap")`, so the two cannot silently drift
 #'   on what they accept. `seed` must be integer-valued (a non-integer would be
-#'   silently truncated by `set.seed()`).
+#'   silently truncated by `set.seed()`), and **both** arguments are
+#'   range-checked against `+/- .Machine$integer.max` via
+#'   `.exceeds_integer_max()`, so neither can reach `as.integer()` and become
+#'   `NA` (#440).
 #' @param B,seed The arguments to validate.
 #' @param fn_name Character; the caller's name, for the error message prefix.
 #' @return `B` coerced to integer.
@@ -85,6 +88,21 @@
 			call. = FALSE
 		)
 	}
+	# `Inf` slips through the branch above entirely -- `Inf < 1` is FALSE and
+	# `Inf != round(Inf)` is FALSE -- and reaches `as.integer()`. The
+	# `!is.finite()` term inside `.exceeds_integer_max()` is what catches it.
+	# Using the shared abs()-based predicate here is also deliberately
+	# defensive: the positivity branch above already establishes `B >= 1`, but
+	# if it is ever reordered, relaxed, or moved behind a flag, this predicate
+	# still rejects a huge negative `B`, where a bare `>` would pass it to
+	# `as.integer()` and reproduce the `NA_integer_` bug this branch exists to
+	# fix. (#440)
+	if (.exceeds_integer_max(B)) {
+		stop(
+			sprintf("%s(): `B` %s.", fn_name, .format_int_max_range(B)),
+			call. = FALSE
+		)
+	}
 	if (
 		!is.null(seed) &&
 			(!is.numeric(seed) ||
@@ -94,6 +112,15 @@
 	) {
 		stop(
 			sprintf("%s(): `seed` must be NULL or a single integer.", fn_name),
+			call. = FALSE
+		)
+	}
+	# Keeps the friendly `fn_name`-flavoured front door for the bootstrap path,
+	# rather than falling through to `.apply_seed()`'s generic wording several
+	# frames later. (#440)
+	if (!is.null(seed) && .exceeds_integer_max(seed)) {
+		stop(
+			sprintf("%s(): `seed` %s.", fn_name, .format_int_max_range(seed)),
 			call. = FALSE
 		)
 	}

--- a/R/simultaneous_bootstrap.R
+++ b/R/simultaneous_bootstrap.R
@@ -69,7 +69,10 @@
 #'   silently truncated by `set.seed()`), and **both** arguments are
 #'   range-checked against `+/- .Machine$integer.max` via
 #'   `.exceeds_integer_max()`, so neither can reach `as.integer()` and become
-#'   `NA` (#440).
+#'   `NA` (#440). When **both** arguments are invalid the `B` error is reported
+#'   first, because its range branch precedes `seed`'s integrality branch --- a
+#'   reordering relative to pre-#440, where a bad `seed` alongside an
+#'   out-of-range `B` reported the `seed` message (#440).
 #' @param B,seed The arguments to validate.
 #' @param fn_name Character; the caller's name, for the error message prefix.
 #' @return `B` coerced to integer.

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -124,10 +124,10 @@ utils::globalVariables(c(
 #'   uniformly-valid desparsified band), and a `gls = FALSE` fit has no analytic
 #'   SEs at all --- so pass `method = "bootstrap"` for high-dimensional bands.
 #' @param B Integer; number of multiplier-bootstrap replicates
-#'   (`method = "bootstrap"` only). Must be within
-#'   `+/- .Machine$integer.max`. Default `1000`.
-#' @param seed Optional integer; if supplied, must be within
-#'   `+/- .Machine$integer.max`, and the bootstrap draws are
+#'   (`method = "bootstrap"` only). Must be a positive integer no greater than
+#'   `.Machine$integer.max`. Default `1000`.
+#' @param seed Optional integer within `+/- .Machine$integer.max`. If supplied,
+#'   the bootstrap draws are
 #'   reproducible (the ambient random-number stream is saved and restored around
 #'   them). If `NULL` (default), the draws come from the ambient generator, so
 #'   results vary run to run. Ignored when `method = "analytic"`.

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -124,8 +124,10 @@ utils::globalVariables(c(
 #'   uniformly-valid desparsified band), and a `gls = FALSE` fit has no analytic
 #'   SEs at all --- so pass `method = "bootstrap"` for high-dimensional bands.
 #' @param B Integer; number of multiplier-bootstrap replicates
-#'   (`method = "bootstrap"` only). Default `1000`.
-#' @param seed Optional integer; if supplied, the bootstrap draws are
+#'   (`method = "bootstrap"` only). Must be within
+#'   `+/- .Machine$integer.max`. Default `1000`.
+#' @param seed Optional integer; if supplied, must be within
+#'   `+/- .Machine$integer.max`, and the bootstrap draws are
 #'   reproducible (the ambient random-number stream is saved and restored around
 #'   them). If `NULL` (default), the draws come from the ambient generator, so
 #'   results vary run to run. Ignored when `method = "analytic"`.

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -531,11 +531,12 @@ twfeCovsWithSimulatedData <- function(
 	se_type = "default",
 	ci_type = c("simultaneous", "pointwise")
 ) {
-	se_type <- match.arg(
-		se_type,
-		c("default", "conservative", "cluster")
-	)
-	ci_type <- match.arg(ci_type)
+	# `se_type` and `ci_type` are deliberately forwarded UNRESOLVED:
+	# `twfeCovs()` runs the same `match.arg()` calls on them, so repeating them
+	# here would validate each argument twice. Partial matches ("conserv",
+	# "point") and the untouched length-2 `ci_type` default both resolve
+	# identically downstream, because the callee's formal defaults are
+	# byte-identical to this wrapper's. Do not restore them (#440).
 
 	sim <- .unpack_simulated_obj(simulated_obj)
 

--- a/R/twfeCovs.R
+++ b/R/twfeCovs.R
@@ -531,8 +531,8 @@ twfeCovsWithSimulatedData <- function(
 	se_type = "default",
 	ci_type = c("simultaneous", "pointwise")
 ) {
-	# `se_type` and `ci_type` are deliberately forwarded UNRESOLVED:
-	# `twfeCovs()` runs the same `match.arg()` calls on them, so repeating them
+	# `se_type` and `ci_type` are deliberately forwarded without `match.arg()`:
+	# `twfeCovs()` runs the same calls on them, so repeating them
 	# here would validate each argument twice. Partial matches ("conserv",
 	# "point") and the untouched length-2 `ci_type` default both resolve
 	# identically downstream, because the callee's formal defaults are

--- a/R/utility.R
+++ b/R/utility.R
@@ -1430,6 +1430,16 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 #'   uniform. Closing that gap is a user-visible breaking change to
 #'   `simulateData()` / `genCoefs()` and deserves its own decision.
 #'
+#'   One narrow exception, and the **only** input this check newly rejects that
+#'   `set.seed()` would have accepted: a non-integral magnitude strictly between
+#'   `.Machine$integer.max` and `2147483648` -- `2147483647.9`, say -- used to
+#'   truncate to `2147483647L` and draw successfully. The magnitude test fires
+#'   before `set.seed()` gets its chance to truncate, so it now errors. That is
+#'   the right outcome for a *seed* argument, whose entire purpose is
+#'   reproducibility: the old path silently drew from a different seed than the
+#'   one supplied. No internal caller can reach it -- all three clip sites emit
+#'   exact integers.
+#'
 #'   The non-finite values the check rejects are `+/-Inf` specifically. `NaN`,
 #'   like `NA`, is caught by the `is.na()` early return above and remains a
 #'   supported "use the ambient generator" value -- so this function does *not*
@@ -1452,11 +1462,19 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 		# hoisting this would turn every supported `seed = NA` call into an
 		# error.
 		if (.exceeds_integer_max(seed)) {
+			# The trailing clause covers both rejected shapes, which fail
+			# differently: `3e9` coerces to NA, whereas a non-integral value in
+			# the sliver just above the ceiling (`2147483647.9`) truncates to a
+			# *valid but different* seed. Saying only "becomes NA" would be
+			# false for the latter -- and silently reseeding from a different
+			# value is the more insidious of the two for a reproducibility
+			# argument. (#440)
 			stop(
 				"seed ",
 				.format_int_max_range(seed),
-				". set.seed() coerces its argument to integer, so larger ",
-				"magnitudes become NA."
+				". set.seed() coerces its argument to integer, so a larger ",
+				"magnitude either becomes NA or is silently truncated to a ",
+				"different seed."
 			)
 		}
 		set.seed(seed)

--- a/R/utility.R
+++ b/R/utility.R
@@ -1345,13 +1345,97 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 	)
 }
 
+# .exceeds_integer_max
+#' @title Is a numeric scalar outside the range `set.seed()` can represent?
+#' @description The single source of truth for the `+/- .Machine$integer.max`
+#'   range rule, shared by `.apply_seed()` (this file),
+#'   `.validate_boot_args()` (`R/simultaneous_bootstrap.R`), and
+#'   `checkFetwfeInputs()` (`R/fetwfe_core.R`). Named rather than inlined so the
+#'   boundary cannot later be tightened in one copy only. Note the boundary is
+#'   strict: exactly `.Machine$integer.max` is accepted, because `getBetaCV()`
+#'   and `.fit_q1_nuisance()` (`R/bridge_selection.R`) and `.cv_lambda_node()`
+#'   (`R/riesz_lasso.R`) all clip a computed default seed to exactly that value.
+#'   R's integer *minimum* is `-2147483647`, so the negative side overflows one
+#'   value earlier than a two's-complement reader expects -- hence `abs()`
+#'   rather than a bare `>`. (#440)
+#' @param x A numeric scalar.
+#' @return `TRUE` if `x` is non-finite or `abs(x)` exceeds
+#'   `.Machine$integer.max`; `FALSE` otherwise. Never `NA`.
+#' @keywords internal
+#' @noRd
+.exceeds_integer_max <- function(x) {
+	# `!is.finite(x)` makes this NA-safe: without it, `.exceeds_integer_max(NA)`
+	# evaluates `abs(NA) > .Machine$integer.max`, which is NA, and `if (NA)`
+	# throws. Every current caller filters NA/NaN upstream and
+	# `abs(+/-Inf) > .Machine$integer.max` is already TRUE, so the term is not
+	# load-bearing *today* -- it is what keeps the predicate safe for the next
+	# caller that filters less.
+	!is.finite(x) || abs(x) > .Machine$integer.max
+}
+
+# .format_int_max_range
+#' @title The shared message tail for an out-of-range integer-valued argument
+#' @description Returns the common middle of the four `.exceeds_integer_max()`
+#'   error messages, so each call site supplies only its own prefix (a bare
+#'   `"seed "`, a `sprintf("%s(): \`B\` ...")` wrapper, or an append to
+#'   `checkFetwfeInputs()`'s `violations` vector). One builder means the
+#'   value-formatting guards below cannot be applied to some sites but not
+#'   others. Named to match this file's existing `.format_input_violations()`.
+#'   (#440)
+#' @param value The offending numeric scalar, echoed back to the user.
+#' @return A character scalar beginning `"must be within +/- ..."`, with no
+#'   leading argument name and no trailing period.
+#' @keywords internal
+#' @noRd
+.format_int_max_range <- function(value) {
+	sprintf(
+		"must be within +/- .Machine$integer.max (%s); got %s",
+		format(.Machine$integer.max, scientific = FALSE),
+		# Two guards, two different defects. `scientific = FALSE` is what makes
+		# 3e9 echo as 3000000000 rather than 3e+09 -- but
+		# format(1e300, scientific = FALSE) is a 301-character number, and this
+		# is the error path, where absurd magnitudes live. And inside the band,
+		# format()'s default of 7 significant digits rounds 2147483647.9 to
+		# 2147483648, which against a stated limit of 2147483647 reads like an
+		# off-by-one in the guard. That corner is reachable precisely because
+		# .apply_seed() deliberately permits non-integral seeds.
+		if (is.finite(value) && abs(value) < 1e15) {
+			format(value, scientific = FALSE, digits = 15)
+		} else {
+			format(value)
+		}
+	)
+}
+
 # .apply_seed
 #' @title Apply a seed argument: `set.seed()`, draw from the ambient RNG, or error
 #' @description The canonical seed-to-RNG mapping shared by the data-generation
 #'   functions and `.with_preserved_rng()`. `NULL` or a scalar `NA` mean "use the
-#'   ambient random-number generator" (no `set.seed()`); a single numeric value is
-#'   passed to `set.seed()`; anything else is an error. (#254)
-#' @param seed `NULL`, a scalar `NA`, or a single numeric value.
+#'   ambient random-number generator" (no `set.seed()`); a single numeric value
+#'   whose magnitude is at most `.Machine$integer.max` is passed to `set.seed()`;
+#'   anything else is an error. (#254, #440)
+#' @details The `.Machine$integer.max` range check (#440) **errors** rather than
+#'   warning and clipping the way `getBetaCV()` does for its own computed
+#'   default. The distinction is deliberate: `getBetaCV()`'s offending value is a
+#'   *package-computed* default the user never supplied, so erroring would punish
+#'   the user for the package's arithmetic, whereas `seed` here is *user input*,
+#'   and silently substituting a different seed would destroy the reproducibility
+#'   the argument exists to provide. The boundary is strict (`>`, not `>=`), so
+#'   exactly `.Machine$integer.max` is still accepted -- three call sites clip
+#'   their computed default to that value on purpose.
+#'
+#'   This is a **range** check only. `.apply_seed()` still lets `set.seed()`
+#'   silently truncate a non-integral seed such as `1.5`, while
+#'   `.validate_boot_args()` rejects it, so the two contracts are **not**
+#'   uniform. Closing that gap is a user-visible breaking change to
+#'   `simulateData()` / `genCoefs()` and deserves its own decision.
+#'
+#'   The non-finite values the check rejects are `+/-Inf` specifically. `NaN`,
+#'   like `NA`, is caught by the `is.na()` early return above and remains a
+#'   supported "use the ambient generator" value -- so this function does *not*
+#'   reject non-finite seeds in general.
+#' @param seed `NULL`, a scalar `NA`, or a single numeric value within
+#'   `+/- .Machine$integer.max`.
 #' @return Invisibly `NULL`; called for its `set.seed()` side effect (or none).
 #' @keywords internal
 #' @noRd
@@ -1363,6 +1447,18 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 		return(invisible(NULL))
 	}
 	if (is.numeric(seed) && length(seed) == 1L) {
+		# Must stay INSIDE this branch, after the NULL/NA early returns:
+		# `abs(NA) > .Machine$integer.max` is NA and `if (NA)` throws, so
+		# hoisting this would turn every supported `seed = NA` call into an
+		# error.
+		if (.exceeds_integer_max(seed)) {
+			stop(
+				"seed ",
+				.format_int_max_range(seed),
+				". set.seed() coerces its argument to integer, so larger ",
+				"magnitudes become NA."
+			)
+		}
 		set.seed(seed)
 		return(invisible(NULL))
 	}
@@ -1380,9 +1476,10 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 #'   assignment), `.simultaneous_cis_impl()` (#192 / #200, the `mvtnorm`
 #'   Genz-Bretz quasi-Monte-Carlo integration), and `getTes()` (#254, the
 #'   expected-cohort-probability truth computation). (#195)
-#' @param seed A single numeric seed (passed to `set.seed()` before `expr`), or
-#'   `NULL` / `NA` to draw from the ambient RNG without reseeding. Either way the
-#'   caller's `.Random.seed` is saved and restored.
+#' @param seed A single numeric seed within `+/- .Machine$integer.max` (passed
+#'   to `set.seed()` before `expr`; a larger magnitude is an error from
+#'   `.apply_seed()`), or `NULL` / `NA` to draw from the ambient RNG without
+#'   reseeding. Either way the caller's `.Random.seed` is saved and restored.
 #' @param expr Expression to evaluate (lazily -- it runs after the caller's seed
 #'   is saved and `set.seed(seed)` is applied). Its value is returned.
 #' @return The value of `expr`.

--- a/man/betwfe.Rd
+++ b/man/betwfe.Rd
@@ -182,7 +182,8 @@ for details.}
 \code{lambda_selection = "bic"}. Default is 10.}
 
 \item{cv_seed}{Integer or \code{NULL}; the seed passed to \code{set.seed()}
-immediately before the \code{cv.grpreg()} call. If \code{NULL} (the default),
+immediately before the \code{cv.grpreg()} call. If supplied, must be
+within \verb{+/- .Machine$integer.max}. If \code{NULL} (the default),
 the seed defaults internally to \code{as.integer(N * T)}. Ignored when
 \code{lambda_selection = "bic"}.}
 

--- a/man/betwfeWithSimulatedData.Rd
+++ b/man/betwfeWithSimulatedData.Rd
@@ -106,7 +106,8 @@ for details.}
 \code{lambda_selection = "bic"}. Default is 10.}
 
 \item{cv_seed}{Integer or \code{NULL}; the seed passed to \code{set.seed()}
-immediately before the \code{cv.grpreg()} call. If \code{NULL} (the default),
+immediately before the \code{cv.grpreg()} call. If supplied, must be
+within \verb{+/- .Machine$integer.max}. If \code{NULL} (the default),
 the seed defaults internally to \code{as.integer(N * T)}. Ignored when
 \code{lambda_selection = "bic"}.}
 

--- a/man/debiasedATT.Rd
+++ b/man/debiasedATT.Rd
@@ -50,10 +50,12 @@ over the \code{N} count-sample units (\code{sum(indep_counts) == N} is enforced)
 the two-sample propensity variance.}
 
 \item{B}{Integer; the number of wild-bootstrap replicates (default \code{1000}).
-Ignored unless \code{method = "bootstrap"}.}
+Must be within \verb{+/- .Machine$integer.max}. Ignored unless
+\code{method = "bootstrap"}.}
 
 \item{seed}{\code{NULL} (draw from the ambient RNG, the default) or a single
-integer for a reproducible bootstrap (the RNG state is saved and restored).
+integer within \verb{+/- .Machine$integer.max} for a reproducible bootstrap
+(the RNG state is saved and restored).
 Ignored unless \code{method = "bootstrap"}.}
 
 \item{multiplier}{The wild-bootstrap weight distribution: \code{"webb"} (default),

--- a/man/debiasedATT.Rd
+++ b/man/debiasedATT.Rd
@@ -50,8 +50,8 @@ over the \code{N} count-sample units (\code{sum(indep_counts) == N} is enforced)
 the two-sample propensity variance.}
 
 \item{B}{Integer; the number of wild-bootstrap replicates (default \code{1000}).
-Must be within \verb{+/- .Machine$integer.max}. Ignored unless
-\code{method = "bootstrap"}.}
+Must be a positive integer no greater than \code{.Machine$integer.max}. Ignored
+unless \code{method = "bootstrap"}.}
 
 \item{seed}{\code{NULL} (draw from the ambient RNG, the default) or a single
 integer within \verb{+/- .Machine$integer.max} for a reproducible bootstrap

--- a/man/fetwfe.Rd
+++ b/man/fetwfe.Rd
@@ -196,7 +196,8 @@ reproducing analyses run against v1.12.0 or earlier --- pass
 
 \item{cv_seed}{Integer or \code{NULL}; the seed passed to \code{set.seed()}
 immediately before the \code{cv.grpreg()} call, controlling fold
-assignment. If \code{NULL} (the default), the seed defaults internally to
+assignment. If supplied, must be within \verb{+/- .Machine$integer.max}.
+If \code{NULL} (the default), the seed defaults internally to
 \code{as.integer(N * T)} so consecutive calls on the same dataset are
 reproducible without the user having to specify a seed. The seed
 actually used is stored on the returned object as \code{cv_seed}.

--- a/man/fetwfeWithSimulatedData.Rd
+++ b/man/fetwfeWithSimulatedData.Rd
@@ -120,7 +120,8 @@ reproducing analyses run against v1.12.0 or earlier --- pass
 
 \item{cv_seed}{Integer or \code{NULL}; the seed passed to \code{set.seed()}
 immediately before the \code{cv.grpreg()} call, controlling fold
-assignment. If \code{NULL} (the default), the seed defaults internally to
+assignment. If supplied, must be within \verb{+/- .Machine$integer.max}.
+If \code{NULL} (the default), the seed defaults internally to
 \code{as.integer(N * T)} so consecutive calls on the same dataset are
 reproducible without the user having to specify a seed. The seed
 actually used is stored on the returned object as \code{cv_seed}.

--- a/man/genCoefs.Rd
+++ b/man/genCoefs.Rd
@@ -137,7 +137,9 @@ all-zero or constant-effect specification is rejected. Defaults to
 \code{NULL}. Mutually exclusive with \code{n_signal_cohorts}.}
 
 \item{seed}{(Optional) Integer. Seed for reproducibility. If supplied, must
-be within \code{+/- .Machine$integer.max}. Three
+be within \code{+/- .Machine$integer.max} --- and because the two offsets
+below are derived from it, the usable maximum here is
+\code{.Machine$integer.max - 2}. Three
 deterministic offsets share this seed: the main coefficient draw uses
 \code{seed}; the assignment coefficients use \code{seed + 1L}; the
 Monte Carlo integration in \code{getTes()} uses \code{seed + 2L}.

--- a/man/genCoefs.Rd
+++ b/man/genCoefs.Rd
@@ -136,7 +136,8 @@ map. The result must be non-degenerate and heterogeneous (\eqn{V_2 > 0}); an
 all-zero or constant-effect specification is rejected. Defaults to
 \code{NULL}. Mutually exclusive with \code{n_signal_cohorts}.}
 
-\item{seed}{(Optional) Integer. Seed for reproducibility. Three
+\item{seed}{(Optional) Integer. Seed for reproducibility. If supplied, must
+be within \code{+/- .Machine$integer.max}. Three
 deterministic offsets share this seed: the main coefficient draw uses
 \code{seed}; the assignment coefficients use \code{seed + 1L}; the
 Monte Carlo integration in \code{getTes()} uses \code{seed + 2L}.

--- a/man/genCoefsCore.Rd
+++ b/man/genCoefsCore.Rd
@@ -49,7 +49,8 @@ deterministically on the per-cohort fused base levels for a sparse,
 non-degenerate, heterogeneous high-dimensional DGP. See \code{genCoefs()} for
 the full description; the two are mutually exclusive.}
 
-\item{seed}{(Optional) Integer. Seed for reproducibility. \code{NA} (or
+\item{seed}{(Optional) Integer. Seed for reproducibility. If supplied, must
+be within \code{+/- .Machine$integer.max}. \code{NA} (or
 \code{NULL}) means "draw from the ambient random-number generator" --- no
 \code{set.seed()} is called.}
 

--- a/man/simulateData.Rd
+++ b/man/simulateData.Rd
@@ -43,7 +43,8 @@ coefficient vector; recovering the truth requires an adequate number of units).}
 \item{seed}{(Optional) Controls the random-number generator for the simulated
 panel. As of fetwfe 1.24.0 the default is \code{NULL}, which draws from the
 ambient random-number generator (respecting any preceding \code{set.seed()})
-and emits a warning; pass an integer for a reproducible panel, or \code{NA}
+and emits a warning; pass an integer within
+\code{+/- .Machine$integer.max} for a reproducible panel, or \code{NA}
 to draw from the ambient generator silently. \code{simulateData()} no longer
 reuses \code{coefs_obj$seed} (the seed \code{genCoefs()} used to build the
 coefficients). Default \code{NULL}.}

--- a/man/simulateDataCore.Rd
+++ b/man/simulateDataCore.Rd
@@ -48,7 +48,8 @@ on the value of \code{gen_ints}:
 \eqn{p = G + (T-1) + d + num\_treats}.
 }}
 
-\item{seed}{(Optional) Integer. Seed for reproducibility.}
+\item{seed}{(Optional) Integer. Seed for reproducibility. If supplied, must
+be within \code{+/- .Machine$integer.max}.}
 
 \item{gen_ints}{Logical. If \code{TRUE}, generate the full design matrix with interactions;
 if \code{FALSE} (the default), generate a design matrix without any interaction terms.}

--- a/man/simultaneousCIs.Rd
+++ b/man/simultaneousCIs.Rd
@@ -100,11 +100,11 @@ uniformly-valid desparsified band), and a \code{gls = FALSE} fit has no analytic
 SEs at all --- so pass \code{method = "bootstrap"} for high-dimensional bands.}
 
 \item{B}{Integer; number of multiplier-bootstrap replicates
-(\code{method = "bootstrap"} only). Must be within
-\verb{+/- .Machine$integer.max}. Default \code{1000}.}
+(\code{method = "bootstrap"} only). Must be a positive integer no greater than
+\code{.Machine$integer.max}. Default \code{1000}.}
 
-\item{seed}{Optional integer; if supplied, must be within
-\verb{+/- .Machine$integer.max}, and the bootstrap draws are
+\item{seed}{Optional integer within \verb{+/- .Machine$integer.max}. If supplied,
+the bootstrap draws are
 reproducible (the ambient random-number stream is saved and restored around
 them). If \code{NULL} (default), the draws come from the ambient generator, so
 results vary run to run. Ignored when \code{method = "analytic"}.}

--- a/man/simultaneousCIs.Rd
+++ b/man/simultaneousCIs.Rd
@@ -100,9 +100,11 @@ uniformly-valid desparsified band), and a \code{gls = FALSE} fit has no analytic
 SEs at all --- so pass \code{method = "bootstrap"} for high-dimensional bands.}
 
 \item{B}{Integer; number of multiplier-bootstrap replicates
-(\code{method = "bootstrap"} only). Default \code{1000}.}
+(\code{method = "bootstrap"} only). Must be within
+\verb{+/- .Machine$integer.max}. Default \code{1000}.}
 
-\item{seed}{Optional integer; if supplied, the bootstrap draws are
+\item{seed}{Optional integer; if supplied, must be within
+\verb{+/- .Machine$integer.max}, and the bootstrap draws are
 reproducible (the ambient random-number stream is saved and restored around
 them). If \code{NULL} (default), the draws come from the ambient generator, so
 results vary run to run. Ignored when \code{method = "analytic"}.}

--- a/tests/testthat/test-seed-range-guard-440.R
+++ b/tests/testthat/test-seed-range-guard-440.R
@@ -1,0 +1,485 @@
+library(testthat)
+library(fetwfe)
+
+# ==============================================================================
+# Out-of-range seed guard at every door (#440).
+#
+# `set.seed()` accepts only values representable as a 32-bit signed integer.
+# Anything larger in magnitude is coerced to NA, so base R emits a coercion
+# WARNING and then an opaque ERROR that never names the argument or the limit.
+# This file pins the package's own message at all four guarded sites, plus the
+# `match.arg()` deletion in the four *WithSimulatedData() wrappers.
+#
+# TWO ASSERTION RULES, both learned the hard way:
+#
+#   1. Every error assertion pins the literal "integer.max" with fixed = TRUE.
+#      A looser pattern such as "seed" is green BEFORE the change too, because
+#      base R's own message -- "supplied seed is not a valid integer" --
+#      contains the word "seed". It does NOT contain "integer.max".
+#
+#   2. Every "no coercion warning" assertion wraps the call in
+#      try(..., silent = TRUE). Without the wrapper the call errors in both
+#      states, expect_no_warning() re-raises that error out of the expectation,
+#      and the test reports an ERROR rather than a pass -- red before AND after.
+#
+# Groups B, C, and G are unchanged-behavior anchors and pass in both states;
+# Groups A, D, E, F, H, and I flip.
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# File-scope fixture. Built once here, above Group A, because Groups G and I
+# both need it: Group G's fits live inside test_that() blocks and do not escape
+# them, so "reuse Group G's fit" is not executable.
+# ------------------------------------------------------------------------------
+coefs <- genCoefs(G = 3, T = 4, d = 2, density = 0.5, eff_size = 1, seed = 1)
+sim <- simulateData(
+	coefs,
+	N = 40,
+	sig_eps_sq = 0.5,
+	sig_eps_c_sq = 0.5,
+	seed = 2
+)
+fit <- suppressWarnings(suppressMessages(fetwfeWithSimulatedData(sim)))
+
+# ==============================================================================
+# Group A -- .apply_seed() rejects out-of-range seeds with the package message
+# ==============================================================================
+
+test_that("Group A: .apply_seed() rejects out-of-range seeds", {
+	expect_error(fetwfe:::.apply_seed(3e9), "integer.max", fixed = TRUE)
+	expect_error(fetwfe:::.apply_seed(-3e9), "integer.max", fixed = TRUE)
+	# R's integer MINIMUM is -2147483647, not -2147483648, so the negative side
+	# overflows one value earlier than a two's-complement reader expects. That
+	# is why the predicate uses abs() rather than a bare comparison.
+	expect_error(
+		fetwfe:::.apply_seed(-2147483648),
+		"integer.max",
+		fixed = TRUE
+	)
+	expect_error(fetwfe:::.apply_seed(Inf), "integer.max", fixed = TRUE)
+	expect_error(fetwfe:::.apply_seed(-Inf), "integer.max", fixed = TRUE)
+})
+
+test_that("Group A: the base-R coercion warning no longer fires", {
+	# try() is load-bearing here -- see rule 2 in the header.
+	expect_no_warning(try(fetwfe:::.apply_seed(3e9), silent = TRUE))
+})
+
+# ==============================================================================
+# Group B -- the boundary is strict (`>`), and that is load-bearing
+# ==============================================================================
+
+test_that("Group B: exactly .Machine$integer.max is still accepted", {
+	# The strict `>` boundary is load-bearing: getBetaCV() and
+	# .fit_q1_nuisance() (R/bridge_selection.R) and .cv_lambda_node()
+	# (R/riesz_lasso.R) all clip a computed default seed to exactly
+	# .Machine$integer.max and feed it through .apply_seed(). A `>=` boundary
+	# would turn ordinary large-N*T fits into errors.
+	expect_no_error(fetwfe:::.apply_seed(.Machine$integer.max))
+	expect_no_warning(fetwfe:::.apply_seed(.Machine$integer.max))
+	expect_no_error(fetwfe:::.apply_seed(-.Machine$integer.max))
+	expect_no_warning(fetwfe:::.apply_seed(-.Machine$integer.max))
+})
+
+test_that("Group B: the boundary seed is actually applied, not skipped", {
+	# Deliberately NOT expect_equal(.with_preserved_rng(int.max, 42), 42):
+	# that asserts only that a literal survives a pass-through, and its only
+	# failure mode is "the call errored", so a silently-skipped seed would
+	# still pass. Comparing draws proves set.seed() ran.
+	got <- fetwfe:::.with_preserved_rng(.Machine$integer.max, runif(1))
+	set.seed(.Machine$integer.max)
+	expect_identical(got, runif(1))
+})
+
+# ==============================================================================
+# Group C -- the guard's placement did not break the ambient-RNG contracts
+# ==============================================================================
+
+test_that("Group C: NULL / NA / NaN seeds still mean 'ambient RNG'", {
+	# A guard hoisted above the is.na() early return would make these throw
+	# "missing value where TRUE/FALSE needed", because abs(NA) >
+	# .Machine$integer.max is NA and `if (NA)` errors.
+	expect_no_error(fetwfe:::.apply_seed(NULL))
+	expect_no_error(fetwfe:::.apply_seed(NA))
+	expect_no_error(fetwfe:::.apply_seed(NA_real_))
+	expect_no_error(fetwfe:::.apply_seed(NA_integer_))
+	# NaN belongs in this group, not Group A: is.na(NaN) is TRUE, so NaN is
+	# caught by the is.na() early return and stays a supported ambient value.
+	# The roxygen must not claim the function "rejects non-finite seeds".
+	expect_no_error(fetwfe:::.apply_seed(NaN))
+})
+
+test_that("Group C: an in-range seed still reaches set.seed()", {
+	fetwfe:::.apply_seed(1)
+	got <- runif(1)
+	set.seed(1)
+	expect_identical(got, runif(1))
+})
+
+# ==============================================================================
+# Group D -- .validate_boot_args() is the bootstrap path's front door
+# ==============================================================================
+
+test_that("Group D: .validate_boot_args() range-checks `seed`", {
+	expect_error(
+		fetwfe:::.validate_boot_args(100, 3e9, "simultaneousCIs"),
+		"integer.max",
+		fixed = TRUE
+	)
+	expect_error(
+		fetwfe:::.validate_boot_args(100, 3e9, "simultaneousCIs"),
+		"simultaneousCIs()",
+		fixed = TRUE
+	)
+	expect_error(
+		fetwfe:::.validate_boot_args(100, -3e9, "simultaneousCIs"),
+		"integer.max",
+		fixed = TRUE
+	)
+	# Inf slips through the pre-existing branches entirely: Inf != round(Inf)
+	# is FALSE and is.na(Inf) is FALSE. The !is.finite() term catches it.
+	expect_error(
+		fetwfe:::.validate_boot_args(100, Inf, "simultaneousCIs"),
+		"integer.max",
+		fixed = TRUE
+	)
+	# Both flavours of the message prefix are witnessed.
+	expect_error(
+		fetwfe:::.validate_boot_args(100, 3e9, "debiasedATT"),
+		"debiasedATT()",
+		fixed = TRUE
+	)
+})
+
+test_that("Group D: .validate_boot_args() range-checks `B`", {
+	# Today this returns NA_integer_ after a coercion warning, which surfaces
+	# several frames later as "vector size cannot be NA".
+	expect_error(
+		fetwfe:::.validate_boot_args(3e9, NULL, "simultaneousCIs"),
+		"integer.max",
+		fixed = TRUE
+	)
+	expect_error(
+		fetwfe:::.validate_boot_args(3e9, NULL, "simultaneousCIs"),
+		"simultaneousCIs()",
+		fixed = TRUE
+	)
+	expect_error(
+		fetwfe:::.validate_boot_args(Inf, NULL, "simultaneousCIs"),
+		"integer.max",
+		fixed = TRUE
+	)
+	# `B = 3e9` is the one path here where the coercion warning genuinely fires
+	# today. Deliberately NOT asserted for `seed = Inf`, which is already
+	# silent on main and would therefore be green in both states.
+	expect_no_warning(
+		try(
+			fetwfe:::.validate_boot_args(3e9, NULL, "simultaneousCIs"),
+			silent = TRUE
+		)
+	)
+})
+
+test_that("Group D: unchanged-behavior anchors", {
+	expect_identical(
+		fetwfe:::.validate_boot_args(100, .Machine$integer.max, "x"),
+		100L
+	)
+	expect_no_warning(
+		fetwfe:::.validate_boot_args(100, .Machine$integer.max, "x")
+	)
+	expect_identical(fetwfe:::.validate_boot_args(100, NULL, "x"), 100L)
+	# This PR is a RANGE fix only. The non-integral contract is unchanged:
+	# .validate_boot_args() still rejects 1.5 while .apply_seed() still
+	# truncates it silently.
+	expect_error(
+		fetwfe:::.validate_boot_args(100, 1.5, "x"),
+		"must be NULL or a single integer",
+		fixed = TRUE
+	)
+	expect_no_error(fetwfe:::.apply_seed(1.5))
+	expect_error(
+		fetwfe:::.validate_boot_args(0, NULL, "x"),
+		"must be a single positive integer",
+		fixed = TRUE
+	)
+})
+
+# ==============================================================================
+# Group E -- cv_seed fails at input validation, for both estimators
+# ==============================================================================
+
+test_that("Group E: fetwfe() rejects an out-of-range cv_seed at entry", {
+	df <- generate_panel_data()
+	expect_error(
+		fetwfe(
+			pdata = df,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			cv_seed = 3e9
+		),
+		"integer.max",
+		fixed = TRUE
+	)
+	expect_error(
+		fetwfe(
+			pdata = df,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			cv_seed = 3e9
+		),
+		"Invalid inputs:",
+		fixed = TRUE
+	)
+})
+
+test_that("Group E: betwfe() rejects an out-of-range cv_seed at entry", {
+	# Both estimators route through the same checkFetwfeInputs(); the
+	# shared-validator claim deserves its own witness.
+	df <- generate_panel_data()
+	expect_error(
+		betwfe(
+			pdata = df,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			cv_seed = 3e9
+		),
+		"integer.max",
+		fixed = TRUE
+	)
+})
+
+test_that("Group E: the cv_seed violation joins the collect-all list", {
+	# Two bad arguments, one message. This is what proves the new check landed
+	# in the `violations` collector rather than as a bare stop().
+	df <- generate_panel_data()
+	msg <- tryCatch(
+		fetwfe(
+			pdata = df,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			covs = c("cov1", "cov2"),
+			response = "y",
+			cv_seed = 3e9,
+			cv_folds = 1L
+		),
+		error = conditionMessage
+	)
+	expect_true(grepl("integer.max", msg, fixed = TRUE))
+	expect_true(grepl("cv_folds must be an integer >= 2", msg, fixed = TRUE))
+})
+
+test_that("Group E: cv_seed = .Machine$integer.max is not rejected", {
+	# Positive control, called directly rather than through a fit: it costs
+	# ~0 s and tests exactly the claim, whereas a full fit's non-rejection
+	# could be confounded by any other failure.
+	df <- generate_panel_data()
+	expect_no_error(
+		fetwfe:::checkFetwfeInputs(
+			pdata = df,
+			time_var = "time",
+			unit_var = "unit",
+			treatment = "treatment",
+			response = "y",
+			covs = c("cov1", "cov2"),
+			cv_seed = .Machine$integer.max
+		)
+	)
+})
+
+# ==============================================================================
+# Group F -- the end-to-end data-generation seed doors
+# ==============================================================================
+
+test_that("Group F: simulateData() and simulateDataCore() reject 3e9", {
+	expect_error(
+		simulateData(
+			coefs,
+			N = 40,
+			sig_eps_sq = 0.5,
+			sig_eps_c_sq = 0.5,
+			seed = 3e9
+		),
+		"integer.max",
+		fixed = TRUE
+	)
+	expect_no_warning(
+		try(
+			simulateData(
+				coefs,
+				N = 40,
+				sig_eps_sq = 0.5,
+				sig_eps_c_sq = 0.5,
+				seed = 3e9
+			),
+			silent = TRUE
+		)
+	)
+	# simulateDataCore() is the function that literally calls .apply_seed(),
+	# and it is exported in its own right -- so it is a door, not a detail.
+	expect_error(
+		simulateDataCore(
+			N = 40,
+			T = 4,
+			G = 3,
+			d = 2,
+			sig_eps_sq = 0.5,
+			sig_eps_c_sq = 0.5,
+			beta = coefs$beta,
+			seed = 3e9
+		),
+		"integer.max",
+		fixed = TRUE
+	)
+})
+
+test_that("Group F: genCoefs() and genCoefsCore() reject 3e9", {
+	expect_error(
+		genCoefs(G = 3, T = 4, d = 2, density = 0.5, eff_size = 1, seed = 3e9),
+		"integer.max",
+		fixed = TRUE
+	)
+	expect_no_warning(
+		try(
+			genCoefs(
+				G = 3,
+				T = 4,
+				d = 2,
+				density = 0.5,
+				eff_size = 1,
+				seed = 3e9
+			),
+			silent = TRUE
+		)
+	)
+	expect_error(
+		genCoefsCore(
+			G = 3,
+			T = 4,
+			d = 2,
+			density = 0.5,
+			eff_size = 1,
+			seed = 3e9
+		),
+		"integer.max",
+		fixed = TRUE
+	)
+})
+
+# ==============================================================================
+# Group G -- deleting the wrappers' match.arg() preserves partial matching
+# ==============================================================================
+
+test_that("Group G: fetwfeWithSimulatedData() still partial-matches", {
+	res <- suppressWarnings(suppressMessages(fetwfeWithSimulatedData(
+		sim,
+		se_type = "conserv",
+		ci_type = "point",
+		fusion_structure = "event"
+	)))
+	expect_identical(res$se_type, "conservative")
+	expect_identical(res$ci_type, "pointwise")
+	expect_identical(res$fusion_structure, "event_study")
+})
+
+test_that("Group G: betwfeWithSimulatedData() still partial-matches", {
+	res <- suppressWarnings(suppressMessages(betwfeWithSimulatedData(
+		sim,
+		se_type = "conserv",
+		ci_type = "point"
+	)))
+	expect_identical(res$se_type, "conservative")
+	expect_identical(res$ci_type, "pointwise")
+})
+
+test_that("Group G: etwfeWithSimulatedData() still partial-matches", {
+	res <- suppressWarnings(suppressMessages(etwfeWithSimulatedData(
+		sim,
+		se_type = "conserv",
+		ci_type = "point"
+	)))
+	expect_identical(res$se_type, "conservative")
+	expect_identical(res$ci_type, "pointwise")
+})
+
+test_that("Group G: twfeCovsWithSimulatedData() still partial-matches", {
+	res <- suppressWarnings(suppressMessages(twfeCovsWithSimulatedData(
+		sim,
+		se_type = "conserv",
+		ci_type = "point"
+	)))
+	expect_identical(res$se_type, "conservative")
+	expect_identical(res$ci_type, "pointwise")
+})
+
+test_that("Group G: a bad se_type still errors, from the core's match.arg()", {
+	# Cheap: the core's match.arg() fires before any fitting.
+	expect_error(
+		fetwfeWithSimulatedData(sim, se_type = "bogus"),
+		"should be one of"
+	)
+	expect_error(
+		betwfeWithSimulatedData(sim, se_type = "bogus"),
+		"should be one of"
+	)
+	expect_error(
+		etwfeWithSimulatedData(sim, se_type = "bogus"),
+		"should be one of"
+	)
+	expect_error(
+		twfeCovsWithSimulatedData(sim, se_type = "bogus"),
+		"should be one of"
+	)
+})
+
+# ==============================================================================
+# Group H -- the documented error-ordering change
+# ==============================================================================
+
+test_that("Group H: a bad simulated_obj now outranks a bad se_type", {
+	# Before the match.arg() deletion the wrapper's own match.arg() fired first
+	# and reported the bad se_type; now .unpack_simulated_obj() fires first.
+	# A real, disclosed behavior change.
+	expect_error(
+		fetwfeWithSimulatedData(list(a = 1), se_type = "bogus"),
+		"must be an object of class 'FETWFE_simulated'",
+		fixed = TRUE
+	)
+})
+
+# ==============================================================================
+# Group I -- the public bootstrap doors
+# ==============================================================================
+
+test_that("Group I: simultaneousCIs() reports the range error itself", {
+	expect_error(
+		simultaneousCIs(fit, method = "bootstrap", seed = 3e9),
+		"integer.max",
+		fixed = TRUE
+	)
+	# Today this is `vector size cannot be NA`, thrown several frames deeper
+	# inside the multiplier draw.
+	expect_error(
+		simultaneousCIs(fit, method = "bootstrap", B = 3e9),
+		"integer.max",
+		fixed = TRUE
+	)
+})
+
+test_that("Group I: debiasedATT() reports the range error itself", {
+	expect_error(
+		debiasedATT(fit, method = "bootstrap", B = 3e9),
+		"integer.max",
+		fixed = TRUE
+	)
+})

--- a/tests/testthat/test-seed-range-guard-440.R
+++ b/tests/testthat/test-seed-range-guard-440.R
@@ -22,8 +22,10 @@ library(fetwfe)
 #      states, expect_no_warning() re-raises that error out of the expectation,
 #      and the test reports an ERROR rather than a pass -- red before AND after.
 #
-# Groups B, C, and G are unchanged-behavior anchors and pass in both states;
-# Groups A, D, E, F, H, and I flip.
+# Groups B, C, and G are unchanged-behavior anchors and pass in both states,
+# and Groups D and E each END with an anchor block ("unchanged-behavior
+# anchors" and "cv_seed = .Machine$integer.max is not rejected"). Everything
+# else in Groups A, D, E, F, H, and I flips.
 # ==============================================================================
 
 # ------------------------------------------------------------------------------
@@ -63,6 +65,57 @@ test_that("Group A: .apply_seed() rejects out-of-range seeds", {
 test_that("Group A: the base-R coercion warning no longer fires", {
 	# try() is load-bearing here -- see rule 2 in the header.
 	expect_no_warning(try(fetwfe:::.apply_seed(3e9), silent = TRUE))
+})
+
+test_that("Group A: the non-integral sliver above the ceiling is rejected", {
+	# The ONLY input this guard newly rejects that set.seed() would have
+	# accepted. On main, set.seed(2147483647.9) truncated to 2147483647L and
+	# drew successfully -- from a different seed than the one supplied, which
+	# is why erroring is the right outcome for a reproducibility argument.
+	# The magnitude test fires before truncation can happen.
+	#
+	# This assertion is also the only thing in the suite that fails if the
+	# `digits = 15` guard in .format_int_max_range() is ever dropped: without
+	# it the echoed value rounds to 2147483648, one ABOVE the stated limit,
+	# reading like an off-by-one in the guard itself.
+	expect_error(
+		fetwfe:::.apply_seed(2147483647.9),
+		"got 2147483647.9",
+		fixed = TRUE
+	)
+	expect_error(
+		fetwfe:::.apply_seed(-2147483647.9),
+		"got -2147483647.9",
+		fixed = TRUE
+	)
+})
+
+test_that("Group A: an absurd magnitude does not produce an absurd message", {
+	# format(1e300, scientific = FALSE) is a 301-character number, and the
+	# error path is exactly where absurd magnitudes live. The `1e15` band
+	# guard in .format_int_max_range() is what keeps this readable.
+	msg <- tryCatch(fetwfe:::.apply_seed(1e300), error = conditionMessage)
+	expect_match(msg, "integer.max", fixed = TRUE)
+	# Pin the echoed VALUE, not the total message length: the value is what the
+	# guard controls, and a length bound would break on any future rewording.
+	# Without the band guard this reads as 300 digits (the value portion alone
+	# goes from 6 characters to 359).
+	expect_match(msg, "got 1e+300", fixed = TRUE)
+	expect_lt(nchar(msg), 250)
+})
+
+test_that("Group A: the shared predicate is NA-safe by contract", {
+	# .exceeds_integer_max()'s roxygen promises "Never NA", and its
+	# !is.finite() term is what delivers that -- `abs(NA) > .Machine$integer.max`
+	# is NA and `if (NA)` throws. Group C cannot witness this: those inputs
+	# return at .apply_seed()'s early returns and never reach the predicate.
+	# Asserted directly so the term is not deleted as "redundant".
+	expect_true(fetwfe:::.exceeds_integer_max(NA))
+	expect_true(fetwfe:::.exceeds_integer_max(NA_real_))
+	expect_true(fetwfe:::.exceeds_integer_max(NA_integer_))
+	expect_true(fetwfe:::.exceeds_integer_max(NaN))
+	expect_true(fetwfe:::.exceeds_integer_max(Inf))
+	expect_false(fetwfe:::.exceeds_integer_max(.Machine$integer.max))
 })
 
 # ==============================================================================
@@ -275,8 +328,25 @@ test_that("Group E: the cv_seed violation joins the collect-all list", {
 		),
 		error = conditionMessage
 	)
-	expect_true(grepl("integer.max", msg, fixed = TRUE))
-	expect_true(grepl("cv_folds must be an integer >= 2", msg, fixed = TRUE))
+	expect_match(msg, "integer.max", fixed = TRUE)
+	expect_match(msg, "cv_folds must be an integer >= 2", fixed = TRUE)
+})
+
+test_that("Group E: the *WithSimulatedData() wrappers forward cv_seed", {
+	# Two of the ten doors that gained a @param clause reach the validator only
+	# by forwarding. Group F applies exactly this reasoning to simulateData(),
+	# so apply it here too rather than trusting a bare `cv_seed = cv_seed`.
+	# No fit runs -- the violation fires during input validation.
+	expect_error(
+		fetwfeWithSimulatedData(sim, cv_seed = 3e9),
+		"integer.max",
+		fixed = TRUE
+	)
+	expect_error(
+		betwfeWithSimulatedData(sim, cv_seed = 3e9),
+		"integer.max",
+		fixed = TRUE
+	)
 })
 
 test_that("Group E: cv_seed = .Machine$integer.max is not rejected", {
@@ -426,19 +496,23 @@ test_that("Group G: a bad se_type still errors, from the core's match.arg()", {
 	# Cheap: the core's match.arg() fires before any fitting.
 	expect_error(
 		fetwfeWithSimulatedData(sim, se_type = "bogus"),
-		"should be one of"
+		"should be one of",
+		fixed = TRUE
 	)
 	expect_error(
 		betwfeWithSimulatedData(sim, se_type = "bogus"),
-		"should be one of"
+		"should be one of",
+		fixed = TRUE
 	)
 	expect_error(
 		etwfeWithSimulatedData(sim, se_type = "bogus"),
-		"should be one of"
+		"should be one of",
+		fixed = TRUE
 	)
 	expect_error(
 		twfeCovsWithSimulatedData(sim, se_type = "bogus"),
-		"should be one of"
+		"should be one of",
+		fixed = TRUE
 	)
 })
 

--- a/tests/testthat/test-simulate-data-seed-250.R
+++ b/tests/testthat/test-simulate-data-seed-250.R
@@ -9,7 +9,9 @@ library(fetwfe)
 #   - seed = NULL (default): draw from the ambient RNG AND emit a warning whose
 #     text contains "ambient".
 #   - seed = NA: draw from the ambient RNG silently (caller-controlled RNG).
-#   - seed = <numeric scalar>: set.seed(seed) -> reproducible panel.
+#   - seed = <numeric scalar within +/- .Machine$integer.max>: set.seed(seed)
+#     -> reproducible panel. A larger magnitude is an error naming the limit
+#     (#440); see test-seed-range-guard-440.R.
 #   - anything else: stop("seed must be ...").
 #
 # These default-path calls (the bare simulateData(coefs, ...) without an


### PR DESCRIPTION
Closes #440 (part **A3 of four** from #366; A1 shipped as #438). #366 stays open until A2 and B land.

## What a user gets

An out-of-range seed now fails with the package's own message instead of base R's coercion warning plus an opaque error. Before:

```
> simulateData(coefs, N = 60, sig_eps_sq = 1, sig_eps_c_sq = 1, seed = 3e9)
Warning: NAs introduced by coercion to integer range
Error: supplied seed is not a valid integer
```

Two lines, neither naming the offending argument or stating the limit, and the first being a warning about *coercion* that gives no hint the value was a seed. After:

```
> simulateData(coefs, N = 60, sig_eps_sq = 1, sig_eps_c_sq = 1, seed = 3e9)
Error: seed must be within +/- .Machine$integer.max (2147483647); got 3000000000.
set.seed() coerces its argument to integer, so a larger magnitude either becomes NA
or is silently truncated to a different seed.
```

Two neighbouring arguments shared the identical hole and are fixed with it:

- **`cv_seed`** now fails during input validation, alongside any other bad argument in the same call, instead of part-way through the fit at the cross-validation fold seeding (0.07 s in, after input prep and the fusion/GLS transforms).
- **`B`** on the bootstrap doors previously became `NA_integer_` and surfaced several frames later as `vector size cannot be NA`. `Inf` slipped through every existing branch for both `B` and `seed`, because `Inf != round(Inf)` is `FALSE`.

**This is a message-quality fix, not a wrong-answer fix.** Every affected path already errored or warned; none silently returned a wrong number. That set the bar for the tests — see below.

Separately and independently, the four `*WithSimulatedData()` wrappers drop **nine** `match.arg()` calls their estimator cores already perform, so each of `se_type`, `ci_type`, and `fusion_structure` is validated in exactly one place.

## What changed

The range rule and its error wording are single-sourced into two internal helpers in `R/utility.R` — `.exceeds_integer_max()` and `.format_int_max_range()` — consumed at four sites: `.apply_seed()`, both arguments of `.validate_boot_args()`, and the `cv_seed` violation collector in `checkFetwfeInputs()`. One predicate means the boundary cannot later be tightened in one copy only; one message builder means the two value-formatting guards cannot be applied to some sites but not others.

Twelve `@param` clauses across **ten exported doors**, enumerated with `getNamespaceExports()` + `formals()` rather than by grep. That enumeration is what caught `genCoefsCore()` and `simulateDataCore()` — both exported, both with man pages, and both the functions that actually make the `.apply_seed()` call, where `genCoefs()` and `simulateData()` only forward to them.

Three implementation constraints, each of which would be a real bug (all three are spelled out in #440 and all three are pinned by tests):

- **Placement** inside `.apply_seed()`'s `is.numeric && length == 1L` branch, after the `NULL`/`NA` early returns. `abs(NA) > .Machine$integer.max` is `NA` and `if (NA)` throws, so hoisting it would turn every supported `seed = NA` call into an error.
- **Strictly `>`, never `>=`.** `getBetaCV()`, `.fit_q1_nuisance()`, and `.cv_lambda_node()` all clip a computed default to *exactly* `.Machine$integer.max` and feed it through `.apply_seed()`. A `>=` boundary breaks ordinary fits with large `N * T`.
- **`abs()`, not a bare `>`.** R's integer minimum is `-2147483647`, so `-2147483648` also coerces to `NA`.

The deliberate divergence from `getBetaCV()`'s warn-and-clip precedent is recorded in the `.apply_seed()` roxygen: clipping is right there because the value is a *package-computed default the user never supplied*, and erroring is right here because the value is *user input*, where silently substituting a different seed would destroy the reproducibility the argument exists to provide.

## Behavior changes, all four

1. **A non-integral magnitude in the sliver `(2147483647, 2147483648)` is now rejected.** `set.seed(2147483647.9)` used to truncate to `2147483647L` and draw successfully — from a *different seed than the one supplied*, which is why erroring is the right outcome for a reproducibility argument. A 32-input accept/reject matrix run against both namespaces found this to be the **only** newly-rejected input, with nothing flipping the other way. It is the one exception to "range check only", and it is now stated in both `NEWS.md` and the roxygen rather than contradicted by them.
2. **`B` and `seed` above the ceiling now error at the front door** rather than deep inside the multiplier draw.
3. **`.validate_boot_args()` reports the `B` error ahead of the `seed` error** when both are invalid, because the new `B` range branch precedes the pre-existing whole-number check on `seed`.
4. **The `match.arg()` deletion moves which error a doubly-bad wrapper call reports.** With both a bad `simulated_obj` and a bad `se_type`, `.unpack_simulated_obj()` now fires first and reports the `simulated_obj` problem. Partial matching is unaffected — every core re-runs `match.arg()` with a byte-identical choice vector, verified with real end-to-end fits through all four wrappers.

## Scope note

This is a **range** fix only. `.apply_seed()` still lets `set.seed()` silently truncate a non-integral seed such as `1.5`, while `.validate_boot_args()` rejects it — the two contracts are **not** uniform, and closing that gap is a user-visible breaking change to `simulateData()` / `genCoefs()` that deserves its own decision. Said explicitly in the roxygen so the next reader does not assume otherwise.

## Testing

New `tests/testthat/test-seed-range-guard-440.R`, nine groups, red-green measured rather than assumed:

```
against unmodified source   [ FAIL 36 | WARN 21 | SKIP 0 | PASS 33 ]   (zero errors)
after the change            [ FAIL  0 | WARN  0 | SKIP 0 | PASS 74 ]
full suite                  4612 -> 4686
```

(The first commit's message quotes `FAIL 29 | PASS 32`, which was correct for the test file
*as of that commit*; the review commit added thirteen assertions, and the numbers above are
the shipped file measured against `origin/main`.)

Two assertion rules the file states in its own header, both learned the hard way during review:

- Every error assertion pins the literal `"integer.max"` with `fixed = TRUE`. A looser pattern such as `"seed"` is **green before the change too**, because base R's own message — `supplied seed is not a valid integer` — contains the word "seed". It does not contain `integer.max`.
- Every "no coercion warning" assertion wraps its call in `try(..., silent = TRUE)`. Without it the call errors in both states, `expect_no_warning()` re-raises that error out of the expectation, and the test reports an **error** rather than a pass — red before *and* after.

Groups B, C, and G are unchanged-behavior anchors that pass in both states; Groups D and E each end with an anchor block. Group B's anchor compares `runif(1)` draws rather than asserting a literal survives a pass-through, so it actually proves the boundary seed was applied. Group I exercises the public `simultaneousCIs()` / `debiasedATT()` doors, without which the user-facing promise would go unwitnessed.

## Gate

```
air format .                        clean
devtools::document()                idempotent; NAMESPACE byte-identical to main
devtools::test()                    [ FAIL 0 | WARN 0 | SKIP 0 | PASS 4686 ]
devtools::check(error_on = "note")  0 errors | 0 warnings | 0 notes
devtools::spell_check()             empty
```

Not even the usual `future file timestamps` environmental NOTE fired. **`urlchecker::url_check()` did not run** — this dev environment has no network egress to `CRAN.R-project.org`. This diff adds and changes **no URLs**, which is what makes the gap tolerable; a networked run is still owed before a CRAN submission.

No exports change. `man/` regenerates for the ten documented doors. `DESCRIPTION` stays at `1.56.18.9000` and `NEWS.md` gains bullets under the existing development header — no version bump, per the submission-time policy.

## Review

Two plan-review rounds and a drift-sentinel pass before implementation; a post-execution review and a second sentinel pass against the diff. The post-execution review returned LGTM with no blockers; the sentinel returned `NEEDS_CHANGES`, not `BLOCKED`. Every finding from both is closed in the second commit. Three things they caught that the plan had wrong: a `match.arg()` count of seven that should have been nine, an `expect_no_warning()` assertion that was inert in both states, and the two `*Core()` doors above.

## Out of scope (deferred follow-ups)

Every item below has a definitive disposition — nothing is left in limbo.

- **(a) Filed #442** — `fusion_structure_supplied` is always `TRUE` through `fetwfeWithSimulatedData()`, because the wrapper forwards `fusion_structure` explicitly, so a `verbose = TRUE` user who supplies `fusion_matrix` and never touches `fusion_structure` is told it was overridden. Pre-existing and **unchanged by this PR** — deleting the wrapper's `match.arg()` changes what value is forwarded, not whether it is forwarded. Verified `missing()` semantics are identical before and after.
- **(a) Filed #443** — `genCoefs()` derives `seed + 1L` and `seed + 2L`, which overflow to `NA_integer_` for an integer seed at the ceiling; `.apply_seed(NA_integer_)` then treats that as "ambient RNG", so the run silently is not reproducible. This PR's guard cannot catch it — the value reaching `.apply_seed()` is `NA`, not out of range. The *double* variant already errors both before and after, which is why `genCoefs()`'s new `@param` clause states the real usable ceiling of `.Machine$integer.max - 2`.
- **(a) Filed #444** — `.fit_q1_nuisance()` and `.cv_lambda_node()` are semantically identical silent clip-to-`integer.max` sites written two different ways. Deliberately **not** folded here: clip-and-continue on a package-computed default is genuinely different from rejecting user input, and folding would reach into the high-dimensional path. Recorded in the Decision Log so it is not re-raised as an oversight.
- **(c) Dropped** — the non-integral-seed contract divergence between `.apply_seed()` and `.validate_boot_args()`. Tightening `.apply_seed()` is a user-visible breaking change to `simulateData()` / `genCoefs()`; #440 scopes this as a range fix, and the divergence is now documented rather than closed.
- **(c) Dropped** — the `genCoefs()` offset corner where a rejected seed is echoed as `seed + 1L`, a value the user never typed. Both states error, so nothing regressed; recorded in the ExecPlan so a future reader does not read it as a bug introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
