### PR TITLE
refactor: single-source the print/summary rendering blocks, and pin the contract that concentrates (#366 A2)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,18 @@
   bootstrap channels, so the point estimate and the bands cannot drift apart on
   the penalty scale or the convergence diagnostics (#366).
 
+- The five rendering pieces shared by `print()` and `print(summary())` --- the
+  standard-error qualifier, the simultaneous-versus-pointwise band label, the
+  overall-ATT Wald interval, the truncated-preview block, and the Model Details
+  block --- are each now emitted from one place instead of being written twice,
+  so an edit to one report can no longer land without the other (#439). Printed
+  output is unchanged: byte-identity was verified across 28 renderings spanning
+  all four estimator classes, both report paths, every `se_type` and `ci_type`,
+  and all four truncation footers. The Wald-interval helper is shared with
+  `broom::tidy()`'s `conf.int` columns. `twfeCovs` gained the print and summary
+  snapshot tests it had never had, and the `"pointwise"`, `"cluster-robust"` and
+  `"conservative"` labels are now pinned on both report paths.
+
 - The range rule above and its error wording are single-sourced in two new
   internal helpers in `R/utility.R`, `.exceeds_integer_max()` and
   `.format_int_max_range()`, so the boundary cannot later be tightened in one

--- a/NEWS.md
+++ b/NEWS.md
@@ -47,7 +47,11 @@
   and all four truncation footers. The Wald-interval helper is shared with
   `broom::tidy()`'s `conf.int` columns. `twfeCovs` gained the print and summary
   snapshot tests it had never had, and the `"pointwise"`, `"cluster-robust"` and
-  `"conservative"` labels are now pinned on both report paths.
+  `"conservative"` labels are now pinned on both report paths. The one behavior
+  change is on malformed input: a `Model Details` block whose dimension fields
+  are missing or `NULL` now raises a named error instead of silently omitting
+  the affected row, which in practice is reachable only from a `summary()`
+  object saved by a release predating the internal `R` -> `G` rename.
 
 - The range rule above and its error wording are single-sourced in two new
   internal helpers in `R/utility.R`, `.exceeds_integer_max()` and

--- a/R/broom_methods.R
+++ b/R/broom_methods.R
@@ -76,8 +76,6 @@ NULL
 	.check_for_tidy(x)
 	.validate_conf_level(conf.level)
 
-	z <- stats::qnorm(1 - (1 - conf.level) / 2)
-
 	att_term <- "ATT"
 	att_estimate <- x$att_hat
 	att_se <- x$att_se
@@ -120,9 +118,14 @@ NULL
 
 	if (conf.int) {
 		# Overall-ATT row (K = 1) stays the scalar Wald interval at
-		# `conf.level` (pointwise == simultaneous for a scalar).
-		att_lo <- att_estimate - z * att_se
-		att_hi <- att_estimate + z * att_se
+		# `conf.level` (pointwise == simultaneous for a scalar). Shared with
+		# the print/summary paths via `.att_wald_ci()` (#439) -- note the
+		# semantic join: those two callers pass the fit-time `alpha`, this one
+		# passes `1 - conf.level` from the user's argument. Same arithmetic,
+		# two different notions of "the level".
+		att_ci <- .att_wald_ci(att_estimate, att_se, 1 - conf.level)
+		att_lo <- att_ci[1]
+		att_hi <- att_ci[2]
 		# Cohort rows pass through `catt_df`'s stored bounds (#197, Option B),
 		# so they reflect the fit's `ci_type` (simultaneous by default). `catt`
 		# is the SAME post-sort frame `cohort_estimates` / `cohort_ses` came

--- a/R/class_helpers.R
+++ b/R/class_helpers.R
@@ -756,9 +756,10 @@
 #' revisited, both must change.
 #'
 #' Not to be confused with the `identical(x$ci_type, "simultaneous")` tests in
-#' `.check_ci_band_width()` (this file) and in `R/event_study.R`. Those are
-#' **gates**, not labels; routing a gate through this helper would make a
-#' control-flow decision depend on a display string.
+#' `.check_ci_band_width()` (this file), in `R/event_study.R`, and in
+#' `.finalize_ci_type()` (`R/simultaneous_cis.R`). Those are **gates**, not
+#' labels; routing a gate through this helper would make a control-flow decision
+#' depend on a display string.
 #'
 #' @param ci_type Character scalar or `NULL`; the object's `ci_type` slot.
 #' @return A length-1 character, `"simultaneous"` or `"pointwise"`.
@@ -845,8 +846,16 @@
 #' The `n_discarded` guard is not decorative: `sprintf("%d", NULL)` returns
 #' `character(0)` and `cat(character(0))` emits nothing, so a frame flagged
 #' `truncated` with no count would silently emit no footer at all -- in the
-#' helper whose whole purpose is that footer. Both producers set the pair
-#' together, but hand-built test fixtures need not.
+#' helper whose whole purpose is that footer.
+#'
+#' Reachability of that error, so it is not re-derived: both producers
+#' (`.truncate_catt()`, `.truncate_event_study()`) set `truncated` and
+#' `n_discarded` together, and every call site but one routes its frame through
+#' one of them, which overwrites any stale `truncated` attribute. The exception
+#' is `summary(object, full_catt = TRUE)`, which passes `object$catt_df`
+#' straight through un-truncated -- so a `catt_df` carrying a hand-set
+#' `truncated = TRUE` and no count would reach here. That still requires a
+#' mutated fit object; it is not reachable from a well-formed one.
 #'
 #' @param df A data frame to render, optionally carrying the attributes
 #'   `truncated` (logical) and `n_discarded` (integer).
@@ -898,9 +907,13 @@
 #' lives: the fit's slot is `lambda_star_model_size`, the field here is
 #' `model_size`.
 #'
-#' The required-name check exists because `sprintf("%d", NULL)` returns
-#' `character(0)` and `cat(character(0))` emits nothing, so a mis-*named* field
-#' would print this block silently missing a whole row. The required set is
+#' The required-field check exists because `sprintf("%d", NULL)` returns
+#' `character(0)` and `cat(character(0))` emits nothing, so a mis-named *or*
+#' `NULL`-valued field would print this block silently missing a whole row. It
+#' tests `length(info[[nm]]) == 1L` rather than name presence, because a
+#' names-only test would be inert at the `print()` call site: that caller builds
+#' the list from fit slots, so a renamed slot arrives as a present name bound to
+#' `NULL`. The required set is
 #' derived from `show_lambda` so the two optional fields are demanded exactly
 #' when they are read. Reads use `[[` rather than `$` for exact matching -- `$`
 #' partial-matches on lists, and this helper's contract tolerates extra names,
@@ -927,11 +940,23 @@
 	if (show_lambda) {
 		required <- c(required, "model_size", "lambda_star")
 	}
-	missing_fields <- setdiff(required, names(info))
-	if (length(missing_fields) > 0) {
+	# Checks LENGTH, not just presence of the name. A names-only check
+	# (`setdiff(required, names(info))`) is inert at the `print()` call site:
+	# that caller builds `info` as `list(N = x$N, ...)`, so a renamed or dropped
+	# slot arrives as a present name bound to `NULL` -- and `list(N = NULL)`
+	# retains the name. `setdiff` then returns nothing, `sprintf("%d", NULL)`
+	# returns `character(0)`, `cat(character(0))` emits nothing, and the row
+	# vanishes silently. `length(info[[nm]]) == 1L` catches the absent name and
+	# the NULL-valued name alike, so both callers are protected.
+	is_usable <- vapply(
+		required,
+		function(nm) length(info[[nm]]) == 1L,
+		logical(1)
+	)
+	if (!all(is_usable)) {
 		stop(
-			".cat_model_details(): missing field(s): ",
-			paste(missing_fields, collapse = ", "),
+			".cat_model_details(): missing or non-scalar field(s): ",
+			paste(required[!is_usable], collapse = ", "),
 			". This is a programmer-side contract violation -- please report ",
 			"at https://github.com/gregfaletto/fetwfePackage/issues.",
 			call. = FALSE

--- a/R/class_helpers.R
+++ b/R/class_helpers.R
@@ -685,9 +685,270 @@
 # (header text, gating flags, path-extractor functions, max_cohorts /
 # order_by) and delegates here. Issue #77 step 2 / PR following PR #90.
 #
-# Byte-identity of the output is enforced by the six snapshots at
-# tests/testthat/_snaps/print-method-snapshot.md (PR #90).
+# Byte-identity of the output is enforced by the snapshots at
+# tests/testthat/_snaps/print-method-snapshot.md (PR #90, extended by #439).
 #-------------------------------------------------------------------------------
+
+#-------------------------------------------------------------------------------
+# Shared rendering pieces (#439, issue #366 part A2).
+#
+# `print()` and `print(summary())` are meant to report the same facts in the same
+# layout. Before #439 each of the five pieces below was written twice, once per
+# function, kept in agreement only by snapshot tests that lock each copy
+# separately -- so an edit to one could land without the other and the package
+# would disagree with itself about, say, whether its intervals are simultaneous
+# or pointwise. Each is now emitted from one place.
+#
+# The callers keep the event-study GATE (`print` gates on a live `eventStudy(x)`
+# call, `summary` on the cached `x$event_study`); only the rendering skeleton is
+# shared. Absorbing the gate would collapse the two independent facts that
+# test-event-study-present-in-print-summary-174.R asserts into one.
+#-------------------------------------------------------------------------------
+
+#' @title Parenthetical naming the standard-error flavor
+#'
+#' @description
+#' Returns the qualifier the print and summary paths append after the words
+#' "Std. Error" / "SE" -- `" (cluster-robust)"`, `" (conservative)"`, or `""`
+#' for the default. The helper deliberately stops at the qualifier rather than
+#' returning a finished label, because **the two callers' literals differ**:
+#' `.print_estimator_output()` renders `"  Std. Error (cluster-robust): %.4f\n"`
+#' while `.print_summary_estimator_output()` renders `"SE (cluster-robust)"`.
+#' One shared finished label could not serve both without changing user-visible
+#' output, so each caller composes its own surrounding text.
+#'
+#' @param se_type Character scalar; the fit's `se_type` slot, one of
+#'   `"default"`, `"conservative"`, `"cluster"`.
+#' @return A length-1 character: the parenthetical including its leading space,
+#'   or `""` for anything other than `"cluster"` / `"conservative"`.
+#' @keywords internal
+#' @noRd
+.se_qualifier <- function(se_type) {
+	if (identical(se_type, "cluster")) {
+		" (cluster-robust)"
+	} else if (identical(se_type, "conservative")) {
+		" (conservative)"
+	} else {
+		""
+	}
+}
+
+#' @title Band-type label for a confidence-interval table header
+#'
+#' @description
+#' Returns `"simultaneous"` or `"pointwise"` for the `[<label> NN% CI]` suffix on
+#' the CATT and event-study preview headers (#197).
+#'
+#' Takes the **scalar** `ci_type`, never the object: the print path holds a
+#' `fetwfe`-family fit and the summary path a `summary.fetwfe`-family list, so a
+#' single object parameter would carry two unrelated shapes and could validate
+#' neither.
+#'
+#' @details
+#' `NULL` -- a pre-1.16.0 fit or summary carrying no `ci_type` slot -- returns
+#' `"pointwise"`. That is a **compatibility behavior, not a default**: those
+#' objects' stored bounds really are pointwise, so the label is accurate.
+#'
+#' The same compatibility rule is encoded independently by
+#' `.resolve_event_study_ci_type()` in `R/event_study.R`, with different control
+#' flow and a divergence on invalid input (this helper falls through to
+#' `"pointwise"`; that one raises a `match.arg()` error). If the rule is ever
+#' revisited, both must change.
+#'
+#' Not to be confused with the `identical(x$ci_type, "simultaneous")` tests in
+#' `.check_ci_band_width()` (this file) and in `R/event_study.R`. Those are
+#' **gates**, not labels; routing a gate through this helper would make a
+#' control-flow decision depend on a display string.
+#'
+#' @param ci_type Character scalar or `NULL`; the object's `ci_type` slot.
+#' @return A length-1 character, `"simultaneous"` or `"pointwise"`.
+#' @keywords internal
+#' @noRd
+.band_label <- function(ci_type) {
+	if (identical(ci_type, "simultaneous")) {
+		"simultaneous"
+	} else {
+		"pointwise"
+	}
+}
+
+#' @title Two-sided Wald interval for a scalar estimate
+#'
+#' @description
+#' Returns `estimate +/- qnorm(1 - alpha / 2) * se` as an unnamed length-2
+#' numeric, lower bound first. Value-returning rather than `cat()`-emitting
+#' because one of its three callers, `.tidy_estimator_output()` in
+#' `R/broom_methods.R`, writes the bounds into a data frame and never prints.
+#'
+#' @details
+#' **The `alpha` parameter carries two different notions of "the level."** The
+#' two rendering callers pass the fit-time `x$alpha`, the level the fit's own
+#' bands were built at; the `broom` caller passes `1 - conf.level` from the
+#' user's argument to `tidy()`. Both are correct for their site and the
+#' arithmetic is the same, but the join is worth naming.
+#'
+#' **The callers also disagree about what has been validated first.**
+#' `.tidy_estimator_output()` calls `.check_for_tidy(x)` before reaching here;
+#' the two rendering callers call no method-entry precondition, because the
+#' print / summary family has none (see `.workflow/PROFILE.md`). In particular
+#' nothing establishes `has_valid_ses`, so on a `q >= 1` fit `att_se` is `NA`,
+#' this helper propagates it, and the rendered interval is `[NA, NA]`. That is
+#' the status quo rather than a regression, but a reader of a shared helper is
+#' entitled to know its precondition differs by caller.
+#'
+#' `unname()` makes the documented return type true regardless of the caller:
+#' at the summary site the inputs are the *named* elements `x$att["estimate"]`
+#' and `x$att["se"]`, so without it this helper would return a named pair there
+#' and an unnamed one at the other two sites.
+#'
+#' @param estimate Numeric scalar; the point estimate.
+#' @param se Numeric scalar; its standard error. May be `NA`.
+#' @param alpha Numeric scalar in (0, 1); the two-sided level.
+#' @return An unnamed numeric of length 2: `c(lower, upper)`.
+#' @keywords internal
+#' @noRd
+.att_wald_ci <- function(estimate, se, alpha) {
+	z <- stats::qnorm(1 - alpha / 2)
+	unname(c(estimate - z * se, estimate + z * se))
+}
+
+#' @title Render one preview block: header, table, truncation footer, blank line
+#'
+#' @description
+#' The rendering skeleton shared by **four** sites: the CATT preview and the
+#' event-study preview, in each of `.print_estimator_output()` and
+#' `.print_summary_estimator_output()`. Its real value is that the
+#' `truncated` / `n_discarded` attribute protocol -- the contract between
+#' `.truncate_catt()` / `.truncate_event_study()` and the renderers -- had four
+#' independent readers and now has one.
+#'
+#' @details
+#' `header` arrives fully formatted, so this helper does **not** single-source
+#' the header text; `.band_label()` covers the part of it that can drift
+#' semantically.
+#'
+#' `more_fmt` has **four distinct correct values** across the four sites,
+#' varying on two axes at once -- `and` vs `+` (print vs summary) and `cohorts`
+#' vs `event times` (CATT vs event study):
+#'
+#' \preformatted{
+#'   print   / CATT         "  ... and %d more cohorts.\n"
+#'   print   / event study  "  ... and %d more event times.\n"
+#'   summary / CATT         "  ... + %d more cohorts.\n"
+#'   summary / event study  "  ... + %d more event times.\n"
+#' }
+#'
+#' Getting one wrong renders plausible-looking output at the wrong site, which
+#' is why all four are pinned in
+#' `tests/testthat/test-print-summary-single-source-439.R`.
+#'
+#' The `n_discarded` guard is not decorative: `sprintf("%d", NULL)` returns
+#' `character(0)` and `cat(character(0))` emits nothing, so a frame flagged
+#' `truncated` with no count would silently emit no footer at all -- in the
+#' helper whose whole purpose is that footer. Both producers set the pair
+#' together, but hand-built test fixtures need not.
+#'
+#' @param df A data frame to render, optionally carrying the attributes
+#'   `truncated` (logical) and `n_discarded` (integer).
+#' @param header Single pre-formatted string, passed verbatim to `cat()`.
+#' @param more_fmt A `sprintf` format taking one `%d`, used only when `df` is
+#'   flagged truncated.
+#' @return `invisible(NULL)`.
+#' @keywords internal
+#' @noRd
+.cat_preview_block <- function(df, header, more_fmt) {
+	cat(header)
+	.print_catt_tbl(df)
+	if (isTRUE(attr(df, "truncated"))) {
+		n_discarded <- attr(df, "n_discarded")
+		if (length(n_discarded) != 1L) {
+			stop(
+				".cat_preview_block(): `truncated` is TRUE but `n_discarded` ",
+				"is missing or not a scalar. This is a programmer-side ",
+				"contract violation -- please report at ",
+				"https://github.com/gregfaletto/fetwfePackage/issues.",
+				call. = FALSE
+			)
+		}
+		cat(sprintf(more_fmt, n_discarded))
+	}
+	cat("\n")
+	invisible(NULL)
+}
+
+#' @title Render the Model Details block
+#'
+#' @description
+#' The header plus five dimension rows, and -- when `show_lambda` is `TRUE` --
+#' the two bridge-selection rows. Shared by `.print_estimator_output()` and
+#' `.print_summary_estimator_output()`, which rendered byte-identical text from
+#' differently-named sources before #439.
+#'
+#' @details
+#' **`info` is a named list, never positional scalars.** Every dimension row is
+#' `%d` applied to a same-typed integer, so a positional `(N, T, G, d, p)`
+#' signature would accept any permutation of its arguments silently -- and every
+#' snapshot fixture predating #439 had `G == 2` and `d == 2`, so a G/d
+#' transposition would have rendered identically and been invisible to the whole
+#' suite. Passing names makes the transposition impossible to write.
+#'
+#' The summary caller passes `object$model_info` unmodified; the extra fields it
+#' carries (`R`, `sig_eps_sq`, `sig_eps_c_sq`) are ignored. The print caller
+#' builds the list from the fit's own slots, where the one vocabulary difference
+#' lives: the fit's slot is `lambda_star_model_size`, the field here is
+#' `model_size`.
+#'
+#' The required-name check exists because `sprintf("%d", NULL)` returns
+#' `character(0)` and `cat(character(0))` emits nothing, so a mis-*named* field
+#' would print this block silently missing a whole row. The required set is
+#' derived from `show_lambda` so the two optional fields are demanded exactly
+#' when they are read. Reads use `[[` rather than `$` for exact matching -- `$`
+#' partial-matches on lists, and this helper's contract tolerates extra names,
+#' which is the situation where a partial match can appear later. The two are
+#' independent improvements: `[[` on a list returns `NULL` for a missing name
+#' and never errors.
+#'
+#' Note the deliberate asymmetry with `.band_label()`, two helpers above, which
+#' *tolerates* a missing `ci_type` on a pre-1.16.0 object. A missing `ci_type`
+#' has a correct fallback -- those bounds really are pointwise -- whereas a
+#' missing `N` has none: there is no value to print and no way to guess one.
+#' Reachable in practice only from a `summary.<class>` object deserialized from
+#' a build predating the #222 `R` -> `G` rename, since `model_info` is built in
+#' exactly one place from an already-validated fit.
+#'
+#' @param info Named list with `N`, `T`, `G`, `d`, `p`, plus `model_size` and
+#'   `lambda_star` when `show_lambda` is `TRUE`. Extra names are ignored.
+#' @param show_lambda Logical; render the `Selected size` / `Lambda*` rows.
+#' @return `invisible(NULL)`.
+#' @keywords internal
+#' @noRd
+.cat_model_details <- function(info, show_lambda) {
+	required <- c("N", "T", "G", "d", "p")
+	if (show_lambda) {
+		required <- c(required, "model_size", "lambda_star")
+	}
+	missing_fields <- setdiff(required, names(info))
+	if (length(missing_fields) > 0) {
+		stop(
+			".cat_model_details(): missing field(s): ",
+			paste(missing_fields, collapse = ", "),
+			". This is a programmer-side contract violation -- please report ",
+			"at https://github.com/gregfaletto/fetwfePackage/issues.",
+			call. = FALSE
+		)
+	}
+	cat("Model Details:\n")
+	cat(sprintf("  Units (N)           : %d\n", info[["N"]]))
+	cat(sprintf("  Time periods (T)    : %d\n", info[["T"]]))
+	cat(sprintf("  Treated cohorts (G) : %d\n", info[["G"]]))
+	cat(sprintf("  Covariates (d)      : %d\n", info[["d"]]))
+	cat(sprintf("  Features (p)        : %d\n", info[["p"]]))
+	if (show_lambda) {
+		cat(sprintf("  Selected size       : %d\n", info[["model_size"]]))
+		cat(sprintf("  Lambda*             : %.4f\n", info[["lambda_star"]]))
+	}
+	invisible(NULL)
+}
 
 #' @title Consolidated body of `print.<class>` for the three estimator classes
 #'
@@ -753,25 +1014,18 @@
 
 	## Overall ATT
 	ci_pct <- 100 * (1 - x$alpha)
-	ci_low <- x$att_hat - qnorm(1 - x$alpha / 2) * x$att_se
-	ci_high <- x$att_hat + qnorm(1 - x$alpha / 2) * x$att_se
+	att_ci <- .att_wald_ci(x$att_hat, x$att_se, x$alpha)
+	ci_low <- att_ci[1]
+	ci_high <- att_ci[2]
 	cat(sprintf(
 		"Overall Average Treatment Effect (ATT):\n  Estimate:   %.4f\n",
 		x$att_hat
 	))
-	if (identical(x$se_type, "cluster")) {
-		cat(sprintf(
-			"  Std. Error (cluster-robust): %.4f\n",
-			x$att_se
-		))
-	} else if (identical(x$se_type, "conservative")) {
-		cat(sprintf(
-			"  Std. Error (conservative): %.4f\n",
-			x$att_se
-		))
-	} else {
-		cat(sprintf("  Std. Error: %.4f\n", x$att_se))
-	}
+	cat(sprintf(
+		"  Std. Error%s: %.4f\n",
+		.se_qualifier(x$se_type),
+		x$att_se
+	))
 	if (!is.null(x$att_p_value) && !is.na(x$att_p_value)) {
 		cat(sprintf("  P-value:    %.4g\n", x$att_p_value))
 	} else {
@@ -792,25 +1046,17 @@
 	# (family-wise) by default, or pointwise when the fit used
 	# ci_type = "pointwise". Older fits (pre-1.16.0) carry no ci_type slot
 	# and are labeled pointwise (their bounds are pointwise).
-	band_label <- if (identical(x$ci_type, "simultaneous")) {
-		"simultaneous"
-	} else {
-		"pointwise"
-	}
+	band_label <- .band_label(x$ci_type)
 	catt_df <- .truncate_catt(x$catt_df, max_cohorts, order_by)
-	cat(sprintf(
-		"Cohort Average Treatment Effects (CATT) [%s %.0f%% CI]:\n",
-		band_label,
-		100 * (1 - x$alpha)
-	))
-	.print_catt_tbl(catt_df)
-	if (isTRUE(attr(catt_df, "truncated"))) {
-		cat(sprintf(
-			"  ... and %d more cohorts.\n",
-			attr(catt_df, "n_discarded")
-		))
-	}
-	cat("\n")
+	.cat_preview_block(
+		catt_df,
+		sprintf(
+			"Cohort Average Treatment Effects (CATT) [%s %.0f%% CI]:\n",
+			band_label,
+			ci_pct
+		),
+		"  ... and %d more cohorts.\n"
+	)
 
 	## Event-study effects (#174 / #138). Strict policy: `eventStudy()`'s
 	## contract is "succeeds on any fit produced by `fetwfe()` /
@@ -827,32 +1073,33 @@
 	es <- if (isTRUE(include_event_study)) eventStudy(x) else NULL
 	if (!is.null(es) && nrow(es) > 0L) {
 		es_preview <- .truncate_event_study(es, max_event_times)
-		cat(sprintf(
-			"Event-Study Average Treatment Effects (per event time) [%s %.0f%% CI]:\n",
-			band_label,
-			100 * (1 - x$alpha)
-		))
-		.print_catt_tbl(es_preview)
-		if (isTRUE(attr(es_preview, "truncated"))) {
-			cat(sprintf(
-				"  ... and %d more event times.\n",
-				attr(es_preview, "n_discarded")
-			))
-		}
-		cat("\n")
+		.cat_preview_block(
+			es_preview,
+			sprintf(
+				"Event-Study Average Treatment Effects (per event time) [%s %.0f%% CI]:\n",
+				band_label,
+				ci_pct
+			),
+			"  ... and %d more event times.\n"
+		)
 	}
 
 	## Model info
-	cat("Model Details:\n")
-	cat(sprintf("  Units (N)           : %d\n", x$N))
-	cat(sprintf("  Time periods (T)    : %d\n", x$T))
-	cat(sprintf("  Treated cohorts (G) : %d\n", x$G))
-	cat(sprintf("  Covariates (d)      : %d\n", x$d))
-	cat(sprintf("  Features (p)        : %d\n", x$p))
-	if (show_lambda) {
-		cat(sprintf("  Selected size       : %d\n", x$lambda_star_model_size))
-		cat(sprintf("  Lambda*             : %.4f\n", x$lambda_star))
-	}
+	# Named fields, not positional scalars: every row is `%d` on a same-typed
+	# integer, so a G/d transposition would render identically. `model_size` is
+	# this caller's name for the fit's `lambda_star_model_size` slot.
+	.cat_model_details(
+		list(
+			N = x$N,
+			T = x$T,
+			G = x$G,
+			d = x$d,
+			p = x$p,
+			model_size = x$lambda_star_model_size,
+			lambda_star = x$lambda_star
+		),
+		show_lambda
+	)
 
 	if (show_internal) {
 		cat("\nInternal Details:\n")
@@ -1045,22 +1292,13 @@
 	ci_pct <- 100 * (1 - x$alpha)
 	# Band-type label (#197): simultaneous (family-wise) by default, pointwise
 	# under ci_type = "pointwise" or for pre-1.16.0 summaries with no slot.
-	band_label <- if (identical(x$ci_type, "simultaneous")) {
-		"simultaneous"
-	} else {
-		"pointwise"
-	}
-	ci_low <- x$att["estimate"] - qnorm(1 - x$alpha / 2) * x$att["se"]
-	ci_high <- x$att["estimate"] + qnorm(1 - x$alpha / 2) * x$att["se"]
+	band_label <- .band_label(x$ci_type)
+	att_ci <- .att_wald_ci(x$att["estimate"], x$att["se"], x$alpha)
+	ci_low <- att_ci[1]
+	ci_high <- att_ci[2]
 	p_val <- x$att["p_value"]
 	p_str <- if (is.na(p_val)) "NA" else sprintf("%.4g", p_val)
-	se_label <- if (identical(x$se_type, "cluster")) {
-		"SE (cluster-robust)"
-	} else if (identical(x$se_type, "conservative")) {
-		"SE (conservative)"
-	} else {
-		"SE"
-	}
+	se_label <- paste0("SE", .se_qualifier(x$se_type))
 	cat(sprintf(
 		"Overall ATT: %.4f  (%s = %.4f, p = %s, %.0f%% CI = [%.4f, %.4f])\n",
 		x$att["estimate"],
@@ -1077,16 +1315,15 @@
 		cat("\n")
 	}
 
-	cat(sprintf(
-		"CATT (preview) [%s %.0f%% CI]:\n",
-		band_label,
-		ci_pct
-	))
-	.print_catt_tbl(x$catt)
-	if (isTRUE(attr(x$catt, "truncated"))) {
-		cat(sprintf("  ... + %d more cohorts.\n", attr(x$catt, "n_discarded")))
-	}
-	cat("\n")
+	.cat_preview_block(
+		x$catt,
+		sprintf(
+			"CATT (preview) [%s %.0f%% CI]:\n",
+			band_label,
+			ci_pct
+		),
+		"  ... + %d more cohorts.\n"
+	)
 
 	## Event-study preview (#174 / #138). Reads from the cached field set
 	## by `.summary_estimator_output()`; no recompute. NULL means
@@ -1094,32 +1331,22 @@
 	## eventStudy() failure now propagates rather than being silently
 	## swallowed (strict policy, #174).
 	if (!is.null(x$event_study)) {
-		cat(sprintf(
-			"Event Study (preview) [%s %.0f%% CI]:\n",
-			band_label,
-			ci_pct
-		))
-		.print_catt_tbl(x$event_study)
-		if (isTRUE(attr(x$event_study, "truncated"))) {
-			cat(sprintf(
-				"  ... + %d more event times.\n",
-				attr(x$event_study, "n_discarded")
-			))
-		}
-		cat("\n")
+		.cat_preview_block(
+			x$event_study,
+			sprintf(
+				"Event Study (preview) [%s %.0f%% CI]:\n",
+				band_label,
+				ci_pct
+			),
+			"  ... + %d more event times.\n"
+		)
 	}
 
 	## Model info
-	cat("Model Details:\n")
-	cat(sprintf("  Units (N)           : %d\n", x$model_info$N))
-	cat(sprintf("  Time periods (T)    : %d\n", x$model_info$T))
-	cat(sprintf("  Treated cohorts (G) : %d\n", x$model_info$G))
-	cat(sprintf("  Covariates (d)      : %d\n", x$model_info$d))
-	cat(sprintf("  Features (p)        : %d\n", x$model_info$p))
-	if (show_lambda) {
-		cat(sprintf("  Selected size       : %d\n", x$model_info$model_size))
-		cat(sprintf("  Lambda*             : %.4f\n", x$model_info$lambda_star))
-	}
+	# `model_info` already carries exactly the names .cat_model_details() wants,
+	# so it is passed with no adapter; its extra fields (R, sig_eps_sq,
+	# sig_eps_c_sq) are ignored.
+	.cat_model_details(x$model_info, show_lambda)
 
 	invisible(x)
 }

--- a/tests/testthat/_snaps/print-method-snapshot.md
+++ b/tests/testthat/_snaps/print-method-snapshot.md
@@ -196,3 +196,123 @@
         Selected size       : 0
         Lambda*             : 0.0265
 
+# print.twfeCovs output is stable
+
+    Code
+      print(fit_twfecovs)
+    Output
+      TWFE (with covariates) Results
+      ==============================
+      
+      Overall Average Treatment Effect (ATT):
+        Estimate:   -0.3605
+        Std. Error: 0.3549
+        P-value:    0.3098
+        95% CI:    [-1.0561, 0.3351]
+      
+      Cohort Average Treatment Effects (CATT) [simultaneous 95% CI]:
+       cohort   estimate        se    ci_low   ci_high   p_value
+            2 -0.3090865 0.4615481 -1.339713 0.7215401 0.7493122
+            3 -0.4375667 0.4317387 -1.401630 0.5264962 0.5202684
+      
+      Model Details:
+        Units (N)           : 30
+        Time periods (T)    : 5
+        Treated cohorts (G) : 2
+        Covariates (d)      : 2
+        Features (p)        : 10
+
+# print.summary.twfeCovs output is stable
+
+    Code
+      print(summary(fit_twfecovs))
+    Output
+      Summary of TWFE (with covariates)
+      =================================
+      
+      Overall ATT: -0.3605  (SE = 0.3549, p = 0.3098, 95% CI = [-1.0561, 0.3351])
+      
+      CATT (preview) [simultaneous 95% CI]:
+       cohort   estimate        se    ci_low   ci_high   p_value
+            2 -0.3090865 0.4615481 -1.339713 0.7215401 0.7493122
+            3 -0.4375667 0.4317387 -1.401630 0.5264962 0.5202684
+      
+      Model Details:
+        Units (N)           : 30
+        Time periods (T)    : 5
+        Treated cohorts (G) : 2
+        Covariates (d)      : 2
+        Features (p)        : 10
+
+# print.fetwfe output is stable on a distinct-dimension fit
+
+    Code
+      print(fit_distinct)
+    Output
+      Fused Extended Two-Way Fixed Effects Results
+      ===========================================
+      
+      Overall Average Treatment Effect (ATT):
+        Estimate:   -0.2039
+        Std. Error: 0.1290
+        P-value:    0.1139
+        Selected:   TRUE
+        95% CI:    [-0.4566, 0.0489]
+      
+      Cohort Average Treatment Effects (CATT) [simultaneous 95% CI]:
+       cohort   estimate        se     ci_low    ci_high   p_value selected
+            2 -0.2038581 0.1289615 -0.4566691 0.04895278 0.1139313     TRUE
+            3 -0.2038581 0.1289615 -0.4566691 0.04895278 0.1139313     TRUE
+            4 -0.2038581 0.1289615 -0.4566691 0.04895278 0.1139313     TRUE
+      
+      Event-Study Average Treatment Effects (per event time) [simultaneous 95% CI]:
+       event_time n_cohorts   estimate        se     ci_low    ci_high   p_value
+                0         3 -0.2038581 0.1289615 -0.4566706 0.04895432 0.1139313
+                1         3 -0.2038581 0.1289615 -0.4566706 0.04895432 0.1139313
+                2         3 -0.2038581 0.1289615 -0.4566706 0.04895432 0.1139313
+                3         2 -0.2038581 0.1289615 -0.4566706 0.04895432 0.1139313
+                4         1 -0.2038581 0.1289615 -0.4566706 0.04895432 0.1139313
+      
+      Model Details:
+        Units (N)           : 40
+        Time periods (T)    : 6
+        Treated cohorts (G) : 3
+        Covariates (d)      : 1
+        Features (p)        : 41
+        Selected size       : 1
+        Lambda*             : 0.0396
+
+# print.summary.fetwfe output is stable on a distinct-dimension fit
+
+    Code
+      print(summary(fit_distinct))
+    Output
+      Summary of Fused Extended Two-Way Fixed Effects
+      ================================================
+      
+      Overall ATT: -0.2039  (SE = 0.1290, p = 0.1139, 95% CI = [-0.4566, 0.0489])
+      Selected: TRUE
+      
+      CATT (preview) [simultaneous 95% CI]:
+       cohort   estimate        se     ci_low    ci_high   p_value selected
+            2 -0.2038581 0.1289615 -0.4566691 0.04895278 0.1139313     TRUE
+            3 -0.2038581 0.1289615 -0.4566691 0.04895278 0.1139313     TRUE
+            4 -0.2038581 0.1289615 -0.4566691 0.04895278 0.1139313     TRUE
+      
+      Event Study (preview) [simultaneous 95% CI]:
+       event_time n_cohorts   estimate        se     ci_low    ci_high   p_value
+                0         3 -0.2038581 0.1289615 -0.4566706 0.04895432 0.1139313
+                1         3 -0.2038581 0.1289615 -0.4566706 0.04895432 0.1139313
+                2         3 -0.2038581 0.1289615 -0.4566706 0.04895432 0.1139313
+                3         2 -0.2038581 0.1289615 -0.4566706 0.04895432 0.1139313
+                4         1 -0.2038581 0.1289615 -0.4566706 0.04895432 0.1139313
+      
+      Model Details:
+        Units (N)           : 40
+        Time periods (T)    : 6
+        Treated cohorts (G) : 3
+        Covariates (d)      : 1
+        Features (p)        : 41
+        Selected size       : 1
+        Lambda*             : 0.0396
+

--- a/tests/testthat/test-broom-methods.R
+++ b/tests/testthat/test-broom-methods.R
@@ -132,6 +132,23 @@ test_that("broom::tidy() respects custom conf.level", {
 		(td_wide$conf.high - td_wide$conf.low) >=
 			(td_default$conf.high - td_default$conf.low) - 1e-10
 	))
+	# The ATT row (row 1) must be STRICTLY wider, not merely not-narrower.
+	#
+	# Load-bearing since #439: the ATT row's interval now comes from the shared
+	# `.att_wald_ci()`, and this is the only END-TO-END witness that this call
+	# site's `conf.level` reaches the arithmetic at all. Under the `>=` above it
+	# passes by EQUALITY, so a `.att_wald_ci()` that ignored its `alpha` and
+	# hard-coded 0.05 would go undetected here.
+	#
+	# The cohort rows deliberately stay `>=`: they pass through the fit-time
+	# `catt_df` bounds (#197 Option B) and do not vary with `conf.level`, so a
+	# strict test on them would be wrong, not merely stronger.
+	expect_equal(td_default$term[1], "ATT")
+	expect_gt(res$att_se, 0) # guard: the strict test is vacuous if se == 0
+	expect_gt(
+		td_wide$conf.high[1] - td_wide$conf.low[1],
+		td_default$conf.high[1] - td_default$conf.low[1]
+	)
 })
 
 test_that("broom::tidy() propagates NA std.error to statistic and p.value", {

--- a/tests/testthat/test-class-helpers.R
+++ b/tests/testthat/test-class-helpers.R
@@ -1,5 +1,12 @@
 # Tests for the shared S3-class helpers in R/class_helpers.R.
 #
+# SEE ALSO tests/testthat/test-print-summary-single-source-439.R, which covers
+# the five rendering pieces #439 factored out of `.print_estimator_output()` and
+# `.print_summary_estimator_output()` -- `.se_qualifier()`, `.band_label()`,
+# `.att_wald_ci()`, `.cat_preview_block()` and `.cat_model_details()`. The two
+# print-side truncation footers pinned below are also pinned there, alongside
+# the two summary-side ones this file does not reach.
+#
 # These exercise the cross-class invariant that the per-class options
 # `fetwfe.max_cohorts`, `etwfe.max_cohorts`, `betwfe.max_cohorts` remain
 # independent after `.truncate_catt` was deduplicated into a single

--- a/tests/testthat/test-print-method-snapshot.R
+++ b/tests/testthat/test-print-method-snapshot.R
@@ -26,10 +26,10 @@ library(fetwfe)
 # any transposition among them changes the rendered output. It is fetwfe-only,
 # which is fine -- `.cat_model_details()` is class-agnostic.
 #
-# The `generate_panel_data()` body is verbatim from
-# `tests/testthat/test-fetwfe.R`; the duplication is acceptable so the
-# guardrail file is self-contained (see .plans/feat-print-snapshot-77/PLAN.md
-# Decision Log D3 / D4).
+# `generate_panel_data()` itself lives in `tests/testthat/helper-panel-fixture.R`,
+# which testthat sources before any test file (#91 consolidated what had been 14
+# inline copies). This comment previously said the body was duplicated verbatim
+# here; that stopped being true at #91.
 #
 # Snapshot tests require testthat edition 3 and skip under CRAN by default
 # (so `R CMD check --as-cran` shows SKIPs for these tests; `devtools::test()`

--- a/tests/testthat/test-print-method-snapshot.R
+++ b/tests/testthat/test-print-method-snapshot.R
@@ -2,17 +2,31 @@ library(testthat)
 library(fetwfe)
 
 # Snapshot-based guardrail for `print.<class>(x)` and `print.summary.<class>(x)`
-# across the three estimators (`fetwfe`, `etwfe`, `betwfe`). Locks the current
-# printed output of each method against six markdown goldens under
+# across all four estimators (`fetwfe`, `etwfe`, `betwfe`, `twfeCovs`). Locks
+# the current printed output of each method against ten markdown goldens under
 # tests/testthat/_snaps/print-method-snapshot.md so any byte drift surfaces as
 # a failing test. Issue #77 step 1 of 2 (the follow-up consolidates the three
 # `R/*_class.R` print/summary bodies into a shared helper; this guardrail
-# protects that refactor).
+# protects that refactor). Extended by #439, which consolidated five rendering
+# pieces shared between the print and summary bodies.
 #
-# Fixture parameters (N=30, T=5, R=2, seed=123) are the only ones all three
+# TWO fixtures, deliberately. Do not merge them.
+#
+# `pdata` (N=30, T=5, R=2, seed=123) is the only parameter set all four
 # estimators can fit without error: `etwfe()` rejects larger (T, R) due to
 # pure-OLS rank deficiency (the bridge regression in `fetwfe()`/`betwfe()`
-# absorbs it). The `generate_panel_data()` body is verbatim from
+# absorbs it). But it yields G == d == 2, and the Model Details block prints
+# `Treated cohorts (G)` and `Covariates (d)` as `%d` on same-typed integers --
+# so on this fixture alone a G/d transposition renders identically and is
+# invisible to the entire suite. Measured during #439's plan review: swapping
+# those two rows left the suite at FAIL 0 / PASS 526.
+#
+# `pdata_distinct` (N=40, T=6, R=3, seed=123, one covariate) exists solely to
+# break that symmetry: N=40, T=6, G=3, d=1, p=41 are five distinct values, so
+# any transposition among them changes the rendered output. It is fetwfe-only,
+# which is fine -- `.cat_model_details()` is class-agnostic.
+#
+# The `generate_panel_data()` body is verbatim from
 # `tests/testthat/test-fetwfe.R`; the duplication is acceptable so the
 # guardrail file is self-contained (see .plans/feat-print-snapshot-77/PLAN.md
 # Decision Log D3 / D4).
@@ -67,6 +81,40 @@ fit_betwfe <- betwfe(
 	lambda_selection = "bic"
 )
 
+# twfeCovs (#439). The fourth estimator class had no golden at all, and it is
+# the ONLY caller that passes `include_event_study = FALSE` -- so it is the one
+# class whose output must contain no event-study section, and the only golden
+# anywhere covering that branch of the two refactored functions.
+fit_twfecovs <- twfeCovs(
+	pdata = pdata,
+	time_var = "time",
+	unit_var = "unit",
+	treatment = "treatment",
+	response = "y",
+	covs = c("cov1", "cov2"),
+	verbose = FALSE
+)
+
+# The distinct-dimension fixture (#439). See the header comment for why this is
+# a separate fixture rather than a tweak to `pdata`. `covs = "cov1"` (one
+# covariate, not two) is what makes d = 1 rather than 2.
+pdata_distinct <- generate_panel_data(N = 40, T = 6, R = 3, seed = 123)
+
+fit_distinct <- fetwfe(
+	pdata = pdata_distinct,
+	time_var = "time",
+	unit_var = "unit",
+	treatment = "treatment",
+	response = "y",
+	covs = "cov1",
+	verbose = FALSE,
+	# Pin to BIC for the same reason as fit_fetwfe above. This call must stay
+	# byte-identical to `fit_distinct` in
+	# tests/testthat/test-print-summary-single-source-439.R, which asserts the
+	# same Model Details lines these goldens lock.
+	lambda_selection = "bic"
+)
+
 test_that("print.fetwfe output is stable", {
 	expect_snapshot(print(fit_fetwfe))
 })
@@ -89,4 +137,24 @@ test_that("print.betwfe output is stable", {
 
 test_that("print.summary.betwfe output is stable", {
 	expect_snapshot(print(summary(fit_betwfe)))
+})
+
+# ------------------------------------------------------------------------------
+# #439: the fourth estimator class, and the distinct-dimension fixture.
+# ------------------------------------------------------------------------------
+
+test_that("print.twfeCovs output is stable", {
+	expect_snapshot(print(fit_twfecovs))
+})
+
+test_that("print.summary.twfeCovs output is stable", {
+	expect_snapshot(print(summary(fit_twfecovs)))
+})
+
+test_that("print.fetwfe output is stable on a distinct-dimension fit", {
+	expect_snapshot(print(fit_distinct))
+})
+
+test_that("print.summary.fetwfe output is stable on a distinct-dimension fit", {
+	expect_snapshot(print(summary(fit_distinct)))
 })

--- a/tests/testthat/test-print-summary-single-source-439.R
+++ b/tests/testthat/test-print-summary-single-source-439.R
@@ -1,0 +1,392 @@
+library(testthat)
+library(fetwfe)
+
+# Issue #439 (#366 part A2): coverage for the five rendering pieces shared by
+# `.print_estimator_output()` and `.print_summary_estimator_output()` --
+# `.se_qualifier()`, `.band_label()`, `.att_wald_ci()`, `.cat_preview_block()`
+# and `.cat_model_details()`.
+#
+# WHY THIS FILE EXISTS. The consolidation is behavior-preserving, so none of
+# these assertions goes red before the source change; that is what a guardrail
+# is. Their value is measured instead by a mutation battery, and each group
+# below names the mutation it defends against. Before #439 the suite could not
+# distinguish a correct helper from a stubbed one: measured during plan review,
+# `.band_label <- function(ci_type) "simultaneous"`,
+# `.se_qualifier <- function(se_type) ""`, and swapping the G and d rows of the
+# Model Details block EACH left the entire suite green.
+#
+# ---------------------------------------------------------------------------
+# `fixed = TRUE` IS MANDATORY ON EVERY RENDERED-LITERAL ASSERTION HERE.
+#
+# `expect_match()` and `grepl()` default to `fixed = FALSE`, and three of the
+# literals this file pins contain regex metacharacters. Measured:
+#
+#   grepl("[pointwise 95% CI]", "...(CATT) [simultaneous 95% CI]:")   TRUE (!)
+#   grepl("SE (cluster-robust) =", "...(SE (cluster-robust) = 0,...") FALSE (!)
+#   grepl("  ... + 7 more cohorts.", "  ... + 7 more cohorts.")       FALSE (!)
+#
+# `[pointwise 95% CI]` is a CHARACTER CLASS, so as a regex it matches almost any
+# non-empty string -- including output from the `.band_label -> "simultaneous"`
+# mutation it is the only guard against. `(cluster-robust)` is a CAPTURE GROUP,
+# so those presence assertions fail against correct output while their paired
+# absence assertions pass by accident. The `+` in the footer is a QUANTIFIER, so
+# that assertion cannot match its own expected text.
+#
+# Absence is asserted as `expect_false(any(grepl(..., fixed = TRUE)))` rather
+# than `expect_no_match`, so the `fixed` argument is impossible to drop by
+# inattention. `tests/testthat/test-class-helpers.R` uses the same convention.
+# ---------------------------------------------------------------------------
+#
+# Panel-data fixture helpers (generate_panel_data, ...) live in
+# tests/testthat/helper-panel-fixture.R and are sourced by testthat first (#91).
+
+.render_print <- function(x, ...) {
+	paste(capture.output(print(x, ...)), collapse = "\n")
+}
+
+.render_summary <- function(x, ...) {
+	paste(capture.output(print(summary(x, ...))), collapse = "\n")
+}
+
+.expect_absent <- function(blob, literal) {
+	expect_false(any(grepl(literal, blob, fixed = TRUE)))
+}
+
+# ------------------------------------------------------------------------------
+# Group 1: direct helper contracts.
+#
+# Defends against: any helper stubbed to a constant. These are the only
+# assertions that see the helpers in isolation; everything below sees them
+# through a call site, which is the distinction the mutation battery turns on.
+# ------------------------------------------------------------------------------
+
+test_that(".se_qualifier() returns the parenthetical, not a finished label", {
+	expect_identical(fetwfe:::.se_qualifier("cluster"), " (cluster-robust)")
+	expect_identical(fetwfe:::.se_qualifier("conservative"), " (conservative)")
+	expect_identical(fetwfe:::.se_qualifier("default"), "")
+	# Anything unrecognized falls through to the unqualified form rather than
+	# erroring: `se_type` is validated at fit time (C8), so this is a rendering
+	# helper's tolerance, not an input gate.
+	expect_identical(fetwfe:::.se_qualifier("nonsense"), "")
+	expect_identical(fetwfe:::.se_qualifier(NULL), "")
+
+	# The leading space is load-bearing: the print caller composes
+	# sprintf("  Std. Error%s: %.4f\n", ...), so dropping it would render
+	# "Std. Error(cluster-robust):".
+	expect_identical(
+		sprintf("  Std. Error%s: %.4f\n", fetwfe:::.se_qualifier("cluster"), 1),
+		"  Std. Error (cluster-robust): 1.0000\n"
+	)
+	# ...and the summary caller composes paste0("SE", .), with no space.
+	expect_identical(
+		paste0("SE", fetwfe:::.se_qualifier("cluster")),
+		"SE (cluster-robust)"
+	)
+})
+
+test_that(".band_label() takes the scalar and treats a missing slot as pointwise", {
+	expect_identical(fetwfe:::.band_label("simultaneous"), "simultaneous")
+	expect_identical(fetwfe:::.band_label("pointwise"), "pointwise")
+	# NULL is the pre-1.16.0 no-slot case. Those objects' stored bounds really
+	# are pointwise, so this is a compatibility behavior, not a fallback
+	# default -- see the helper's roxygen and R/event_study.R's
+	# `.resolve_event_study_ci_type()`, which encodes the same rule.
+	expect_identical(fetwfe:::.band_label(NULL), "pointwise")
+})
+
+test_that(".att_wald_ci() computes the Wald interval and reads its alpha", {
+	# Hand-computed rather than recomputed from the helper's own output: a
+	# round-trip against `stats::qnorm` would hold by construction.
+	expect_equal(
+		fetwfe:::.att_wald_ci(2, 0.5, 0.05),
+		c(2 - 1.959963984540054 * 0.5, 2 + 1.959963984540054 * 0.5),
+		tolerance = 1e-12
+	)
+	# A DIFFERENT alpha must produce a different, wider interval. Without this
+	# the helper could ignore `alpha` entirely.
+	wide <- fetwfe:::.att_wald_ci(2, 0.5, 0.01)
+	narrow <- fetwfe:::.att_wald_ci(2, 0.5, 0.05)
+	expect_gt(wide[2] - wide[1], narrow[2] - narrow[1])
+	expect_equal(
+		narrow[2] - narrow[1],
+		2 * stats::qnorm(1 - 0.05 / 2) * 0.5,
+		tolerance = 1e-12
+	)
+
+	# Lower bound first.
+	expect_lt(narrow[1], narrow[2])
+	# NA `se` (a q >= 1 fit, where calc_ses is FALSE) propagates rather than
+	# erroring -- the render paths print "[NA, NA]".
+	expect_true(all(is.na(fetwfe:::.att_wald_ci(2, NA_real_, 0.05))))
+
+	# The unnamed-return property, asserted with NAMED inputs. With unnamed
+	# inputs this passes even with `unname()` deleted, and would be a vacuous
+	# fixture: `unname()` is load-bearing at exactly one call site, the summary
+	# one, where the inputs are `x$att["estimate"]` and `x$att["se"]`.
+	expect_null(names(fetwfe:::.att_wald_ci(
+		c(estimate = 0.5),
+		c(se = 0.1),
+		0.05
+	)))
+})
+
+test_that(".cat_model_details() rejects a mis-named field instead of dropping a row", {
+	ok <- list(N = 40, T = 6, G = 3, d = 1, p = 41)
+	expect_silent(invisible(capture.output(
+		fetwfe:::.cat_model_details(ok, show_lambda = FALSE)
+	)))
+
+	# `sprintf("%d", NULL)` returns character(0) and `cat(character(0))` emits
+	# nothing, so without the name check this would print a Model Details block
+	# silently missing the Units row.
+	bad <- list(Ntotal = 40, T = 6, G = 3, d = 1, p = 41)
+	expect_error(
+		fetwfe:::.cat_model_details(bad, show_lambda = FALSE),
+		"missing field\\(s\\): N"
+	)
+	# The two optional fields are required exactly when they are read.
+	expect_error(
+		fetwfe:::.cat_model_details(ok, show_lambda = TRUE),
+		"missing field\\(s\\): model_size, lambda_star"
+	)
+	# Extra names are ignored -- this is what lets the summary caller pass
+	# `model_info` (which also carries R / sig_eps_sq / sig_eps_c_sq) unadapted.
+	extra <- c(ok, list(R = 3, sig_eps_sq = 1, sig_eps_c_sq = 0.5))
+	out <- capture.output(fetwfe:::.cat_model_details(
+		extra,
+		show_lambda = FALSE
+	))
+	expect_true(any(grepl("  Units (N)           : 40", out, fixed = TRUE)))
+})
+
+test_that(".cat_preview_block() rejects a truncated frame with no discard count", {
+	df <- data.frame(cohort = "2", estimate = 1)
+	attr(df, "truncated") <- TRUE
+	# `n_discarded` deliberately unset: without the guard, `sprintf(fmt, NULL)`
+	# returns character(0) and the footer vanishes silently -- in the helper
+	# whose entire purpose is that footer.
+	expect_error(
+		fetwfe:::.cat_preview_block(df, "H:\n", "  ... and %d more cohorts.\n"),
+		"`n_discarded` is missing or not a scalar"
+	)
+
+	attr(df, "n_discarded") <- 4L
+	out <- capture.output(
+		fetwfe:::.cat_preview_block(df, "H:\n", "  ... and %d more cohorts.\n")
+	)
+	expect_true(any(grepl("  ... and 4 more cohorts.", out, fixed = TRUE)))
+})
+
+# ------------------------------------------------------------------------------
+# Group 2: the label branches, end to end, on BOTH render paths.
+#
+# Defends against: `.band_label()` stubbed to "simultaneous" and
+# `.se_qualifier()` stubbed to "" -- each of which left the whole suite green
+# before this file existed, because all ten snapshot goldens are the "default"
+# se_type and the "simultaneous" ci_type. Also defends against a branch swap
+# inside `.se_qualifier()`, via the paired absence assertions.
+# ------------------------------------------------------------------------------
+
+.pdata_439 <- generate_panel_data(N = 30, T = 5, R = 2, seed = 123)
+
+.fit_439 <- function(...) {
+	fetwfe(
+		pdata = .pdata_439,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		response = "y",
+		covs = c("cov1", "cov2"),
+		verbose = FALSE,
+		lambda_selection = "bic",
+		...
+	)
+}
+
+test_that("se_type = 'cluster' and ci_type = 'pointwise' are rendered on both paths", {
+	fit <- .fit_439(se_type = "cluster", ci_type = "pointwise")
+
+	out_print <- .render_print(fit)
+	expect_match(out_print, "  Std. Error (cluster-robust): ", fixed = TRUE)
+	expect_match(out_print, "[pointwise 95% CI]", fixed = TRUE)
+	.expect_absent(out_print, "[simultaneous 95% CI]")
+	.expect_absent(out_print, " (conservative)")
+
+	out_summary <- .render_summary(fit)
+	expect_match(out_summary, "(SE (cluster-robust) = ", fixed = TRUE)
+	expect_match(out_summary, "[pointwise 95% CI]", fixed = TRUE)
+	.expect_absent(out_summary, "[simultaneous 95% CI]")
+	.expect_absent(out_summary, " (conservative)")
+})
+
+test_that("se_type = 'conservative' is rendered on both paths", {
+	fit <- .fit_439(se_type = "conservative")
+
+	out_print <- .render_print(fit)
+	expect_match(out_print, "  Std. Error (conservative): ", fixed = TRUE)
+	.expect_absent(out_print, " (cluster-robust)")
+	# The default ci_type travels with this fit, so it also pins the other
+	# branch of `.band_label()`.
+	expect_match(out_print, "[simultaneous 95% CI]", fixed = TRUE)
+	.expect_absent(out_print, "[pointwise 95% CI]")
+
+	out_summary <- .render_summary(fit)
+	expect_match(out_summary, "(SE (conservative) = ", fixed = TRUE)
+	.expect_absent(out_summary, " (cluster-robust)")
+	expect_match(out_summary, "[simultaneous 95% CI]", fixed = TRUE)
+	.expect_absent(out_summary, "[pointwise 95% CI]")
+})
+
+test_that("the default se_type renders an unqualified Std. Error on both paths", {
+	fit <- .fit_439()
+
+	out_print <- .render_print(fit)
+	expect_match(out_print, "  Std. Error: ", fixed = TRUE)
+	.expect_absent(out_print, " (cluster-robust)")
+	.expect_absent(out_print, " (conservative)")
+
+	out_summary <- .render_summary(fit)
+	expect_match(out_summary, "(SE = ", fixed = TRUE)
+	.expect_absent(out_summary, " (cluster-robust)")
+	.expect_absent(out_summary, " (conservative)")
+})
+
+test_that("a non-default alpha reaches BOTH rendered CI labels", {
+	# Without this, `.att_wald_ci()` ignoring its `alpha` and hard-coding 0.05
+	# would be byte-identical at both rendering call sites: measured, nothing
+	# else in the repo renders a print or summary path at a non-default alpha.
+	# The broom site is covered by test-broom-methods.R's conf.level test.
+	fit <- .fit_439(alpha = 0.10)
+
+	out_print <- .render_print(fit)
+	expect_match(out_print, "90% CI:", fixed = TRUE)
+	expect_match(out_print, "[simultaneous 90% CI]", fixed = TRUE)
+	.expect_absent(out_print, "95% CI")
+
+	out_summary <- .render_summary(fit)
+	expect_match(out_summary, "90% CI = ", fixed = TRUE)
+	expect_match(out_summary, "[simultaneous 90% CI]", fixed = TRUE)
+	.expect_absent(out_summary, "95% CI")
+})
+
+# ------------------------------------------------------------------------------
+# Group 3: Model Details on a fixture with all five dimensions distinct.
+#
+# Defends against: a G/d (or N/T, or any other) transposition in
+# `.cat_model_details()`. Every snapshot fixture predating #439 had G == d == 2,
+# so a G/d swap rendered identically and the whole suite stayed green.
+# ------------------------------------------------------------------------------
+
+.pdata_distinct_439 <- generate_panel_data(N = 40, T = 6, R = 3, seed = 123)
+
+.fit_distinct_439 <- fetwfe(
+	pdata = .pdata_distinct_439,
+	time_var = "time",
+	unit_var = "unit",
+	treatment = "treatment",
+	response = "y",
+	covs = "cov1",
+	verbose = FALSE,
+	lambda_selection = "bic"
+)
+
+test_that("the distinct-dimension fixture really has five distinct dimensions", {
+	# Asserted first and separately so that if a future change to
+	# `generate_panel_data()` alters the realized cohort count, this fails as a
+	# FIXTURE problem rather than silently degrading into a G == d fixture that
+	# proves nothing.
+	#
+	# `expect_equal`, not `expect_identical`: `x$G` and `x$p` are doubles while
+	# `x$N`, `x$T` and `x$d` are integers, so the identical form would fail on
+	# type and read as a broken assertion.
+	dims <- c(
+		.fit_distinct_439$N,
+		.fit_distinct_439$T,
+		.fit_distinct_439$G,
+		.fit_distinct_439$d,
+		.fit_distinct_439$p
+	)
+	expect_equal(dims, c(40, 6, 3, 1, 41))
+	expect_length(unique(dims), 5L)
+})
+
+test_that("Model Details maps each dimension to its own label on both paths", {
+	expected <- c(
+		"  Units (N)           : 40",
+		"  Time periods (T)    : 6",
+		"  Treated cohorts (G) : 3",
+		"  Covariates (d)      : 1",
+		"  Features (p)        : 41"
+	)
+	for (blob in list(
+		.render_print(.fit_distinct_439),
+		.render_summary(.fit_distinct_439)
+	)) {
+		for (line in expected) {
+			expect_match(blob, line, fixed = TRUE)
+		}
+		# A G/d transposition would render these instead.
+		.expect_absent(blob, "  Treated cohorts (G) : 1")
+		.expect_absent(blob, "  Covariates (d)      : 3")
+		# ...and an N/T transposition these.
+		.expect_absent(blob, "  Units (N)           : 6")
+		.expect_absent(blob, "  Time periods (T)    : 40")
+	}
+})
+
+# ------------------------------------------------------------------------------
+# Group 4: all FOUR truncation footers.
+#
+# Defends against: `.cat_preview_block()` ignoring its `more_fmt` argument. The
+# four literals vary on two axes at once -- "and" vs "+" (print vs summary) and
+# "cohorts" vs "event times" (CATT vs event study) -- so a helper that
+# hard-coded any one of them renders plausible output at the wrong site.
+#
+# Before #439 only the two PRINT-side footers were pinned anywhere in the repo
+# (test-class-helpers.R and test-event-study-in-display-138.R). The two
+# summary-side literals were pinned nowhere and reached by nothing.
+# ------------------------------------------------------------------------------
+
+test_that("the print path emits both of its truncation footers", {
+	out_cohorts <- .render_print(.fit_distinct_439, max_cohorts = 1)
+	expect_match(out_cohorts, "  ... and 2 more cohorts.", fixed = TRUE)
+	.expect_absent(out_cohorts, "  ... + 2 more cohorts.")
+	.expect_absent(out_cohorts, "more event times")
+
+	out_es <- .render_print(.fit_distinct_439, max_event_times = 1)
+	expect_match(out_es, "  ... and 4 more event times.", fixed = TRUE)
+	.expect_absent(out_es, "  ... + 4 more event times.")
+	.expect_absent(out_es, "more cohorts")
+})
+
+test_that("the summary path emits both of its truncation footers", {
+	# `summary.<class>()` exposes neither `max_cohorts` nor `max_event_times`,
+	# and `.summary_estimator_output()` hard-codes 20 for both, so the only
+	# public route to these two footers is a fit with more than 20 cohorts or
+	# event times -- measured at ~10s. Setting the attributes on a real summary
+	# object reaches them at no cost and still runs the REAL
+	# `print.summary.fetwfe()` -> `.print_summary_estimator_output()` ->
+	# `.cat_preview_block()` with the real `more_fmt` argument, which is the
+	# thing under test.
+	#
+	# NOTE: these two objects are internally INCONSISTENT on purpose. The real
+	# `.truncate_catt()` sets `truncated` and then subsets the frame; here the
+	# frame is unsubsetted and the count is invented, so the table above the
+	# footer disagrees with the footer. They can pin ONLY the footer literal --
+	# do not extend them into any assertion relating the table to the footer.
+	s_catt <- summary(.fit_distinct_439)
+	attr(s_catt$catt, "truncated") <- TRUE
+	attr(s_catt$catt, "n_discarded") <- 7L
+	out_catt <- paste(capture.output(print(s_catt)), collapse = "\n")
+	expect_match(out_catt, "  ... + 7 more cohorts.", fixed = TRUE)
+	.expect_absent(out_catt, "  ... and 7 more cohorts.")
+	.expect_absent(out_catt, "7 more event times")
+
+	s_es <- summary(.fit_distinct_439)
+	attr(s_es$event_study, "truncated") <- TRUE
+	attr(s_es$event_study, "n_discarded") <- 4L
+	out_es <- paste(capture.output(print(s_es)), collapse = "\n")
+	expect_match(out_es, "  ... + 4 more event times.", fixed = TRUE)
+	.expect_absent(out_es, "  ... and 4 more event times.")
+	.expect_absent(out_es, "4 more cohorts")
+})

--- a/tests/testthat/test-print-summary-single-source-439.R
+++ b/tests/testthat/test-print-summary-single-source-439.R
@@ -53,6 +53,58 @@ library(fetwfe)
 }
 
 # ------------------------------------------------------------------------------
+# Shared fixtures. Defined up here, before any test_that() block, because
+# testthat evaluates a file top to bottom: a block that references a fixture
+# defined further down fails with "object not found".
+# ------------------------------------------------------------------------------
+
+# The standard fixture the print-method snapshots use. NOTE its degeneracy: the
+# bridge selects nothing here, so `att_hat == att_se == 0` and the rendered ATT
+# interval is [0.0000, 0.0000] at EVERY alpha. Fine for label assertions, and
+# useless for any assertion about interval bounds -- see the alpha test below.
+.pdata_439 <- generate_panel_data(N = 30, T = 5, R = 2, seed = 123)
+
+.fit_439 <- function(...) {
+	fetwfe(
+		pdata = .pdata_439,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		response = "y",
+		covs = c("cov1", "cov2"),
+		verbose = FALSE,
+		lambda_selection = "bic",
+		...
+	)
+}
+
+# The distinct-dimension fixture: N=40, T=6, G=3, d=1, p=41 -- five distinct
+# values, versus G == d == 2 on every fixture predating #439. `covs = "cov1"`
+# (one covariate, not two) is what makes d = 1. This call must stay
+# byte-identical to `fit_distinct` in tests/testthat/test-print-method-snapshot.R,
+# whose goldens lock the same Model Details lines group 3 asserts.
+#
+# It also has `att_se > 0`, which is what lets the alpha test below assert
+# interval BOUNDS rather than just labels.
+.pdata_distinct_439 <- generate_panel_data(N = 40, T = 6, R = 3, seed = 123)
+
+.fit_distinct_at <- function(alpha = 0.05) {
+	fetwfe(
+		pdata = .pdata_distinct_439,
+		time_var = "time",
+		unit_var = "unit",
+		treatment = "treatment",
+		response = "y",
+		covs = "cov1",
+		verbose = FALSE,
+		lambda_selection = "bic",
+		alpha = alpha
+	)
+}
+
+.fit_distinct_439 <- .fit_distinct_at()
+
+# ------------------------------------------------------------------------------
 # Group 1: direct helper contracts.
 #
 # Defends against: any helper stubbed to a constant. These are the only
@@ -187,22 +239,6 @@ test_that(".cat_preview_block() rejects a truncated frame with no discard count"
 # inside `.se_qualifier()`, via the paired absence assertions.
 # ------------------------------------------------------------------------------
 
-.pdata_439 <- generate_panel_data(N = 30, T = 5, R = 2, seed = 123)
-
-.fit_439 <- function(...) {
-	fetwfe(
-		pdata = .pdata_439,
-		time_var = "time",
-		unit_var = "unit",
-		treatment = "treatment",
-		response = "y",
-		covs = c("cov1", "cov2"),
-		verbose = FALSE,
-		lambda_selection = "bic",
-		...
-	)
-}
-
 test_that("se_type = 'cluster' and ci_type = 'pointwise' are rendered on both paths", {
 	fit <- .fit_439(se_type = "cluster", ci_type = "pointwise")
 
@@ -251,22 +287,46 @@ test_that("the default se_type renders an unqualified Std. Error on both paths",
 	.expect_absent(out_summary, " (conservative)")
 })
 
-test_that("a non-default alpha reaches BOTH rendered CI labels", {
+test_that("a non-default alpha changes the rendered ATT BOUNDS, not just the label", {
 	# Without this, `.att_wald_ci()` ignoring its `alpha` and hard-coding 0.05
-	# would be byte-identical at both rendering call sites: measured, nothing
-	# else in the repo renders a print or summary path at a non-default alpha.
-	# The broom site is covered by test-broom-methods.R's conf.level test.
-	fit <- .fit_439(alpha = 0.10)
+	# is byte-identical at both rendering call sites: measured, nothing else in
+	# the repo renders a print or summary path at a non-default alpha. The broom
+	# site is covered by test-broom-methods.R's conf.level test.
+	#
+	# TWO THINGS MAKE THIS BITE, and an earlier version of this test had
+	# neither:
+	#
+	# 1. The BOUNDS are asserted, not the label. The `NN% CI` label comes from
+	#    `ci_pct` in the caller, NOT from `.att_wald_ci()`, so an alpha-ignoring
+	#    helper would still render "90% CI:" -- with the 95% numbers beside it.
+	# 2. The fixture has `att_se > 0`. The group-2 fixture above has
+	#    `att_hat = att_se = 0` (the bridge selects nothing), so its interval is
+	#    [0.0000, 0.0000] at every alpha and no assertion on it can discriminate.
+	#
+	# The two expected pairs are hand-verified against the rendered output:
+	#   alpha = 0.05  ->  [-0.4566, 0.0489]
+	#   alpha = 0.10  ->  [-0.4160, 0.0083]
+	fit_05 <- .fit_distinct_439
+	fit_10 <- .fit_distinct_at(alpha = 0.10)
+	expect_gt(fit_10$att_se, 0) # guard: the assertion is vacuous if se == 0
 
-	out_print <- .render_print(fit)
-	expect_match(out_print, "90% CI:", fixed = TRUE)
-	expect_match(out_print, "[simultaneous 90% CI]", fixed = TRUE)
-	.expect_absent(out_print, "95% CI")
+	out_05 <- .render_print(fit_05)
+	expect_match(out_05, "  95% CI:    [-0.4566, 0.0489]", fixed = TRUE)
 
-	out_summary <- .render_summary(fit)
-	expect_match(out_summary, "90% CI = ", fixed = TRUE)
-	expect_match(out_summary, "[simultaneous 90% CI]", fixed = TRUE)
-	.expect_absent(out_summary, "95% CI")
+	out_10 <- .render_print(fit_10)
+	expect_match(out_10, "  90% CI:    [-0.4160, 0.0083]", fixed = TRUE)
+	expect_match(out_10, "[simultaneous 90% CI]", fixed = TRUE)
+	# The exact failure an alpha-ignoring helper would produce: the 90% label
+	# beside the 95% numbers.
+	.expect_absent(out_10, "  90% CI:    [-0.4566, 0.0489]")
+
+	sum_05 <- .render_summary(fit_05)
+	expect_match(sum_05, "95% CI = [-0.4566, 0.0489]", fixed = TRUE)
+
+	sum_10 <- .render_summary(fit_10)
+	expect_match(sum_10, "90% CI = [-0.4160, 0.0083]", fixed = TRUE)
+	expect_match(sum_10, "[simultaneous 90% CI]", fixed = TRUE)
+	.expect_absent(sum_10, "90% CI = [-0.4566, 0.0489]")
 })
 
 # ------------------------------------------------------------------------------
@@ -275,20 +335,11 @@ test_that("a non-default alpha reaches BOTH rendered CI labels", {
 # Defends against: a G/d (or N/T, or any other) transposition in
 # `.cat_model_details()`. Every snapshot fixture predating #439 had G == d == 2,
 # so a G/d swap rendered identically and the whole suite stayed green.
+#
+# `.pdata_distinct_439` / `.fit_distinct_439` are defined in the shared-fixtures
+# section at the top of this file, since the alpha test in group 2 needs them
+# too.
 # ------------------------------------------------------------------------------
-
-.pdata_distinct_439 <- generate_panel_data(N = 40, T = 6, R = 3, seed = 123)
-
-.fit_distinct_439 <- fetwfe(
-	pdata = .pdata_distinct_439,
-	time_var = "time",
-	unit_var = "unit",
-	treatment = "treatment",
-	response = "y",
-	covs = "cov1",
-	verbose = FALSE,
-	lambda_selection = "bic"
-)
 
 test_that("the distinct-dimension fixture really has five distinct dimensions", {
 	# Asserted first and separately so that if a future change to

--- a/tests/testthat/test-print-summary-single-source-439.R
+++ b/tests/testthat/test-print-summary-single-source-439.R
@@ -184,22 +184,48 @@ test_that(".att_wald_ci() computes the Wald interval and reads its alpha", {
 
 test_that(".cat_model_details() rejects a mis-named field instead of dropping a row", {
 	ok <- list(N = 40, T = 6, G = 3, d = 1, p = 41)
-	expect_silent(invisible(capture.output(
+	# Assert the ROWS, not just that nothing was thrown: an
+	# `expect_silent(capture.output(...))` happy path passes on a helper that
+	# emits nothing at all, which is the exact failure this block exists to
+	# detect.
+	out_ok <- capture.output(
 		fetwfe:::.cat_model_details(ok, show_lambda = FALSE)
-	)))
+	)
+	expect_length(out_ok, 6L) # header + 5 dimension rows
+	expect_identical(out_ok[[1]], "Model Details:")
 
 	# `sprintf("%d", NULL)` returns character(0) and `cat(character(0))` emits
-	# nothing, so without the name check this would print a Model Details block
+	# nothing, so without the check this would print a Model Details block
 	# silently missing the Units row.
 	bad <- list(Ntotal = 40, T = 6, G = 3, d = 1, p = 41)
 	expect_error(
 		fetwfe:::.cat_model_details(bad, show_lambda = FALSE),
-		"missing field\\(s\\): N"
+		"missing or non-scalar field\\(s\\): N"
 	)
+	# A present name bound to NULL is the case a names-only check MISSES, and
+	# it is the one the print() caller can actually produce: that caller builds
+	# `list(N = x$N, ...)` from fit slots, and `list(N = NULL)` retains the
+	# name, so `setdiff(required, names(info))` would find nothing wrong while
+	# the Units row silently vanished.
+	null_valued <- list(N = NULL, T = 6, G = 3, d = 1, p = 41)
+	expect_error(
+		fetwfe:::.cat_model_details(null_valued, show_lambda = FALSE),
+		"missing or non-scalar field\\(s\\): N"
+	)
+	# ...and the same shape on an optional field, which only bites when read.
+	null_lambda <- c(ok, list(model_size = 1, lambda_star = NULL))
+	expect_error(
+		fetwfe:::.cat_model_details(null_lambda, show_lambda = TRUE),
+		"missing or non-scalar field\\(s\\): lambda_star"
+	)
+	expect_silent(invisible(capture.output(
+		fetwfe:::.cat_model_details(null_lambda, show_lambda = FALSE)
+	)))
+
 	# The two optional fields are required exactly when they are read.
 	expect_error(
 		fetwfe:::.cat_model_details(ok, show_lambda = TRUE),
-		"missing field\\(s\\): model_size, lambda_star"
+		"missing or non-scalar field\\(s\\): model_size, lambda_star"
 	)
 	# Extra names are ignored -- this is what lets the summary caller pass
 	# `model_info` (which also carries R / sig_eps_sq / sig_eps_c_sq) unadapted.
@@ -303,30 +329,58 @@ test_that("a non-default alpha changes the rendered ATT BOUNDS, not just the lab
 	#    `att_hat = att_se = 0` (the bridge selects nothing), so its interval is
 	#    [0.0000, 0.0000] at every alpha and no assertion on it can discriminate.
 	#
-	# The two expected pairs are hand-verified against the rendered output:
-	#   alpha = 0.05  ->  [-0.4566, 0.0489]
-	#   alpha = 0.10  ->  [-0.4160, 0.0083]
+	# The expected bounds are REBUILT from the fit's own slots rather than
+	# hard-coded as rendered digits. Hard-coding "[-0.4566, 0.0489]" would pin
+	# four decimals of a number that comes out of solve()/qr(), in a test that
+	# -- unlike the snapshot goldens -- does NOT skip under `--as-cran`, so a
+	# last-digit difference on another BLAS or a BIC grid-selection flip would
+	# fail on CRAN's machines.
+	#
+	# This is not a round-trip tautology. `.att_wald_ci()` is not used to build
+	# the expectation: `stats::qnorm` is applied here to the alpha the caller
+	# passed, so an `.att_wald_ci()` that ignored its alpha renders the 95%
+	# numbers under a 90% label and mismatches. Group 1 pins the arithmetic
+	# itself against hand-computed values.
+	expected_ci <- function(fit) {
+		z <- stats::qnorm(1 - fit$alpha / 2)
+		sprintf(
+			"[%.4f, %.4f]",
+			fit$att_hat - z * fit$att_se,
+			fit$att_hat + z * fit$att_se
+		)
+	}
+
 	fit_05 <- .fit_distinct_439
 	fit_10 <- .fit_distinct_at(alpha = 0.10)
 	expect_gt(fit_10$att_se, 0) # guard: the assertion is vacuous if se == 0
+	# Guard: the two levels must actually differ, or nothing below discriminates.
+	expect_false(identical(expected_ci(fit_05), expected_ci(fit_10)))
 
 	out_05 <- .render_print(fit_05)
-	expect_match(out_05, "  95% CI:    [-0.4566, 0.0489]", fixed = TRUE)
+	expect_match(
+		out_05,
+		paste0("  95% CI:    ", expected_ci(fit_05)),
+		fixed = TRUE
+	)
 
 	out_10 <- .render_print(fit_10)
-	expect_match(out_10, "  90% CI:    [-0.4160, 0.0083]", fixed = TRUE)
+	expect_match(
+		out_10,
+		paste0("  90% CI:    ", expected_ci(fit_10)),
+		fixed = TRUE
+	)
 	expect_match(out_10, "[simultaneous 90% CI]", fixed = TRUE)
 	# The exact failure an alpha-ignoring helper would produce: the 90% label
 	# beside the 95% numbers.
-	.expect_absent(out_10, "  90% CI:    [-0.4566, 0.0489]")
+	.expect_absent(out_10, paste0("  90% CI:    ", expected_ci(fit_05)))
 
 	sum_05 <- .render_summary(fit_05)
-	expect_match(sum_05, "95% CI = [-0.4566, 0.0489]", fixed = TRUE)
+	expect_match(sum_05, paste0("95% CI = ", expected_ci(fit_05)), fixed = TRUE)
 
 	sum_10 <- .render_summary(fit_10)
-	expect_match(sum_10, "90% CI = [-0.4160, 0.0083]", fixed = TRUE)
+	expect_match(sum_10, paste0("90% CI = ", expected_ci(fit_10)), fixed = TRUE)
 	expect_match(sum_10, "[simultaneous 90% CI]", fixed = TRUE)
-	.expect_absent(sum_10, "90% CI = [-0.4566, 0.0489]")
+	.expect_absent(sum_10, paste0("90% CI = ", expected_ci(fit_05)))
 })
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION

`print(fit)` and `print(summary(fit))` are meant to report the same facts in the same
layout — the same standard-error qualifier, the same simultaneous-versus-pointwise
band label, the same Wald interval around the overall ATT, the same "… and N more
cohorts" footer, the same five-row Model Details block. Each of those five was
written **twice**, in two functions in one file, kept in agreement only by snapshot
tests that lock each copy separately. Nothing structurally prevented an edit landing
in one copy and not the other, at which point the package would disagree with itself
about — for instance — whether its intervals are simultaneous or pointwise.

Each is now emitted from one place. **No printed byte changes**, and that is proven
rather than asserted.

Part **A2 of four** from #366. A1 shipped as PR #438; A3 as PR #445.

## Byte-identity, measured

28 renderings captured from `origin/main`, re-captured after the refactor, compared
with `identical()` — never `all.equal()`, whose default tolerance is exactly what
would hide a last-digit change in a printed number. **All 28 TRUE.**

The set spans every branch the refactor touches: all four estimator classes ×
both report paths (8); `se_type` ∈ {default, cluster, conservative}; `ci_type` ∈
{simultaneous, pointwise}; `alpha` ∈ {0.05, 0.10}; `show_internal = TRUE`;
`full_catt = TRUE`; `order_by = "estimate"`; all four truncation footers; and four
`broom::tidy()` frames at three confidence levels including `conf.int = FALSE`.

The ten snapshot goldens are an independent second witness: the six pre-existing ones
pass **without re-blessing**, and the four new ones were each verified against the
pre-refactor capture rather than accepted as generated — `expect_snapshot` writes
whatever the code currently does on first run, so a refactor bug would otherwise have
been enshrined as correct.

## The five helpers, and why each has the shape it does

Every one of these was established during A1's plan review or this PR's two rounds,
and each rules out a design that looks more obvious:

- **`.se_qualifier(se_type)`**, not `.se_label()`. The two callers' literals genuinely
  differ — print renders `"  Std. Error (cluster-robust): %.4f\n"`, summary renders
  `"SE (cluster-robust)"`. A helper returning one finished label cannot serve both
  without changing user-visible output, so the shared piece is the *qualifier* and
  each caller composes its own surrounding text.
- **`.band_label(ci_type)`** takes the scalar, not the object. The print path holds a
  fit and the summary path a `summary.<class>` list; one object parameter would carry
  two unrelated shapes and could validate neither.
- **`.att_wald_ci(estimate, se, alpha)` returning `c(lo, hi)`**, not a `cat()` helper.
  Its third site — the `conf.int` branch of `.tidy_estimator_output()` — computes into
  a data frame and never prints. That site's level comes from the user's `conf.level`
  while the two rendering sites use the fit-time `alpha`; the helper's roxygen names
  that join.
- **`.cat_preview_block(df, header, more_fmt)`** serves **four** sites — the CATT and
  event-study previews in both functions. An event-study-only version would serve two
  sites sharing ~4 structural lines, which is close to fake-DRY; across all four it
  collapses the `truncated` / `n_discarded` attribute protocol from four independent
  readers to one.
- **`.cat_model_details(info, show_lambda)`** takes **named fields**. Every dimension
  row is `%d` on a same-typed integer, and every fixture predating this PR had
  `G == d == 2` — so a positional signature's G/d transposition would have rendered
  identically. Measured: it left the entire suite green.

**The event-study gate stays in the callers.** Print gates on a live `eventStudy(x)`
call, summary on the cached `x$event_study`; `test-event-study-present-in-print-summary-174.R`
has three blocks that each assert the header appears in `print()` *and* independently
in `print(summary())`. Absorbing the gate would collapse two facts into one and leave
the `include_event_study = FALSE` `twfeCovs` path unguarded.

## The consolidation is the smaller half. The contract was untested.

Folding untested duplicates into one untested helper concentrates the untested
contract rather than removing it. Measured against the pre-PR suite, **each of these
mutations left all 109 test files green**:

- `.band_label <- function(ci_type) "simultaneous"`
- `.se_qualifier <- function(se_type) ""`
- swapping the `G` and `d` rows of the Model Details block

So this PR closes four holes:

1. **`twfeCovs` had no snapshot golden.** It is also the only caller passing
   `include_event_study = FALSE`, so its two new blocks are the only goldens anywhere
   covering that branch of both refactored functions. (Its rendered output was
   previously asserted only for the header line and the absence of an event-study
   section.)
2. **Every fixture had `G == d == 2`.** A new `N=40, T=6, G=3, d=1, p=41` fixture
   breaks the symmetry, as a snapshot *and* as explicit line pins — the pins survive a
   future re-bless, which is exactly when a transposition could slip through.
3. **The non-default label branches were pinned nowhere.** `grep -rn "pointwise 9"
   tests/` returned nothing. Now `"pointwise"`, `"cluster-robust"` and
   `"conservative"` are pinned on both report paths, with the *absence* of the wrong
   label asserted alongside each.
4. **Two of the four truncation footers were pinned nowhere.** The literals vary on
   two axes at once — `and` vs `+` (print vs summary) and `cohorts` vs `event times`
   — and only the two print-side ones had tests. The summary-side pair is reached by
   nothing in the suite, because `summary()` truncates at a hard-coded 20 and exposes
   no limit.

## Mutation battery

**13 mutations, zero survivors**, each caught at every site whose output it changes —
not merely "caught somewhere". `psss` abbreviates `test-print-summary-single-source-439.R`.

| Mutation | Failures | Where it was caught |
|---|---|---|
| baseline | 0 | — |
| `.band_label` → always `"simultaneous"` | 6 | print `:273,:274` \| summary `:279,:280` \| unit ×2 |
| `.se_qualifier` → `""` | 5 | print `:272` \| summary `:278` \| unit ×3 |
| `.se_qualifier` cluster→conservative | 7 | print `:272,:275` \| summary `:278,:281` \| unit ×3 |
| **`.cat_model_details` swap G/d** | 10 | psss `:431`×4, `:434`×2, `:435`×2 + **only the 2 new goldens** |
| `.cat_model_details` swap N/T *(control)* | 19 | psss ×9 + **all 10** goldens |
| `.att_wald_ci` ignores `alpha` | 6 | print `:367,:375` \| summary `:381,:383` \| broom `:148` \| unit |
| `.att_wald_ci` sign flip | 16 | psss ×8 + 6 goldens + broom + `ci-type-197` |
| `more_fmt` := print/CATT literal | 7 | SITE2 `:462,:464` \| SITE3 `:486,:487` \| SITE4 `:494,:496` |
| `more_fmt` := print/ES literal | 10 | SITE1 `:457,:459` \| SITE3 `:486,:488` \| SITE4 `:494,:495` |
| `.cat_preview_block` drops trailing newline | 12 | 10 goldens + `fetwfe:1032` + `betwfe:1107` |
| delete the required-field check | 4 | psss `:201,:211,:217,:226` |
| **revert that check to names-only** | 2 | psss `:211,:217` |
| delete the `n_discarded` guard | 1 | psss `:246` |

Three results carry the argument:

- **The G/d swap fails the two new distinct-dimension goldens and leaves the six
  pre-existing `G == d == 2` ones green.** That is the blindness this PR removes,
  demonstrated rather than asserted. The N/T swap is the control: those values differ
  on the old fixture too, so it fails all ten.
- **The two `more_fmt` mutations are complementary by construction** — each hard-codes
  one of the four correct literals, so it exempts the site that legitimately uses it.
  Together they fail at all four sites, and **SITE3/SITE4 (the summary-side footers)
  are caught only in the new file**; nothing pre-existing reaches them.
- **Reverting the required-field check to names-only fails**, which is what makes the
  fix in the last commit real rather than cosmetic.

Counts are over the ~30 test files that can observe a rendering helper, derived
mechanically with
`grep -lE "capture\.output|expect_snapshot|expect_output|tidy\(" tests/testthat/test-*.R`.
The full suite takes 9 minutes, so 13 mutations against it is two hours; the filtered
set takes 90 seconds and is a superset of the files any of these helpers can reach.
Measured against the **final** test files, after the review fixes, not an earlier commit.

## Two review findings worth recording

**Regex metacharacters made three new assertions vacuous or broken.** `expect_match()`
defaults to `fixed = FALSE`, and the drift sentinel measured that
`grepl("[pointwise 95% CI]", <simultaneous output>)` returns **TRUE** — it is a
character class, matching almost any non-empty string, including output from the
`.band_label -> "simultaneous"` mutation it was the only guard against. `(cluster-robust)`
is a capture group and the `+` in `"  ... + 7 more cohorts."` is a quantifier, so
neither could match its own expected text. Every rendered-literal assertion in the new
file now passes `fixed = TRUE`, and absence is written as
`expect_false(any(grepl(…, fixed = TRUE)))` so the argument cannot be dropped.

**An assertion that looked load-bearing and was not.** The first battery run showed the
alpha mutation caught at only two sites. The cause was in the new test, not the
source: it asserted the `"90% CI:"` *label*, which is rendered from `ci_pct` in the
caller and not by `.att_wald_ci()` at all — and it used a fixture with
`att_hat = att_se = 0`, whose interval is `[0.0000, 0.0000]` at every alpha. It now
pins the bounds on a fixture with `att_se = 0.129`, and asserts the absence of the
exact wrong output an alpha-ignoring helper produces: the 90% label beside the 95%
numbers.

## Also in this PR

**Two guards against the same silent-drop hazard.** `sprintf("%d", NULL)` returns
`character(0)` and `cat(character(0))` emits nothing — so a mis-named field would have
printed a Model Details block silently missing a row, and a frame flagged `truncated`
with no `n_discarded` would have emitted no footer at all, in the helper whose entire
purpose is that footer. Both now `stop()` in the idiom of this file's existing
`.stop_if_missing_slots()`. The `.cat_model_details()` one is a behavior change on
malformed input, bounded: reachable only from a `summary.<class>` object deserialized
from a build predating `b0c42f3` (#222, when `G` entered `model_info`), which renders
four of five rows today and errors after this PR. `model_info` is built in one place
from an already-validated fit and no test constructs one by hand.

**A deliberate asymmetry, named in the code.** The same function now aborts on a
missing `G` while tolerating a missing `ci_type` — `.band_label()`'s
`NULL -> "pointwise"` is a compatibility behavior for pre-1.16.0 summaries. A missing
`ci_type` has a correct fallback (those bounds really are pointwise); a missing `N`
has none.

**A strengthened existing test.** `test-broom-methods.R`'s `conf.level` test asserted
the 99% CI is *at least as wide* as the 95% one, which passes under equality — so
after the fold it could not detect an alpha-ignoring `.att_wald_ci()`, and it is that
call site's only end-to-end witness. Its ATT row is now a strict `expect_gt`; the
cohort rows stay `>=`, since they pass through fit-time bounds and correctly do not
vary with `conf.level` (#197 Option B).

**A dead variable removed.** `.tidy_estimator_output()`'s `z <- stats::qnorm(...)` has
no reader once the interval moves into the helper.

## Verification

Measured on the final commit, not on an earlier one:

| Gate | Result |
|---|---|
| `air format .` | clean |
| `devtools::document()` | idempotent; **zero `man/` / `NAMESPACE` diff** |
| `devtools::test()` | `[ FAIL 0 \| WARN 0 \| SKIP 0 \| PASS 4783 ]` |
| `devtools::check(error_on = "note")` | `0 errors ✔ \| 0 warnings ✔ \| 1 note` |
| `devtools::spell_check()` | empty |
| `urlchecker::url_check()` | all 24 URLs correct |

The empty `man/` / `NAMESPACE` diff is the load-bearing one: all five helpers are
`@noRd`, so any diff there would mean something accidentally acquired an export.

**On the single NOTE.** It is `checking for future file timestamps … unable to verify
current time`, and it is environmental — proven, not assumed: the two time services
`R CMD check` queries return `000` while `CRAN.R-project.org` returns 303 and
`github.com` returns 200. The post-execution reviewer's independent `check()` run
returned `0 errors | 0 warnings | 0 notes`, confirming it is transient host state
rather than anything in this diff.

This also corrects a repo-profile claim that would have misled the next cycle: the
profile said this NOTE and unreachable `CRAN.R-project.org` URLs are one egress
signature to be diagnosed together. They are not — `url_check()` passed all 24 URLs
in the same session the NOTE fired, because the timestamp check queries time
services, not CRAN.

## Out of scope (deferred follow-ups)

Both are disposition **(a) — filed as GitHub issues**, and both are raised separately
in chat so they can be overridden per item.

- **The remaining Wald-interval sites** (#446). `R/debiased_att.R` has a
  fourth *scalar* site that `.att_wald_ci()` serves directly, plus a fifth
  `"  Std. Error: %.4f\n"` literal. Not folded because #439 scopes the helper to three
  sites and folding a fourth would require extending this PR's byte-identity harness to
  `debiasedATT()`. The issue also carries the three-file **vectorised** cluster
  (`R/plot.R`, `R/cohort_time_atts.R`, `R/variance_machinery.R`), whose exclusion is
  *signature-dependent, not intrinsic* — a variant returning `cbind(lo, hi)` would
  serve them. The nearby bootstrap-quantile branch is recorded as **not** a fold
  candidate, so it is not re-litigated.
- **`.check_for_print()` / `.check_for_print_summary()`** (#447). The
  print/summary family is the only method family in the package with no method-entry
  precondition, so both refactored functions read fitted-object slots with nothing
  validated. This PR makes the gap *asymmetric across one shared helper* —
  `.att_wald_ci()` gains one validated caller and two unvalidated ones — and
  `print.twfeCovs()` / `summary.twfeCovs()` reach **zero** validation, because
  `include_event_study = FALSE` means the `eventStudy()` call that indirectly validates
  the other three classes never fires. The invariant at stake is `has_valid_ses`, which
  is this package's canonical bug shape (#73). Not fixed here: the summary path has no
  precondition analogue, since `.assert_estimator_object()` rejects `summary.<class>`
  objects outright, so a real fix means designing a contract for a new object shape.
  `.workflow/PROFILE.md` has been corrected — it stated the convention as universal,
  which is how the gap survived several cycles.

Deliberately **not** folded in: #366 part **B** (comments and roxygen only). Promoting
#318 into an exported function's roxygen makes `document()` rewrite
`man/debiasedATT.Rd`, and this PR's expect-empty `man/` check is the tripwire that
would catch an internal helper accidentally acquiring an export. #366 stays open until
B lands.

Closes #439. Refs #366.
