### PR TITLE
test: restore the #400 scaffold guardrail's detection power (#429 items 1, 2, 4)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -83,6 +83,20 @@
   consequence: when both `simulated_obj` and `se_type` are invalid, the reported
   error is now the `simulated_obj` one rather than the `se_type` one (#440).
 
+- The error `simultaneousCIs()` raises on a singular Gram matrix is now written
+  once instead of twice (#429). The live text and the test that pins it were
+  two hand-kept copies of the same sentence, so rewriting the live one left the
+  whole test suite green. The shared internal constant is named for the
+  analytic method, because the bootstrap path raises a different error and this
+  one's advice --- switch to `method = "bootstrap"` --- would be wrong there.
+  The guardrail on the shared standard-error scaffold also regained the
+  detection power it lost when that scaffold was consolidated: absolute
+  standard errors are now pinned on all six of its fixtures rather than two, and
+  the policy that `eventStudy()` and `cohortTimeATTs()` report `NA` standard
+  errors where `simultaneousCIs()` raises an error is asserted at those three
+  functions rather than only at the internal helper behind them. No estimator
+  behavior changes.
+
 - Every pull request and every push to `main` now runs `R CMD check --as-cran`
   on six operating-system and R-version combinations --- macOS, Windows, and
   Ubuntu on R release, plus Ubuntu on `devel`, `oldrel-1`, and `oldrel-2` ---

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -355,10 +355,19 @@ simultaneousCIs.twfeCovs <- simultaneousCIs.fetwfe
 #-------------------------------------------------------------------------------
 # The exact error simultaneousCIs() raises when the recomputed Gram on the
 # selected support is singular, on the ANALYTIC path only. Single-sourced
-# (#429): the live call site below and
-# tests/testthat/test-recompute-gram-sandwich-400.R both read this, so the two
-# cannot drift. Previously each wrote the literal out by hand, and no test read
-# the live copy -- rewriting it left the whole suite green.
+# (#429): the live call site below, tests/testthat/test-recompute-gram-sandwich-400.R
+# and tests/testthat/test-singular-gram-call-site-policy-429.R all read this, so
+# the copies cannot drift. Previously the live text and the test's were two
+# hand-kept literals and no test read the live one -- rewriting it left the
+# whole suite green.
+#
+# What pins the TEXT is narrower than what pins the routing. Every
+# expect_identical() against this constant is a tautology with respect to its
+# content, since both sides read the same symbol; those assertions pin that the
+# call site still routes THIS message through the helper unmodified (mutating
+# either reddens them). The only thing holding the wording itself is the pair of
+# grepl(..., fixed = TRUE) anchors in test-singular-gram-call-site-policy-429.R,
+# which run against the message a live simultaneousCIs() call actually raised.
 #
 # NOT for the bootstrap path: .simultaneous_cis_bootstrap()'s singular-Gram
 # error lives in R/simultaneous_bootstrap.R and says something different. This

--- a/R/simultaneous_cis.R
+++ b/R/simultaneous_cis.R
@@ -352,6 +352,26 @@ simultaneousCIs.betwfe <- simultaneousCIs.fetwfe
 #' @export
 simultaneousCIs.twfeCovs <- simultaneousCIs.fetwfe
 
+#-------------------------------------------------------------------------------
+# The exact error simultaneousCIs() raises when the recomputed Gram on the
+# selected support is singular, on the ANALYTIC path only. Single-sourced
+# (#429): the live call site below and
+# tests/testthat/test-recompute-gram-sandwich-400.R both read this, so the two
+# cannot drift. Previously each wrote the literal out by hand, and no test read
+# the live copy -- rewriting it left the whole suite green.
+#
+# NOT for the bootstrap path: .simultaneous_cis_bootstrap()'s singular-Gram
+# error lives in R/simultaneous_bootstrap.R and says something different. This
+# message's remedy sentence is "use method = 'bootstrap'", which would be
+# nonsense there.
+#-------------------------------------------------------------------------------
+
+.SINGULAR_GRAM_ANALYTIC_STOP_MSG <- paste0(
+	"simultaneousCIs(): the Gram matrix on the selected support is not ",
+	"invertible; the analytic method's assumptions are not satisfied. ",
+	"For a high-dimensional (p >= NT) design, use method = 'bootstrap'."
+)
+
 #' @title Shared worker for simultaneousCIs()
 #' @description Reconstructs the K x K joint covariance from the fit's stored
 #'   slots, computes the simultaneous critical value via `mvtnorm::qmvnorm()`,
@@ -823,11 +843,7 @@ simultaneousCIs.twfeCovs <- simultaneousCIs.fetwfe
 		sel_treat_inds_shifted = sel_treat_inds_shifted,
 		se_type = se_type,
 		on_singular = "stop",
-		stop_message = paste0(
-			"simultaneousCIs(): the Gram matrix on the selected support is not ",
-			"invertible; the analytic method's assumptions are not satisfied. ",
-			"For a high-dimensional (p >= NT) design, use method = 'bootstrap'."
-		)
+		stop_message = .SINGULAR_GRAM_ANALYTIC_STOP_MSG
 	)
 	gram_inv <- gs$gram_inv
 	sandwich_full <- gs$sandwich_full

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -595,7 +595,7 @@ getPsiGUnfused <- function(
 #'     with `.SINGULAR_GRAM_ANALYTIC_STOP_MSG`. The helper's own direct unit test
 #'     (`test-recompute-gram-sandwich-400.R`) covers the same axis synthetically.
 #'     **This paragraph is the canonical statement of what is reachable from
-#'     where**; the two test files cross-reference it rather than restating it.
+#'     where**; the test files point here for the canonical version.
 #'   - **Fit time** (`getCohortATTsFinal()`) performs the FIRST inversion, and its
 #'     degrade branch IS REACHABLE through an ordinary public fit -- it is the
 #'     designed backstop, not a defensive nicety. `R/utility.R`'s `#395` note says

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -580,11 +580,22 @@ getPsiGUnfused <- function(
 #'   `NA`), whereas `simultaneousCIs()` STOPs. The two kinds of caller reach that
 #'   branch very differently, and only one of them cannot:
 #'
-#'   - **Access-time** callers cannot reach it. `has_valid_ses = TRUE` already
-#'     implies the fit's own `getGramInv()` succeeded on this exact support, so
-#'     the recompute is re-inverting a matrix known to be invertible. For them
-#'     the branch is genuinely defensive, and is exercised only by the helper's
-#'     direct unit test.
+#'   - **Access-time** callers cannot reach it on an ORDINARY fit.
+#'     `has_valid_ses = TRUE` already implies the fit's own `getGramInv()`
+#'     succeeded on this exact support, so the recompute is re-inverting a matrix
+#'     known to be invertible. They CAN reach it on an object hand-modified after
+#'     construction -- the case `R/class_helpers.R`'s validators are documented
+#'     to exist for ("defense-in-depth; the object may have been hand-modified
+#'     between construction and method call"), since no validator inspects the
+#'     rank of `X_final`. Duplicating one selected column of `X_final` onto
+#'     another makes the selected support rank-deficient while leaving the object
+#'     valid, and `test-singular-gram-call-site-policy-429.R` uses exactly that
+#'     to pin the degrade/stop split where a user observes it: `eventStudy()` and
+#'     `cohortTimeATTs()` return all-`NA` SEs while `simultaneousCIs()` errors
+#'     with `.SINGULAR_GRAM_ANALYTIC_STOP_MSG`. The helper's own direct unit test
+#'     (`test-recompute-gram-sandwich-400.R`) covers the same axis synthetically.
+#'     **This paragraph is the canonical statement of what is reachable from
+#'     where**; the two test files cross-reference it rather than restating it.
 #'   - **Fit time** (`getCohortATTsFinal()`) performs the FIRST inversion, and its
 #'     degrade branch IS REACHABLE through an ordinary public fit -- it is the
 #'     designed backstop, not a defensive nicety. `R/utility.R`'s `#395` note says

--- a/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
+++ b/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
@@ -387,15 +387,14 @@ test_that("an SE-unavailable fit degrades consistently: accessors -> NA, simulta
 	expect_error(simultaneousCIs(fq, family = "event_study"), "calc_ses")
 	expect_error(simultaneousCIs(fq, family = "all_post_treatment"), "calc_ses")
 
-	# NB: the *shared-scaffold* singular-Gram branch (recomputed selected-support
+	# NB: the fits exercised here degrade because has_valid_ses = FALSE, which is
+	# NOT the *shared-scaffold* singular-Gram branch (recomputed selected-support
 	# Gram singular -> res_gram$calc_ses = FALSE; the two accessors degrade to NA
-	# while simultaneousCIs STOPs "not invertible") is UNREACHABLE from the
-	# ACCESS-TIME callers exercised here -- has_valid_ses = TRUE already implies
-	# the fit's own getGramInv() on that support succeeded. It is reachable from
-	# the fit-time caller getCohortATTsFinal(); see the roxygen on
-	# .recompute_gram_and_sandwich() in R/variance_machinery.R and
-	# test-fit-time-singular-gram-degrade-400.R. Phase 2 guards the
-	# on_singular = c("degrade", "stop") policy with a direct unit test of the
-	# extracted helper (feeding it a rank-deficient support), which is the only
-	# place the asymmetry can be exercised.
+	# while simultaneousCIs STOPs "not invertible"). An ordinary fit cannot reach
+	# that branch from an ACCESS-TIME caller -- has_valid_ses = TRUE already
+	# implies the fit's own getGramInv() on that support succeeded -- but a
+	# hand-modified one can, and the fit-time caller getCohortATTsFinal() reaches
+	# it outright. For the canonical statement of what is reachable from where,
+	# and the tests that pin each route, see the roxygen on
+	# .recompute_gram_and_sandwich() in R/variance_machinery.R.
 })

--- a/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
+++ b/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
@@ -81,6 +81,21 @@
 # Part 2 are the first-class regression guard now (#429). These anchors are
 # kept because they still catch a divergence introduced OUTSIDE the shared
 # helper, in an accessor's own assembly of the result.
+#
+# That residual is larger than it sounds, and is the reason not to delete them:
+# they are currently the ONLY assertions in this file covering simultaneousCIs()'s
+# SE path. None of the eighteen Part 2 pins goes through simultaneousCIs() at all
+# -- they read eventStudy(), cohortStudy() and cohortTimeATTs(). Measured on the
+# #451 review: scaling Sigma one level downstream of the scaffold
+# (`Sigma <- 1.5 * (Sigma_1 + Sigma_2)` in .simultaneous_cis_impl()) fires 18
+# failures, every one of them here and none in Part 2.
+#
+# Which sets up the same trap one layer up: .assemble_joint_cov_var1/2 are
+# ALREADY shared helpers, so the next consolidation routing both sides of these
+# anchors through one of them hollows this block exactly as the #400 fold
+# hollowed it against the scaffold -- and at that moment simultaneousCIs() SEs
+# have no absolute pin anywhere. Pre-empting that with a fourth pinned vector per
+# fixture (via .g400_se_of_sci()) is #429 PR B's job.
 
 .g400_expect_anchors <- function(fit, label) {
 	a <- fit$alpha
@@ -124,7 +139,7 @@
 	expect_lt(max(abs(cs$se - .g400_se_of_sci(co))), 1e-12)
 }
 
-test_that("the shared scaffold yields cross-accessor-consistent SEs across classes and se_types (#400 guardrail)", {
+test_that("cross-accessor routing anchors: accessors agree, but are blind to changes inside the shared scaffold (#400/#429)", {
 	for (label in names(.g400_fits)) {
 		.g400_expect_anchors(.g400_fits[[label]], label)
 	}
@@ -233,10 +248,15 @@ test_that("scaffold SEs match pinned pre-refactor values on the fetwfe/cluster f
 # Two notes for the reader:
 #
 #   * Six inline blocks here, while Part 1 loops one helper over all six
-#     fixtures. Deliberate: a separate test_that() gives each fixture its own
-#     name in the reporter, so "how many fixtures did this mutation reach?" is
+#     fixtures. The reason is consistency: the fetwfe/default and fetwfe/cluster
+#     blocks were already written this way, and matching them beats mixing two
+#     shapes in one section. What matters is that each fixture gets its own name
+#     in the reporter, so "how many fixtures did this mutation reach?" is
 #     answered by counting failing test names rather than by parsing info=
-#     strings off one aggregated test.
+#     strings off one aggregated test -- but a loop delivers that too, by
+#     building the name with paste0(), which is exactly what
+#     test-singular-gram-call-site-policy-429.R does. Either shape is fine here;
+#     inline is not load-bearing.
 #   * betwfe's cohortTimeATTs()$se[4] is EXACTLY zero on both betwfe fixtures.
 #     That is a real pinned value, not a placeholder: the bridge selects that
 #     cell out (13 of 14 cells selected on this fixture -- see the comment at

--- a/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
+++ b/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
@@ -1,11 +1,13 @@
 # Cross-accessor byte-identity guardrail for the shared access-time inference
 # scaffold (#400, Phase 1 -- the blocking prerequisite for the refactor).
 #
-# NB the next four sentences are STALE (tracked in #430): the sequence they
+# NB the next two sentences are STALE (tracked in #430): the sequence they
 # describe has been single-sourced in .recompute_gram_and_sandwich() since
 # #413/#414, so there are no longer several copies to drift apart. They are left
 # as written -- rewriting them is #430's job, not this file's -- but do not read
-# them as a description of the tree.
+# them as a description of the tree. The two sentences after those are still
+# accurate: this file does pin the anchors and the literal values, and there
+# genuinely was no unified cross-accessor fixture before it.
 #
 # The "resolve selected support -> recompute Gram inverse -> cluster sandwich"
 # sequence is duplicated across eventStudy(), cohortTimeATTs(), and
@@ -221,9 +223,12 @@ test_that("scaffold SEs match pinned pre-refactor values on the fetwfe/cluster f
 # mutation inside .recompute_gram_and_sandwich() reddened 3 of what should be 18
 # assertions -- Part 1's anchors having gone hollow, nothing else in the file
 # could see it. With all six pinned, scaling sandwich_full reddens the three
-# `cluster` blocks and scaling gram_inv reddens the three `default` ones (the
-# `default` SEs never touch sandwich_full at all, because
-# .compute_cluster_robust_sandwich() forms its own gram_inv_full internally).
+# `cluster` blocks (the `default` SEs never see it -- the helper returns
+# sandwich_full = NULL unless se_type == "cluster") and scaling gram_inv reddens
+# the three `default` ones (the `cluster` SEs never see it --
+# .compute_cluster_robust_sandwich() solves its own crossprod(X_S_centered) and
+# never touches the helper's gram_inv). The two mutations are exact
+# complements; together they reach 18 of 18 assertions.
 #
 # Two notes for the reader:
 #

--- a/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
+++ b/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
@@ -1,6 +1,12 @@
 # Cross-accessor byte-identity guardrail for the shared access-time inference
 # scaffold (#400, Phase 1 -- the blocking prerequisite for the refactor).
 #
+# NB the next four sentences are STALE (tracked in #430): the sequence they
+# describe has been single-sourced in .recompute_gram_and_sandwich() since
+# #413/#414, so there are no longer several copies to drift apart. They are left
+# as written -- rewriting them is #430's job, not this file's -- but do not read
+# them as a description of the tree.
+#
 # The "resolve selected support -> recompute Gram inverse -> cluster sandwich"
 # sequence is duplicated across eventStudy(), cohortTimeATTs(), and
 # simultaneousCIs() (R/event_study.R, R/cohort_time_atts.R, R/simultaneous_cis.R).
@@ -64,7 +70,15 @@
 	(sci$ci$pointwise_ci_high - sci$ci$estimate) / sci$pointwise_critical_value
 }
 
-# --- Part 1: cross-accessor equality (the first-class regression guard) --------
+# --- Part 1: cross-accessor equality (no longer the first-class guard) ---------
+#
+# Measured at a45407b: BOTH mutations inside .recompute_gram_and_sandwich()
+# (scaling sandwich_full, scaling gram_inv) leave this entire block green,
+# because after the #400 fold both sides of every anchor call that helper -- so
+# each anchor now compares the helper against itself. The absolute pins in
+# Part 2 are the first-class regression guard now (#429). These anchors are
+# kept because they still catch a divergence introduced OUTSIDE the shared
+# helper, in an accessor's own assembly of the result.
 
 .g400_expect_anchors <- function(fit, label) {
 	a <- fit$alpha
@@ -197,6 +211,163 @@ test_that("scaffold SEs match pinned pre-refactor values on the fetwfe/cluster f
 			0.1930629,
 			0.1382049,
 			0.2308755
+		),
+		tolerance = 1e-6
+	)
+})
+
+# The remaining four fixtures, pinned for the same structural reason (#429).
+# Before this, Part 2 covered fetwfe/default and fetwfe/cluster only, so a
+# mutation inside .recompute_gram_and_sandwich() reddened 3 of what should be 18
+# assertions -- Part 1's anchors having gone hollow, nothing else in the file
+# could see it. With all six pinned, scaling sandwich_full reddens the three
+# `cluster` blocks and scaling gram_inv reddens the three `default` ones (the
+# `default` SEs never touch sandwich_full at all, because
+# .compute_cluster_robust_sandwich() forms its own gram_inv_full internally).
+#
+# Two notes for the reader:
+#
+#   * Six inline blocks here, while Part 1 loops one helper over all six
+#     fixtures. Deliberate: a separate test_that() gives each fixture its own
+#     name in the reporter, so "how many fixtures did this mutation reach?" is
+#     answered by counting failing test names rather than by parsing info=
+#     strings off one aggregated test.
+#   * betwfe's cohortTimeATTs()$se[4] is EXACTLY zero on both betwfe fixtures.
+#     That is a real pinned value, not a placeholder: the bridge selects that
+#     cell out (13 of 14 cells selected on this fixture -- see the comment at
+#     the top of this file).
+
+test_that("scaffold SEs match pinned pre-refactor values on the etwfe/default fixture (#400 guardrail, #429)", {
+	fit <- .g400_fits[["etwfe/default"]]
+	expect_equal(
+		eventStudy(fit)$se,
+		c(0.1639891, 0.2085174, 0.2833031, 0.2903975, 0.3223087),
+		tolerance = 1e-6
+	)
+	expect_equal(
+		cohortStudy(fit)$se,
+		c(0.2266507, 0.1954749, 0.1990295, 0.2088314),
+		tolerance = 1e-6
+	)
+	expect_equal(
+		cohortTimeATTs(fit)$se,
+		c(
+			0.2820758,
+			0.2887492,
+			0.2977382,
+			0.3223087,
+			0.3223087,
+			0.2606832,
+			0.2726312,
+			0.3009939,
+			0.3009939,
+			0.2648504,
+			0.2952462,
+			0.2952462,
+			0.2696002,
+			0.2696002
+		),
+		tolerance = 1e-6
+	)
+})
+
+test_that("scaffold SEs match pinned pre-refactor values on the betwfe/default fixture (#400 guardrail, #429)", {
+	fit <- .g400_fits[["betwfe/default"]]
+	expect_equal(
+		eventStudy(fit)$se,
+		c(0.1591995, 0.2037659, 0.2572252, 0.3070540, 0.2826046),
+		tolerance = 1e-6
+	)
+	expect_equal(
+		cohortStudy(fit)$se,
+		c(0.1490514, 0.1604112, 0.1738290, 0.1978270),
+		tolerance = 1e-6
+	)
+	expect_equal(
+		cohortTimeATTs(fit)$se,
+		c(
+			0.2515420,
+			0.2568852,
+			0.2661261,
+			0.0000000,
+			0.2826046,
+			0.2407671,
+			0.2529209,
+			0.2566070,
+			0.2715172,
+			0.2542477,
+			0.2581047,
+			0.2749440,
+			0.2484576,
+			0.2666360
+		),
+		tolerance = 1e-6
+	)
+})
+
+test_that("scaffold SEs match pinned pre-refactor values on the etwfe/cluster fixture (#400 guardrail, #429)", {
+	fit <- .g400_fits[["etwfe/cluster"]]
+	expect_equal(
+		eventStudy(fit)$se,
+		c(0.1594857, 0.2023723, 0.2713419, 0.2610870, 0.3509609),
+		tolerance = 1e-6
+	)
+	expect_equal(
+		cohortStudy(fit)$se,
+		c(0.2396085, 0.1776220, 0.1807051, 0.1994378),
+		tolerance = 1e-6
+	)
+	expect_equal(
+		cohortTimeATTs(fit)$se,
+		c(
+			0.2793386,
+			0.3315840,
+			0.2900008,
+			0.2623502,
+			0.3509609,
+			0.2679904,
+			0.2633195,
+			0.2752361,
+			0.2808612,
+			0.2747036,
+			0.2777359,
+			0.2615971,
+			0.2568748,
+			0.2671456
+		),
+		tolerance = 1e-6
+	)
+})
+
+test_that("scaffold SEs match pinned pre-refactor values on the betwfe/cluster fixture (#400 guardrail, #429)", {
+	fit <- .g400_fits[["betwfe/cluster"]]
+	expect_equal(
+		eventStudy(fit)$se,
+		c(0.1570818, 0.1998555, 0.2497265, 0.3059113, 0.3083088),
+		tolerance = 1e-6
+	)
+	expect_equal(
+		cohortStudy(fit)$se,
+		c(0.1648825, 0.1514423, 0.1534372, 0.2044426),
+		tolerance = 1e-6
+	)
+	expect_equal(
+		cohortTimeATTs(fit)$se,
+		c(
+			0.2422136,
+			0.2893479,
+			0.2629059,
+			0.0000000,
+			0.3083088,
+			0.2450568,
+			0.2540328,
+			0.2599244,
+			0.2661369,
+			0.2542525,
+			0.2623674,
+			0.2549319,
+			0.2640755,
+			0.2708483
 		),
 		tolerance = 1e-6
 	)

--- a/tests/testthat/test-recompute-gram-sandwich-400.R
+++ b/tests/testthat/test-recompute-gram-sandwich-400.R
@@ -145,4 +145,11 @@ test_that(".recompute_gram_and_sandwich() defaults to degrade and errors without
 	)
 	expect_s3_class(e, "error")
 	expect_null(conditionCall(e))
+	# ...and that it is the RIGHT error, not merely a call-less one. Without
+	# this the block would pass on any error at all, including one raised
+	# before the on_singular branch was reached.
+	expect_identical(
+		conditionMessage(e),
+		fetwfe:::.SINGULAR_GRAM_ANALYTIC_STOP_MSG
+	)
 })

--- a/tests/testthat/test-recompute-gram-sandwich-400.R
+++ b/tests/testthat/test-recompute-gram-sandwich-400.R
@@ -43,15 +43,10 @@ test_that(".recompute_gram_and_sandwich() degrades vs stops on a singular select
 	expect_null(gs$treat_block_mask)
 
 	# on_singular = "stop" -> errors with EXACTLY the stop_message it is given
-	# (pins the helper's verbatim propagation). NB: the live call-site literal in
-	# .simultaneous_cis_impl() is a SEPARATE copy of this string, kept byte-identical
-	# by hand -- that singular-Gram path is unreachable through any public fit, so no
-	# integration test exercises it; edit one copy, edit both.
-	msg <- paste0(
-		"simultaneousCIs(): the Gram matrix on the selected support is not ",
-		"invertible; the analytic method's assumptions are not satisfied. ",
-		"For a high-dimensional (p >= NT) design, use method = 'bootstrap'."
-	)
+	# (pins the helper's verbatim propagation). The string below is the very
+	# object .simultaneous_cis_impl() passes at its live call site: since #429
+	# both read the package-level constant, so the two cannot drift apart.
+	msg <- fetwfe:::.SINGULAR_GRAM_ANALYTIC_STOP_MSG
 	err <- tryCatch(
 		suppressWarnings(fetwfe:::.recompute_gram_and_sandwich(
 			X_final = X_sing,

--- a/tests/testthat/test-recompute-gram-sandwich-400.R
+++ b/tests/testthat/test-recompute-gram-sandwich-400.R
@@ -1,14 +1,10 @@
 # Direct unit test for the extracted scaffold helper .recompute_gram_and_sandwich()
 # (#400 Phase 2a). Its one genuine policy axis is `on_singular` (degrade vs stop
-# on a singular recomputed Gram). For the ACCESS-TIME callers that branch is
-# defensive-only and unreachable through any public fit (a fit with valid SEs
-# already inverted its Gram on this support). It is NOT defensive-only for the
-# fit-time caller getCohortATTsFinal(), which performs the first inversion and
-# where the degrade IS reachable -- see the roxygen on
-# .recompute_gram_and_sandwich() in R/variance_machinery.R and the end-to-end
-# regression test in test-fit-time-singular-gram-degrade-400.R. The degrade/stop
-# ASYMMETRY, though, can still only be exercised here, by feeding the helper a
-# rank-deficient selected support directly.
+# on a singular recomputed Gram). This file exercises that axis SYNTHETICALLY, by
+# feeding the helper a rank-deficient selected support directly. For which
+# callers can reach the branch through a public door, and how, see the roxygen on
+# .recompute_gram_and_sandwich() in R/variance_machinery.R -- it is the canonical
+# statement and it names the end-to-end tests.
 
 test_that(".recompute_gram_and_sandwich() degrades vs stops on a singular selected-support Gram (#400)", {
 	# Rank-deficient support: feature columns 1 and 2 are identical, so the centered

--- a/tests/testthat/test-recompute-gram-sandwich-400.R
+++ b/tests/testthat/test-recompute-gram-sandwich-400.R
@@ -87,9 +87,13 @@ test_that(".recompute_gram_and_sandwich() degrades vs stops on a singular select
 # Two properties of the helper's own signature, both of which used to be
 # invisible to the whole suite (#429 item 4): reordering the `on_singular`
 # default and dropping `call. = FALSE` from its stop() each left every test
-# green. The rank-deficient support is the same one the block above builds --
-# feature columns 1 and 2 identical, so the centered Gram on the selected
-# support {1, 2, 3} is singular.
+# green. This block rebuilds a rank-deficient support of the same shape as the
+# one above -- feature columns 1 and 2 identical, so the centered Gram on the
+# selected support {1, 2, 3} is singular. It is rebuilt rather than hoisted to
+# file scope because `T <- 2L` there would shadow base R's `T` for every other
+# block in the file. Nothing enforces that the two stay identical, and nothing
+# needs to: each block only requires *a* singular support, so an edit to one
+# does not invalidate the other.
 test_that(".recompute_gram_and_sandwich() defaults to degrade and errors without a call (#429)", {
 	N <- 4L
 	T <- 2L

--- a/tests/testthat/test-recompute-gram-sandwich-400.R
+++ b/tests/testthat/test-recompute-gram-sandwich-400.R
@@ -87,3 +87,62 @@ test_that(".recompute_gram_and_sandwich() degrades vs stops on a singular select
 	expect_false(is.null(gs_ok$sandwich_full))
 	expect_length(gs_ok$treat_block_mask, length(sel_feat_inds))
 })
+
+# Two properties of the helper's own signature, both of which used to be
+# invisible to the whole suite (#429 item 4): reordering the `on_singular`
+# default and dropping `call. = FALSE` from its stop() each left every test
+# green. The rank-deficient support is the same one the block above builds --
+# feature columns 1 and 2 identical, so the centered Gram on the selected
+# support {1, 2, 3} is singular.
+test_that(".recompute_gram_and_sandwich() defaults to degrade and errors without a call (#429)", {
+	N <- 4L
+	T <- 2L
+	n <- N * T
+	x1 <- as.double(seq_len(n))
+	X_sing <- cbind(x1, x1, rep(c(1, 0), n / 2))
+	shared <- list(
+		X_final = X_sing,
+		y_final = rep(0, n),
+		N = N,
+		T = T,
+		treat_inds = c(1L, 2L),
+		num_treats = 2L,
+		sel_feat_inds = c(1L, 2L, 3L),
+		sel_treat_inds_shifted = c(1L, 2L),
+		se_type = "default"
+	)
+
+	# match.arg() takes the first element, so the default IS the order of the
+	# formal. The structural half names the intent...
+	expect_identical(
+		eval(formals(fetwfe:::.recompute_gram_and_sandwich)$on_singular),
+		c("degrade", "stop")
+	)
+	# ...and the behavioral half is what catches a reorder: called on a singular
+	# support WITHOUT on_singular, the helper must degrade rather than error.
+	gs_default <- suppressWarnings(do.call(
+		fetwfe:::.recompute_gram_and_sandwich,
+		shared
+	))
+	expect_false(isTRUE(gs_default$calc_ses))
+
+	# call. = FALSE on the "stop" branch. Without it R attaches this internal
+	# helper's own call, so the user sees
+	# `Error in .recompute_gram_and_sandwich(X_final = ..., ...)` with the whole
+	# design matrix deparsed into it instead of the actionable message.
+	e <- tryCatch(
+		suppressWarnings(do.call(
+			fetwfe:::.recompute_gram_and_sandwich,
+			c(
+				shared,
+				list(
+					on_singular = "stop",
+					stop_message = fetwfe:::.SINGULAR_GRAM_ANALYTIC_STOP_MSG
+				)
+			)
+		)),
+		error = function(e) e
+	)
+	expect_s3_class(e, "error")
+	expect_null(conditionCall(e))
+})

--- a/tests/testthat/test-singular-gram-call-site-policy-429.R
+++ b/tests/testthat/test-singular-gram-call-site-policy-429.R
@@ -152,8 +152,14 @@ for (.cs429_case in .cs429_cases) {
 			# expect_warning() OUTSIDE and tryCatch() INSIDE is the only order
 			# that works (suppressWarnings() inside makes the warning
 			# expectation fail; with no tryCatch the error escapes and aborts
-			# the block). expect_error() is unusable here because it treats its
-			# pattern as a regex and the message contains "(p >= NT)".
+			# the block).
+			#
+			# tryCatch rather than expect_error() because the caught condition
+			# is reused by the two content anchors below -- one call, three
+			# assertions. Note expect_error() would need fixed = TRUE if it were
+			# used: its pattern defaults to a regex and this message contains
+			# "(p >= NT)", so the default form does not match its own subject.
+			# Measured: default FAILS, fixed = TRUE PASSES.
 			e <- expect_warning(
 				tryCatch(
 					simultaneousCIs(fit_mod, family = "cohort"),

--- a/tests/testthat/test-singular-gram-call-site-policy-429.R
+++ b/tests/testthat/test-singular-gram-call-site-policy-429.R
@@ -54,8 +54,8 @@
 			)
 		}
 	),
-	# etwfe selects nothing, so it drives the scalar-NA "all features" sentinel
-	# branch of the scaffold rather than an index vector.
+	# etwfe performs no selection, so it drives the scalar-NA "all features"
+	# sentinel branch of the scaffold rather than an index vector.
 	list(
 		label = "etwfe",
 		fit = function() etwfeWithSimulatedData(.cs429_dat, verbose = FALSE)
@@ -77,11 +77,17 @@
 	}
 	x
 }
-# The selected support, derived the way .resolve_selected_support() derives it:
-# the nonzero theta entries after the intercept for the bridge estimators, and
-# every column for the OLS-family ones (whose support is the NA sentinel). A
-# wrong answer here fails safe -- it would leave the Gram invertible and turn
-# the degrade assertions red rather than green.
+# The selected support, derived the way .resolve_selected_support() derives it
+# for the two cases this file uses: the nonzero theta entries after the
+# intercept for `fetwfe`, and every column for `etwfe` (whose support is the NA
+# sentinel). A wrong answer here fails safe -- it would leave the Gram
+# invertible and turn the degrade assertions red rather than green.
+#
+# The branch is `fetwfe` vs everything-else, NOT bridge vs OLS. `betwfe` is a
+# bridge estimator but its class is "betwfe" alone -- it does not inherit
+# "fetwfe" -- so it would take the every-column branch and get the wrong
+# support. Adding a `betwfe` case means changing this predicate first; the
+# natural form is `if (!is.null(x$internal$theta_hat))`.
 .cs429_sel <- function(x) {
 	if (inherits(x, "fetwfe")) {
 		which(x$internal$theta_hat[2:(x$p + 1)] != 0)

--- a/tests/testthat/test-singular-gram-call-site-policy-429.R
+++ b/tests/testthat/test-singular-gram-call-site-policy-429.R
@@ -1,0 +1,172 @@
+# Call-site policy test for the shared singular-Gram branch (#429 item 4).
+#
+# .recompute_gram_and_sandwich() carries the package's one genuine inference
+# policy split in its `on_singular` argument: when the recomputed Gram on the
+# selected support is singular, eventStudy() and cohortTimeATTs() DEGRADE
+# (all-NA standard errors) while simultaneousCIs() STOPs. Until now that split
+# was asserted only by test-recompute-gram-sandwich-400.R, which calls the
+# helper directly with a hand-built rank-deficient matrix -- nothing pinned it
+# where a user actually observes it, at the three public accessors.
+#
+# The way in is the scenario the method-entry validators exist for.
+# R/class_helpers.R says they re-run as "defense-in-depth; the object may have
+# been hand-modified between construction and method call". So: take a real
+# fit and overwrite one SELECTED column of X_final with another selected
+# column. The selected support becomes rank-deficient while every slot the
+# validators inspect is untouched, so the object stays valid and the branch
+# becomes reachable. See the roxygen on .recompute_gram_and_sandwich() in
+# R/variance_machinery.R for the canonical statement of what is reachable from
+# where.
+#
+# cohortStudy() is deliberately NOT driven here: its `se` is a FIT-TIME value
+# read straight out of the stored catt_df slot (R/cohort_study.R recomputes
+# nothing), so modifying X_final after construction cannot change it.
+
+.cs429_dat <- local({
+	cf <- genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = 2, seed = 429)
+	simulateData(cf, N = 80, sig_eps_sq = 1, sig_eps_c_sq = 0.5, seed = 429)
+})
+
+# q = 0.5 is load-bearing on the two fetwfe cases: at q = 1 (and q = 2) the
+# UNMODIFIED fit already has calc_ses = FALSE, and then every degrade assertion
+# below would pass while measuring nothing. That is what the PRECOND blocks
+# exist to catch.
+.cs429_cases <- list(
+	list(
+		label = "fetwfe/default",
+		fit = function() {
+			fetwfeWithSimulatedData(
+				.cs429_dat,
+				q = 0.5,
+				se_type = "default",
+				verbose = FALSE
+			)
+		}
+	),
+	list(
+		label = "fetwfe/cluster",
+		fit = function() {
+			fetwfeWithSimulatedData(
+				.cs429_dat,
+				q = 0.5,
+				se_type = "cluster",
+				verbose = FALSE
+			)
+		}
+	),
+	# etwfe selects nothing, so it drives the scalar-NA "all features" sentinel
+	# branch of the scaffold rather than an index vector.
+	list(
+		label = "etwfe",
+		fit = function() etwfeWithSimulatedData(.cs429_dat, verbose = FALSE)
+	)
+)
+
+# X_final lives under $internal for fetwfe and at top level for etwfe/betwfe.
+.cs429_calc_ses <- function(x) {
+	if (inherits(x, "fetwfe")) x$internal$calc_ses else x$calc_ses
+}
+.cs429_get_X <- function(x) {
+	if (inherits(x, "fetwfe")) x$internal$X_final else x$X_final
+}
+.cs429_set_X <- function(x, M) {
+	if (inherits(x, "fetwfe")) {
+		x$internal$X_final <- M
+	} else {
+		x$X_final <- M
+	}
+	x
+}
+# The selected support, derived the way .resolve_selected_support() derives it:
+# the nonzero theta entries after the intercept for the bridge estimators, and
+# every column for the OLS-family ones (whose support is the NA sentinel). A
+# wrong answer here fails safe -- it would leave the Gram invertible and turn
+# the degrade assertions red rather than green.
+.cs429_sel <- function(x) {
+	if (inherits(x, "fetwfe")) {
+		which(x$internal$theta_hat[2:(x$p + 1)] != 0)
+	} else {
+		seq_len(ncol(x$X_final))
+	}
+}
+
+for (.cs429_case in .cs429_cases) {
+	# Precondition, on the UNMODIFIED fit. Kept in its own test_that() so a
+	# failure is attributable: without it the POLICY block below would pass
+	# vacuously on any fit that reported no standard errors to begin with.
+	test_that(
+		paste0(
+			"PRECOND ",
+			.cs429_case$label,
+			": the unmodified fit reports real SEs (#429)"
+		),
+		{
+			fit <- .cs429_case$fit()
+			expect_true(isTRUE(.cs429_calc_ses(fit)))
+			expect_true(any(is.finite(eventStudy(fit)$se)))
+		}
+	)
+
+	test_that(
+		paste0(
+			"POLICY ",
+			.cs429_case$label,
+			": a singular selected-support Gram degrades at eventStudy()/cohortTimeATTs() and stops at simultaneousCIs() (#429)"
+		),
+		{
+			fit <- .cs429_case$fit()
+			sel <- .cs429_sel(fit)
+			X_mod <- .cs429_get_X(fit)
+			X_mod[, sel[2]] <- X_mod[, sel[1]]
+			fit_mod <- .cs429_set_X(fit, X_mod)
+
+			# 1. The modified object is still a VALID fit -- no validator
+			# inspects the rank of X_final -- so what follows is the accessors'
+			# policy on a legitimate object, not on a broken one.
+			expect_no_error(fetwfe:::.assert_estimator_object(fit_mod))
+
+			# 2-3. Degrade. The warning assertion is NOT hygiene: it is what
+			# attributes the all-NA SEs to the singular-Gram branch
+			# specifically, rather than to the calc_ses = FALSE path that Part 3
+			# of test-cross-accessor-scaffold-guardrail-400.R already covers. Do
+			# not replace it with suppressWarnings(). expect_warning() returns
+			# its expression's value, so each accessor is called exactly once.
+			# The `length(x) > 0 &&` clause matters because
+			# all(is.na(numeric(0))) is TRUE.
+			es_se <- expect_warning(eventStudy(fit_mod), "not invertible")$se
+			expect_true(length(es_se) > 0 && all(is.na(es_se)))
+			cta_se <- expect_warning(
+				cohortTimeATTs(fit_mod),
+				"not invertible"
+			)$se
+			expect_true(length(cta_se) > 0 && all(is.na(cta_se)))
+
+			# 4. Stop, with EXACTLY the shared constant. The nesting is
+			# prescribed and the obvious simplifications fail on correct code:
+			# expect_warning() OUTSIDE and tryCatch() INSIDE is the only order
+			# that works (suppressWarnings() inside makes the warning
+			# expectation fail; with no tryCatch the error escapes and aborts
+			# the block). expect_error() is unusable here because it treats its
+			# pattern as a regex and the message contains "(p >= NT)".
+			e <- expect_warning(
+				tryCatch(
+					simultaneousCIs(fit_mod, family = "cohort"),
+					error = function(e) e
+				),
+				"not invertible"
+			)
+			expect_s3_class(e, "error")
+			# conditionMessage() errors on a non-condition, which would abort
+			# the block before the two content anchors ran -- same shape and
+			# same reason as the length guard above.
+			emsg <- if (inherits(e, "condition")) {
+				conditionMessage(e)
+			} else {
+				NA_character_
+			}
+			expect_identical(emsg, fetwfe:::.SINGULAR_GRAM_ANALYTIC_STOP_MSG)
+			expect_true(grepl("not invertible", emsg, fixed = TRUE))
+			expect_true(grepl("method = 'bootstrap'", emsg, fixed = TRUE))
+		}
+	)
+}


### PR DESCRIPTION
Refs #429 — items 1, 2 and 4 of its nine; PR B follows with the rest. The error `simultaneousCIs()` raises on a singular Gram is now written once, as `.SINGULAR_GRAM_ANALYTIC_STOP_MSG`, read by both the live call site and the test that pins it; the guardrail file pins absolute SEs on all six of its fixtures instead of two; and the degrade-vs-stop policy is asserted at `eventStudy()`, `cohortTimeATTs()` and `simultaneousCIs()` rather than only at the helper behind them.

No estimator behavior changes — the one functional edit binds an existing literal to a name, and `R/variance_machinery.R` is roxygen-only. Gate clean: `Status: OK`, 0/0/0 with no timestamp NOTE; suite 4835 passing, up 52.

**The measurement.** Scaling `sandwich_full` by 1.5 inside the shared helper fires 3 assertions on `main` today. It fires 9 here, and 18 alongside its complement (`gram_inv * 1.01`) — 6 of 6 pin blocks, 18 of 18 `expect_equal` calls, over a four-file filter. Nine is what this guardrail produced at birth, before the consolidation it licensed consumed it. (Those 3 on `main` are the `fetwfe/cluster` pin block — **not** #429's "3 failures, Anchor C only", which went stale when `26c5e19` folded the fit-time scaffold and hollowed Anchor C too. Same number, different assertions.)

Two limits on that number. It scopes to the **Gram/sandwich scaffold only**: every fixture comes from `*WithSimulatedData()`, which PROFILE § 12.4 names as unable to exercise the variance-component estimator, so the pins are blind to the Pesaran path by construction. And eight mutations all landing shows **reachability of the assertions, not representativeness of the defects**.

Part 1's anchors fire zero under both mutations, before and after — once both sides call the same helper they cannot see it change. But they are **not** decorative, and the file now says why: they are the only assertions covering `simultaneousCIs()`'s SE path, since no Part 2 pin goes through it. Scaling `Sigma` one level downstream fires 18 failures, all of them there. `.assemble_joint_cov_var1/2` are already shared helpers, so the next consolidation hollows those anchors the same way — and then that path has no pin at all. PR B pre-empts it with a fourth pinned vector per fixture.

## Worth your attention

Three judgment calls I would rather you made than I did.

The constant's name deviates from the `.SINGULAR_GRAM_STOP_MSG` the issue proposed. There are three distinct singular-Gram strings in `R/`, and the bootstrap path's is a different message — a generic name invites reuse where this one's own advice, "use `method = 'bootstrap'`", would be wrong.

Single-sourcing costs something the issue's recipe understates. The message now exists once and its *content* is pinned only by two substring anchors, so a rewrite that kept "not invertible" and "method = 'bootstrap'" would still pass. Better than two copies that could drift, but not "cannot silently change."

Flipping that call site's `on_singular` to `"degrade"` does not degrade gracefully — it produces `non-conformable arguments` with the internal call deparsed into it. So `"stop"` there is load-bearing rather than stylistic.

## Out of scope (deferred follow-ups)

- **`test-getCohortATTsFinal-unification.R`'s "pre-#118 reference implementation" calls the live helper**, so it is not an independent reference. Folded into #430, along with two stale `skip_on_cran()` justifications reading "the package has no CI".
- **The `getGramInv()` singular-Gram message is duplicated** between `R/variance_machinery.R` and `R/gls_machinery.R`. Folded into #431, which already collects fixes of that shape.
- **#429 items 3, 5, 6, 7, 8, 9** — not deferred; they ship in PR B, next.
