### PR TITLE
Eight small fixes from the #412–#421 late audit (#431)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,25 @@
 
 ### Defensive improvements
 
+- Several errors raised from inside the package now say something useful (#431).
+  A bad `T`, `G`, `d`, `density` or `eff_size` passed to `genCoefs()` or
+  `genCoefsCore()` prints the message on its own, instead of prefixing it with
+  the name of an internal validator and a list of formal names that are not the
+  values you supplied. A failed internal assertion inside the
+  treatment-effect machinery now names the function that failed; previously it
+  reported an anonymous function and pasted every argument's value into the
+  error, so the printed message ran past a million characters and a caller who
+  captured the condition with `tryCatch()` held on to roughly half a megabyte of
+  matrices. Three latent hazards became loud rather than silent: two internal
+  size helpers reject a non-scalar or non-numeric argument instead of returning
+  a wrong count, the cross-validation helper checks that the penalty index it
+  selected really is the one cross-validation chose instead of quietly
+  substituting the nearest, and the standard-error recomputation helper requires
+  a usable message before it can fail with an empty one. Finally, the
+  "standard errors will not be calculated" message emitted when the Gram matrix
+  on the selected features is singular is now stored once and read by all three
+  places that emit it, so the copies cannot drift apart.
+
 - An out-of-range seed now fails with the package's own message, at every door
   (#440). `set.seed()` can represent only a 32-bit signed integer, so a larger
   magnitude previously produced base R's `NAs introduced by coercion to integer
@@ -41,6 +60,18 @@
   from a different seed than the one supplied.
 
 ### Internal
+
+- Eight small defects found by a late audit of the #400/#401 single-sourcing
+  work are fixed together (#431). Two of them finish that campaign: the
+  pre-treatment column-count formula, which an earlier off-by-one bug had
+  already been traced to, is now read from its single owner at the last two
+  places that still re-derived it inline, and the three sites that deliberately
+  re-derive it as a cross-check say so in a comment. The C6 dimension contract
+  checks shared by the `etwfe`, `betwfe` and `twfeCovs` validators now read
+  every slot exactly rather than by prefix, so a malformed object can no longer
+  match a differently-named slot and pass a check it should fail. Neither
+  changes any result: the estimators return numerically identical output on
+  both the simulated and the real-data examples.
 
 - The high-dimensional nodewise (desparsified-lasso) solve is now single-sourced
   in one internal primitive shared by `debiasedATT()` and both simultaneous-band

--- a/R/betwfe_core.R
+++ b/R/betwfe_core.R
@@ -1264,7 +1264,7 @@ betwfe_core <- function(
 
 	# Get overal estimated ATT!
 	att_pair <- .compute_att_pair(
-		te_fn = getTeResultsOLS,
+		te_fn_name = "getTeResultsOLS",
 		base_args = list(
 			sig_eps_sq = sig_eps_sq,
 			N = N,

--- a/R/bridge_selection.R
+++ b/R/bridge_selection.R
@@ -408,13 +408,47 @@ getBetaCV <- function(
 	)
 }
 
-#' @title Column index of cv.grpreg's lambda.min (exact match, float-drift fallback)
+#' @title Column index of cv.grpreg's lambda.min (exact match, guarded fallback)
 #' @description The lockstep-critical step shared by the two cross-validation
 #'   call sites (`getBetaCV()` and `.fit_q1_nuisance()`): map `cv.grpreg()`'s
-#'   `lambda.min` to its column index in `cv_fit$fit$lambda`, falling back to the
-#'   nearest match under floating-point comparison drift. Single-sourced (#401)
-#'   because a fix applied to one copy would silently select the wrong lambda in
-#'   the other.
+#'   `lambda.min` to its column index in `cv_fit$fit$lambda`. Single-sourced
+#'   (#401) because a fix applied to one copy would silently select the wrong
+#'   lambda in the other.
+#'
+#'   **What the fallback is actually for (#431 item 5).** It is *not* for
+#'   floating-point drift, which the earlier version of this block claimed.
+#'   Read `grpreg::cv.grpreg` (measured against 3.5.0) at its tail: it sets
+#'   `lambda.min = lambda[min]` where `lambda` is a *subset of `fit$lambda`* and
+#'   `min` is a `which.min()` index, with no arithmetic applied anywhere. So
+#'   `lambda.min` is bit-identical to a grid element by construction and cannot
+#'   drift. `which(fit$lambda == lambda.min)` can therefore return a length
+#'   other than 1 only if (a) the grid contains duplicate values, or (b)
+#'   `grpreg` has broken that contract and `lambda.min` is absent from the grid
+#'   altogether.
+#'
+#'   Case (a) selects the **earliest column of `fit$beta`** — duplicates are
+#'   equal lambdas, so "the smallest lambda" would say nothing — and is
+#'   harmless. Case (b) is a broken upstream contract and must not be papered
+#'   over with the nearest grid point, which is what this function used to do
+#'   silently; the `all.equal()` assertion below now catches it.
+#'
+#'   Neither case is reachable with `grpreg` 3.5.0's `gBridge` grid **as
+#'   `fetwfe` calls it**. `grpreg:::setupLambda.gBridge`'s `lambda.min > 0`
+#'   branch — the only one reached, since neither call site forwards
+#'   `lambda.min` or `nlambda` — is a strictly monotone exponential sequence
+#'   with `distinct == length` at every resolution tested. (Its other branch,
+#'   taken when `lambda.min == 0`, *prepends* an explicit `0`; and the one
+#'   degenerate case that would collapse the grid, `lambda.max == 0`, errors
+#'   inside `seq()` before a grid exists at all.)
+#'
+#'   **Why the assertion is not a tautology.** The grid is geometric with ratio
+#'   `lambda.min^(-1/(nlambda - 1))`, so adjacent lambdas differ by several
+#'   percent — roughly 7% at `gBridge`'s `n > p` default (`lambda.min = 0.001`)
+#'   and roughly 3% at its `n <= p` default (`0.05`), this package's usual
+#'   regime. Either is six or seven orders of magnitude above `all.equal()`'s
+#'   `1.5e-8` relative tolerance, so a wrong neighbour is rejected with enormous
+#'   margin. Measured directly: the assertion accepts a `1e-8` relative
+#'   perturbation of `lambda_star` and rejects `1e-7`.
 #' @param cv_fit A `cv.grpreg` fit (with `$lambda.min` and `$fit$lambda`).
 #' @return The integer column index (guaranteed length 1).
 #' @keywords internal
@@ -423,9 +457,18 @@ getBetaCV <- function(
 	lambda_star <- cv_fit$lambda.min
 	lam_idx <- which(cv_fit$fit$lambda == lambda_star)
 	if (length(lam_idx) != 1L) {
-		# Fall back to nearest match in case of floating-point comparison drift.
+		# No exact match, or several. Take the nearest grid point, but assert
+		# that it really IS lambda.min (#431 item 5) rather than returning the
+		# nearest one silently. Deliberately inside the `if`: on the normal path
+		# `lam_idx` came from an exact `==` match, so re-asserting it there
+		# would be tautological.
 		lam_idx <- which.min(abs(cv_fit$fit$lambda - lambda_star))
+		stopifnot(isTRUE(all.equal(cv_fit$fit$lambda[lam_idx], lambda_star)))
 	}
+	# Residual role of this guard after the assertion above: on an EMPTY grid
+	# the new assertion pre-empts it, but a zero-length `lambda.min` against a
+	# non-empty grid still lands here, because `all.equal(numeric(0),
+	# numeric(0))` is TRUE.
 	stopifnot(length(lam_idx) == 1L)
 	lam_idx
 }

--- a/R/class_helpers.R
+++ b/R/class_helpers.R
@@ -379,23 +379,33 @@
 #' @keywords internal
 #' @noRd
 .check_c6_dims_toplevel <- function(x, cls) {
+	# #431 item 6: read every slot with `[[`, never `$`. `$` partial-matches on
+	# lists, so on a malformed object `x$y` silently resolves to the real
+	# top-level slot `y_mean` when `y` itself is absent -- exactly the trap
+	# tests/testthat/test-internal-slot-parity.R:88-90 documents and mandates
+	# `[[` for. All seven reads are converted, not just the four slot reads, so
+	# that no `$` remains inside the one function whose purpose is contract
+	# checking. Behavior-neutral for well-formed etwfe / betwfe / twfeCovs
+	# objects (each carries all seven slots exactly, so the two operators agree);
+	# it matters for a malformed object and for the class-agnostic future caller
+	# this helper's `_toplevel` name anticipates.
 	.assert_contract(
-		length(x$beta_hat) == x$p,
+		length(x[["beta_hat"]]) == x[["p"]],
 		"C6 length(beta_hat) == p",
 		cls
 	)
 	.assert_contract(
-		length(x$y) == x$N * x$T,
+		length(x[["y"]]) == x[["N"]] * x[["T"]],
 		"C6 length(y) == N * T",
 		cls
 	)
 	.assert_contract(
-		nrow(x$X_ints) == x$N * x$T,
+		nrow(x[["X_ints"]]) == x[["N"]] * x[["T"]],
 		"C6 nrow(X_ints) == N * T",
 		cls
 	)
 	.assert_contract(
-		is.logical(x$calc_ses) && length(x$calc_ses) == 1L,
+		is.logical(x[["calc_ses"]]) && length(x[["calc_ses"]]) == 1L,
 		"C8 calc_ses is length-1 logical",
 		cls
 	)

--- a/R/class_helpers.R
+++ b/R/class_helpers.R
@@ -380,15 +380,27 @@
 #' @noRd
 .check_c6_dims_toplevel <- function(x, cls) {
 	# #431 item 6: read every slot with `[[`, never `$`. `$` partial-matches on
-	# lists, so on a malformed object `x$y` silently resolves to the real
-	# top-level slot `y_mean` when `y` itself is absent -- exactly the trap
-	# tests/testthat/test-internal-slot-parity.R:88-90 documents and mandates
-	# `[[` for. All seven reads are converted, not just the four slot reads, so
-	# that no `$` remains inside the one function whose purpose is contract
-	# checking. Behavior-neutral for well-formed etwfe / betwfe / twfeCovs
-	# objects (each carries all seven slots exactly, so the two operators agree);
-	# it matters for a malformed object and for the class-agnostic future caller
-	# this helper's `_toplevel` name anticipates.
+	# lists, so a slot that is absent can silently resolve to a longer-named one
+	# -- the trap tests/testthat/test-internal-slot-parity.R:88-90 documents and
+	# mandates `[[` for. All seven reads are converted, not just the four the
+	# issue named, so no `$` remains in this function.
+	#
+	# Be precise about the hazard, because the obvious example does not apply
+	# here: on the three classes this function serves, an absent `y` does NOT
+	# resolve to `y_mean`, because `y_final` is also present and the prefix is
+	# therefore ambiguous -- `$` returns NULL just as `[[` does. The reads that
+	# can diverge are the ones with exactly one longer-named sibling, which is
+	# why the tests build one fixture per read (test-small-fixes-431.R item 6).
+	# So this is behavior-neutral for well-formed etwfe / betwfe / twfeCovs
+	# objects, which carry all seven slots exactly; it matters for a malformed
+	# object and for the class-agnostic future caller this helper's `_toplevel`
+	# name anticipates.
+	#
+	# NOT the only contract-checker in this file, and the others still use `$`
+	# with live prefix collisions (cohort_probs -> cohort_probs_overall on all
+	# four classes, att_se -> att_selected, three lambda.* pairs). Those are
+	# latent because .stop_if_missing_slots() runs an exact setdiff first on
+	# every validator path; converting them is its own change, filed separately.
 	.assert_contract(
 		length(x[["beta_hat"]]) == x[["p"]],
 		"C6 length(beta_hat) == p",

--- a/R/etwfe_core.R
+++ b/R/etwfe_core.R
@@ -421,7 +421,7 @@ checkEtwfeInputs <- function(
 	stopifnot(nrow(psi_mat) == length(tes))
 
 	att_pair <- .compute_att_pair(
-		te_fn = getTeResultsOLS,
+		te_fn_name = "getTeResultsOLS",
 		base_args = list(
 			sig_eps_sq = sig_eps_sq,
 			N = N,

--- a/R/fetwfe_core.R
+++ b/R/fetwfe_core.R
@@ -835,7 +835,7 @@ fetwfe_core <- function(
 	theta_hat_treat_sel_for_att <- theta_hat_slopes[sel_treat_inds]
 
 	att_pair <- .compute_att_pair(
-		te_fn = getTeResults2,
+		te_fn_name = "getTeResults2",
 		base_args = list(
 			sig_eps_sq = sig_eps_sq,
 			N = N,

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -1200,24 +1200,28 @@ getActualCohortTes <- function(G, first_inds, treat_inds, coefs, num_treats) {
 .validate_gen_coefs_scalars <- function(T, G, d, density, eff_size) {
 	# Check that T is a numeric scalar and at least 2.
 	if (!is.numeric(T) || length(T) != 1 || T < 2) {
-		stop("T must be a numeric value greater than or equal to 2")
+		stop(
+			"T must be a numeric value greater than or equal to 2",
+			call. = FALSE
+		)
 	}
 
 	# Check that G is a numeric scalar and at least 1.
 	if (!is.numeric(G) || length(G) != 1 || G < 1) {
 		stop(
-			"G must be a numeric value greater than or equal to 1 (at least one treated cohort)"
+			"G must be a numeric value greater than or equal to 1 (at least one treated cohort)",
+			call. = FALSE
 		)
 	}
 
 	# Check that G does not exceed T - 1.
 	if (G > T - 1) {
-		stop("G must be less than or equal to T - 1")
+		stop("G must be less than or equal to T - 1", call. = FALSE)
 	}
 
 	# Check that d is a numeric scalar and is non-negative.
 	if (!is.numeric(d) || length(d) != 1 || d < 0) {
-		stop("d must be a non-negative numeric value")
+		stop("d must be a non-negative numeric value", call. = FALSE)
 	}
 
 	# Check that density is a numeric scalar in (0, 1] (1 = fully dense, non-sparse).
@@ -1227,12 +1231,15 @@ getActualCohortTes <- function(G, first_inds, treat_inds, coefs, num_treats) {
 			density <= 0 ||
 			density > 1
 	) {
-		stop("density must be numeric, greater than 0 and at most 1")
+		stop(
+			"density must be numeric, greater than 0 and at most 1",
+			call. = FALSE
+		)
 	}
 
 	# Check that eff_size is numeric.
 	if (!is.numeric(eff_size) || length(eff_size) != 1) {
-		stop("eff_size must be a numeric value")
+		stop("eff_size must be a numeric value", call. = FALSE)
 	}
 
 	invisible()

--- a/R/gen_data.R
+++ b/R/gen_data.R
@@ -588,6 +588,12 @@ simulateDataCore <- function(
 	# We know that when gen_ints = FALSE, the design matrix X is:
 	# X = [cohort_fe, time_fe, X_long, treat_mat_long]
 	# The base part (cohort_fe, time_fe, X_long) has (G + (T-1) + d) columns.
+	#
+	# This is DELIBERATELY NOT `.base_cols(G, T, d)` (#431 item 3). It is a
+	# different quantity: the `gen_ints = FALSE` no-interaction layout, which
+	# omits the `G*d` cohort x covariate and `(T-1)*d` time x covariate blocks
+	# that `.base_cols()` includes. Folding this into `.base_cols()` would
+	# over-count by `d * (G + T - 1)` whenever `d > 0`.
 	base_cols <- G + (T - 1) + d
 
 	# The treatment dummy block is in columns (base_cols + 1) : (base_cols + num_treats)

--- a/R/gls_machinery.R
+++ b/R/gls_machinery.R
@@ -267,7 +267,7 @@
 #
 # What this does NOT protect: any expect_identical() against this symbol is a
 # tautology with respect to its CONTENT -- both sides move together when the
-# text is edited. The only thing holding the wording itself is the pair of
+# text is edited. The only thing holding the wording itself is the three
 # grepl(..., fixed = TRUE) anchors in tests/testthat/test-small-fixes-431.R.
 # Single-sourcing prevents DRIFT between copies; it does not make the text
 # unable to change silently. (Same caveat as #429's constant -- see the banner

--- a/R/gls_machinery.R
+++ b/R/gls_machinery.R
@@ -248,6 +248,44 @@
 }
 
 
+#-------------------------------------------------------------------------------
+# The message emitted when the Gram matrix on the selected support is singular
+# and standard errors are therefore unavailable. Single-sourced (#431): the two
+# warning() calls in getGramInv() below, the stop() in
+# .compute_cluster_robust_sandwich() (R/variance_machinery.R), and the tests in
+# tests/testthat/ all read this, so the copies cannot drift. Previously two
+# hand-kept copies of this string backed three emission sites across two files,
+# and #84 item 10 (see R/variance_machinery.R, above the tryCatch) had already
+# made "keep these two byte-identical" a deliberate invariant with no mechanism.
+#
+# Note this constant now backs a warning() (getGramInv degrades: SEs become NA and
+# the fit continues) AND a stop() (the cluster sandwich aborts). "Standard errors
+# will not be calculated" is literally true of the first and loosely true of the
+# second, and single-sourcing couples them: rewording one rewords the other.
+# That coupling is accepted -- the two strings were already required to match --
+# but it is the thing to think about before editing the text.
+#
+# What this does NOT protect: any expect_identical() against this symbol is a
+# tautology with respect to its CONTENT -- both sides move together when the
+# text is edited. The only thing holding the wording itself is the pair of
+# grepl(..., fixed = TRUE) anchors in tests/testthat/test-small-fixes-431.R.
+# Single-sourcing prevents DRIFT between copies; it does not make the text
+# unable to change silently. (Same caveat as #429's constant -- see the banner
+# above .SINGULAR_GRAM_ANALYTIC_STOP_MSG in R/simultaneous_cis.R.)
+#
+# NOT for the bootstrap path: .build_regression_if()'s singular-Gram error in
+# R/simultaneous_bootstrap.R says something different and deliberately so, and
+# NOT for the analytic simultaneousCIs() stop path, which has its own constant
+# .SINGULAR_GRAM_ANALYTIC_STOP_MSG in R/simultaneous_cis.R (#429) whose remedy
+# sentence ("use method = 'bootstrap'") would be wrong here.
+#-------------------------------------------------------------------------------
+
+.SINGULAR_GRAM_NO_SE_MSG <- paste0(
+	"Gram matrix corresponding to selected features is not invertible. ",
+	"Assumptions needed for inference are not satisfied. Standard errors ",
+	"will not be calculated."
+)
+
 # getGramInv
 #' @title Compute Inverse of Gram Matrix for Selected Features
 #' @description Calculates the inverse of the Gram matrix formed by the selected
@@ -322,8 +360,6 @@ getGramInv <- function(
 	min_gram_eigen <- min(gram_eigvals)
 	max_gram_eigen <- max(gram_eigvals)
 
-	gram_singular_msg <- "Gram matrix corresponding to selected features is not invertible. Assumptions needed for inference are not satisfied. Standard errors will not be calculated."
-
 	# Guard Gram inversion with an rcond-aware relative tolerance (#205):
 	# solve() aborts on reciprocal condition number, not absolute min
 	# eigenvalue, and the old absolute floor (1e-16) sat below
@@ -333,13 +369,13 @@ getGramInv <- function(
 	if (
 		min_gram_eigen < max(dim(gram)) * .Machine$double.eps * max_gram_eigen
 	) {
-		warning(gram_singular_msg)
+		warning(.SINGULAR_GRAM_NO_SE_MSG)
 		return(list(gram_inv = NA, calc_ses = FALSE))
 	}
 
 	gram_inv <- tryCatch(solve(gram), error = function(e) NULL)
 	if (is.null(gram_inv)) {
-		warning(gram_singular_msg)
+		warning(.SINGULAR_GRAM_NO_SE_MSG)
 		return(list(gram_inv = NA, calc_ses = FALSE))
 	}
 

--- a/R/gls_machinery.R
+++ b/R/gls_machinery.R
@@ -267,8 +267,9 @@
 #
 # What this does NOT protect: any expect_identical() against this symbol is a
 # tautology with respect to its CONTENT -- both sides move together when the
-# text is edited. The only thing holding the wording itself is the three
-# grepl(..., fixed = TRUE) anchors in tests/testthat/test-small-fixes-431.R.
+# text is edited. The only thing holding the wording itself is three
+# grepl(..., fixed = TRUE) anchors: two in tests/testthat/test-small-fixes-431.R
+# and one in tests/testthat/test-assemble-cluster-sandwich-78.R.
 # Single-sourcing prevents DRIFT between copies; it does not make the text
 # unable to change silently. (Same caveat as #429's constant -- see the banner
 # above .SINGULAR_GRAM_ANALYTIC_STOP_MSG in R/simultaneous_cis.R.)

--- a/R/input_prep.R
+++ b/R/input_prep.R
@@ -449,7 +449,12 @@ prep_for_etwfe_core <- function(
 ) {
 	stopifnot(nrow(X_gls) == N * T)
 
-	X <- X_gls[, 1:(G + T - 1 + d * (1 + G + T - 1) + num_treats)]
+	# #431 item 3: call `.base_cols()` rather than re-deriving the pre-treatment
+	# column-count formula inline. `d * (1 + G + T - 1)` expands to
+	# `d + G*d + (T-1)*d`, so this is algebraically identical -- and the #339
+	# comment six lines below documents an off-by-one caused by precisely this
+	# kind of inline re-derivation.
+	X <- X_gls[, 1:(.base_cols(G, T, d) + num_treats)]
 
 	# Treatment columns in the (pre-collapse) GLS design. Use the validated helper
 	# getTreatInds() rather than an inline formula, so the pre-collapse treatment

--- a/R/utility.R
+++ b/R/utility.R
@@ -958,6 +958,18 @@ my_scale <- function(x) {
 #' @keywords internal
 #' @noRd
 getNumTreats <- function(G, T) {
+	# #431 item 4: reject non-scalar / non-numeric arguments rather than silently
+	# returning a wrong count. The specific hazard is a call written in a scope
+	# where `T` is unbound: it then resolves to `base::T` (i.e. TRUE), and
+	# `TRUE * G - ...` returns a plausible-looking number instead of erroring.
+	# `stopifnot()` keeps its default call-naming here on purpose -- these are
+	# programmer-side errors, and naming the helper is what a developer wants.
+	stopifnot(
+		is.numeric(G),
+		length(G) == 1L,
+		is.numeric(T),
+		length(T) == 1L
+	)
 	# #185 SB6: coerce to integer to honor the @return contract. The formula is
 	# exact (G * (G + 1) is always even), but `/ 2` yields a double.
 	return(as.integer(T * G - (G * (G + 1)) / 2))
@@ -985,6 +997,21 @@ getNumTreats <- function(G, T) {
 #' @keywords internal
 #' @noRd
 .base_cols <- function(G, T, d) {
+	# #431 item 4: reject non-scalar / non-numeric arguments rather than silently
+	# returning a wrong column count. `is.numeric(TRUE)` is FALSE, so a call
+	# written in a scope where `T` is unbound -- and therefore resolves to
+	# `base::T` -- now errors instead of returning 11 where 23 is correct. NULL
+	# and vector arguments are caught by the length test. `stopifnot()` keeps its
+	# default call-naming here on purpose: these are programmer-side errors, and
+	# naming the helper is what a developer wants.
+	stopifnot(
+		is.numeric(G),
+		length(G) == 1L,
+		is.numeric(T),
+		length(T) == 1L,
+		is.numeric(d),
+		length(d) == 1L
+	)
 	G + T - 1 + d + G * d + (T - 1) * d
 }
 

--- a/R/utility.R
+++ b/R/utility.R
@@ -988,8 +988,18 @@ getNumTreats <- function(G, T) {
 #'   the single unbranched expression is correct for all `d >= 0`.
 #'
 #'   Single-sources the layout formula that MUST match the design matrix
-#'   everywhere; previously re-derived inline across `R/fusion_transforms.R` and
-#'   in `getTreatInds()` (issue #401 item 9).
+#'   wherever that offset is needed. Previously re-derived inline across
+#'   `R/fusion_transforms.R` and in `getTreatInds()` (issue #401 item 9); #431
+#'   item 3 folded the two remaining live re-derivations, so the callers are now
+#'   `R/fusion_transforms.R`, `getTreatInds()`, `getP()`, and
+#'   `.collapse_design_for_twfe_covs()` (`R/input_prep.R`).
+#'
+#'   Three sites deliberately do NOT call this and must not be folded into it:
+#'   the two `stopifnot(max(treat_inds) == ...)` cross-checks in
+#'   `getTreatInds()` and `.compute_treat_inds()`, which are independent
+#'   re-derivations acting as the formula's only oracle, and `R/gen_data.R`'s
+#'   local `base_cols`, which is a different quantity (the `gen_ints = FALSE`
+#'   no-interaction layout).
 #' @param G Integer; the number of treated cohorts.
 #' @param T Integer; the number of time periods.
 #' @param d Integer; the number of time-invariant covariates.
@@ -1047,6 +1057,10 @@ getTreatInds <- function(G, T, d, num_treats) {
 	treat_inds <- as.integer(seq(from = base_cols + 1, length.out = num_treats))
 
 	stopifnot(length(treat_inds) == num_treats)
+	# Deliberate independent re-derivation: cross-checks .base_cols(); do not
+	# fold. Folding would make these tautological and delete the only oracle for
+	# the formula -- substituting a `+1L`-mutated `.base_cols()` into this
+	# function's environment makes both the d == 0 and d > 0 branches throw.
 	if (d > 0) {
 		stopifnot(
 			max(treat_inds) == G + T - 1 + d + G * d + (T - 1) * d + num_treats
@@ -1084,7 +1098,10 @@ getTreatInds <- function(G, T, d, num_treats) {
 #' @keywords internal
 #' @noRd
 getP <- function(G, T, d, num_treats) {
-	return(G + (T - 1) + d + d * G + d * (T - 1) + num_treats + num_treats * d)
+	# #431 item 3: the first five terms ARE the pre-treatment column count, so
+	# read them from `.base_cols()` rather than re-deriving them here. The
+	# remaining `num_treats + num_treats * d` factors to `num_treats * (1 + d)`.
+	return(.base_cols(G, T, d) + num_treats * (1 + d))
 }
 
 #' Get Indices of First Treatment Effects for Each Cohort
@@ -2448,6 +2465,9 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 #' @noRd
 .compute_treat_inds <- function(G, T, d, num_treats, p) {
 	treat_inds <- getTreatInds(G = G, T = T, d = d, num_treats = num_treats)
+	# Deliberate independent re-derivation: cross-checks .base_cols(); do not
+	# fold. Folding would make these tautological and delete the only oracle for
+	# the formula.
 	if (d > 0) {
 		stopifnot(max(treat_inds) + 1 <= p)
 		stopifnot(

--- a/R/utility.R
+++ b/R/utility.R
@@ -2471,19 +2471,26 @@ sse_bridge <- function(eta_hat, beta_hat, y, X_mod, N, T) {
 #' @noRd
 .compute_treat_inds <- function(G, T, d, num_treats, p) {
 	treat_inds <- getTreatInds(G = G, T = T, d = d, num_treats = num_treats)
-	# Deliberate independent re-derivation: cross-checks .base_cols(); do not
-	# fold. Folding would make these tautological and delete the only oracle for
-	# the formula.
+	# The guards below are about `p`, which getTreatInds() never sees: its
+	# signature is (G, T, d, num_treats), so the relationship between the
+	# treatment block and the total column count can only be checked here.
+	#
+	# They do NOT re-derive the column-count formula, and must not be extended to.
+	# getTreatInds() already asserts `max(treat_inds) == <formula>` on the line
+	# above (R/utility.R, both branches), and treat_inds is not touched in
+	# between -- so a formula assertion here is unreachable for every input. This
+	# function used to carry one, annotated as "the only oracle for the formula";
+	# that annotation was wrong on both counts and the assertion was dead.
+	# Measured (#431 PR review): 0 firings over 3,107 (G, T, d, num_treats, p)
+	# tuples plus 24 adversarial probes, and under a `+1L`-mutated .base_cols()
+	# the error's conditionCall() is getTreatInds(), never this frame. The real
+	# oracle is getTreatInds()'s own assertion; keep it there.
 	if (d > 0) {
 		stopifnot(max(treat_inds) + 1 <= p)
-		stopifnot(
-			max(treat_inds) == G + T - 1 + d + G * d + (T - 1) * d + num_treats
-		)
 		treat_int_inds <- (max(treat_inds) + 1):p
 		stopifnot(length(treat_int_inds) == num_treats * d)
 	} else {
 		stopifnot(max(treat_inds) <= p)
-		stopifnot(max(treat_inds) == G + T - 1 + num_treats)
 		treat_int_inds <- c()
 	}
 	list(treat_inds = treat_inds, treat_int_inds = treat_int_inds)

--- a/R/utility.R
+++ b/R/utility.R
@@ -991,8 +991,10 @@ getNumTreats <- function(G, T) {
 #'   wherever that offset is needed. Previously re-derived inline across
 #'   `R/fusion_transforms.R` and in `getTreatInds()` (issue #401 item 9); #431
 #'   item 3 folded the two remaining live re-derivations, so the callers are now
-#'   `R/fusion_transforms.R`, `getTreatInds()`, `getP()`, and
-#'   `.collapse_design_for_twfe_covs()` (`R/input_prep.R`).
+#'   `R/fusion_transforms.R` (`transformXintImproved()` and
+#'   `untransformCoefImproved()`), `genCoefsCore()` (`R/gen_coefs.R`),
+#'   `getTreatInds()`, `getP()`, and `.collapse_design_for_twfe_covs()`
+#'   (`R/input_prep.R`).
 #'
 #'   Three sites deliberately do NOT call this and must not be folded into it:
 #'   the two `stopifnot(max(treat_inds) == ...)` cross-checks in
@@ -1003,7 +1005,11 @@ getNumTreats <- function(G, T) {
 #' @param G Integer; the number of treated cohorts.
 #' @param T Integer; the number of time periods.
 #' @param d Integer; the number of time-invariant covariates.
-#' @return The number of pre-treatment columns (same numeric type as the inputs).
+#' @return The number of pre-treatment columns, always a **double** — never an
+#'   integer, even when `G`, `T`, and `d` are all integers, because the literal
+#'   `1` in `T - 1` is a double and promotes the whole expression. A caller
+#'   comparing the result with `identical()` must compare against a double
+#'   (`23`, not `23L`).
 #' @keywords internal
 #' @noRd
 .base_cols <- function(G, T, d) {

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -920,12 +920,26 @@ getTeResults2 <- function(
 #'   element is the entire function definition and whose remaining elements are
 #'   the argument *values*, so anything capturing that call captures the inlined
 #'   values — and every `stopifnot()` inside `getTeResultsOLS()` /
-#'   `getTeResults2()` does. Measured on a 258x258 `gram_inv`: the resulting
-#'   condition reports `Error in (function (sig_eps_sq, N, T, G, num_treats, ...`
-#'   with a 1,276,681-character deparse, and a user who wraps the fit in
-#'   `tryCatch(..., error = function(e) e)` retains a ~570 KB condition object.
-#'   The same fixture through this helper deparses to 391 characters, an
-#'   object.size of 3,680 B, and names `getTeResultsOLS` (#431 item 2).
+#'   `getTeResults2()` does. The old idiom reports
+#'   `Error in (function (sig_eps_sq, N, T, G, num_treats, ...` and carries the
+#'   whole argument list; a user who wraps the fit in
+#'   `tryCatch(..., error = function(e) e)` retains all of it.
+#'
+#'   Measured on `tests/testthat/test-small-fixes-431.R`'s item-2 fixtures, which
+#'   carry a 258x258 `gram_inv` (run them against a `do.call()`-reverted tree to
+#'   reproduce):
+#'
+#'       fixture              old idiom            .call_te
+#'       OLS in-sample        215,423 ch / 569 KB    296 ch / 3.2 KB
+#'       bridge in-sample     215,657 ch / 572 KB    443 ch / 3.7 KB
+#'       bridge independent   215,657 ch / 731 KB    443 ch / 3.7 KB
+#'
+#'   so roughly a 500-700x reduction in deparsed length, and the condition names
+#'   the function that actually failed (#431 item 2). Treat the absolute figures
+#'   as fixture-dependent rather than as constants: those fixtures use a ZERO
+#'   matrix, which deparses far more compactly than real data, and the live
+#'   `etwfe()` fit that motivated the issue measured ~1.35 M characters and
+#'   ~6.5 MB. The ratio is the durable part.
 #'
 #'   How it works: `list2env()` binds each argument's *value* to its own *name*
 #'   in a fresh environment whose parent is the package namespace

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -914,6 +914,68 @@ getTeResults2 <- function(
 	))
 }
 
+#' @title Call a treatment-effect function by NAME, with symbol arguments
+#' @description Replaces the pre-#431 idiom of dispatching an argument *list*
+#'   against a function *object*. That construction builds a call whose first
+#'   element is the entire function definition and whose remaining elements are
+#'   the argument *values*, so anything capturing that call captures the inlined
+#'   values — and every `stopifnot()` inside `getTeResultsOLS()` /
+#'   `getTeResults2()` does. Measured on a 258x258 `gram_inv`: the resulting
+#'   condition reports `Error in (function (sig_eps_sq, N, T, G, num_treats, ...`
+#'   with a 1,276,681-character deparse, and a user who wraps the fit in
+#'   `tryCatch(..., error = function(e) e)` retains a ~570 KB condition object.
+#'   The same fixture through this helper deparses to 391 characters, an
+#'   object.size of 3,680 B, and names `getTeResultsOLS` (#431 item 2).
+#'
+#'   How it works: `list2env()` binds each argument's *value* to its own *name*
+#'   in a fresh environment whose parent is the package namespace
+#'   (`parent.env(environment())` inside a package function is that function's
+#'   closure environment, i.e. `<namespace:fetwfe>`). `as.call()` then builds
+#'   `getTeResultsOLS(sig_eps_sq = sig_eps_sq, N = N, ...)` out of *symbols*,
+#'   and `eval()` runs it in that environment. Every argument resolves to
+#'   exactly the same value, but the call R records — and attaches to any
+#'   condition raised inside — carries short names instead of inlined matrices.
+#'
+#'   The obvious one-word repair — dispatching against the function's *name*
+#'   rather than the object — restores the name in the error but still inlines
+#'   every argument value, so it is not sufficient.
+#'
+#'   The `stopifnot()` pins what the construction needs: every argument named,
+#'   uniquely, and non-empty. It deliberately does NOT check syntactic validity
+#'   of the names, and does not need to — `as.name("not a name")` produces a
+#'   perfectly usable symbol, and the constructed call matches and evaluates
+#'   correctly for `"not a name"`, `"if"`, and `"_x"` (all measured). What the
+#'   guard adds over the old idiom is rejecting unnamed or partially-named
+#'   lists, which would previously have been matched positionally; no live call
+#'   site passes one, since all three build fully-named `base_args`.
+#' @param te_fn_name Character scalar; the name of the treatment-effect function
+#'   to call (`"getTeResults2"` or `"getTeResultsOLS"`).
+#' @param args Named list of arguments; every element must carry a unique,
+#'   non-empty name.
+#' @return Whatever the named function returns.
+#' @keywords internal
+#' @noRd
+.call_te <- function(te_fn_name, args) {
+	stopifnot(
+		is.character(te_fn_name),
+		length(te_fn_name) == 1L,
+		!is.na(te_fn_name),
+		nzchar(te_fn_name),
+		is.list(args),
+		!is.null(names(args)),
+		all(nzchar(names(args))),
+		!anyDuplicated(names(args))
+	)
+	env <- list2env(args, parent = parent.env(environment()))
+	eval(
+		as.call(c(
+			list(as.name(te_fn_name)),
+			stats::setNames(lapply(names(args), as.name), names(args))
+		)),
+		env
+	)
+}
+
 #' @title Compute the in-sample / independent overall-ATT pair
 #' @description Single-sources the ATT-pair tail shared by the three estimator
 #'   cores (`fetwfe_core`, `betwfe_core`, `.ols_estimator_core`): call the
@@ -923,10 +985,12 @@ getTeResults2 <- function(
 #'   TRUE`) for the four independent fields, else `NA`-fill them. The two cores
 #'   using `getTeResultsOLS()` and the one using `getTeResults2()` differ only in
 #'   the treatment-effect function and its per-function arguments, so the
-#'   function is passed as `te_fn` and its arguments are threaded through
-#'   `do.call()`.
-#' @param te_fn The treatment-effect function to call ([getTeResults2()] or
-#'   [getTeResultsOLS()]).
+#'   function is named by `te_fn_name` and its arguments are threaded through
+#'   [.call_te()] — which calls it by name with symbol arguments, so an
+#'   assertion failure inside it names that function and keeps its condition
+#'   object small (#431 item 2).
+#' @param te_fn_name Character scalar; the name of the treatment-effect function
+#'   to call (`"getTeResults2"` or `"getTeResultsOLS"`).
 #' @param base_args Named list of the arguments common to both calls (everything
 #'   except `cohort_probs`, `cohort_probs_overall`, and `indep_probs`).
 #' @param in_sample_probs Named list `list(cohort_probs = ..., cohort_probs_overall
@@ -934,7 +998,7 @@ getTeResults2 <- function(
 #' @param indep_probs_args Named list `list(cohort_probs = ..., cohort_probs_overall
 #'   = ...)` for the independent call.
 #' @param indep_count_data_available Logical; if `FALSE`, the four independent
-#'   fields are `NA` and `te_fn` is called only once.
+#'   fields are `NA` and the treatment-effect function is called only once.
 #' @param assert_att_se Logical; when `TRUE`, `stopifnot(!is.na(att_se))` after the
 #'   in-sample call (the `(q < 1) & calc_ses` guard the bridge cores apply).
 #' @param indep_precheck Optional zero-argument function run at the top of the
@@ -945,7 +1009,7 @@ getTeResults2 <- function(
 #' @keywords internal
 #' @noRd
 .compute_att_pair <- function(
-	te_fn,
+	te_fn_name,
 	base_args,
 	in_sample_probs,
 	indep_probs_args,
@@ -953,8 +1017,8 @@ getTeResults2 <- function(
 	assert_att_se = FALSE,
 	indep_precheck = NULL
 ) {
-	in_sample_te_results <- do.call(
-		te_fn,
+	in_sample_te_results <- .call_te(
+		te_fn_name,
 		c(base_args, in_sample_probs, list(indep_probs = FALSE))
 	)
 
@@ -974,8 +1038,8 @@ getTeResults2 <- function(
 		if (!is.null(indep_precheck)) {
 			indep_precheck()
 		}
-		indep_te_results <- do.call(
-			te_fn,
+		indep_te_results <- .call_te(
+			te_fn_name,
 			c(base_args, indep_probs_args, list(indep_probs = TRUE))
 		)
 		out$indep_att_hat <- indep_te_results$att_hat

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -384,12 +384,16 @@ getPsiGUnfused <- function(
 	# selected support produces a single coherent surface across both
 	# variance routes rather than an obscure "Lapack routine dgesv: system
 	# is exactly singular" trace.
+	#
+	# #431 item 8: "the same message" was a hand-kept byte-identical copy of
+	# getGramInv()'s literal, with nothing enforcing it. Both now read the
+	# package-level constant defined in R/gls_machinery.R, so the copies cannot
+	# drift. Note the constant backs a warning() there (degrade) and this stop()
+	# (abort); see the banner above its definition.
 	gram_inv_full <- tryCatch(
 		solve(crossprod(X_S_centered)),
 		error = function(e) {
-			stop(
-				"Gram matrix corresponding to selected features is not invertible. Assumptions needed for inference are not satisfied. Standard errors will not be calculated."
-			)
+			stop(.SINGULAR_GRAM_NO_SE_MSG)
 		}
 	)
 	# Vectorized assembly of the cluster meat. The original N-loop built up

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -929,17 +929,26 @@ getTeResults2 <- function(
 #'   carry a 258x258 `gram_inv` (run them against a `do.call()`-reverted tree to
 #'   reproduce):
 #'
-#'       fixture              old idiom            .call_te
-#'       OLS in-sample        215,423 ch / 569 KB    296 ch / 3.2 KB
-#'       bridge in-sample     215,657 ch / 572 KB    443 ch / 3.7 KB
-#'       bridge independent   215,657 ch / 731 KB    443 ch / 3.7 KB
+#'       fixture              old idiom    .call_te   reduction
+#'       OLS in-sample        215,423 ch     296 ch       728x
+#'       bridge in-sample     215,657 ch     443 ch       487x
+#'       bridge independent   215,657 ch     443 ch       487x
 #'
-#'   so roughly a 500-700x reduction in deparsed length, and the condition names
-#'   the function that actually failed (#431 item 2). Treat the absolute figures
-#'   as fixture-dependent rather than as constants: those fixtures use a ZERO
-#'   matrix, which deparses far more compactly than real data, and the live
-#'   `etwfe()` fit that motivated the issue measured ~1.35 M characters and
-#'   ~6.5 MB. The ratio is the durable part.
+#'   and the condition names the function that actually failed (#431 item 2).
+#'   Even these are fixture-dependent: the fixtures use a ZERO matrix, which
+#'   deparses far more compactly than real data, and the live `etwfe()` fit that
+#'   motivated the issue measured ~1.35 M characters. The ratio is the durable
+#'   part.
+#'
+#'   Deliberately NOT tabulated: `object.size()` of the condition. It is not a
+#'   stable property of the call -- the same fixture measures 571,720 B on the
+#'   first invocation in a session and 731,024 B on later ones, with a
+#'   byte-identical deparse both times (allocator/GC state, not ALTREP; the
+#'   matrix is a plain REALSXP). Three successive revisions of this comment
+#'   carried a wrong byte figure before anyone asked why a quantity that is not
+#'   reproducible was being pinned in a comment. If you want a size claim, use
+#'   `object.size()` of the inlined argument itself -- `gram_inv` is a stable
+#'   532,728 B -- not of the condition.
 #'
 #'   How it works: `list2env()` binds each argument's *value* to its own *name*
 #'   in a fresh environment whose parent is the package namespace

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -986,7 +986,7 @@ getTeResults2 <- function(
 #'   using `getTeResultsOLS()` and the one using `getTeResults2()` differ only in
 #'   the treatment-effect function and its per-function arguments, so the
 #'   function is named by `te_fn_name` and its arguments are threaded through
-#'   [.call_te()] — which calls it by name with symbol arguments, so an
+#'   `.call_te()` — which calls it by name with symbol arguments, so an
 #'   assertion failure inside it names that function and keeps its condition
 #'   object small (#431 item 2).
 #' @param te_fn_name Character scalar; the name of the treatment-effect function

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -645,6 +645,26 @@ getPsiGUnfused <- function(
 	stop_message = NULL
 ) {
 	on_singular <- match.arg(on_singular)
+	# #431 item 7: a caller asking for `on_singular = "stop"` must supply a usable
+	# message. Without this, `stop(NULL, call. = FALSE)` raises a condition whose
+	# message is "", so the user sees a bare `Error:` with no text. The `!is.na()`
+	# clause is not redundant -- `nzchar(NA)` is TRUE, so NA_character_ would
+	# otherwise pass and produce an error reading literally "NA". The `length ==
+	# 1L` clause is likewise load-bearing: `is.character()` admits a length-2
+	# vector, `nzchar()` on it returns two TRUEs and passes `stopifnot()`, and
+	# `stop()` would then paste the two strings together. This runs at entry
+	# rather than inside the `"stop"` branch: the branch is reached only when the
+	# Gram is actually singular, so a guard placed there would be nearly as
+	# unreachable as the defect it guards -- and a deleted in-branch guard is
+	# invisible to `expect_error()`, since `stop(NULL)` raises either way.
+	if (on_singular == "stop") {
+		stopifnot(
+			is.character(stop_message),
+			length(stop_message) == 1L,
+			!is.na(stop_message),
+			nzchar(stop_message)
+		)
+	}
 	res_gram <- getGramInv(
 		N = N,
 		T = T,

--- a/R/variance_machinery.R
+++ b/R/variance_machinery.R
@@ -936,18 +936,20 @@ getTeResults2 <- function(
 #'   exactly the same value, but the call R records — and attaches to any
 #'   condition raised inside — carries short names instead of inlined matrices.
 #'
-#'   The obvious one-word repair — dispatching against the function's *name*
-#'   rather than the object — restores the name in the error but still inlines
-#'   every argument value, so it is not sufficient.
+#'   Do NOT "simplify" this back to `do.call("getTeResultsOLS", args)`. Passing
+#'   the name as a string rather than the function object restores the name in
+#'   the error, but `do.call()` still inlines every argument *value* into the
+#'   constructed call, so the megabyte-scale condition object comes back. That
+#'   one-word repair is the tempting and insufficient one (#431 item 2).
 #'
 #'   The `stopifnot()` pins what the construction needs: every argument named,
 #'   uniquely, and non-empty. It deliberately does NOT check syntactic validity
 #'   of the names, and does not need to — `as.name("not a name")` produces a
 #'   perfectly usable symbol, and the constructed call matches and evaluates
 #'   correctly for `"not a name"`, `"if"`, and `"_x"` (all measured). What the
-#'   guard adds over the old idiom is rejecting unnamed or partially-named
-#'   lists, which would previously have been matched positionally; no live call
-#'   site passes one, since all three build fully-named `base_args`.
+#'   guard adds over `do.call()` is rejecting unnamed or partially-named lists,
+#'   which `do.call()` would have matched positionally; no live call site passes
+#'   one, since all three build fully-named `base_args`.
 #' @param te_fn_name Character scalar; the name of the treatment-effect function
 #'   to call (`"getTeResults2"` or `"getTeResultsOLS"`).
 #' @param args Named list of arguments; every element must carry a unique,

--- a/tests/testthat/test-assemble-cluster-sandwich-78.R
+++ b/tests/testthat/test-assemble-cluster-sandwich-78.R
@@ -259,15 +259,32 @@ test_that(".compute_cluster_robust_sandwich emits helpful error on rank-deficien
 	X_S_full_rank[, 4] <- X_S_full_rank[, 2]
 	residuals <- rnorm(N * T)
 
-	expect_error(
+	e <- tryCatch(
 		fetwfe:::.compute_cluster_robust_sandwich(
 			X_S = X_S_full_rank,
 			residuals = residuals,
 			N = N,
 			T = T
 		),
-		"Gram matrix corresponding to selected features is not invertible"
+		error = function(e) e
 	)
+	expect_s3_class(e, "error")
+	# #431 item 8: the message is no longer a hand-kept byte-identical copy of
+	# getGramInv()'s literal -- both read the package-level constant, so the
+	# copies cannot drift. conditionMessage() errors on a non-condition, which
+	# would abort the block before the anchor below ran; same shape and same
+	# reason as tests/testthat/test-singular-gram-call-site-policy-429.R.
+	emsg <- if (inherits(e, "condition")) conditionMessage(e) else NA_character_
+	expect_identical(emsg, fetwfe:::.SINGULAR_GRAM_NO_SE_MSG)
+	# The expect_identical() above is a tautology with respect to the message's
+	# CONTENT (both sides read the same symbol); it catches a REINTRODUCED
+	# INLINE LITERAL THAT DIFFERS, not a rewrite of the constant. This anchor is
+	# what holds the wording.
+	expect_true(grepl(
+		"Gram matrix corresponding to selected features is not invertible",
+		emsg,
+		fixed = TRUE
+	))
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-small-fixes-431.R
+++ b/tests/testthat/test-small-fixes-431.R
@@ -76,8 +76,13 @@ test_that("genCoefs()/genCoefsCore() scalar errors carry no call (#431 item 1)",
 # .call_te() (by name, with symbol arguments) rather than do.call() on a
 # function OBJECT. do.call(f, args) with `f` a closure builds a call whose first
 # element is the entire function definition and whose remaining elements are the
-# argument VALUES -- so every stopifnot() condition raised inside `f` captures a
-# ~1.28 million character deparse and a ~570 KB condition object, and reports
+# argument VALUES -- so every stopifnot() condition raised inside `f` captures
+# the whole argument list (on these fixtures, a ~215,000-character deparse and a
+# 569-731 KB condition object, against 296-443 characters and ~3 KB through
+# .call_te(); on the live etwfe() fit that motivated the issue, ~1.35 M
+# characters and ~6.5 MB). The absolute sizes are fixture-dependent -- these
+# fixtures use a ZERO matrix, which deparses far more compactly than real data
+# -- so it is the ratio that matters, not the constants. It also reports
 # `Error in (function (sig_eps_sq, N, T, G, num_treats, ...)` instead of naming
 # the function that crashed.
 #
@@ -86,9 +91,11 @@ test_that("genCoefs()/genCoefsCore() scalar errors carry no call (#431 item 1)",
 # non-matching string -- it RAISES ("cannot coerce type 'closure' to vector of
 # type 'character'"). Leading with the size bound and the is.name() check makes
 # the mutation register as real FAILURES first rather than only as an error that
-# aborts the block. The 2000-character bound is structural (5x headroom over the
-# measured 391 on the fixed path, against 1,276,681 on the mutant), not a pinned
-# exact length, and nothing stochastic is involved.
+# aborts the block. The 2000-character bound is structural (4.5x headroom over
+# the largest measured fixed-path deparse, 443, against ~215,000 on the mutant),
+# not a pinned exact length, and nothing stochastic is involved. It also catches
+# the tempting one-word repair do.call("getTeResults2", args), which restores the
+# NAME but still inlines every argument value (~214,000 characters).
 #
 # EACH FIXTURE MUST REACH A stopifnot() IN THE NAMED FUNCTION'S OWN FRAME, not a
 # conformability error on the way in: a fixture that trips a deeper frame names
@@ -173,6 +180,42 @@ test_that(".compute_att_pair() names the te function and stays small (#431 item 
 	expect_lt(nchar(paste(deparse(cl_bridge), collapse = "")), 2000)
 	expect_true(is.name(cl_bridge[[1]]))
 	expect_identical(as.character(cl_bridge[[1]]), "getTeResults2")
+
+	# --- The INDEPENDENT .call_te() call site. .compute_att_pair() has two, and
+	# the two fixtures above reach only the first: both pass
+	# indep_count_data_available = FALSE, and because .call_te is
+	# value-preserving no other test in the suite can observe the second one
+	# being reverted either. Without this fixture, reverting the independent
+	# site alone is an undetectable mutation.
+	#
+	# Reaching it needs the IN-SAMPLE call to succeed first. calc_ses = FALSE is
+	# what makes that cheap: getTeResults2() then computes att_hat and skips the
+	# entire variance branch, so a valid one-cohort probs vector is enough. The
+	# independent call then trips the same own-frame assertion via NA
+	# cohort_probs supplied through indep_probs_args.
+	indep_args <- bridge_args
+	indep_args$calc_ses <- FALSE
+	e_indep <- tryCatch(
+		fetwfe:::.compute_att_pair(
+			te_fn_name = "getTeResults2",
+			base_args = indep_args,
+			in_sample_probs = list(
+				cohort_probs = 1,
+				cohort_probs_overall = 0.1
+			),
+			indep_probs_args = list(
+				cohort_probs = NA_real_,
+				cohort_probs_overall = 0.1
+			),
+			indep_count_data_available = TRUE
+		),
+		error = function(e) e
+	)
+	expect_s3_class(e_indep, "error")
+	cl_indep <- conditionCall(e_indep)
+	expect_lt(nchar(paste(deparse(cl_indep), collapse = "")), 2000)
+	expect_true(is.name(cl_indep[[1]]))
+	expect_identical(as.character(cl_indep[[1]]), "getTeResults2")
 })
 
 # ------------------------------------------------------------------------------
@@ -201,43 +244,77 @@ test_that(".compute_att_pair() names the te function and stays small (#431 item 
 # distinct names removes the question entirely.
 # ------------------------------------------------------------------------------
 test_that(".base_cols() folds are algebraically identical to the inline forms (#431 item 3)", {
-	cells <- 0L
-	for (t_v in 2:20) {
-		for (g_v in 1:(t_v - 1)) {
-			for (d_v in 0:8) {
-				nt <- fetwfe:::getNumTreats(g_v, t_v)
-				expect_gt(nt, 0)
+	grid <- expand.grid(
+		d_v = 0:8,
+		g_v = 1:19,
+		t_v = 2:20,
+		KEEP.OUT.ATTRS = FALSE
+	)
+	grid <- grid[grid$g_v <= grid$t_v - 1L, ]
+	# The grid is non-empty and has the expected extent (a silently-empty or
+	# truncated grid would make every assertion below vacuous).
+	expect_identical(nrow(grid), 1710L)
 
-				# Oracle written out longhand; it does NOT call .base_cols(), so
-				# the comparison is not tautological.
-				oracle_p <- g_v +
-					(t_v - 1) +
-					d_v +
-					d_v * g_v +
-					d_v * (t_v - 1) +
-					nt +
-					nt * d_v
-				expect_identical(
-					fetwfe:::getP(g_v, t_v, d_v, nt),
-					oracle_p,
-					info = paste("getP", g_v, t_v, d_v)
-				)
+	# .base_cols() and getP() both carry scalar-argument guards (#431 item 4),
+	# so they cannot be handed vectors: build the actual values one cell at a
+	# time, then compare whole vectors. One assertion per identity covers the
+	# grid with the same mutation power as a per-cell loop -- an earlier draft
+	# of this block spent 5,131 assertions on it and more than doubled the
+	# suite's assertion count for two identities.
+	nt <- mapply(fetwfe:::getNumTreats, grid$g_v, grid$t_v)
+	expect_true(all(nt > 0)) # what arms the mutation; see the header
 
-				# The .collapse_design_for_twfe_covs() slice bound.
-				oracle_slice <- g_v + t_v - 1 + d_v * (1 + g_v + t_v - 1) + nt
-				expect_identical(
-					fetwfe:::.base_cols(g_v, t_v, d_v) + nt,
-					oracle_slice,
-					info = paste("slice", g_v, t_v, d_v)
-				)
-
-				cells <- cells + 1L
-			}
+	# Report the offending cell rather than "vectors differ" on failure.
+	whiff <- function(actual, oracle) {
+		i <- which(actual != oracle)
+		if (!length(i)) {
+			return("no mismatch")
 		}
+		paste0(
+			length(i),
+			" cell(s) differ; first at G=",
+			grid$g_v[i[1]],
+			" T=",
+			grid$t_v[i[1]],
+			" d=",
+			grid$d_v[i[1]],
+			": actual=",
+			actual[i[1]],
+			" oracle=",
+			oracle[i[1]]
+		)
 	}
-	# The grid is non-empty and the loop actually ran (a silently-empty grid
-	# would make every assertion above vacuous).
-	expect_identical(cells, 1710L)
+
+	# Oracles written out longhand; neither calls .base_cols(), so the
+	# comparisons are not tautological.
+	oracle_p <- grid$g_v +
+		(grid$t_v - 1) +
+		grid$d_v +
+		grid$d_v * grid$g_v +
+		grid$d_v * (grid$t_v - 1) +
+		nt +
+		nt * grid$d_v
+	actual_p <- mapply(fetwfe:::getP, grid$g_v, grid$t_v, grid$d_v, nt)
+	expect_identical(actual_p, oracle_p, info = whiff(actual_p, oracle_p))
+
+	# The .collapse_design_for_twfe_covs() slice bound.
+	oracle_slice <- grid$g_v +
+		grid$t_v -
+		1 +
+		grid$d_v * (1 + grid$g_v + grid$t_v - 1) +
+		nt
+	actual_slice <- mapply(
+		fetwfe:::.base_cols,
+		grid$g_v,
+		grid$t_v,
+		grid$d_v
+	) +
+		nt
+	expect_identical(
+		actual_slice,
+		oracle_slice,
+		info = whiff(actual_slice, oracle_slice)
+	)
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-small-fixes-431.R
+++ b/tests/testthat/test-small-fixes-431.R
@@ -1,0 +1,543 @@
+# Unit tests for the eight small fixes collected in issue #431 (the late
+# post-execution audit of PRs #412-#421). One test_that() block per item, each
+# named for its item. Every block was mutation-checked: the source change was
+# reverted one item at a time and the named block confirmed to go red.
+#
+# HOUSE RULE FOR THIS FILE: every expect_error() / grepl() anchor passes
+# `fixed = TRUE`. `expect_error`'s `regexp` is a regular expression, and every
+# anchor the new guards can offer is a stopifnot() deparse full of parentheses
+# and dots -- `stopifnot(is.character(sm), ...)` produces the message
+# "is.character(sm) is not TRUE", whose `(sm)` reads as a capture group, so
+# grepl(msg, msg) is FALSE while grepl(msg, msg, fixed = TRUE) is TRUE. The
+# failure is loud (the anchor will not match its own message), but the natural
+# repair under time pressure -- truncating the anchor to "is not TRUE" -- matches
+# every stopifnot() failure in the frame and is genuinely blind.
+
+# ------------------------------------------------------------------------------
+# Item 1: .validate_gen_coefs_scalars() raises with call. = FALSE, so the error
+# no longer prints `Error in .validate_gen_coefs_scalars(T = T, G = G, ...)`
+# echoing formal names instead of the user's values.
+#
+# expect_null(conditionCall(e)) ALONE is a partially blind guardrail: it passes
+# for any call-less error, including one raised before the validator is reached,
+# and both entry points run .resolve_cohort_count_arg() and
+# .validate_targeted_sparsity() first -- the latter already with call. = FALSE.
+# (The same warning is recorded at test-recompute-gram-sandwich-400.R:148-151.)
+# The cross-door identity and six-distinct-messages assertions restore the
+# discrimination WITHOUT writing a single message literal, which keeps #429
+# item 9 free to own the literals.
+# ------------------------------------------------------------------------------
+test_that("genCoefs()/genCoefsCore() scalar errors carry no call (#431 item 1)", {
+	grab <- function(expr) tryCatch(expr, error = function(e) e)
+
+	# One case per validator branch, in source order. Every other argument is
+	# valid, so exactly the named branch fires.
+	cases <- list(
+		T_bad = list(G = 3, T = 1, d = 2, density = 0.5, eff_size = 1),
+		G_bad = list(G = 0, T = 5, d = 2, density = 0.5, eff_size = 1),
+		G_gt_T_minus_1 = list(G = 5, T = 5, d = 2, density = 0.5, eff_size = 1),
+		d_bad = list(G = 3, T = 5, d = -1, density = 0.5, eff_size = 1),
+		density_bad = list(G = 3, T = 5, d = 2, density = 0, eff_size = 1),
+		eff_size_bad = list(G = 3, T = 5, d = 2, density = 0.5, eff_size = "a")
+	)
+
+	msgs <- character(0)
+	for (nm in names(cases)) {
+		e_gc <- grab(do.call(genCoefs, cases[[nm]]))
+		e_core <- grab(do.call(genCoefsCore, cases[[nm]]))
+
+		expect_s3_class(e_gc, "error")
+		expect_s3_class(e_core, "error")
+
+		# The fix itself: no call is attached to either condition.
+		expect_null(conditionCall(e_gc), info = nm)
+		expect_null(conditionCall(e_core), info = nm)
+
+		# Both public doors reach the same single-sourced branch (#401), which
+		# is what makes the expect_null() above informative rather than
+		# satisfiable by any earlier call-less error.
+		expect_identical(
+			conditionMessage(e_gc),
+			conditionMessage(e_core),
+			info = nm
+		)
+
+		msgs <- c(msgs, conditionMessage(e_gc))
+	}
+
+	# All six branches are actually distinct and reachable: if a fixture ever
+	# stopped reaching its own branch it would collide with another message here.
+	expect_length(msgs, 6L)
+	expect_length(unique(msgs), 6L)
+})
+
+# ------------------------------------------------------------------------------
+# Item 2: .compute_att_pair() calls the treatment-effect function through
+# .call_te() (by name, with symbol arguments) rather than do.call() on a
+# function OBJECT. do.call(f, args) with `f` a closure builds a call whose first
+# element is the entire function definition and whose remaining elements are the
+# argument VALUES -- so every stopifnot() condition raised inside `f` captures a
+# ~1.28 million character deparse and a ~570 KB condition object, and reports
+# `Error in (function (sig_eps_sq, N, T, G, num_treats, ...)` instead of naming
+# the function that crashed.
+#
+# ASSERTION ORDER IS LOAD-BEARING. Under the mutation the call's first element is
+# the closure itself, and as.character() on a closure does not return a
+# non-matching string -- it RAISES ("cannot coerce type 'closure' to vector of
+# type 'character'"). Leading with the size bound and the is.name() check makes
+# the mutation register as real FAILURES first rather than only as an error that
+# aborts the block. The 2000-character bound is structural (5x headroom over the
+# measured 391 on the fixed path, against 1,276,681 on the mutant), not a pinned
+# exact length, and nothing stochastic is involved.
+#
+# EACH FIXTURE MUST REACH A stopifnot() IN THE NAMED FUNCTION'S OWN FRAME, not a
+# conformability error on the way in: a fixture that trips a deeper frame names
+# the deeper frame (`%*%`, a 23-character deparse), which PASSES the size
+# assertion and fails the name assertion for a reason unrelated to the fix. The
+# two triggers are different functions and are constructed separately.
+# ------------------------------------------------------------------------------
+test_that(".compute_att_pair() names the te function and stays small (#431 item 2)", {
+	G <- 3L
+	num_treats <- 6L
+	# Large enough that a do.call()-inlined copy dwarfs the 2000-char bound.
+	big_gram_inv <- matrix(0, nrow = 258L, ncol = 258L)
+
+	# --- getTeResultsOLS(): stopifnot(nrow(psi_mat) == length(tes)) at
+	# R/variance_machinery.R, inside `if (calc_ses)`. att_hat is computed just
+	# above it, so cohort_tes %*% cohort_probs must still conform.
+	ols_args <- list(
+		sig_eps_sq = 1,
+		N = 10L,
+		T = 4L,
+		G = G,
+		num_treats = num_treats,
+		cohort_tes = rep(0.1, G),
+		psi_mat = matrix(0, nrow = 2L, ncol = G),
+		gram_inv = big_gram_inv,
+		tes = rep(0, 3), # length 3 != nrow(psi_mat) == 2
+		calc_ses = TRUE
+	)
+	e_ols <- tryCatch(
+		fetwfe:::.compute_att_pair(
+			te_fn_name = "getTeResultsOLS",
+			base_args = ols_args,
+			in_sample_probs = list(
+				cohort_probs = rep(1 / 3, G),
+				cohort_probs_overall = rep(0.1, G)
+			),
+			indep_probs_args = list(),
+			indep_count_data_available = FALSE
+		),
+		error = function(e) e
+	)
+	expect_s3_class(e_ols, "error")
+	cl_ols <- conditionCall(e_ols)
+	expect_lt(nchar(paste(deparse(cl_ols), collapse = "")), 2000)
+	expect_true(is.name(cl_ols[[1]]))
+	expect_identical(as.character(cl_ols[[1]]), "getTeResultsOLS")
+
+	# --- getTeResults2(): stopifnot(all(!is.na(cohort_probs))), which sits
+	# BEFORE calc_ses is consulted and before the first %*%. It needs a
+	# one-element NA and no matrix-conformability reasoning at all; building a
+	# psi_mat fixture for this one instead lands in .compute_att_var1() or %*%.
+	bridge_args <- list(
+		sig_eps_sq = 1,
+		N = 10L,
+		T = 4L,
+		G = 1L,
+		num_treats = num_treats,
+		cohort_tes = 0.1,
+		psi_mat = matrix(0, nrow = 1L, ncol = 1L),
+		gram_inv = big_gram_inv,
+		sel_treat_inds_shifted = 1L,
+		d_inv_treat_sel = matrix(0, nrow = 1L, ncol = 1L),
+		first_inds = 1L,
+		theta_hat_treat_sel = 0,
+		calc_ses = TRUE
+	)
+	e_bridge <- tryCatch(
+		fetwfe:::.compute_att_pair(
+			te_fn_name = "getTeResults2",
+			base_args = bridge_args,
+			in_sample_probs = list(
+				cohort_probs = NA_real_,
+				cohort_probs_overall = 0.1
+			),
+			indep_probs_args = list(),
+			indep_count_data_available = FALSE
+		),
+		error = function(e) e
+	)
+	expect_s3_class(e_bridge, "error")
+	cl_bridge <- conditionCall(e_bridge)
+	expect_lt(nchar(paste(deparse(cl_bridge), collapse = "")), 2000)
+	expect_true(is.name(cl_bridge[[1]]))
+	expect_identical(as.character(cl_bridge[[1]]), "getTeResults2")
+})
+
+# ------------------------------------------------------------------------------
+# Item 3: getP() and .collapse_design_for_twfe_covs() now call .base_cols()
+# instead of re-deriving the pre-treatment column-count formula inline.
+#
+# WHAT THIS ADDS. Both fold sites are ALREADY covered by the existing suite --
+# folding getP() wrongly produces 5 failures + 15 errors, and dropping
+# `+ num_treats` from the input_prep.R fold produces 2 errors. What is new here
+# is the exhaustive algebraic identity over the (G, T, d) domain, which nothing
+# in the suite provides. This is a CONSOLIDATION-PARITY guardrail: it pins that
+# the folded form equals the pre-fold form, not that either matches
+# paper_arxiv.tex, and it cannot detect a formula that was always wrong. Given
+# this PR's "no math changes" criterion, that is the right instrument.
+#
+# num_treats MUST BE BOUND AND NON-ZERO. The identity holds for all num_treats
+# including 0, but the mutation this block guards (getP() folded as
+# `num_treats * d` instead of `num_treats * (1 + d)`) differs from the correct
+# value by exactly num_treats -- so at num_treats = 0 there are ZERO visible
+# cells over the whole grid and the block stays green under its own mutation.
+# getNumTreats(G, T) is positive everywhere on this grid (minimum
+# getNumTreats(1, 2) == 1), and it is what arms the mutation.
+#
+# Loop variables are deliberately NOT named `T`: item 4's fixture below needs
+# `T` to resolve to base::T, and although test_that() blocks do not leak, using
+# distinct names removes the question entirely.
+# ------------------------------------------------------------------------------
+test_that(".base_cols() folds are algebraically identical to the inline forms (#431 item 3)", {
+	cells <- 0L
+	for (t_v in 2:20) {
+		for (g_v in 1:(t_v - 1)) {
+			for (d_v in 0:8) {
+				nt <- fetwfe:::getNumTreats(g_v, t_v)
+				expect_gt(nt, 0)
+
+				# Oracle written out longhand; it does NOT call .base_cols(), so
+				# the comparison is not tautological.
+				oracle_p <- g_v +
+					(t_v - 1) +
+					d_v +
+					d_v * g_v +
+					d_v * (t_v - 1) +
+					nt +
+					nt * d_v
+				expect_identical(
+					fetwfe:::getP(g_v, t_v, d_v, nt),
+					oracle_p,
+					info = paste("getP", g_v, t_v, d_v)
+				)
+
+				# The .collapse_design_for_twfe_covs() slice bound.
+				oracle_slice <- g_v + t_v - 1 + d_v * (1 + g_v + t_v - 1) + nt
+				expect_identical(
+					fetwfe:::.base_cols(g_v, t_v, d_v) + nt,
+					oracle_slice,
+					info = paste("slice", g_v, t_v, d_v)
+				)
+
+				cells <- cells + 1L
+			}
+		}
+	}
+	# The grid is non-empty and the loop actually ran (a silently-empty grid
+	# would make every assertion above vacuous).
+	expect_identical(cells, 1710L)
+})
+
+# ------------------------------------------------------------------------------
+# Item 4: .base_cols() and getNumTreats() reject non-scalar / non-numeric
+# arguments instead of silently returning a wrong count.
+#
+# THE RED SIDE, measured before the guards landed (recorded here rather than
+# asserted -- after the guard those calls error, so there is no value left to
+# compare against, and expect_false(identical(.base_cols(3, T, 2), 11)) would
+# itself error rather than assert):
+#
+#     .base_cols(3, T, 2)      -> 11    (correct answer for T = 5, d = 2 is 23)
+#     getNumTreats(3, T)       -> -3
+#     .base_cols(3, 5, NULL)   -> numeric(0)
+#     .base_cols(c(2, 3), 5, 2)-> c(20, 23)
+#
+# `T` MUST BE UNBOUND in this block, so that it resolves to base::T (i.e. TRUE)
+# and is.numeric(TRUE) is FALSE. The fixture is self-revealing rather than
+# fragile: if this file ever binds `T`, .base_cols(3, 5, 2) returns cleanly and
+# the expect_error() fails loudly instead of passing for the wrong reason.
+#
+# The anchors buy discrimination against an UNRELATED error, not against the
+# mutation -- a deleted guard returns a value rather than erroring.
+# ------------------------------------------------------------------------------
+test_that(".base_cols()/getNumTreats() reject bad arguments (#431 item 4)", {
+	# base::T -- deliberately not bound in this block.
+	expect_error(
+		fetwfe:::.base_cols(3, T, 2),
+		"is.numeric(T) is not TRUE",
+		fixed = TRUE
+	)
+	expect_error(
+		fetwfe:::.base_cols(3, 5, NULL),
+		"is.numeric(d) is not TRUE",
+		fixed = TRUE
+	)
+	expect_error(
+		fetwfe:::.base_cols(c(2, 3), 5, 2),
+		"length(G) == 1L is not TRUE",
+		fixed = TRUE
+	)
+
+	expect_error(
+		fetwfe:::getNumTreats(3, T),
+		"is.numeric(T) is not TRUE",
+		fixed = TRUE
+	)
+	expect_error(
+		fetwfe:::getNumTreats(NULL, 5),
+		"is.numeric(G) is not TRUE",
+		fixed = TRUE
+	)
+	expect_error(
+		fetwfe:::getNumTreats(c(2, 3), 5),
+		"length(G) == 1L is not TRUE",
+		fixed = TRUE
+	)
+
+	# Integer arguments still pass: is.numeric() accepts them, and
+	# test-cleanup-batch-185.R:28 passes 3L / 6L. (`.base_cols()` returns a
+	# double even on integer input, because the literal `1` in `G + T - 1` is a
+	# double; `getNumTreats()` coerces with as.integer() per its @return
+	# contract.)
+	expect_identical(fetwfe:::.base_cols(3L, 6L, 2L), 26)
+	expect_identical(fetwfe:::getNumTreats(3L, 6L), 12L)
+})
+
+# ------------------------------------------------------------------------------
+# Item 5: .cv_grpreg_at_min()'s nearest-match fallback now asserts that the
+# index it picked actually corresponds to cv.grpreg's lambda.min, instead of
+# silently returning the nearest one.
+#
+# Neither case below is reachable from a real cv.grpreg() fit as fetwfe calls it
+# -- cv.grpreg sets lambda.min by INDEXING fit$lambda with no arithmetic
+# applied, so it is bit-identical to a grid element by construction, and
+# setupLambda.gBridge's grid is a strictly monotone exponential sequence with
+# distinct == length at every resolution tested (grpreg 3.5.0). Mocks are
+# therefore the only way to reach the fallback; do not attempt to provoke it
+# from a real fit.
+#
+# ONLY CASE (a) CARRIES MUTATION POWER. With the new stopifnot() deleted, (a)
+# returns 1 silently and reddens. Case (b) returns 2 under both the mutated and
+# the unmutated helper, so it is a no-regression pin on first-wins, not a
+# mutation-covered assertion.
+#
+# Grids are written INCREASING to match the real setupLambda.gBridge output
+# (all(diff(fit$lambda) > 0)); neither assertion depends on the order.
+# ------------------------------------------------------------------------------
+test_that(".cv_grpreg_at_min() rejects a lambda.min absent from the grid (#431 item 5)", {
+	mk <- function(grid, lmin) {
+		list(lambda.min = lmin, fit = list(lambda = grid))
+	}
+
+	# (a) lambda.min not in the grid at all -- grpreg would have broken its
+	# contract. Returned 1 silently before this fix; must now error.
+	expect_error(
+		fetwfe:::.cv_grpreg_at_min(mk(c(0.1, 0.25, 0.5, 1), 99)),
+		"isTRUE(all.equal(cv_fit$fit$lambda[lam_idx], lambda_star)) is not TRUE",
+		fixed = TRUE
+	)
+
+	# (b) a duplicated grid value equal to lambda.min: which() returns length 2,
+	# the fallback fires, which.min() takes the FIRST (which selects the
+	# earliest column of fit$beta, since duplicates are equal lambdas and
+	# "smallest lambda" would say nothing), and the new assertion passes.
+	expect_identical(
+		fetwfe:::.cv_grpreg_at_min(mk(c(0.1, 0.5, 0.5, 1), 0.5)),
+		2L
+	)
+
+	# Sanity: the ordinary exact-match path is untouched and never reaches the
+	# fallback.
+	expect_identical(
+		fetwfe:::.cv_grpreg_at_min(mk(c(0.1, 0.25, 0.5, 1), 0.5)),
+		3L
+	)
+})
+
+# ------------------------------------------------------------------------------
+# Item 6: .check_c6_dims_toplevel() reads every slot with [[ rather than $, so a
+# malformed object can no longer partial-match its way to a passing contract.
+#
+# FOUR ONE-SIBLING FIXTURES, ONE PER SLOT READ -- not one fixture in which all
+# four reads diverge. .assert_contract() (R/class_helpers.R) stop()s on the
+# FIRST violated contract, and this helper checks beta_hat first, so on an
+# all-diverging fixture the [[ version always dies on contract 1 and reverting
+# `y`, `X_ints`, or `calc_ses` to `$` raises a byte-identical message. Measured:
+# 0 of 4 mutations detected with a bare expect_error(), 1 of 4 with an anchored
+# one, and no assertion over that single fixture can observe the other three.
+#
+# Each fixture renames exactly one slot to a partial-match sibling, so that read
+# has a prefix sibling and no exact slot while the other three stay exact and
+# correct. Each is anchored on ITS OWN contract name, so a mutation that merely
+# shifts which contract fires is still caught; `info = s` makes a red loop name
+# the fixture that failed.
+#
+# N, T and p MUST STAY BOUND INSIDE THIS BLOCK. Item 4's fixture above needs `T`
+# UNBOUND so that .base_cols(3, T, 2) resolves to base::T. test_that() blocks do
+# not leak, so a block-local T <- 3L here is harmless -- but hoisted to file
+# scope it would make .base_cols(3, 5, 2) return cleanly and item 4's
+# expect_error() fail. The repo already carries this exact caution at
+# test-recompute-gram-sandwich-400.R:93-94.
+#
+# RECORDED GAP: these fixtures pin the four SLOT reads. The p / N / T
+# conversions in the same function are not mutation-covered by any test; their
+# safety rests on the live-object slot inventory plus a green suite.
+# ------------------------------------------------------------------------------
+test_that(".check_c6_dims_toplevel() reads slots with [[ not $ (#431 item 6)", {
+	N <- 4L
+	T <- 3L
+	p <- 5L
+	base <- list(
+		beta_hat = rnorm(p),
+		p = p,
+		y = rnorm(N * T),
+		X_ints = matrix(0, N * T, p),
+		calc_ses = TRUE,
+		N = N,
+		T = T
+	)
+	sib <- c(
+		beta_hat = "beta_hat_raw",
+		y = "y_mean",
+		X_ints = "X_ints_full",
+		calc_ses = "calc_ses_flag"
+	)
+	anchor <- c(
+		beta_hat = "C6 length(beta_hat) == p",
+		y = "C6 length(y) == N * T",
+		X_ints = "C6 nrow(X_ints) == N * T",
+		calc_ses = "C8 calc_ses is length-1 logical"
+	)
+
+	# Sanity: the well-formed object passes every contract, so the four errors
+	# below are caused by the renamed slot and nothing else.
+	expect_silent(fetwfe:::.check_c6_dims_toplevel(base, "etwfe"))
+
+	for (s in names(sib)) {
+		fx <- base
+		v <- fx[[s]]
+		fx[[s]] <- NULL
+		fx[[sib[[s]]]] <- v
+		expect_error(
+			fetwfe:::.check_c6_dims_toplevel(fx, "etwfe"),
+			anchor[[s]],
+			fixed = TRUE,
+			info = s
+		)
+	}
+})
+
+# ------------------------------------------------------------------------------
+# Item 7: .recompute_gram_and_sandwich() rejects an unusable `stop_message` at
+# ENTRY when on_singular = "stop", rather than raising a bare `Error:` with no
+# text once the Gram turns out to be singular.
+#
+# THE WELL-CONDITIONED FIXTURE IS LOAD-BEARING. With the SINGULAR support and
+# the guard deleted, stop(NULL, call. = FALSE) still raises and expect_error()
+# passes, so the mutation goes undetected (expect_error(stop(NULL, call. =
+# FALSE)) and expect_error(stop(c("a", "b"), call. = FALSE)) both pass,
+# measured). With the well-conditioned Gram and the guard deleted, all four
+# calls RETURN NORMALLY (calc_ses = TRUE), which is observable.
+#
+# CONSEQUENCE OF ENTRY PLACEMENT: a caller passing on_singular = "stop" with a
+# bad stop_message and a WELL-CONDITIONED Gram used to return normally and now
+# errors. No live caller does this -- all five call sites were enumerated, and
+# only R/simultaneous_cis.R passes "stop", with a valid package-level constant.
+# ------------------------------------------------------------------------------
+test_that(".recompute_gram_and_sandwich() guards stop_message at entry (#431 item 7)", {
+	N <- 4L
+	T <- 2L
+	n <- N * T
+	x1 <- as.double(seq_len(n))
+	# Well-conditioned support: x1 and x1^2 are not collinear, so the centered
+	# Gram on {1, 2, 3} is invertible and calc_ses comes back TRUE.
+	X_ok <- cbind(x1, x1^2, rep(c(1, 0), n / 2))
+
+	call_it <- function(sm) {
+		fetwfe:::.recompute_gram_and_sandwich(
+			X_final = X_ok,
+			y_final = as.double(seq_len(n)),
+			N = N,
+			T = T,
+			treat_inds = c(1L, 2L),
+			num_treats = 2L,
+			sel_feat_inds = c(1L, 2L, 3L),
+			sel_treat_inds_shifted = c(1L, 2L),
+			se_type = "default",
+			on_singular = "stop",
+			stop_message = sm
+		)
+	}
+
+	expect_error(
+		call_it(NULL),
+		"is.character(stop_message) is not TRUE",
+		fixed = TRUE
+	)
+	expect_error(call_it(""), "nzchar(stop_message) is not TRUE", fixed = TRUE)
+	expect_error(
+		call_it(NA_character_),
+		"!is.na(stop_message) is not TRUE",
+		fixed = TRUE
+	)
+	expect_error(
+		call_it(c("a", "b")),
+		"length(stop_message) == 1L is not TRUE",
+		fixed = TRUE
+	)
+
+	# A valid message still returns normally on this well-conditioned support --
+	# so the four errors above are the guard, not a helper that always fails.
+	ok <- call_it("a real message")
+	expect_true(isTRUE(ok$calc_ses))
+})
+
+# ------------------------------------------------------------------------------
+# Item 8: the singular-Gram "standard errors will not be calculated" message is
+# a single package-level constant read by getGramInv()'s two warning() calls and
+# by .compute_cluster_robust_sandwich()'s stop().
+#
+# BE HONEST ABOUT WHAT EACH ASSERTION BUYS. The expect_identical() assertions are
+# tautologies with respect to the message's CONTENT -- after the fold, both
+# sides read the same symbol, so they move together when the text is edited.
+# They exist to catch a REINTRODUCED INLINE LITERAL THAT DIFFERS, not a rewrite
+# of the constant. Only the two grepl(..., fixed = TRUE) anchors hold the
+# wording. Same caveat as #429's constant (see R/simultaneous_cis.R).
+# ------------------------------------------------------------------------------
+test_that("the singular-Gram no-SE message is single-sourced (#431 item 8)", {
+	msg <- fetwfe:::.SINGULAR_GRAM_NO_SE_MSG
+
+	# The only assertions in this block that hold the wording itself.
+	expect_true(grepl("not invertible", msg, fixed = TRUE))
+	expect_true(grepl(
+		"Standard errors will not be calculated",
+		msg,
+		fixed = TRUE
+	))
+
+	# getGramInv()'s warning path: a rank-deficient selected support (columns 1
+	# and 2 identical) trips the minimum-eigenvalue branch, which degrades to
+	# calc_ses = FALSE and warns with the constant.
+	N <- 4L
+	T <- 2L
+	n <- N * T
+	x1 <- as.double(seq_len(n))
+	X_sing <- cbind(x1, x1, rep(c(1, 0), n / 2))
+	w <- tryCatch(
+		fetwfe:::getGramInv(
+			N = N,
+			T = T,
+			X_final = X_sing,
+			treat_inds = c(1L, 2L),
+			num_treats = 2L,
+			calc_ses = TRUE,
+			sel_feat_inds = c(1L, 2L, 3L),
+			sel_treat_inds_shifted = c(1L, 2L)
+		),
+		warning = function(w) w
+	)
+	expect_s3_class(w, "warning")
+	expect_identical(conditionMessage(w), msg)
+})

--- a/tests/testthat/test-small-fixes-431.R
+++ b/tests/testthat/test-small-fixes-431.R
@@ -77,12 +77,14 @@ test_that("genCoefs()/genCoefsCore() scalar errors carry no call (#431 item 1)",
 # function OBJECT. do.call(f, args) with `f` a closure builds a call whose first
 # element is the entire function definition and whose remaining elements are the
 # argument VALUES -- so every stopifnot() condition raised inside `f` captures
-# the whole argument list (on these fixtures, a ~215,000-character deparse and a
-# 569-731 KB condition object, against 296-443 characters and ~3 KB through
-# .call_te(); on the live etwfe() fit that motivated the issue, ~1.35 M
-# characters and ~6.5 MB). The absolute sizes are fixture-dependent -- these
-# fixtures use a ZERO matrix, which deparses far more compactly than real data
-# -- so it is the ratio that matters, not the constants. It also reports
+# the whole argument list: on these fixtures a ~215,000-character deparse
+# against 296-443 characters through .call_te(), a 487x-728x reduction; on the
+# live etwfe() fit that motivated the issue, ~1.35 M characters. Sizes are
+# fixture-dependent -- these fixtures use a ZERO matrix, which deparses far more
+# compactly than real data -- so it is the ratio that matters. Do NOT add an
+# object.size() figure for the condition: it is order-dependent within a session
+# (571,720 B on the first call, 731,024 B afterwards, identical deparse both
+# times) and three revisions of this file shipped a wrong one. It also reports
 # `Error in (function (sig_eps_sq, N, T, G, num_treats, ...)` instead of naming
 # the function that crashed.
 #
@@ -580,8 +582,9 @@ test_that(".recompute_gram_and_sandwich() guards stop_message at entry (#431 ite
 # tautologies with respect to the message's CONTENT -- after the fold, both
 # sides read the same symbol, so they move together when the text is edited.
 # They exist to catch a REINTRODUCED INLINE LITERAL THAT DIFFERS, not a rewrite
-# of the constant. Only the two grepl(..., fixed = TRUE) anchors hold the
-# wording. Same caveat as #429's constant (see R/simultaneous_cis.R).
+# of the constant. Only the grepl(..., fixed = TRUE) anchors hold the wording:
+# the two below, plus one in test-assemble-cluster-sandwich-78.R. Same caveat as
+# #429's constant (see R/simultaneous_cis.R).
 # ------------------------------------------------------------------------------
 test_that("the singular-Gram no-SE message is single-sourced (#431 item 8)", {
 	msg <- fetwfe:::.SINGULAR_GRAM_NO_SE_MSG


### PR DESCRIPTION

Closes #431. Eight small, behavior-affecting defects from the late post-execution audit of PRs #412–#421 — seven from the issue body, one from its later comment. **No estimate, standard error, or confidence interval changes anywhere:** all four estimators return `identical()` output on both the simulated smoke fixture and the `bacondecomp::divorce` example.

## What changes for a user

Errors stop naming internal machinery. A bad argument to `genCoefs()` / `genCoefsCore()` prints its message alone instead of prefixing it with a validator's name and a list of formal names that are not the values you passed. A failed assertion inside the treatment-effect machinery now names the function that failed — previously `do.call()` on a function *object* inlined every argument value into the recorded call, so the printed error ran past a million characters and `tryCatch()` handed the caller megabytes of matrices. Measured on this PR's own fixtures, the deparsed call drops ~500–700×.

Three latent hazards became loud: `.base_cols()` and `getNumTreats()` reject non-scalar or non-numeric arguments instead of returning a wrong column count; `.cv_grpreg_at_min()` asserts the penalty index it fell back to really is `cv.grpreg`'s `lambda.min` rather than the nearest one; and `.recompute_gram_and_sandwich()` requires a usable `stop_message` instead of failing with an empty `Error:`.

Two duplicated formulas and one duplicated error string stop being hand-kept copies: the pre-treatment column-count formula (already the cause of one off-by-one, #339) is now read from its single owner at the last two inline re-derivations, and the singular-Gram "standard errors will not be calculated" message becomes one constant read by all three emission sites. The three sites that deliberately re-derive the formula as a cross-check now say so, so nobody folds away the only oracle. `.check_c6_dims_toplevel()` reads every slot exactly rather than by prefix, closing a latent partial-match false negative.

## Verification

`R CMD check` 0/0/0 with no environmental NOTE; 961 blocks / 4,907 assertions / 0 failed; spelling clean; 25/25 URLs. Every behavior-affecting item has a test demonstrated to fail before its source change and pass after — 14 mutations run one at a time against a clean control, including both `.call_te()` call sites separately. Two mutations are recorded in the plan as *not* test-detectable, with reasons, rather than counted as checked.

Reviewed by a pre-implementation plan reviewer (three rounds), a drift sentinel (both passes), and a post-execution reviewer. No design finding at any stage; every blocker raised was in how the work was measured.
