### PR TITLE
test: restore the test power the #400/#401 consolidation consumed (#429 items 3, 5, 6, 7, 8, 9)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,25 @@
 
 ### Internal
 
+- The remaining six items of the test-power audit that followed the #400/#401
+  single-sourcing campaign now have coverage, closing #429. Six named mutations
+  of shipped code each used to leave the test file that claims the contract
+  entirely green, and each now reddens a named assertion in it: deleting the
+  shared C6/C8 dimension check from the `etwfe`, `betwfe` or `twfeCovs`
+  validator; three separate defects in the internal helper that computes the
+  in-sample and independent ATT pair; flipping the flag that keeps an ordinary
+  fit silent when the bridge penalty zeroes every treatment effect in the
+  high-dimensional regime; adding, removing or reordering a column of the
+  degenerate confidence-band data frame; dropping the `drop = FALSE` that keeps
+  a single-column selection matrix a matrix on the `fetwfe` branch; and
+  weakening any of the sixteen scalar argument checks that `genCoefs()` and
+  `genCoefsCore()` share. `simultaneousCIs()`'s own standard-error path also
+  gained an absolute pinned value on each of the cross-accessor guardrail's six
+  fixtures, so it no longer rests only on agreement with the other accessors ---
+  an agreement a further consolidation would hollow, exactly as the #400 fold
+  already hollowed the anchors before it. Tests only: no file under `R/` is
+  touched and no estimator behavior changes.
+
 - Eight small defects found by a late audit of the #400/#401 single-sourcing
   work are fixed together (#431). Two of them finish that campaign: the
   pre-treatment column-count formula, which an earlier off-by-one bug had

--- a/NEWS.md
+++ b/NEWS.md
@@ -62,9 +62,10 @@
 ### Internal
 
 - The remaining six items of the test-power audit that followed the #400/#401
-  single-sourcing campaign now have coverage, closing #429. Six named mutations
-  of shipped code each used to leave the test file that claims the contract
-  entirely green, and each now reddens a named assertion in it: deleting the
+  single-sourcing campaign now have coverage, closing #429. Six classes of
+  mutation to shipped code are now caught by the test file that claims the
+  contract, where before they were invisible to it --- entirely so for five of
+  the six, and for nine of the sixteen argument checks in the sixth: deleting the
   shared C6/C8 dimension check from the `etwfe`, `betwfe` or `twfeCovs`
   validator; three separate defects in the internal helper that computes the
   in-sample and independent ATT pair; flipping the flag that keeps an ordinary

--- a/tests/testthat/test-c6-toplevel-routing-429.R
+++ b/tests/testthat/test-c6-toplevel-routing-429.R
@@ -1,0 +1,136 @@
+# Issue #429 item 3: the three class validators must ROUTE through
+# .check_c6_dims_toplevel().
+#
+# tests/testthat/test-small-fixes-431.R:467-509 already tests the helper
+# DIRECTLY, with hand-built one-slot fixtures, so "helper body ->
+# invisible(NULL)" is dead as a mutant. What survives is one level up: deleting
+# the `.check_c6_dims_toplevel(x, cls)` call from any ONE of the three class
+# validators (R/etwfe_class.R:147, R/betwfe_class.R:165,
+# R/twfeCovs_class.R:158) leaves that direct unit test green. Nothing else
+# covers it -- tests/testthat/test-class-validators.R:181-192 is the only
+# validator-level C6 test and it drives .validate_fetwfe(), which has its own
+# NESTED C6 variant and never calls this helper at all.
+#
+# Shape: twelve cells = three classes x four contracts, each cell a single
+# mutation applied to a COPY of a live fit. One mutation per copy is mandatory
+# here: .assert_contract() stops on the FIRST violated contract, so a fixture
+# breaking several at once only ever demonstrates the earliest and the anchored
+# assertions on the others pass vacuously (PR #452 hit exactly this trap).
+#
+# Nine of the twelve cells are redundant TODAY -- any single cell of a class's
+# row kills that class's routing mutant. They stop being redundant the moment
+# the shared helper is split per class, which is the refactor shape this issue
+# exists because of.
+#
+# HOUSE RULE: every expect_error() anchor passes `fixed = TRUE`. The contract
+# names contain parentheses and `*` (`C6 nrow(X_ints) == N * T`), which a
+# default `regexp =` would read as metacharacters.
+
+# ------------------------------------------------------------------------------
+# Shared fixture: one simulated panel, three live fits. Recipe copied from
+# tests/testthat/test-class-validators.R:21-36 (which is file-local there and so
+# cannot be called from here; see the plan's Decision Log for why it was not
+# promoted to a helper-*.R). suppressWarnings() alone, matching that source.
+# ------------------------------------------------------------------------------
+.c6r429_sim <- simulateData(
+	genCoefs(G = 2, T = 3, d = 2, density = 0.5, eff_size = 1, seed = 17052026),
+	N = 80,
+	sig_eps_sq = 1,
+	sig_eps_c_sq = 0.5,
+	seed = 17052026
+)
+
+.c6r429_fits <- list(
+	etwfe = suppressWarnings(etwfeWithSimulatedData(.c6r429_sim)),
+	betwfe = suppressWarnings(betwfeWithSimulatedData(.c6r429_sim, q = 0.5)),
+	twfeCovs = suppressWarnings(twfeCovsWithSimulatedData(.c6r429_sim))
+)
+
+.c6r429_validators <- list(
+	etwfe = fetwfe:::.validate_etwfe,
+	betwfe = fetwfe:::.validate_betwfe,
+	twfeCovs = fetwfe:::.validate_twfeCovs
+)
+
+test_that("etwfe/betwfe/twfeCovs validators route through .check_c6_dims_toplevel() (#429 item 3)", {
+	for (cls in names(.c6r429_fits)) {
+		fit <- .c6r429_fits[[cls]]
+		validate <- .c6r429_validators[[cls]]
+
+		# Baseline. Without this the four errors below could be attributable to
+		# a fixture that was already off-contract rather than to the mutation.
+		expect_silent(validate(fit))
+
+		# --- C6, three dimension contracts -----------------------------------
+		cells <- list(
+			beta_hat = list(
+				mutate = function(o) {
+					o$beta_hat <- o$beta_hat[-1]
+					o
+				},
+				contract = "C6 length(beta_hat) == p"
+			),
+			y = list(
+				mutate = function(o) {
+					o$y <- o$y[-1]
+					o
+				},
+				contract = "C6 length(y) == N * T"
+			),
+			X_ints = list(
+				mutate = function(o) {
+					o$X_ints <- o$X_ints[-1, , drop = FALSE]
+					o
+				},
+				contract = "C6 nrow(X_ints) == N * T"
+			)
+		)
+
+		for (cell in names(cells)) {
+			expect_error(
+				validate(cells[[cell]]$mutate(fit)),
+				paste0(
+					".validate_",
+					cls,
+					"(): contract violation `",
+					cells[[cell]]$contract,
+					"`"
+				),
+				fixed = TRUE,
+				info = paste(cls, cell)
+			)
+		}
+
+		# --- C8, calc_ses ----------------------------------------------------
+		# C8 cannot be reached by the naive mutation, and the reason is
+		# structural: isTRUE(x) is TRUE only for a length-1 logical with no
+		# attributes -- exactly what C8 asserts -- so any object violating C8
+		# makes isTRUE(calc_ses) FALSE, which sends .check_se_consistency() (C1,
+		# which runs first) down its "standard errors must be NA" branch.
+		# Reaching C8 therefore requires NA-ing the SE-bearing slots first,
+		# which is the genuine calc_ses = FALSE shape. (`att_p_value` is the
+		# slot; `p_value` is a COLUMN of catt_df.)
+		na_only <- fit
+		na_only$att_se <- NA_real_
+		na_only$catt_ses <- rep(NA_real_, length(na_only$catt_ses))
+		na_only$att_p_value <- NA_real_
+
+		# Control: the NA-ing ALONE is legal. Without this, a future change that
+		# made the NA-ing itself illegal would turn the C8 cell green for the
+		# wrong reason.
+		expect_silent(validate(na_only))
+
+		mutated <- na_only
+		mutated$calc_ses <- "TRUE"
+		expect_error(
+			validate(mutated),
+			paste0(
+				".validate_",
+				cls,
+				"(): contract violation `C8 calc_ses is length-1 logical`"
+			),
+			fixed = TRUE,
+			info = paste(cls, "calc_ses")
+		)
+	}
+})

--- a/tests/testthat/test-compute-att-pair-429.R
+++ b/tests/testthat/test-compute-att-pair-429.R
@@ -103,6 +103,14 @@ test_that(".compute_att_pair() maps the in-sample fields correctly (#429 item 5)
 	# exactly this shape passed macOS/Windows and failed all four Linux jobs on
 	# #427's first cross-platform run. (It happens to be bit-identical on
 	# macOS/Accelerate, which is precisely the evidence that misleads.)
+	#
+	# RECORDED LIMIT: because gram_inv and psi_mat are both the identity here,
+	# this pins the SCALING of att_var_1 -- sig_eps_sq, the cohort-probability
+	# weighting, and the 1/(N*T) divisor -- and not the quadratic form itself. A
+	# mutation that transposed or mis-ordered the psi/gram product would survive
+	# this assertion. That is deliberate: this file is a unit test of
+	# .compute_att_pair()'s FIELD MAPPING, and the quadratic form belongs to
+	# .compute_att_var1(), whose own coverage is elsewhere.
 	expect_equal(out$in_sample_att_var_1, 1 / 300)
 
 	# With no independent count data, all four independent fields are NA.

--- a/tests/testthat/test-compute-att-pair-429.R
+++ b/tests/testthat/test-compute-att-pair-429.R
@@ -211,8 +211,17 @@ test_that(".compute_att_pair() runs indep_precheck once, before the independent 
 		cohort_probs_overall = c(0.2, 0.2)
 	)
 
-	# Half one: with NO precheck, the independent call itself raises.
-	expect_error(
+	# Half one: with NO precheck, the independent call itself raises -- and it
+	# raises something OTHER than the precheck's marker. That second clause is
+	# the whole content of this half, so it is what gets asserted.
+	#
+	# Deliberately NOT anchored on "non-conformable arguments": that is base R's
+	# wording for the `%*%` failure, not the package's, and CI runs R-devel. The
+	# assert_att_se anchor a hundred lines above was softened off a base-R
+	# stopifnot() deparse for exactly this reason, and pinning a different
+	# base-R string here would have been the same mistake with a different
+	# message.
+	e_no_pre <- tryCatch(
 		fetwfe:::.compute_att_pair(
 			"getTeResultsOLS",
 			.cap429_base_args,
@@ -220,9 +229,10 @@ test_that(".compute_att_pair() runs indep_precheck once, before the independent 
 			poisoned,
 			TRUE
 		),
-		"non-conformable arguments",
-		fixed = TRUE
+		error = function(e) e
 	)
+	expect_s3_class(e_no_pre, "error")
+	expect_false(grepl("PRECHECK", conditionMessage(e_no_pre), fixed = TRUE))
 
 	# Half two: with a precheck that stops, the precheck's error is the one that
 	# surfaces -- so the precheck DISPLACED an error the independent call would

--- a/tests/testthat/test-compute-att-pair-429.R
+++ b/tests/testthat/test-compute-att-pair-429.R
@@ -1,0 +1,240 @@
+# Issue #429 item 5: a direct unit test of .compute_att_pair()
+# (R/variance_machinery.R:1036-1082), the helper the #400/#401 consolidation
+# created by folding the in-sample / independent ATT pair out of every
+# estimator. It has no direct unit test of its own contract: the three call
+# sites at tests/testthat/test-small-fixes-431.R:108-221 are all ERROR-path
+# fixtures that exercise .call_te()'s naming, never the helper's field mapping,
+# its assert_att_se guard, or its precheck ordering.
+#
+# Four named mutations of R/variance_machinery.R:1036-1082 must redden this
+# file:
+#   (1) map `in_sample_att_se_no_prob` to `att_te_se` instead of
+#       `att_te_se_no_prob`                                    -> block (a)
+#   (2) drop the `assert_att_se` guard                          -> block (b)
+#   (3) drop the `indep_precheck()` call                        -> block (c)
+#   (4) move that call AFTER the independent .call_te()         -> block (c)
+#
+# Every fixture is a hand-built argument list driving the real
+# getTeResultsOLS(). No simulation, no fitting, nothing random.
+#
+# .compute_att_pair()'s first parameter is `te_fn_name`, a CHARACTER SCALAR and
+# not a function object (renamed in #431 item 2; .call_te() resolves the name in
+# the package namespace). Calling shape copied from
+# tests/testthat/test-small-fixes-431.R:130-141.
+
+# ------------------------------------------------------------------------------
+# Shared fixture. Deliberately degenerate in the arithmetic, not in the code
+# path: psi_mat and gram_inv are both the 2x2 identity, which makes att_var_1
+# hand-derivable (see block (a)) without changing which branches run.
+# ------------------------------------------------------------------------------
+.cap429_base_args <- list(
+	sig_eps_sq = 1,
+	N = 50L,
+	T = 3L,
+	G = 2L,
+	num_treats = 2L,
+	cohort_tes = c(1, 2),
+	psi_mat = matrix(c(1, 0, 0, 1), nrow = 2L, ncol = 2L),
+	gram_inv = diag(2),
+	tes = c(0.5, 1.5),
+	calc_ses = TRUE
+)
+
+.cap429_in_sample_probs <- list(
+	cohort_probs = c(0.5, 0.5),
+	cohort_probs_overall = c(0.2, 0.2)
+)
+
+# ------------------------------------------------------------------------------
+# (a) The five in-sample fields land in the right result slots.
+# ------------------------------------------------------------------------------
+test_that(".compute_att_pair() maps the in-sample fields correctly (#429 item 5)", {
+	out <- fetwfe:::.compute_att_pair(
+		"getTeResultsOLS",
+		.cap429_base_args,
+		.cap429_in_sample_probs,
+		list(),
+		FALSE
+	)
+
+	expect_identical(
+		names(out),
+		c(
+			"in_sample_att_hat",
+			"in_sample_att_se",
+			"in_sample_att_se_no_prob",
+			"in_sample_att_var_1",
+			"in_sample_att_var_2",
+			"indep_att_hat",
+			"indep_att_se",
+			"indep_att_var_1",
+			"indep_att_var_2"
+		)
+	)
+
+	# THE assertion mutation (1) has to walk past: in_sample_att_se_no_prob must
+	# be the no-probability SE, i.e. sqrt(att_var_1). Both sides here are the
+	# same double produced by the same code path (R/variance_machinery.R
+	# computes att_te_se_no_prob <- sqrt(att_var_1) from the same local), so
+	# exactness is legitimate under .workflow/PROFILE.md section 12 gotcha 8.
+	expect_identical(
+		out$in_sample_att_se_no_prob,
+		sqrt(out$in_sample_att_var_1)
+	)
+
+	# NON-VACUITY CONTROL, and it is load-bearing rather than decorative: the
+	# two SEs COINCIDE when att_var_2 is zero, and mutation (1) would then be
+	# invisible. Measured on this fixture: att_var_1 = 0.003333, att_var_2 =
+	# 0.0125, se_no_prob = 0.057735, att_se = 0.125831.
+	expect_true(out$in_sample_att_var_2 > 0)
+	expect_false(isTRUE(all.equal(
+		out$in_sample_att_se,
+		out$in_sample_att_se_no_prob
+	)))
+
+	# Absolute, hand-derived reference. With gram_inv and psi_mat both the
+	# identity, att_var_1 collapses to
+	#     sig_eps_sq * sum(cohort_probs^2) / (N * T) = 1 * 0.5 / 150 = 1/300,
+	# so this literal is derived from the formula rather than recovered from the
+	# function's own output. expect_equal() at the default tolerance rather than
+	# expect_identical(): the two sides are NOT the same arithmetic -- one is a
+	# BLAS t(psi) %*% gram_inv %*% psi chain, the other a scalar literal
+	# division -- and .workflow/PROFILE.md section 12 gotcha 8 records that
+	# exactly this shape passed macOS/Windows and failed all four Linux jobs on
+	# #427's first cross-platform run. (It happens to be bit-identical on
+	# macOS/Accelerate, which is precisely the evidence that misleads.)
+	expect_equal(out$in_sample_att_var_1, 1 / 300)
+
+	# With no independent count data, all four independent fields are NA.
+	expect_true(is.na(out$indep_att_hat))
+	expect_true(is.na(out$indep_att_se))
+	expect_true(is.na(out$indep_att_var_1))
+	expect_true(is.na(out$indep_att_var_2))
+})
+
+# ------------------------------------------------------------------------------
+# (b) assert_att_se is what throws.
+# ------------------------------------------------------------------------------
+test_that(".compute_att_pair()'s assert_att_se guard fires on an NA SE (#429 item 5)", {
+	no_se_args <- .cap429_base_args
+	no_se_args$calc_ses <- FALSE
+
+	# The anchor is the FIELD NAME, not base R's full stopifnot() deparse
+	# ("!is.na(out$in_sample_att_se) is not TRUE"). That format belongs to base
+	# R, not to this package, and CI runs R-devel. The field name still
+	# discriminates: without the guard there is no error at all, and any other
+	# error would not name this field.
+	expect_error(
+		fetwfe:::.compute_att_pair(
+			"getTeResultsOLS",
+			no_se_args,
+			.cap429_in_sample_probs,
+			list(),
+			FALSE,
+			assert_att_se = TRUE
+		),
+		"in_sample_att_se",
+		fixed = TRUE
+	)
+
+	# CONTROL that makes the assertion above non-vacuous: the identical call
+	# with the guard off returns normally, with the NA the guard rejects. So the
+	# error is attributable to assert_att_se and to nothing else in the fixture.
+	out <- fetwfe:::.compute_att_pair(
+		"getTeResultsOLS",
+		no_se_args,
+		.cap429_in_sample_probs,
+		list(),
+		FALSE,
+		assert_att_se = FALSE
+	)
+	expect_true(is.na(out$in_sample_att_se))
+})
+
+# ------------------------------------------------------------------------------
+# (c) indep_precheck runs exactly once, and BEFORE the independent .call_te().
+# ------------------------------------------------------------------------------
+test_that(".compute_att_pair() runs indep_precheck once, before the independent call (#429 item 5)", {
+	indep_probs_args <- list(
+		cohort_probs = c(0.4, 0.6),
+		cohort_probs_overall = c(0.2, 0.2)
+	)
+
+	# --- called exactly once when independent count data is available --------
+	n_calls <- 0L
+	out <- fetwfe:::.compute_att_pair(
+		"getTeResultsOLS",
+		.cap429_base_args,
+		.cap429_in_sample_probs,
+		indep_probs_args,
+		TRUE,
+		indep_precheck = function() n_calls <<- n_calls + 1L
+	)
+	expect_identical(n_calls, 1L)
+	expect_true(is.finite(out$indep_att_hat))
+	# The independent branch really ran on the independent probabilities:
+	# c(1, 2) %*% c(0.4, 0.6) = 1.6, against the in-sample c(0.5, 0.5) -> 1.5.
+	expect_equal(out$indep_att_hat, 1.6)
+	expect_equal(out$in_sample_att_hat, 1.5)
+
+	# --- CONTROL: not called at all when there is no independent count data --
+	n_calls_off <- 0L
+	out_off <- fetwfe:::.compute_att_pair(
+		"getTeResultsOLS",
+		.cap429_base_args,
+		.cap429_in_sample_probs,
+		indep_probs_args,
+		FALSE,
+		indep_precheck = function() n_calls_off <<- n_calls_off + 1L
+	)
+	expect_identical(n_calls_off, 0L)
+	expect_true(is.na(out_off$indep_att_hat))
+	expect_true(is.na(out_off$indep_att_se))
+	expect_true(is.na(out_off$indep_att_var_1))
+	expect_true(is.na(out_off$indep_att_var_2))
+
+	# --- ORDERING, and this is the half that tests ordering AS ordering ------
+	# Poison the independent probabilities: a length-3 cohort_probs against
+	# length-2 cohort_tes. (NA-poisoning does NOT work here -- the
+	# stopifnot(all(!is.na(cohort_probs))) lives in getTeResults2(), not in
+	# getTeResultsOLS().)
+	poisoned <- list(
+		cohort_probs = c(0.3, 0.3, 0.4),
+		cohort_probs_overall = c(0.2, 0.2)
+	)
+
+	# Half one: with NO precheck, the independent call itself raises.
+	expect_error(
+		fetwfe:::.compute_att_pair(
+			"getTeResultsOLS",
+			.cap429_base_args,
+			.cap429_in_sample_probs,
+			poisoned,
+			TRUE
+		),
+		"non-conformable arguments",
+		fixed = TRUE
+	)
+
+	# Half two: with a precheck that stops, the precheck's error is the one that
+	# surfaces -- so the precheck DISPLACED an error the independent call would
+	# otherwise have raised, which is what "runs before" means operationally.
+	# Both halves are required; either alone shows only that something errored.
+	n_calls_order <- 0L
+	expect_error(
+		fetwfe:::.compute_att_pair(
+			"getTeResultsOLS",
+			.cap429_base_args,
+			.cap429_in_sample_probs,
+			poisoned,
+			TRUE,
+			indep_precheck = function() {
+				n_calls_order <<- n_calls_order + 1L
+				stop("PRECHECK-RAN-FIRST")
+			}
+		),
+		"PRECHECK-RAN-FIRST",
+		fixed = TRUE
+	)
+	expect_identical(n_calls_order, 1L)
+})

--- a/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
+++ b/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
@@ -82,20 +82,36 @@
 # kept because they still catch a divergence introduced OUTSIDE the shared
 # helper, in an accessor's own assembly of the result.
 #
-# That residual is larger than it sounds, and is the reason not to delete them:
-# they are currently the ONLY assertions in this file covering simultaneousCIs()'s
-# SE path. None of the eighteen Part 2 pins goes through simultaneousCIs() at all
-# -- they read eventStudy(), cohortStudy() and cohortTimeATTs(). Measured on the
-# #451 review: scaling Sigma one level downstream of the scaffold
-# (`Sigma <- 1.5 * (Sigma_1 + Sigma_2)` in .simultaneous_cis_impl()) fires 18
-# failures, every one of them here and none in Part 2.
+# That residual used to be the whole story, and it is why these anchors were not
+# deleted: until #429 PR B they were the ONLY assertions in this file covering
+# simultaneousCIs()'s SE path, because the original eighteen Part 2 pins read
+# eventStudy(), cohortStudy() and cohortTimeATTs() and none of them went through
+# simultaneousCIs() at all. Measured on the #451 review: scaling Sigma one level
+# downstream of the scaffold (`Sigma <- 1.5 * (Sigma_1 + Sigma_2)` in
+# .simultaneous_cis_impl()) fired 18 failures, every one of them here and none in
+# Part 2.
 #
-# Which sets up the same trap one layer up: .assemble_joint_cov_var1/2 are
-# ALREADY shared helpers, so the next consolidation routing both sides of these
-# anchors through one of them hollows this block exactly as the #400 fold
-# hollowed it against the scaffold -- and at that moment simultaneousCIs() SEs
-# have no absolute pin anywhere. Pre-empting that with a fourth pinned vector per
-# fixture (via .g400_se_of_sci()) is #429 PR B's job.
+# Which set up the same trap one layer up: .assemble_joint_cov_var1/2 are ALREADY
+# shared helpers, so the next consolidation routing both sides of these anchors
+# through one of them hollows this block exactly as the #400 fold hollowed it
+# against the scaffold.
+#
+# THAT IS NOW PRE-EMPTED (#429 PR B). Each of the six Part 2 blocks carries a
+# FOURTH pinned vector, .g400_se_of_sci(simultaneousCIs(fit, family = "cohort")),
+# so simultaneousCIs()'s SE assembly has an absolute pin on every fixture --
+# twenty-four pins in Part 2, not eighteen. An absolute pin cannot be hollowed by
+# consolidating the two things being compared, because there is only one thing.
+# Re-measured 2026-08-17 on the finished file: the same Sigma mutation now fires
+# 24 failures, 18 in Part 1 and exactly one in each of the six Part 2 blocks.
+#
+# The fourth vector's VALUE equals the cohortStudy() pin sitting a few lines
+# above it in the same block -- for fetwfe/default and fetwfe/cluster the seven
+# printed digits are character-identical. That is not a defect and not
+# avoidable by changing family (event_study reproduces eventStudy()$se,
+# all_post_treatment reproduces cohortTimeATTs()$se): the agreement IS what
+# Anchor C asserts. The point of pinning it separately is that Anchor C can no
+# longer tell the two paths apart, and one absolute value should survive on the
+# simultaneousCIs() side when it goes fully hollow.
 
 .g400_expect_anchors <- function(fit, label) {
 	a <- fit$alpha
@@ -179,6 +195,21 @@ test_that("scaffold SEs match pinned pre-refactor values on the fetwfe/default f
 		),
 		tolerance = 1e-6
 	)
+	# #429: the fourth pin -- simultaneousCIs()'s OWN SE assembly, recovered by
+	# .g400_se_of_sci(). Its value equals the cohortStudy() pin above (here,
+	# character-identical at seven digits); that agreement is Anchor C's
+	# invariant, and Part 1's header says why pinning it separately is the point.
+	# DO NOT "simplify" this to
+	# expect_equal(.g400_se_of_sci(...), cohortStudy(fit)$se): that converts an
+	# absolute pin back into precisely the parity assertion consolidation
+	# hollows. Verified byte-identical on origin/main as well as this branch.
+	expect_equal(
+		.g400_se_of_sci(
+			simultaneousCIs(fit, family = "cohort", alpha = fit$alpha)
+		),
+		c(0.1738941, 0.1479012, 0.1596468, 0.1438447),
+		tolerance = 1e-6
+	)
 })
 
 # The cluster fixture needs its own ABSOLUTE pins, and the reason is structural.
@@ -231,6 +262,15 @@ test_that("scaffold SEs match pinned pre-refactor values on the fetwfe/cluster f
 		),
 		tolerance = 1e-6
 	)
+	# #429: the fourth pin -- see the fetwfe/default block for the rationale and
+	# for the "do not simplify this into a cohortStudy() comparison" prohibition.
+	expect_equal(
+		.g400_se_of_sci(
+			simultaneousCIs(fit, family = "cohort", alpha = fit$alpha)
+		),
+		c(0.1853167, 0.1275883, 0.1469086, 0.1456402),
+		tolerance = 1e-6
+	)
 })
 
 # The remaining four fixtures, pinned for the same structural reason (#429).
@@ -243,7 +283,11 @@ test_that("scaffold SEs match pinned pre-refactor values on the fetwfe/cluster f
 # the three `default` ones (the `cluster` SEs never see it --
 # .compute_cluster_robust_sandwich() solves its own crossprod(X_S_centered) and
 # never touches the helper's gram_inv). The two mutations are exact
-# complements; together they reach 18 of 18 assertions.
+# complements; together they reach 18 of those 18 assertions. (That count is the
+# three eventStudy/cohortStudy/cohortTimeATTs vectors per fixture. #429 PR B
+# added a fourth, simultaneousCIs()-based vector to each block, taking Part 2 to
+# twenty-four; the two mutations above were measured against the original
+# eighteen and have not been re-measured against the fourth.)
 #
 # Two notes for the reader:
 #
@@ -294,6 +338,15 @@ test_that("scaffold SEs match pinned pre-refactor values on the etwfe/default fi
 		),
 		tolerance = 1e-6
 	)
+	# #429: the fourth pin -- see the fetwfe/default block for the rationale and
+	# for the "do not simplify this into a cohortStudy() comparison" prohibition.
+	expect_equal(
+		.g400_se_of_sci(
+			simultaneousCIs(fit, family = "cohort", alpha = fit$alpha)
+		),
+		c(0.2266507, 0.1954749, 0.1990295, 0.2088314),
+		tolerance = 1e-6
+	)
 })
 
 test_that("scaffold SEs match pinned pre-refactor values on the betwfe/default fixture (#400 guardrail, #429)", {
@@ -326,6 +379,15 @@ test_that("scaffold SEs match pinned pre-refactor values on the betwfe/default f
 			0.2484576,
 			0.2666360
 		),
+		tolerance = 1e-6
+	)
+	# #429: the fourth pin -- see the fetwfe/default block for the rationale and
+	# for the "do not simplify this into a cohortStudy() comparison" prohibition.
+	expect_equal(
+		.g400_se_of_sci(
+			simultaneousCIs(fit, family = "cohort", alpha = fit$alpha)
+		),
+		c(0.1490514, 0.1604112, 0.1738290, 0.1978270),
 		tolerance = 1e-6
 	)
 })
@@ -362,6 +424,15 @@ test_that("scaffold SEs match pinned pre-refactor values on the etwfe/cluster fi
 		),
 		tolerance = 1e-6
 	)
+	# #429: the fourth pin -- see the fetwfe/default block for the rationale and
+	# for the "do not simplify this into a cohortStudy() comparison" prohibition.
+	expect_equal(
+		.g400_se_of_sci(
+			simultaneousCIs(fit, family = "cohort", alpha = fit$alpha)
+		),
+		c(0.2396085, 0.1776220, 0.1807051, 0.1994378),
+		tolerance = 1e-6
+	)
 })
 
 test_that("scaffold SEs match pinned pre-refactor values on the betwfe/cluster fixture (#400 guardrail, #429)", {
@@ -394,6 +465,15 @@ test_that("scaffold SEs match pinned pre-refactor values on the betwfe/cluster f
 			0.2640755,
 			0.2708483
 		),
+		tolerance = 1e-6
+	)
+	# #429: the fourth pin -- see the fetwfe/default block for the rationale and
+	# for the "do not simplify this into a cohortStudy() comparison" prohibition.
+	expect_equal(
+		.g400_se_of_sci(
+			simultaneousCIs(fit, family = "cohort", alpha = fit$alpha)
+		),
+		c(0.1648825, 0.1514423, 0.1534372, 0.2044426),
 		tolerance = 1e-6
 	)
 })

--- a/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
+++ b/tests/testthat/test-cross-accessor-scaffold-guardrail-400.R
@@ -105,13 +105,18 @@
 # 24 failures, 18 in Part 1 and exactly one in each of the six Part 2 blocks.
 #
 # The fourth vector's VALUE equals the cohortStudy() pin sitting a few lines
-# above it in the same block -- for fetwfe/default and fetwfe/cluster the seven
-# printed digits are character-identical. That is not a defect and not
-# avoidable by changing family (event_study reproduces eventStudy()$se,
-# all_post_treatment reproduces cohortTimeATTs()$se): the agreement IS what
-# Anchor C asserts. The point of pinning it separately is that Anchor C can no
-# longer tell the two paths apart, and one absolute value should survive on the
-# simultaneousCIs() side when it goes fully hollow.
+# above it in the same block: in ALL SIX blocks the seven printed digits are
+# character-identical, which you can confirm without running anything by
+# comparing the literal pairs in each block. (They are not bit-identical --
+# identical() is FALSE on all six, 8e-17 to 2e-16 apart -- which is why the
+# tolerance is 1e-6 and not 0. An earlier draft of this comment said only
+# fetwfe/default and fetwfe/cluster matched, implying the other four differed.)
+# That is not a defect and not avoidable by changing family (event_study
+# reproduces eventStudy()$se, all_post_treatment reproduces
+# cohortTimeATTs()$se): the agreement IS what Anchor C asserts. The point of
+# pinning it separately is that Anchor C can no longer tell the two paths
+# apart, and one absolute value should survive on the simultaneousCIs() side
+# when it goes fully hollow.
 
 .g400_expect_anchors <- function(fit, label) {
 	a <- fit$alpha

--- a/tests/testthat/test-degenerate-band-policy-429.R
+++ b/tests/testthat/test-degenerate-band-policy-429.R
@@ -11,9 +11,19 @@
 # Item 7. The degenerate early return's data.frame() (R/simultaneous_cis.R:
 # 641-649) had no absolute column-name pin on this arm. Adding, removing or
 # reordering a column there was invisible to the high-dim path.
-# (test-degenerate-jacobian-225.R now carries the same pin on the fixed-p arm;
-# the two arms enter the same data.frame() through different guards, so both are
-# needed.)
+# (test-degenerate-jacobian-225.R now carries the same pin on the fixed-p arm.)
+#
+# THE TWO PINS ARE REDUNDANT TODAY, and the honest reason to keep both is the
+# same one test-c6-toplevel-routing-429.R:20-23 gives for its nine redundant
+# cells. R/simultaneous_cis.R:623 is a SINGLE outer guard; the inner if/else
+# below it chooses only between warning() and message(), and both branches fall
+# through to one `ses <- rep(0, K)` and one data.frame() at :641-649. So either
+# pin alone catches an add, a remove or a reorder -- measured, 4 failures from
+# one and 3 from the other. They stop being redundant the moment that branch is
+# split per regime, which is exactly the shape #429 exists because of. (An
+# earlier draft of this comment claimed the two arms "enter the same
+# data.frame() through different guards, so both are needed" -- there is one
+# guard, and that reasoning was backwards.)
 #
 # FIXTURE FAILURE MODE, stated because CI is gating over four Linux/OpenBLAS
 # jobs: `p >= N*T` is deterministic, but `all(catt_hats == 0)` is the outcome of
@@ -45,9 +55,13 @@
 	seed = 55
 )
 
+# NO suppressWarnings() here, deliberately. Block (a) below asserts that these
+# exact calls emit no warning, so suppressing one here would contradict the
+# file's own claim and would hide a fixture that started warning -- the failure
+# this file exists to detect. Measured: both fits are warning-free.
 .dbp429_fits <- list(
-	fetwfe = suppressWarnings(fetwfeWithSimulatedData(.dbp429_sim, q = 0.5)),
-	betwfe = suppressWarnings(betwfeWithSimulatedData(.dbp429_sim, q = 0.5))
+	fetwfe = fetwfeWithSimulatedData(.dbp429_sim, q = 0.5),
+	betwfe = betwfeWithSimulatedData(.dbp429_sim, q = 0.5)
 )
 
 .dbp429_ci_names <- c(
@@ -167,6 +181,14 @@ test_that("the #304 policy keeps the fit silent while simultaneousCIs() warns (#
 
 # ------------------------------------------------------------------------------
 # (b) Item 7 -- the degenerate $ci schema, high-dim arm.
+#
+# THIS BLOCK IS NOT SELF-PROTECTING, and the dependency is declared rather than
+# assumed: a NON-degenerate fit returns these same six column names from the
+# ordinary path at R/simultaneous_cis.R:1014-1022, so nothing asserted below
+# would notice if the fixture stopped being degenerate. What rules that out is
+# the invariants block at the top of this file (`all(catt_hats == 0)` plus
+# `p >= N*T`), which fails loudly on the same run. Do not move these assertions
+# into a file that lacks those invariants.
 # ------------------------------------------------------------------------------
 test_that("the degenerate band's $ci carries exactly six columns in order (#429 item 7)", {
 	for (nm in names(.dbp429_fits)) {

--- a/tests/testthat/test-degenerate-band-policy-429.R
+++ b/tests/testthat/test-degenerate-band-policy-429.R
@@ -1,0 +1,178 @@
+# Issue #429 items 6 and 7: the #304 degenerate-band silence policy, and the
+# schema of the degenerate early return, in the HIGH-DIMENSIONAL (p >= N*T) arm.
+#
+# Item 6. .fit_band_for_family() (R/simultaneous_cis.R:1173-1198) hardcodes
+# `warn_degenerate_highdim = FALSE` at :1182, which is what keeps a plain
+# fetwfe() / betwfe() call SILENT when the bridge penalty zeroes every treatment
+# effect in the high-dimensional regime, while a direct simultaneousCIs() call
+# WARNS. Nothing asserted the fit-time half, so flipping that FALSE to TRUE --
+# which would make every high-dim degenerate fit start warning -- was invisible.
+#
+# Item 7. The degenerate early return's data.frame() (R/simultaneous_cis.R:
+# 641-649) had no absolute column-name pin on this arm. Adding, removing or
+# reordering a column there was invisible to the high-dim path.
+# (test-degenerate-jacobian-225.R now carries the same pin on the fixed-p arm;
+# the two arms enter the same data.frame() through different guards, so both are
+# needed.)
+#
+# FIXTURE FAILURE MODE, stated because CI is gating over four Linux/OpenBLAS
+# jobs: `p >= N*T` is deterministic, but `all(catt_hats == 0)` is the outcome of
+# a cross-validated penalized fit. If this file goes red on, say,
+# `ubuntu-latest (oldrel-2)` and green everywhere else, the FIXTURE drifted out
+# of the degenerate high-dim regime -- the policy did not change. The four
+# invariants in the first block are what makes that read as a loud failure
+# rather than as silent vacuity. (simulateData(..., seed = 55) calls set.seed()
+# without restoring, so the CV folds are deterministic within a platform; the
+# residual risk is BLAS, not RNG.)
+
+# ------------------------------------------------------------------------------
+# Fixture, at file scope: every block below needs it, and test_that()
+# environments do not leak.
+# ------------------------------------------------------------------------------
+.dbp429_cf <- genCoefs(
+	G = 4,
+	T = 6,
+	d = 12,
+	density = 0.5,
+	eff_size = 2,
+	seed = 55
+)
+.dbp429_sim <- simulateData(
+	.dbp429_cf,
+	N = 30,
+	sig_eps_sq = 1,
+	sig_eps_c_sq = 0.5,
+	seed = 55
+)
+
+.dbp429_fits <- list(
+	fetwfe = suppressWarnings(fetwfeWithSimulatedData(.dbp429_sim, q = 0.5)),
+	betwfe = suppressWarnings(betwfeWithSimulatedData(.dbp429_sim, q = 0.5))
+)
+
+.dbp429_ci_names <- c(
+	"effect",
+	"estimate",
+	"simultaneous_ci_low",
+	"simultaneous_ci_high",
+	"pointwise_ci_low",
+	"pointwise_ci_high"
+)
+
+# ------------------------------------------------------------------------------
+# The fixture invariants get their own block, FIRST in the file, so that both of
+# the blocks below run on an asserted regime. Tucking them inside block (a)
+# would leave block (b)'s column pins running on an unasserted fixture, which is
+# the same vacuity these assertions exist to prevent, moved one block over.
+# ------------------------------------------------------------------------------
+test_that("the degenerate high-dim fixture really is degenerate and high-dim (#429 items 6-7)", {
+	for (nm in names(.dbp429_fits)) {
+		fit <- .dbp429_fits[[nm]]
+		# Measured on this fixture: p = 311, N*T = 180.
+		expect_true(fit$p >= fit$N * fit$T, info = nm)
+		expect_true(all(fit$catt_hats == 0), info = nm)
+		# calc_ses and ci_type are the two the silence assertions actually
+		# depend on: .apply_simultaneous_catt_band() returns NULL unless
+		# has_valid_ses, and .finalize_ci_type() early-returns unless ci_type is
+		# "simultaneous". Without these, a fixture that lost either would make
+		# every silence assertion below pass for the wrong reason.
+		expect_true(fit$calc_ses, info = nm)
+		expect_identical(fit$ci_type, "simultaneous", info = nm)
+	}
+})
+
+# ------------------------------------------------------------------------------
+# (a) Item 6 -- both halves of the #304 policy: the fit is silent, the direct
+# accessor warns.
+# ------------------------------------------------------------------------------
+test_that("the #304 policy keeps the fit silent while simultaneousCIs() warns (#429 item 6)", {
+	# Fit-time silence. These are deliberately SECOND fits, not the file-scope
+	# ones: expect_no_warning() has to wrap the call itself, so the fit-time
+	# half of the policy necessarily costs one extra fit per estimator. Do not
+	# "optimize" these into the file-scope fits -- that would silently delete
+	# the fit-time half.
+	expect_no_warning(fetwfeWithSimulatedData(.dbp429_sim, q = 0.5))
+	expect_no_warning(betwfeWithSimulatedData(.dbp429_sim, q = 0.5))
+
+	for (nm in names(.dbp429_fits)) {
+		fit <- .dbp429_fits[[nm]]
+
+		for (fam in c("cohort", "event_study")) {
+			# The anchor is deliberately NOT "zeroed out every treatment", which
+			# is a shared prefix of the warning() arm (:625-633) and the
+			# message() arm (:634-639). "bridge selection is NOT " appears only
+			# in the high-dimensional warning, which is the arm this file exists
+			# to reach.
+			expect_warning(
+				simultaneousCIs(fit, family = fam),
+				"bridge selection is NOT ",
+				fixed = TRUE,
+				info = paste(nm, fam)
+			)
+		}
+
+		# The other route into the same mutated line. Do NOT write
+		# expect_no_warning(eventStudy(fit)) here: measured, eventStudy() calls
+		# .fit_band_for_family() ZERO times on this fixture and can never reach
+		# the degenerate arm. An all-zeroed bridge makes .event_study_fetwfe()
+		# force its local calc_ses <- FALSE (R/event_study.R:550), which closes
+		# the :820 gate -- and that is the SAME condition as the degenerate
+		# branch at R/simultaneous_cis.R:623. A fixture that reaches one cannot
+		# reach the other. The fit itself calls the helper exactly once, for the
+		# COHORT family only, so a direct call is the only coverage the
+		# event-study family can have at all.
+		#
+		# expected_rows is derived, not hardcoded: nrow(catt_df) is K for the
+		# cohort family, T - 1L is K for the event-study family. A wrong value
+		# makes the helper return NULL rather than error, which is why the
+		# non-vacuity control below matters.
+		expected_rows <- c(
+			cohort = nrow(fit$catt_df),
+			event_study = fit$T - 1L
+		)
+		for (fam in c("cohort", "event_study")) {
+			expect_no_warning(
+				fetwfe:::.fit_band_for_family(
+					fit,
+					fam,
+					0.05,
+					expected_rows[[fam]]
+				)
+			)
+			# NON-VACUITY CONTROL, not coverage. It adds nothing against the
+			# `warn_degenerate_highdim = TRUE` mutation (the return stays
+			# non-NULL under it). Its job is that .fit_band_for_family() returns
+			# NULL on both a tryCatch()ed error and a row-count mismatch, and
+			# expect_no_warning() passes perfectly happily on a NULL.
+			expect_false(
+				is.null(fetwfe:::.fit_band_for_family(
+					fit,
+					fam,
+					0.05,
+					expected_rows[[fam]]
+				)),
+				info = paste(nm, fam)
+			)
+		}
+	}
+})
+
+# ------------------------------------------------------------------------------
+# (b) Item 7 -- the degenerate $ci schema, high-dim arm.
+# ------------------------------------------------------------------------------
+test_that("the degenerate band's $ci carries exactly six columns in order (#429 item 7)", {
+	for (nm in names(.dbp429_fits)) {
+		for (fam in c("cohort", "event_study")) {
+			# Block (a) owns the warning assertions; here the warning is noise.
+			sci <- suppressWarnings(simultaneousCIs(
+				.dbp429_fits[[nm]],
+				family = fam
+			))
+			expect_identical(
+				names(sci$ci),
+				.dbp429_ci_names,
+				info = paste(nm, fam)
+			)
+		}
+	}
+})

--- a/tests/testthat/test-degenerate-band-policy-429.R
+++ b/tests/testthat/test-degenerate-band-policy-429.R
@@ -126,6 +126,14 @@ test_that("the #304 policy keeps the fit silent while simultaneousCIs() warns (#
 		# cohort family, T - 1L is K for the event-study family. A wrong value
 		# makes the helper return NULL rather than error, which is why the
 		# non-vacuity control below matters.
+		#
+		# One standing caution for whoever reuses these calls:
+		# .fit_band_for_family() hardcodes has_valid_ses = TRUE. That is sound
+		# here only because the invariants block above pins fit$calc_ses, so
+		# these fits genuinely have valid standard errors. Pointed at a
+		# calc_ses = FALSE fit, the helper would assert an invariant the object
+		# does not satisfy, and whatever it returned would be meaningless
+		# rather than wrong-and-loud.
 		expected_rows <- c(
 			cohort = nrow(fit$catt_df),
 			event_study = fit$T - 1L

--- a/tests/testthat/test-degenerate-jacobian-225.R
+++ b/tests/testthat/test-degenerate-jacobian-225.R
@@ -4,16 +4,20 @@ library(fetwfe)
 # Issue #225 (remaining items, deferred from #227): two regression tests for the
 # recently-added inference surface that previously had no isolated coverage.
 #
-#   Item 1 -- the K=0 "degenerate support" branch of .simultaneous_cis_impl()
-#     (R/simultaneous_cis.R:405-432): when bridge selection zeroes EVERY treatment
-#     effect, simultaneousCIs() returns collapsed point bands at zero, with the
-#     pointwise critical value and NA adjusted p-values. No test reached it.
+#   Item 1 -- the K=0 "degenerate support" early return of
+#     .simultaneous_cis_impl(), guarded by
+#     `length(sel_treat_inds_shifted) == 0L && !highdim_fetwfe_bootstrap`: when
+#     bridge selection zeroes EVERY treatment effect, simultaneousCIs() returns
+#     collapsed point bands at zero, with the pointwise critical value and NA
+#     adjusted p-values. No test reached it.
 #
 #   Item 2 -- the K=1 second-variance ("Sigma_2") term computed two ways: the
-#     joint .assemble_joint_cov_var2() (R/variance_machinery.R:1259, used by the
-#     simultaneous-CI worker) vs the scalar getSecondVarTermOLS()
-#     (R/variance_machinery.R:251, used by eventStudy()). They are the same
+#     joint .assemble_joint_cov_var2() (used by the simultaneous-CI worker) vs
+#     the scalar getSecondVarTermOLS() (used by eventStudy()). They are the same
 #     quantity in different parameterizations; nothing cross-checked them.
+#
+# References here are by FUNCTION NAME, not by R/ line number: all three of the
+# line numbers this header used to carry had gone stale (#429).
 #
 # Both are test-only drift sentinels; the shipped behavior is correct. Each is
 # verified to FAIL on a deliberately-broken version of the guarded path.
@@ -69,10 +73,30 @@ test_that("simultaneousCIs() K=0 degenerate branch returns collapsed point bands
 	for (fam in c("event_study", "cohort", "all_post_treatment")) {
 		expect_message(
 			sci <- simultaneousCIs(.deg_fit_225, family = fam),
-			"zeroed out every treatment effect"
+			"zeroed out every treatment effect",
+			fixed = TRUE
 		)
 		expect_s3_class(sci, "simultaneous_cis")
 		expect_identical(sci$K, as.integer(expected_K[[fam]]))
+
+		# #429 item 7: absolute column-name pin on the degenerate early
+		# return's data.frame(). Adding, removing or reordering a column there
+		# was invisible. This fixture is the FIXED-p arm (it reaches the
+		# message() branch); the high-dim arm, which enters the same
+		# data.frame() through the warning() guard, is pinned in
+		# test-degenerate-band-policy-429.R.
+		expect_identical(
+			names(sci$ci),
+			c(
+				"effect",
+				"estimate",
+				"simultaneous_ci_low",
+				"simultaneous_ci_high",
+				"pointwise_ci_low",
+				"pointwise_ci_high"
+			),
+			info = fam
+		)
 
 		# Every estimate is zero (the support is empty).
 		expect_true(all(sci$ci$estimate == 0))

--- a/tests/testthat/test-gen-coefs-validator-429.R
+++ b/tests/testthat/test-gen-coefs-validator-429.R
@@ -103,31 +103,54 @@ test_that("the unmodified base arguments succeed through both doors (#429 item 9
 test_that(".validate_gen_coefs_scalars() pins all sixteen conditions on both doors (#429 item 9)", {
 	expect_length(.gcv429_cells, 16L)
 
+	# CAPTURE, DO NOT expect_error()-AND-REUSE. A cell whose mutation makes the
+	# call SUCCEED has to fail this loop cleanly rather than abort it.
+	# expect_error() on a non-erroring call records its failure and returns the
+	# expression's VALUE, and conditionMessage() on that value raises -- which
+	# ends the whole test_that() block and silently skips every later cell.
+	#
+	# That is reachable, not hypothetical: with `length(eff_size) != 1` dropped,
+	# genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = c(1, 2)) succeeds
+	# and returns a FETWFE_coefs object (measured). It is harmless today ONLY
+	# because that condition is cell 16 of 16 -- add a cell after it, or reorder
+	# the list, and dropping that one check would hide every cell downstream of
+	# it. The mutation battery would still show the row as detected, because the
+	# aborted block reports a failure either way.
+	#
+	# The two accessors degrade to a readable value instead of raising, so all
+	# five assertions per cell still run and a red cell names itself.
+	msg_of <- function(x) {
+		if (inherits(x, "condition")) {
+			conditionMessage(x)
+		} else {
+			paste0("<no error; returned ", class(x)[1], ">")
+		}
+	}
+	call_of <- function(x) {
+		if (inherits(x, "condition")) {
+			conditionCall(x)
+		} else {
+			quote(NO_ERROR_RAISED)
+		}
+	}
+
 	for (cell in .gcv429_cells) {
 		args <- utils::modifyList(.gcv429_base, cell$over)
 
-		e_gc <- expect_error(
-			do.call(genCoefs, args),
-			cell$lit,
-			fixed = TRUE,
-			info = paste("genCoefs:", cell$id)
+		e_gc <- tryCatch(do.call(genCoefs, args), error = function(e) e)
+		e_core <- tryCatch(do.call(genCoefsCore, args), error = function(e) e)
+
+		expect_true(
+			grepl(cell$lit, msg_of(e_gc), fixed = TRUE),
+			info = paste("genCoefs:", cell$id, "--", msg_of(e_gc))
 		)
-		e_core <- expect_error(
-			do.call(genCoefsCore, args),
-			cell$lit,
-			fixed = TRUE,
-			info = paste("genCoefsCore:", cell$id)
+		expect_true(
+			grepl(cell$lit, msg_of(e_core), fixed = TRUE),
+			info = paste("genCoefsCore:", cell$id, "--", msg_of(e_core))
 		)
 
-		expect_identical(
-			conditionMessage(e_gc),
-			conditionMessage(e_core),
-			info = cell$id
-		)
-		expect_null(conditionCall(e_gc), info = paste("genCoefs:", cell$id))
-		expect_null(
-			conditionCall(e_core),
-			info = paste("genCoefsCore:", cell$id)
-		)
+		expect_identical(msg_of(e_gc), msg_of(e_core), info = cell$id)
+		expect_null(call_of(e_gc), info = paste("genCoefs:", cell$id))
+		expect_null(call_of(e_core), info = paste("genCoefsCore:", cell$id))
 	}
 })

--- a/tests/testthat/test-gen-coefs-validator-429.R
+++ b/tests/testthat/test-gen-coefs-validator-429.R
@@ -1,0 +1,133 @@
+# Issue #429 item 9: all SIXTEEN atomic conditions of
+# .validate_gen_coefs_scalars() (R/gen_coefs.R:1200-1246), through BOTH public
+# doors.
+#
+# The validator is the single-sourced scalar gate that #401 folded out of
+# genCoefs() and genCoefsCore(). Ten of its sixteen atomic conditions had no
+# message-anchored test, and the whole `G` message literal was unpinned, so
+# weakening most of them was invisible to the two files that claim to cover this
+# surface.
+#
+# Each cell asserts three things, and all three are needed:
+#   (1) the error message contains the condition's own literal, `fixed = TRUE`;
+#   (2) the two doors produce IDENTICAL messages (this is what shows the cell
+#       reached the single-sourced validator rather than some door-local check);
+#   (3) conditionCall() is NULL -- the `call. = FALSE` contract from #431 item 1.
+#
+# WHY THE MESSAGE LITERAL IS WHAT CARRIES THE POWER, not expect_error() alone.
+# Both doors carry THREE consecutive redundant backstops --
+# `stopifnot(G >= 1); stopifnot(T >= 2); stopifnot(G <= T - 1)` at
+# R/gen_coefs.R:474-476 and :918-920 -- so three of the sixteen cells (G < 1,
+# T < 2, G > T - 1) error SOMEWHERE regardless of what the validator does. A
+# bare expect_error() on those would be satisfied by the backstop and the
+# mutant would walk.
+#
+# WHY THE FIXTURES CARRY NO OTHER ARGUMENTS. The two doors run their prologues
+# in different orders: genCoefsCore() runs .resolve_cohort_count_arg() (:898),
+# match.arg(fusion_structure) (:900) and .validate_targeted_sparsity() (:906)
+# BEFORE the scalar validator (:910), while genCoefs() runs the scalar validator
+# (:375) BEFORE match.arg() (:383). Keep every argument that genCoefsCore()
+# validates before :910 out of these fixtures -- `fusion_structure`,
+# `n_signal_cohorts`, `treat_base_levels` and the deprecated `R` alias -- or a
+# fixture bad in two ways at once will produce different messages from the two
+# doors and break assertion (2) for a reason unrelated to this item.
+#
+# This file SUPERSEDES nothing in test-genCoefs.R / test-genCoefsCore.R. Six of
+# these cells overlap with the ten assertions there, but those use bare
+# `regexp =` (and one, "density must be", is a truncated prefix), so the cells
+# here are strictly stronger; the older ones stay as door-level smoke tests.
+
+.gcv429_base <- list(G = 3, T = 5, d = 2, density = 0.5, eff_size = 1)
+
+.gcv429_T_msg <- "T must be a numeric value greater than or equal to 2"
+.gcv429_G_msg <-
+	"G must be a numeric value greater than or equal to 1 (at least one treated cohort)"
+.gcv429_GT_msg <- "G must be less than or equal to T - 1"
+.gcv429_d_msg <- "d must be a non-negative numeric value"
+.gcv429_dens_msg <- "density must be numeric, greater than 0 and at most 1"
+.gcv429_eff_msg <- "eff_size must be a numeric value"
+
+# One row per atomic condition, in source order.
+.gcv429_cells <- list(
+	list(id = "T not numeric", over = list(T = "5"), lit = .gcv429_T_msg),
+	list(id = "T length != 1", over = list(T = c(5, 6)), lit = .gcv429_T_msg),
+	list(id = "T < 2", over = list(T = 1), lit = .gcv429_T_msg),
+	list(id = "G not numeric", over = list(G = "3"), lit = .gcv429_G_msg),
+	list(id = "G length != 1", over = list(G = c(2, 3)), lit = .gcv429_G_msg),
+	list(id = "G < 1", over = list(G = 0), lit = .gcv429_G_msg),
+	list(id = "G > T - 1", over = list(G = 5, T = 5), lit = .gcv429_GT_msg),
+	list(id = "d not numeric", over = list(d = "2"), lit = .gcv429_d_msg),
+	list(id = "d length != 1", over = list(d = c(1, 2)), lit = .gcv429_d_msg),
+	list(id = "d < 0", over = list(d = -1), lit = .gcv429_d_msg),
+	list(
+		id = "density not numeric",
+		over = list(density = "0.5"),
+		lit = .gcv429_dens_msg
+	),
+	list(
+		id = "density length != 1",
+		over = list(density = c(0.4, 0.5)),
+		lit = .gcv429_dens_msg
+	),
+	list(id = "density <= 0", over = list(density = 0), lit = .gcv429_dens_msg),
+	list(
+		id = "density > 1",
+		over = list(density = 1.1),
+		lit = .gcv429_dens_msg
+	),
+	list(
+		id = "eff_size not numeric",
+		over = list(eff_size = "1"),
+		lit = .gcv429_eff_msg
+	),
+	list(
+		id = "eff_size length != 1",
+		over = list(eff_size = c(1, 2)),
+		lit = .gcv429_eff_msg
+	)
+)
+
+# ------------------------------------------------------------------------------
+# SANITY BLOCK, first in the file. Without it, a change that made EVERY input
+# fail would leave all sixteen negative cells green.
+# ------------------------------------------------------------------------------
+test_that("the unmodified base arguments succeed through both doors (#429 item 9)", {
+	gc <- do.call(genCoefs, .gcv429_base)
+	expect_s3_class(gc, "FETWFE_coefs")
+
+	core <- do.call(genCoefsCore, .gcv429_base)
+	expect_true(is.list(core))
+	expect_identical(names(core), c("beta", "theta"))
+})
+
+test_that(".validate_gen_coefs_scalars() pins all sixteen conditions on both doors (#429 item 9)", {
+	expect_length(.gcv429_cells, 16L)
+
+	for (cell in .gcv429_cells) {
+		args <- utils::modifyList(.gcv429_base, cell$over)
+
+		e_gc <- expect_error(
+			do.call(genCoefs, args),
+			cell$lit,
+			fixed = TRUE,
+			info = paste("genCoefs:", cell$id)
+		)
+		e_core <- expect_error(
+			do.call(genCoefsCore, args),
+			cell$lit,
+			fixed = TRUE,
+			info = paste("genCoefsCore:", cell$id)
+		)
+
+		expect_identical(
+			conditionMessage(e_gc),
+			conditionMessage(e_core),
+			info = cell$id
+		)
+		expect_null(conditionCall(e_gc), info = paste("genCoefs:", cell$id))
+		expect_null(
+			conditionCall(e_core),
+			info = paste("genCoefsCore:", cell$id)
+		)
+	}
+})

--- a/tests/testthat/test-resolve-selected-support-contract-400.R
+++ b/tests/testthat/test-resolve-selected-support-contract-400.R
@@ -107,13 +107,24 @@ test_that("fetwfe d_inv_treat_sel stays a 1-col matrix with a single selection (
 	# dropped), which is why the k >= 1 block above cannot see the mutation.
 	#
 	# This deliberately leaves `f` OFF-CONTRACT: its theta_hat no longer agrees
-	# with its beta_hat, att_selected, catt_hats or catt_df, so
-	# .validate_fetwfe() would reject it. That is safe only because
-	# .resolve_selected_support() is a pure internal reader with no precondition
-	# call. DO NOT extend this block to call any of the seven
-	# .check_for_*-guarded accessors (eventStudy, augment, tidy, glance, plot,
-	# coef, simultaneousCIs) on `f` -- each would fail on a contract unrelated
-	# to drop = FALSE.
+	# with its beta_hat, att_selected, catt_hats or catt_df. That is safe here
+	# only because .resolve_selected_support() is a pure internal reader with no
+	# precondition call.
+	#
+	# DO NOT extend this block to call any of the seven .check_for_*-guarded
+	# accessors (eventStudy, augment, tidy, glance, plot, coef,
+	# simultaneousCIs) on `f`. Be precise about why, because the reassuring
+	# version of this warning is false and was shipped in an earlier draft:
+	# .validate_fetwfe() does NOT reject this object. It never reads
+	# internal$theta_hat, so it accepts the fixture silently (measured; a
+	# trimmed-beta_hat control on the same fit raises `C6 length(beta_hat) == p`,
+	# which is what proves the validator is live rather than absent). Six of the
+	# seven accessors then run clean and return DIFFERENT numbers -- eventStudy(f)$se
+	# collapses from c(0.13677, 0.20340, 0.24978, 0.26261) to a constant 0.11772.
+	# Only augment() errors, and it errors on the unmutated fit too, for an
+	# unrelated reason. So the hazard is a silently wrong answer, not a loud
+	# rejection: exactly the failure mode this package's validators exist for,
+	# in the one gap they do not cover.
 	f <- fits$fetwfe
 	num_treats <- length(f$treat_inds)
 	f$internal$theta_hat[1L + f$treat_inds] <- 0

--- a/tests/testthat/test-resolve-selected-support-contract-400.R
+++ b/tests/testthat/test-resolve-selected-support-contract-400.R
@@ -11,6 +11,11 @@ library(fetwfe)
 #     cells selected, d_inv_treat_sel = full diag(num_treats).
 #   - fetwfe/betwfe: d_inv_treat_sel keeps drop = FALSE (a matrix even with a
 #     single selected treatment cell) and is NULL when nothing is selected.
+#
+# #429 item 8: the k = 1 drop = FALSE case is now covered for BOTH branches. It
+# used to be exercised for betwfe only, while this header claimed it for
+# "fetwfe/betwfe" -- so removing drop = FALSE from the fetwfe branch of
+# .resolve_selected_support() left this file green.
 # ------------------------------------------------------------------------------
 
 .resolve <- get(".resolve_selected_support", envir = asNamespace("fetwfe"))
@@ -91,6 +96,43 @@ test_that("betwfe d_inv_treat_sel stays a 1-col matrix with a single selection (
 	expect_length(r$sel_treat_inds_shifted, 1L)
 	expect_true(is.matrix(r$d_inv_treat_sel)) # drop=FALSE: NOT dropped to a vector
 	expect_identical(ncol(r$d_inv_treat_sel), 1L)
+})
+
+test_that("fetwfe d_inv_treat_sel stays a 1-col matrix with a single selection (#429 item 8)", {
+	# The fetwfe branch has to be forced DIFFERENTLY from betwfe's above: betwfe
+	# reads its selection from the `beta_hat` ARGUMENT, while fetwfe ignores
+	# beta_hat entirely and reads x$internal$theta_hat. So the mutation goes on
+	# the fit object, with the `1L +` offset the resolver's intercept-dropping
+	# slice implies. The ordinary fit selects k = 6 here (a 10x6 subset is not
+	# dropped), which is why the k >= 1 block above cannot see the mutation.
+	#
+	# This deliberately leaves `f` OFF-CONTRACT: its theta_hat no longer agrees
+	# with its beta_hat, att_selected, catt_hats or catt_df, so
+	# .validate_fetwfe() would reject it. That is safe only because
+	# .resolve_selected_support() is a pure internal reader with no precondition
+	# call. DO NOT extend this block to call any of the seven
+	# .check_for_*-guarded accessors (eventStudy, augment, tidy, glance, plot,
+	# coef, simultaneousCIs) on `f` -- each would fail on a contract unrelated
+	# to drop = FALSE.
+	f <- fits$fetwfe
+	num_treats <- length(f$treat_inds)
+	f$internal$theta_hat[1L + f$treat_inds] <- 0
+	f$internal$theta_hat[1L + f$treat_inds[1]] <- 1 # exactly one selected cell
+	r <- do.call(.resolve, .args_for(f))
+
+	expect_length(r$sel_treat_inds_shifted, 1L)
+	# The two load-bearing assertions: without drop = FALSE, d_inv_treat[, 1] is
+	# a bare length-num_treats vector, so is.matrix() is FALSE and dim() is NULL.
+	expect_true(is.matrix(r$d_inv_treat_sel))
+	expect_identical(dim(r$d_inv_treat_sel), c(as.integer(num_treats), 1L))
+
+	# Branch identity: the fetwfe branch must not be silently producing what the
+	# betwfe branch would from the same selection. Measured here, the fetwfe
+	# column is the all-ones vector (cohort 1's fused base column lifts every
+	# CATT equally), which diag(num_treats)[, 1] is not. Do NOT "strengthen"
+	# this into a pin on the column's exact contents -- that is
+	# genInvTwoWayFusionTransformMat()'s contract and is tested elsewhere.
+	expect_false(identical(r$d_inv_treat_sel[, 1], diag(num_treats)[, 1]))
 })
 
 test_that("fetwfe/betwfe d_inv_treat_sel is NULL on empty selection (#400)", {


### PR DESCRIPTION
Closes #429 — the six remaining items after PR #451, plus the fourth pinned SE vector `test-cross-accessor-scaffold-guardrail-400.R:96` assigns to "PR B" by name.

Tests only. No file under `R/`, `man/`, `NAMESPACE` or `DESCRIPTION` changes, so nothing an estimator returns moves. Gate: `Status: OK`, 0/0/0, no timestamp NOTE; `url_check()` 25 URLs clean.

**The measurement.** Seven classes of mutation to shipped code that the test file claiming the contract could not see, and now can: deleting the shared C6/C8 check from any of the three class validators (0→4 each); three defects plus an ordering defect in `.compute_att_pair()`; flipping the flag that keeps an ordinary `fetwfe()` fit silent on a degenerate high-dimensional band (0→6); adding, removing or reordering a column of the degenerate `$ci` frame (0→7); dropping `drop = FALSE` on the fetwfe branch of `.resolve_selected_support()`; weakening any of the sixteen `genCoefs()` scalar checks; and perturbing `simultaneousCIs()`'s SE path, where the `Sigma` mutation now fires **24** in that file rather than 18 — one new red in each of the six Part 2 blocks.

Two honest limits. Item 9 is a *partial* restoration: five of its sixteen conditions already reddened an existing file and two more were already asserted there, so nine were invisible rather than sixteen. And two of the sixteen mutations make `genCoefs()` non-terminating (see #436), so their detection is inferred structurally rather than run.

## Worth your attention

The fourth pinned vector reproduces `cohortStudy(fit)$se` to the seventh printed digit in all six blocks — that agreement *is* what Anchor C asserts, and pinning it absolutely is the point, since Anchor C can no longer tell the two paths apart. The comment forbids the tempting cleanup of comparing against `cohortStudy()` directly, which would undo it.

Three claims in the first draft were false and are corrected in the last commit — most consequentially, `.validate_fetwfe()` **accepts** the deliberately off-contract fixture in the `drop = FALSE` block rather than rejecting it, and six of seven guarded accessors then return silently different numbers. The advice was right; the reason was inverted toward reassurance.

## Out of scope

- **Bootstrap-only extra field on `extras`** — filed as #455. One of the two entries in #429's table no numbered item covered. Not re-measured this cycle.
- **Byte-exact re-expansion of a `simultaneousCIs.<class>` alias** — filed as #456. It survives: `identical()` ignores srcrefs by default, and `ignore.srcref = FALSE` is blind on an installed package.
