### PR TITLE
Cap the two uncapped retry loops, and name the argument on a missing value (#436)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,31 @@
   estimate, band, standard error, or selected support changes; what changes is
   that a result already known to be unreliable is now announced.
 
+- `genCoefs()` and `genCoefsCore()` no longer spin forever on a legal but
+  degenerate `density` (#436): selecting the nonzero coefficients is rejection
+  sampling whose expected number of attempts grows without bound as `density`
+  approaches 0, so a value such as `1e-300` --- which the argument checks accept
+  --- previously never returned, with no message and no error, and the retry is
+  now capped at 10,000 attempts and fails with a message naming the attempt
+  count, the coefficient-vector length and the `density` supplied.
+
+- `simulateData()` and `simulateDataCore()` no longer spin forever at the
+  smallest `N` their argument checks admit (#436): allocating `N` units among
+  `G + 1` groups is also rejection sampling, and at `N = G + 1` every group must
+  receive exactly one unit, which happens with probability 4.8e-13 at `G = 30`,
+  so the draw is now capped at 1,000,000 attempts and fails with a message
+  naming `N`, `G`, the per-group bar it could not clear, the attempt count and
+  the way out --- increasing `N` by about 25% takes the expected number of draws
+  from millions to under 200 in every configuration measured.
+
+- A missing value passed to `genCoefs()` or `genCoefsCore()` now produces the
+  package's own message rather than R's `missing value where TRUE/FALSE needed`
+  (#436): a typed `NA` such as `NA_real_` or `NA_integer_`, and `NaN`, satisfy
+  `is.numeric()` and so reached a comparison that evaluated to `NA`, and all
+  five of `T`, `G`, `d`, `density` and `eff_size` were affected. What these
+  functions accept is unchanged --- every such input already failed, just
+  without saying which argument was at fault.
+
 ### Internal
 
 - The remaining six items of the test-power audit that followed the #400/#401

--- a/NEWS.md
+++ b/NEWS.md
@@ -93,14 +93,21 @@
   receive exactly one unit, which happens with probability 4.8e-13 at `G = 30`,
   so the draw is now capped at 1,000,000 attempts and fails with a message
   naming `N`, `G`, the per-group bar it could not clear, the attempt count and
-  the way out --- increasing `N` by about 25% takes the expected number of draws
-  from millions to under 200 in every configuration measured. Note that no cap
-  can serve every admissible `N`, so a small number of calls that used to
-  succeed will now error instead: at the tightest `guarantee_rank_condition =
-  TRUE` size, `G = 8`, `d = 4`, `N = 45`, twelve of twelve seeds succeeded
-  before and eleven of twelve succeed now. Such a call was already a coin flip
-  between a result and a session that never returned; it is now a coin flip
-  between a result and an error that says how to fix it.
+  the way out --- at small `G`, increasing `N` by about 25% takes the expected
+  number of draws from hundreds of thousands or millions to under 200, though
+  the headroom needed grows with `G`.
+
+- **Some `simulateData()` calls that used to succeed now error instead** (#436).
+  No cap can serve every admissible `N`, and the retry cost near the smallest
+  admissible sizes is a smooth distribution rather than a clean split between
+  workable and hopeless --- so bounding it necessarily cuts off the slowest
+  successes along with the calls that never finish. Measured over ten seeds at
+  `G = 14`, `T = 15`, `d = 1`, `N = 15` --- the default mode, no
+  `guarantee_rank_condition` --- ten of ten succeeded before, in a median of
+  0.96 seconds, and eight of ten succeed now. The same happens at the
+  `guarantee_rank_condition = TRUE` sizes. If a `simulateData()` call near
+  `N = G + 1` or `N = (G + 1)(d + 1)` starts failing, raise `N`: this is the
+  cost of never hanging, and the error names the way out.
 
 - A missing value passed to `genCoefs()` or `genCoefsCore()` now names the
   argument at fault (#436). A typed `NA` such as `NA_real_` or `NA_integer_`,

--- a/NEWS.md
+++ b/NEWS.md
@@ -94,15 +94,23 @@
   so the draw is now capped at 1,000,000 attempts and fails with a message
   naming `N`, `G`, the per-group bar it could not clear, the attempt count and
   the way out --- increasing `N` by about 25% takes the expected number of draws
-  from millions to under 200 in every configuration measured.
+  from millions to under 200 in every configuration measured. Note that no cap
+  can serve every admissible `N`, so a small number of calls that used to
+  succeed will now error instead: at the tightest `guarantee_rank_condition =
+  TRUE` size, `G = 8`, `d = 4`, `N = 45`, twelve of twelve seeds succeeded
+  before and eleven of twelve succeed now. Such a call was already a coin flip
+  between a result and a session that never returned; it is now a coin flip
+  between a result and an error that says how to fix it.
 
-- A missing value passed to `genCoefs()` or `genCoefsCore()` now produces the
-  package's own message rather than R's `missing value where TRUE/FALSE needed`
-  (#436): a typed `NA` such as `NA_real_` or `NA_integer_`, and `NaN`, satisfy
-  `is.numeric()` and so reached a comparison that evaluated to `NA`, and all
-  five of `T`, `G`, `d`, `density` and `eff_size` were affected. What these
-  functions accept is unchanged --- every such input already failed, just
-  without saying which argument was at fault.
+- A missing value passed to `genCoefs()` or `genCoefsCore()` now names the
+  argument at fault (#436). A typed `NA` such as `NA_real_` or `NA_integer_`,
+  and `NaN`, satisfy `is.numeric()`, so all five of `T`, `G`, `d`, `density`
+  and `eff_size` slipped past the argument checks; for the first four the
+  comparison that followed evaluated to `NA` and R raised
+  `missing value where TRUE/FALSE needed`, while `eff_size` --- whose check
+  makes no comparison --- passed validation outright and failed later inside
+  the coefficient assembly. What these functions accept is unchanged: every
+  such input already failed, just without saying which argument was at fault.
 
 ### Internal
 

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -109,7 +109,9 @@
 #'   corresponding to covariate main effects and interactions are included in \code{beta}.
 #' @param density Numeric in (0,1]. The probability that any given entry in the initial
 #'   coefficient vector \code{theta} is nonzero. \code{density = 1} gives a fully dense
-#'   (non-sparse) coefficient vector.
+#'   (non-sparse) coefficient vector. A \code{density} so small that an all-zero draw is
+#'   near-certain is rejected rather than retried forever: the coefficient draw is retried
+#'   at most 10,000 times and then errors.
 #' @param eff_size Numeric. The magnitude used to scale nonzero entries in \code{theta}. Each
 #'   nonzero entry is set to \code{eff_size} or \code{-eff_size} (with a 60 percent chance for a
 #'   positive value).
@@ -794,7 +796,9 @@ getTes <- function(coefs_obj, distribution = "gaussian") {
 #' corresponding to covariate main effects and interactions are included in \code{beta}.
 #' @param density Numeric in (0,1]. The probability that any given entry in the initial
 #' coefficient vector \code{theta} is nonzero. \code{density = 1} gives a fully dense
-#' (non-sparse) coefficient vector.
+#' (non-sparse) coefficient vector. A \code{density} so small that an all-zero draw is
+#' near-certain is rejected rather than retried forever: the coefficient draw is retried
+#' at most 10,000 times and then errors.
 #' @param eff_size Numeric. The magnitude used to scale nonzero entries in \code{theta}. Each
 #' nonzero entry is set to \code{eff_size} or \code{-eff_size} (with a 60 percent chance for a
 #' positive value).

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -936,9 +936,37 @@ genCoefsCore <- function(
 		#      line, re-drawn on an all-zero result, then the rfunc sign draw whose
 		#      length depends on it) and hence `theta`/`beta` are byte-identical to
 		#      pre-#332 behavior. ----
-		# Make sure at least one feature is selected
+		# Make sure at least one feature is selected. The retry is rejection
+		# sampling and terminates with probability 1, but the expected number of
+		# attempts is 1 / (1 - (1 - density)^p), which grows without bound as
+		# `density` approaches 0 -- so a legal-but-degenerate `density` (e.g.
+		# 1e-300, which passes .validate_gen_coefs_scalars()) would otherwise
+		# spin forever with no diagnostic (#436). Cap the attempts and fail with
+		# an actionable message instead. The cap bounds how many times the draw
+		# below is repeated; it does not change the draw, so the RNG stream --
+		# and hence `theta`/`beta` -- stays byte-identical for every input that
+		# terminates today.
+		max_tries <- 10000L
+		tries <- 0L
 		pass_condition <- FALSE
 		while (!pass_condition) {
+			tries <- tries + 1L
+			if (tries > max_tries) {
+				stop(
+					sprintf(
+						paste0(
+							"Could not draw a coefficient vector with at least ",
+							"one nonzero entry in %d attempts: no draw of %d ",
+							"Bernoulli(density) coefficients contained a nonzero ",
+							"entry at density = %g. Try a larger `density`."
+						),
+						max_tries,
+						p,
+						density
+					),
+					call. = FALSE
+				)
+			}
 			theta_inds <- which(as.logical(rbinom(
 				n = p,
 				size = 1,

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -1226,8 +1226,19 @@ getActualCohortTes <- function(G, first_inds, treat_inds, coefs, num_treats) {
 #' @keywords internal
 #' @noRd
 .validate_gen_coefs_scalars <- function(T, G, d, density, eff_size) {
+	# The `is.na()` clause in each block below closes #436's second hole:
+	# NA_real_, NA_integer_ and NaN pass `is.numeric()`, so the comparison that
+	# follows evaluated to NA and `if (NA)` raised R's own
+	# `missing value where TRUE/FALSE needed` instead of the block's message.
+	# (Bare `NA` is logical, so `is.numeric()` already caught it.) EACH CLAUSE
+	# MUST SIT AFTER ITS `length(x) != 1` CLAUSE: `||` errors on a length-2
+	# operand under this package's R (>= 4.4.0) floor, so `is.na()` first turns
+	# a length-2 fixture into `'length = 2' in coercion to 'logical(1)'` --
+	# a different, worse error (measured). Placing it before the comparisons is
+	# for readability only; `NA || TRUE` is TRUE, so it would also work last.
+
 	# Check that T is a numeric scalar and at least 2.
-	if (!is.numeric(T) || length(T) != 1 || T < 2) {
+	if (!is.numeric(T) || length(T) != 1 || is.na(T) || T < 2) {
 		stop(
 			"T must be a numeric value greater than or equal to 2",
 			call. = FALSE
@@ -1235,7 +1246,7 @@ getActualCohortTes <- function(G, first_inds, treat_inds, coefs, num_treats) {
 	}
 
 	# Check that G is a numeric scalar and at least 1.
-	if (!is.numeric(G) || length(G) != 1 || G < 1) {
+	if (!is.numeric(G) || length(G) != 1 || is.na(G) || G < 1) {
 		stop(
 			"G must be a numeric value greater than or equal to 1 (at least one treated cohort)",
 			call. = FALSE
@@ -1248,7 +1259,7 @@ getActualCohortTes <- function(G, first_inds, treat_inds, coefs, num_treats) {
 	}
 
 	# Check that d is a numeric scalar and is non-negative.
-	if (!is.numeric(d) || length(d) != 1 || d < 0) {
+	if (!is.numeric(d) || length(d) != 1 || is.na(d) || d < 0) {
 		stop("d must be a non-negative numeric value", call. = FALSE)
 	}
 
@@ -1256,6 +1267,7 @@ getActualCohortTes <- function(G, first_inds, treat_inds, coefs, num_treats) {
 	if (
 		!is.numeric(density) ||
 			length(density) != 1 ||
+			is.na(density) ||
 			density <= 0 ||
 			density > 1
 	) {
@@ -1266,7 +1278,7 @@ getActualCohortTes <- function(G, first_inds, treat_inds, coefs, num_treats) {
 	}
 
 	# Check that eff_size is numeric.
-	if (!is.numeric(eff_size) || length(eff_size) != 1) {
+	if (!is.numeric(eff_size) || length(eff_size) != 1 || is.na(eff_size)) {
 		stop("eff_size must be a numeric value", call. = FALSE)
 	}
 

--- a/R/gen_coefs.R
+++ b/R/gen_coefs.R
@@ -1231,9 +1231,15 @@ getActualCohortTes <- function(G, first_inds, treat_inds, coefs, num_treats) {
 #' @noRd
 .validate_gen_coefs_scalars <- function(T, G, d, density, eff_size) {
 	# The `is.na()` clause in each block below closes #436's second hole:
-	# NA_real_, NA_integer_ and NaN pass `is.numeric()`, so the comparison that
-	# follows evaluated to NA and `if (NA)` raised R's own
-	# `missing value where TRUE/FALSE needed` instead of the block's message.
+	# NA_real_, NA_integer_ and NaN pass `is.numeric()`. For `T`, `G`, `d` and
+	# `density` that meant the comparison which follows evaluated to NA and
+	# `if (NA)` raised R's own `missing value where TRUE/FALSE needed` instead
+	# of the block's message. `eff_size` failed DIFFERENTLY and is worth calling
+	# out, because the obvious one-sentence summary is wrong for it: its check
+	# has no comparison at all, so a missing value passed validation outright
+	# and died later in the `beta` assembly on
+	# `all(!is.na(beta[...])) is not TRUE` (measured). Either way no wrong
+	# answer was ever returned -- only a cryptic message.
 	# (Bare `NA` is logical, so `is.numeric()` already caught it.) EACH CLAUSE
 	# MUST SIT AFTER ITS `length(x) != 1` CLAUSE: `||` errors on a length-2
 	# operand under this package's R (>= 4.4.0) floor, so `is.na()` first turns

--- a/R/gen_data.R
+++ b/R/gen_data.R
@@ -18,7 +18,12 @@
 #'
 #' @param coefs_obj An object of class \code{"FETWFE_coefs"} containing the coefficient vector
 #' and simulation parameters.
-#' @param N Integer. Number of units in the panel.
+#' @param N Integer. Number of units in the panel. Units are allocated among
+#'   the `G + 1` groups by a retry that is bounded at 1,000,000 attempts; an
+#'   `N` at or very near the smallest admissible size (`G + 1`, or
+#'   `(G + 1) * (d + 1)` when `guarantee_rank_condition = TRUE`) can exhaust
+#'   that budget and error rather than returning. Raising `N` is the fix, and
+#'   the error says so.
 #' @param sig_eps_sq Numeric. Variance of the idiosyncratic (observation-level) noise.
 #' @param sig_eps_c_sq Numeric. Variance of the unit-level random effects.
 #'   Must be non-negative; `0` is allowed (yields a panel with no unit-level
@@ -258,7 +263,12 @@ simulateData <- function(
 #'
 #' See the simulation studies section of Faletto (2025) for details.
 #'
-#' @param N Integer. Number of units in the panel.
+#' @param N Integer. Number of units in the panel. Units are allocated among
+#'   the `G + 1` groups by a retry that is bounded at 1,000,000 attempts; an
+#'   `N` at or very near the smallest admissible size (`G + 1`, or
+#'   `(G + 1) * (d + 1)` when `guarantee_rank_condition = TRUE`) can exhaust
+#'   that budget and error rather than returning. Raising `N` is the fix, and
+#'   the error says so.
 #' @param T Integer. Number of time periods.
 #' @param G Integer. Number of treated cohorts (with treatment starting in periods 2 to T).
 #' @param d Integer. Number of time-invariant covariates.

--- a/R/sim_helpers.R
+++ b/R/sim_helpers.R
@@ -313,7 +313,10 @@ genCohortTimeFE <- function(N, T, G, d, guarantee_rank_condition = FALSE) {
 #' Generate Random Cohort Assignments
 #'
 #' Assigns N units to G+1 groups (G treated cohorts + 1 never-treated group)
-#' ensuring each group has at least one unit.
+#' ensuring each group has at least one unit. The draw is repeated until every
+#' group clears its bar; that retry is bounded at 1,000,000 attempts, after
+#' which the function errors with a message naming `N`, `G`, the bar and the
+#' attempt count rather than spinning forever (#436).
 #'
 #' @param N Integer. Total number of units to assign.
 #' @param G Integer. Number of treated cohorts.
@@ -334,8 +337,72 @@ genCohortTimeFE <- function(N, T, G, d, guarantee_rank_condition = FALSE) {
 genAssignments <- function(N, G, guarantee_rank_condition = FALSE, d = NA) {
 	# Make sure at least one observation in each cohort
 	stopifnot(N >= G + 1)
+	# The retry below is rejection sampling. The callers' assertions
+	# (`N >= G + 1`, and `N >= (G + 1) * (d + 1)` under
+	# guarantee_rank_condition) guarantee only that the bar is ACHIEVABLE, not
+	# that it is achievable in practice: at N = G + 1 every group must receive
+	# exactly one unit, so P(success) = (G+1)! / (G+1)^(G+1), which is 4.8e-13
+	# at G = 30. Both floors are reachable from a plain simulateData() call, and
+	# both used to spin forever with no diagnostic (#436). Cap the attempts and
+	# fail with a message naming N, G, the bar, and the escape -- a ~25% larger
+	# N takes E[draws] from 1e5-1e7 down to under 200 everywhere it was
+	# measured. The cap bounds how many times the draw below is repeated; it
+	# does not change the draw, so the simulation stream is unmoved for every
+	# input that terminates today.
+	max_tries <- 1000000L
+	tries <- 0L
 	pass_condition <- FALSE
 	while (!pass_condition) {
+		tries <- tries + 1L
+		if (tries > max_tries) {
+			if (guarantee_rank_condition) {
+				# Render the NUMBER, never the symbolic `d + 1`: two blocks in
+				# tests/testthat/test-simulate-data-highdim-293.R match the bare
+				# pattern "d \\+ 1" to prove the callers' up-front
+				# stopifnot(N >= (G + 1) * (d + 1)) fired, and the symbolic form
+				# would match this message too -- silently converting them from
+				# "the guard fired" into "either the guard or the cap fired".
+				bar_desc <- sprintf("at least %s units", d + 1)
+				# ONE percent sign, not two. `suggestion` is an ARGUMENT
+				# substituted into `%s` below, not part of a format string, and
+				# sprintf() does not re-scan substituted arguments -- so a `%%`
+				# here would reach the user literally as `25%%`. Every other
+				# `%%` in R/ sits in a format string, where doubling is correct.
+				suggestion <- paste0(
+					"Try a larger N -- increasing N by about 25% is ",
+					"typically enough -- or set ",
+					"guarantee_rank_condition = FALSE."
+				)
+			} else {
+				bar_desc <- "at least one unit"
+				suggestion <- "Try a larger N."
+			}
+			stop(
+				sprintf(
+					# `%s` for N, G, G + 1 and d + 1: none of them is
+					# guaranteed integral, and sprintf("%d", 31.5) is an error
+					# -- reachable from simulateData(c1, N = 31.5), which would
+					# otherwise exhaust the cap and then die on `invalid format
+					# '%d'`, replacing a hang with a different cryptic error.
+					# `%d` is right for max_tries alone, which is an integer
+					# literal we control; keep its `L` suffix, since
+					# sprintf("%s", 1000000) renders `1e+06` and would take the
+					# `in 1000000 attempts` literal down with it.
+					paste0(
+						"Could not draw cohort assignments giving every one ",
+						"of the %s groups %s in %d attempts, at ",
+						"N = %s and G = %s. %s"
+					),
+					G + 1,
+					bar_desc,
+					max_tries,
+					N,
+					G,
+					suggestion
+				),
+				call. = FALSE
+			)
+		}
 		assignments <- rmultinom(
 			n = 1,
 			size = N,

--- a/R/sim_helpers.R
+++ b/R/sim_helpers.R
@@ -367,10 +367,21 @@ genAssignments <- function(N, G, guarantee_rank_condition = FALSE, d = NA) {
 				# substituted into `%s` below, not part of a format string, and
 				# sprintf() does not re-scan substituted arguments -- so a `%%`
 				# here would reach the user literally as `25%%`. Every other
-				# `%%` in R/ sits in a format string, where doubling is correct.
+				# `%%` in R/ is either inside a format string (where doubling
+				# is correct) or the modulo operator (R/debiased_att.R:479,
+				# where it is neither); this one is the only argument-position
+				# case.
+				#
+				# The headroom figure is deliberately hedged. A 25% larger N
+				# empties the retry budget at G <= 10 (measured: E[draws] falls
+				# from 1e5-1e7 to under 200), but NOT at larger G -- at
+				# G = 25, d = 1 a 25% bump still needs ~6e5 to 2.4e6 draws, so
+				# two of three seeds land back on the cap. Do not restore a
+				# flat "25% is enough": it is false exactly where the cap
+				# actually fires.
 				suggestion <- paste0(
-					"Try a larger N -- increasing N by about 25% is ",
-					"typically enough -- or set ",
+					"Try a larger N -- 25% more is usually enough at small G, ",
+					"and the headroom needed grows with G -- or set ",
 					"guarantee_rank_condition = FALSE."
 				)
 			} else {
@@ -385,9 +396,11 @@ genAssignments <- function(N, G, guarantee_rank_condition = FALSE, d = NA) {
 					# otherwise exhaust the cap and then die on `invalid format
 					# '%d'`, replacing a hang with a different cryptic error.
 					# `%d` is right for max_tries alone, which is an integer
-					# literal we control; keep its `L` suffix, since
-					# sprintf("%s", 1000000) renders `1e+06` and would take the
-					# `in 1000000 attempts` literal down with it.
+					# literal we control. Keep its `L` suffix -- `%d` does not
+					# need it today (sprintf("%d", 1000000) on a double is
+					# "1000000"), but sprintf("%s", 1000000) renders `1e+06`,
+					# so a later switch of this one field to `%s` would take
+					# the `in 1000000 attempts` literal down with it.
 					paste0(
 						"Could not draw cohort assignments giving every one ",
 						"of the %s groups %s in %d attempts, at ",

--- a/man/genCoefs.Rd
+++ b/man/genCoefs.Rd
@@ -34,7 +34,9 @@ corresponding to covariate main effects and interactions are included in \code{b
 
 \item{density}{Numeric in (0,1]. The probability that any given entry in the initial
 coefficient vector \code{theta} is nonzero. \code{density = 1} gives a fully dense
-(non-sparse) coefficient vector.}
+(non-sparse) coefficient vector. A \code{density} so small that an all-zero draw is
+near-certain is rejected rather than retried forever: the coefficient draw is retried
+at most 10,000 times and then errors.}
 
 \item{eff_size}{Numeric. The magnitude used to scale nonzero entries in \code{theta}. Each
 nonzero entry is set to \code{eff_size} or \code{-eff_size} (with a 60 percent chance for a

--- a/man/genCoefsCore.Rd
+++ b/man/genCoefsCore.Rd
@@ -29,7 +29,9 @@ corresponding to covariate main effects and interactions are included in \code{b
 
 \item{density}{Numeric in (0,1]. The probability that any given entry in the initial
 coefficient vector \code{theta} is nonzero. \code{density = 1} gives a fully dense
-(non-sparse) coefficient vector.}
+(non-sparse) coefficient vector. A \code{density} so small that an all-zero draw is
+near-certain is rejected rather than retried forever: the coefficient draw is retried
+at most 10,000 times and then errors.}
 
 \item{eff_size}{Numeric. The magnitude used to scale nonzero entries in \code{theta}. Each
 nonzero entry is set to \code{eff_size} or \code{-eff_size} (with a 60 percent chance for a

--- a/man/simulateData.Rd
+++ b/man/simulateData.Rd
@@ -18,7 +18,12 @@ simulateData(
 \item{coefs_obj}{An object of class \code{"FETWFE_coefs"} containing the coefficient vector
 and simulation parameters.}
 
-\item{N}{Integer. Number of units in the panel.}
+\item{N}{Integer. Number of units in the panel. Units are allocated among
+the \code{G + 1} groups by a retry that is bounded at 1,000,000 attempts; an
+\code{N} at or very near the smallest admissible size (\code{G + 1}, or
+\code{(G + 1) * (d + 1)} when \code{guarantee_rank_condition = TRUE}) can exhaust
+that budget and error rather than returning. Raising \code{N} is the fix, and
+the error says so.}
 
 \item{sig_eps_sq}{Numeric. Variance of the idiosyncratic (observation-level) noise.}
 

--- a/man/simulateDataCore.Rd
+++ b/man/simulateDataCore.Rd
@@ -22,7 +22,12 @@ simulateDataCore(
 )
 }
 \arguments{
-\item{N}{Integer. Number of units in the panel.}
+\item{N}{Integer. Number of units in the panel. Units are allocated among
+the \code{G + 1} groups by a retry that is bounded at 1,000,000 attempts; an
+\code{N} at or very near the smallest admissible size (\code{G + 1}, or
+\code{(G + 1) * (d + 1)} when \code{guarantee_rank_condition = TRUE}) can exhaust
+that budget and error rather than returning. Raising \code{N} is the fix, and
+the error says so.}
 
 \item{T}{Integer. Number of time periods.}
 

--- a/tests/testthat/helper-condition-accessors.R
+++ b/tests/testthat/helper-condition-accessors.R
@@ -1,0 +1,32 @@
+# Degrading accessors for condition objects captured with tryCatch().
+#
+# WHY THESE EXIST, rather than expect_error()-and-reuse. A cell whose mutation
+# makes the call SUCCEED has to fail its loop cleanly rather than abort it.
+# expect_error() on a non-erroring call records its failure and returns the
+# expression's VALUE, and conditionMessage() on that value raises -- which ends
+# the whole test_that() block and silently skips every later cell. The mutation
+# battery would still show the row as detected, because the aborted block
+# reports a failure either way, so the loss is invisible.
+#
+# These two degrade to a readable value instead of raising, so every assertion
+# in a loop still runs and a red cell names itself.
+#
+# Shared by test-gen-coefs-validator-429.R, test-gencoefs-retry-cap-436.R and
+# test-genassignments-retry-cap-436.R. Extracted here (#436) once the third
+# byte-identical copy arrived; testthat sources helper-*.R before the tests.
+
+msg_of <- function(x) {
+	if (inherits(x, "condition")) {
+		conditionMessage(x)
+	} else {
+		paste0("<no error; returned ", class(x)[1], ">")
+	}
+}
+
+call_of <- function(x) {
+	if (inherits(x, "condition")) {
+		conditionCall(x)
+	} else {
+		quote(NO_ERROR_RAISED)
+	}
+}

--- a/tests/testthat/test-gen-coefs-validator-429.R
+++ b/tests/testthat/test-gen-coefs-validator-429.R
@@ -8,9 +8,10 @@
 # genCoefs() and genCoefsCore(). At the time, ten of the sixteen atomic
 # conditions it then had carried no message-anchored test, and the whole `G`
 # message literal was unpinned, so weakening most of them was invisible to the
-# two files that claim to cover this surface. #436 later added a fifth
-# condition to each of the five blocks (`is.na()`), taking the count to
-# twenty-one.
+# two files that claim to cover this surface. #436 later added one condition
+# (`is.na()`) to each of the five blocks, taking the count to twenty-one. It
+# is not the fifth condition in each: it lands fourth in `T`, `G` and `d`,
+# fifth in `density`, and third in `eff_size`.
 #
 # Each cell asserts three things, and all three are needed:
 #   (1) the error message contains the condition's own literal, `fixed = TRUE`;
@@ -20,8 +21,8 @@
 #
 # WHY THE MESSAGE LITERAL IS WHAT CARRIES THE POWER, not expect_error() alone.
 # Both doors carry THREE consecutive redundant backstops --
-# `stopifnot(G >= 1); stopifnot(T >= 2); stopifnot(G <= T - 1)` at
-# R/gen_coefs.R:474-476 and :918-920 -- so three of the twenty-one cells
+# `stopifnot(G >= 1); stopifnot(T >= 2); stopifnot(G <= T - 1)`, in both
+# genCoefs() and genCoefsCore() -- so three of the twenty-one cells
 # (G < 1, T < 2, G > T - 1) error SOMEWHERE regardless of what the validator
 # does. A bare expect_error() on those would be satisfied by the backstop and
 # the mutant would walk.

--- a/tests/testthat/test-gen-coefs-validator-429.R
+++ b/tests/testthat/test-gen-coefs-validator-429.R
@@ -1,12 +1,16 @@
-# Issue #429 item 9: all SIXTEEN atomic conditions of
-# .validate_gen_coefs_scalars() (R/gen_coefs.R:1200-1246), through BOTH public
-# doors.
+# Issue #429 item 9: all TWENTY-ONE atomic conditions of
+# .validate_gen_coefs_scalars() -- find it by searching R/gen_coefs.R for
+# `.validate_gen_coefs_scalars <- function`; the line range this header used to
+# quote went stale the first time anything above it moved -- through BOTH
+# public doors.
 #
 # The validator is the single-sourced scalar gate that #401 folded out of
-# genCoefs() and genCoefsCore(). Ten of its sixteen atomic conditions had no
-# message-anchored test, and the whole `G` message literal was unpinned, so
-# weakening most of them was invisible to the two files that claim to cover this
-# surface.
+# genCoefs() and genCoefsCore(). At the time, ten of the sixteen atomic
+# conditions it then had carried no message-anchored test, and the whole `G`
+# message literal was unpinned, so weakening most of them was invisible to the
+# two files that claim to cover this surface. #436 later added a fifth
+# condition to each of the five blocks (`is.na()`), taking the count to
+# twenty-one.
 #
 # Each cell asserts three things, and all three are needed:
 #   (1) the error message contains the condition's own literal, `fixed = TRUE`;
@@ -17,10 +21,10 @@
 # WHY THE MESSAGE LITERAL IS WHAT CARRIES THE POWER, not expect_error() alone.
 # Both doors carry THREE consecutive redundant backstops --
 # `stopifnot(G >= 1); stopifnot(T >= 2); stopifnot(G <= T - 1)` at
-# R/gen_coefs.R:474-476 and :918-920 -- so three of the sixteen cells (G < 1,
-# T < 2, G > T - 1) error SOMEWHERE regardless of what the validator does. A
-# bare expect_error() on those would be satisfied by the backstop and the
-# mutant would walk.
+# R/gen_coefs.R:474-476 and :918-920 -- so three of the twenty-one cells
+# (G < 1, T < 2, G > T - 1) error SOMEWHERE regardless of what the validator
+# does. A bare expect_error() on those would be satisfied by the backstop and
+# the mutant would walk.
 #
 # WHY THE FIXTURES CARRY NO OTHER ARGUMENTS. The two doors run their prologues
 # in different orders: genCoefsCore() runs .resolve_cohort_count_arg() (:898),
@@ -51,13 +55,16 @@
 .gcv429_cells <- list(
 	list(id = "T not numeric", over = list(T = "5"), lit = .gcv429_T_msg),
 	list(id = "T length != 1", over = list(T = c(5, 6)), lit = .gcv429_T_msg),
+	list(id = "T NA", over = list(T = NA_real_), lit = .gcv429_T_msg),
 	list(id = "T < 2", over = list(T = 1), lit = .gcv429_T_msg),
 	list(id = "G not numeric", over = list(G = "3"), lit = .gcv429_G_msg),
 	list(id = "G length != 1", over = list(G = c(2, 3)), lit = .gcv429_G_msg),
+	list(id = "G NA", over = list(G = NA_real_), lit = .gcv429_G_msg),
 	list(id = "G < 1", over = list(G = 0), lit = .gcv429_G_msg),
 	list(id = "G > T - 1", over = list(G = 5, T = 5), lit = .gcv429_GT_msg),
 	list(id = "d not numeric", over = list(d = "2"), lit = .gcv429_d_msg),
 	list(id = "d length != 1", over = list(d = c(1, 2)), lit = .gcv429_d_msg),
+	list(id = "d NA", over = list(d = NA_real_), lit = .gcv429_d_msg),
 	list(id = "d < 0", over = list(d = -1), lit = .gcv429_d_msg),
 	list(
 		id = "density not numeric",
@@ -67,6 +74,11 @@
 	list(
 		id = "density length != 1",
 		over = list(density = c(0.4, 0.5)),
+		lit = .gcv429_dens_msg
+	),
+	list(
+		id = "density NA",
+		over = list(density = NA_real_),
 		lit = .gcv429_dens_msg
 	),
 	list(id = "density <= 0", over = list(density = 0), lit = .gcv429_dens_msg),
@@ -84,12 +96,17 @@
 		id = "eff_size length != 1",
 		over = list(eff_size = c(1, 2)),
 		lit = .gcv429_eff_msg
+	),
+	list(
+		id = "eff_size NA",
+		over = list(eff_size = NA_real_),
+		lit = .gcv429_eff_msg
 	)
 )
 
 # ------------------------------------------------------------------------------
 # SANITY BLOCK, first in the file. Without it, a change that made EVERY input
-# fail would leave all sixteen negative cells green.
+# fail would leave all twenty-one negative cells green.
 # ------------------------------------------------------------------------------
 test_that("the unmodified base arguments succeed through both doors (#429 item 9)", {
 	gc <- do.call(genCoefs, .gcv429_base)
@@ -100,8 +117,8 @@ test_that("the unmodified base arguments succeed through both doors (#429 item 9
 	expect_identical(names(core), c("beta", "theta"))
 })
 
-test_that(".validate_gen_coefs_scalars() pins all sixteen conditions on both doors (#429 item 9)", {
-	expect_length(.gcv429_cells, 16L)
+test_that(".validate_gen_coefs_scalars() pins all twenty-one conditions on both doors (#429 item 9)", {
+	expect_length(.gcv429_cells, 21L)
 
 	# CAPTURE, DO NOT expect_error()-AND-REUSE. A cell whose mutation makes the
 	# call SUCCEED has to fail this loop cleanly rather than abort it.
@@ -111,10 +128,11 @@ test_that(".validate_gen_coefs_scalars() pins all sixteen conditions on both doo
 	#
 	# That is reachable, not hypothetical: with `length(eff_size) != 1` dropped,
 	# genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = c(1, 2)) succeeds
-	# and returns a FETWFE_coefs object (measured). It is harmless today ONLY
-	# because that condition is cell 16 of 16 -- add a cell after it, or reorder
-	# the list, and dropping that one check would hide every cell downstream of
-	# it. The mutation battery would still show the row as detected, because the
+	# and returns a FETWFE_coefs object (measured). It used to be harmless
+	# because that condition was the last cell in the list; #436's
+	# `eff_size NA` cell now sits after it, so dropping that one check WOULD
+	# hide the cell downstream of it were it not for the two accessors below.
+	# The mutation battery would still show the row as detected, because the
 	# aborted block reports a failure either way.
 	#
 	# The two accessors degrade to a readable value instead of raising, so all

--- a/tests/testthat/test-gen-coefs-validator-429.R
+++ b/tests/testthat/test-gen-coefs-validator-429.R
@@ -120,38 +120,17 @@ test_that("the unmodified base arguments succeed through both doors (#429 item 9
 test_that(".validate_gen_coefs_scalars() pins all twenty-one conditions on both doors (#429 item 9)", {
 	expect_length(.gcv429_cells, 21L)
 
-	# CAPTURE, DO NOT expect_error()-AND-REUSE. A cell whose mutation makes the
-	# call SUCCEED has to fail this loop cleanly rather than abort it.
-	# expect_error() on a non-erroring call records its failure and returns the
-	# expression's VALUE, and conditionMessage() on that value raises -- which
-	# ends the whole test_that() block and silently skips every later cell.
+	# CAPTURE, DO NOT expect_error()-AND-REUSE. The loop below reads each
+	# captured condition through `msg_of()` / `call_of()`, which live in
+	# helper-condition-accessors.R and degrade to a readable value instead of
+	# raising; that file explains why. What is specific to THIS file:
 	#
-	# That is reachable, not hypothetical: with `length(eff_size) != 1` dropped,
-	# genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = c(1, 2)) succeeds
-	# and returns a FETWFE_coefs object (measured). It used to be harmless
-	# because that condition was the last cell in the list; #436's
+	# The hazard is reachable, not hypothetical. With `length(eff_size) != 1`
+	# dropped, genCoefs(G = 3, T = 5, d = 2, density = 0.5, eff_size = c(1, 2))
+	# succeeds and returns a FETWFE_coefs object (measured). That used to be
+	# harmless because the condition was the last cell in the list; #436's
 	# `eff_size NA` cell now sits after it, so dropping that one check WOULD
-	# hide the cell downstream of it were it not for the two accessors below.
-	# The mutation battery would still show the row as detected, because the
-	# aborted block reports a failure either way.
-	#
-	# The two accessors degrade to a readable value instead of raising, so all
-	# five assertions per cell still run and a red cell names itself.
-	msg_of <- function(x) {
-		if (inherits(x, "condition")) {
-			conditionMessage(x)
-		} else {
-			paste0("<no error; returned ", class(x)[1], ">")
-		}
-	}
-	call_of <- function(x) {
-		if (inherits(x, "condition")) {
-			conditionCall(x)
-		} else {
-			quote(NO_ERROR_RAISED)
-		}
-	}
-
+	# hide the cell downstream of it if the accessors raised.
 	for (cell in .gcv429_cells) {
 		args <- utils::modifyList(.gcv429_base, cell$over)
 

--- a/tests/testthat/test-genassignments-retry-cap-436.R
+++ b/tests/testthat/test-genassignments-retry-cap-436.R
@@ -1,0 +1,189 @@
+# Issue #436: genAssignments() drew rmultinom(1, N, rep(1/(G+1), G+1)) until
+# every group cleared its bar -- 1 unit normally, `d + 1` under
+# guarantee_rank_condition = TRUE -- with no upper bound on attempts. Its
+# callers assert `N >= G + 1` and `N >= (G + 1) * (d + 1)`, which guarantees
+# only that the bar is ACHIEVABLE, not that it is achievable in practice: at
+# N = G + 1 every group must get exactly one unit, so
+# P = (G+1)! / (G+1)^(G+1), which is 4.8e-13 at G = 30. Both floors are
+# reachable from a plain simulateData() call and both used to hang. The loop is
+# now capped at 1,000,000 attempts.
+#
+# EVERY simulateData() CALL HERE PASSES `seed = NA` WITH A `set.seed(k)`
+# IMMEDIATELY BEFORE IT, and both halves are mandatory. simulateData() warns
+# only when `seed` is NULL; `seed = NA` is silent by design and means "use the
+# ambient stream", so the preceding set.seed() is what supplies
+# reproducibility. A blanket suppressWarnings() would instead make the suite's
+# WARN-count watch unfalsifiable on exactly the blocks where a new warning is
+# most likely, and `seed = NA` WITHOUT the set.seed() would leave the boundary
+# block below drawing an unseeded geometric with mean 7,148 -- a varying
+# runtime that someone would later "fix" by passing `seed = 1`, silently
+# re-introducing the warning this rule exists to prevent.
+#
+# PER DECISION LOG D8 THIS FILE CARRIES NO DRAW-COUNT PIN, unlike its
+# genCoefsCore() sibling. Replaying 1,000,000 rmultinom draws to pin the
+# boundary costs 0.85-1.32 s on every run of a 9-minute suite across six CI
+# jobs, and what it would buy is detection of a `>` vs `>=` off-by-one that
+# moves the budget by one draw in a million and has no user-visible
+# consequence whatsoever. An ABSENT cap is caught by the timeout guard, and a
+# WRONG cap value by the exact literal `in 1000000 attempts`.
+
+.gar436_coefs_plain <- genCoefs(
+	G = 30,
+	T = 31,
+	d = 1,
+	density = 0.2,
+	eff_size = 1,
+	seed = 1L
+)
+
+.gar436_coefs_grc <- genCoefs(
+	G = 12,
+	T = 13,
+	d = 4,
+	density = 0.2,
+	eff_size = 1,
+	seed = 2L
+)
+
+.gar436_coefs_boundary <- genCoefs(
+	G = 10,
+	T = 11,
+	d = 1,
+	density = 0.2,
+	eff_size = 1,
+	seed = 3L
+)
+
+test_that("an infeasible N = G + 1 panel errors instead of hanging (#436)", {
+	setTimeLimit(elapsed = 60, transient = TRUE)
+	on.exit(setTimeLimit(), add = TRUE)
+
+	# N = G + 1 is exactly the boundary genCohortTimeFE()'s
+	# stopifnot(N >= G + 1) admits, and P(success) = 31!/31^31 = 4.8e-13 here.
+	# The literal is `in 1000000 attempts` with fixed = TRUE: a bare "1000000"
+	# would be a substring of a 10x-mutated cap's message.
+	set.seed(1)
+	expect_error(
+		simulateData(
+			.gar436_coefs_plain,
+			N = 31,
+			sig_eps_sq = 0.5,
+			sig_eps_c_sq = 0.5,
+			seed = NA
+		),
+		"in 1000000 attempts",
+		fixed = TRUE
+	)
+})
+
+test_that("an infeasible guarantee_rank_condition panel errors instead of hanging (#436)", {
+	setTimeLimit(elapsed = 60, transient = TRUE)
+	on.exit(setTimeLimit(), add = TRUE)
+
+	msg_of <- function(x) {
+		if (inherits(x, "condition")) {
+			conditionMessage(x)
+		} else {
+			paste0("<no error; returned ", class(x)[1], ">")
+		}
+	}
+	call_of <- function(x) {
+		if (inherits(x, "condition")) {
+			conditionCall(x)
+		} else {
+			quote(NO_ERROR_RAISED)
+		}
+	}
+
+	# N = (G + 1) * (d + 1) = 65 is the boundary simulateDataCore()'s own
+	# stopifnot() admits, and it is a MUCH harsher regime than the bar-1 floor:
+	# P = 2.7e-6 at G = 8, d = 4. This is also the first thing in the package to
+	# exercise guarantee_rank_condition = TRUE inside genAssignments() at all.
+	set.seed(2)
+	e <- tryCatch(
+		simulateData(
+			.gar436_coefs_grc,
+			N = 65,
+			sig_eps_sq = 0.5,
+			sig_eps_c_sq = 0.5,
+			guarantee_rank_condition = TRUE,
+			seed = NA
+		),
+		error = function(e) e
+	)
+
+	expect_true(grepl("in 1000000 attempts", msg_of(e), fixed = TRUE))
+
+	# TWO literals, each asserted on the thing it names, because all three of
+	# the obvious single choices are defective:
+	#   * "d + 1" would blind the two assertions in
+	#     test-simulate-data-highdim-293.R that match the bare pattern
+	#     "d \\+ 1" to prove the up-front stopifnot() fired -- a mutation that
+	#     today HANGS would become a pass;
+	#   * a bare "25%" matches a `%%`-escaped message and the correct one
+	#     alike, and observes `suggestion` rather than the `bar_desc` this
+	#     block exists to exercise;
+	#   * "units in 1000000 attempts" discriminates from the other branch only
+	#     by the plural `s` (the plain branch says "at least one unit"), which
+	#     a future grammar fix would silently delete -- note d = 0 under
+	#     guarantee_rank_condition = TRUE renders "at least 1 units".
+	expect_true(grepl("at least 5 units", msg_of(e), fixed = TRUE))
+	expect_true(grepl("about 25% is", msg_of(e), fixed = TRUE))
+
+	# The `call. = FALSE` contract from #431 item 1.
+	expect_null(call_of(e))
+})
+
+test_that("a feasible boundary panel still succeeds with the cap in place (#436)", {
+	setTimeLimit(elapsed = 60, transient = TRUE)
+	on.exit(setTimeLimit(), add = TRUE)
+
+	# G = 10, N = G + 1: exact P = 1.399e-4, E[draws] = 7,148 -- feasible, and
+	# the only thing here exercising the SUCCESS path near the boundary. It
+	# cannot flake (P(false error) = 1.7e-61 at cap 1e6). It is NOT evidence
+	# about "a cap set too low": its power against a 100000L cap is 8.4e-7, and
+	# the cap value is pinned deterministically by the exact literal above.
+	set.seed(3)
+	sim <- simulateData(
+		.gar436_coefs_boundary,
+		N = 11,
+		sig_eps_sq = 0.5,
+		sig_eps_c_sq = 0.5,
+		seed = NA
+	)
+
+	expect_s3_class(sim, "FETWFE_simulated")
+	expect_equal(nrow(sim$pdata), 11 * 11)
+})
+
+test_that("a comfortable panel returns promptly in both bar modes (#436)", {
+	setTimeLimit(elapsed = 60, transient = TRUE)
+	on.exit(setTimeLimit(), add = TRUE)
+
+	# The controls from the reproduction: the same coefficient objects at an
+	# N the multinomial clears easily. Without these, a mutation that made
+	# genAssignments() error unconditionally would still satisfy every
+	# expect_error() above.
+	set.seed(4)
+	sim_plain <- simulateData(
+		.gar436_coefs_plain,
+		N = 200,
+		sig_eps_sq = 0.5,
+		sig_eps_c_sq = 0.5,
+		seed = NA
+	)
+	expect_s3_class(sim_plain, "FETWFE_simulated")
+	expect_equal(nrow(sim_plain$pdata), 200 * 31)
+
+	set.seed(5)
+	sim_grc <- simulateData(
+		.gar436_coefs_grc,
+		N = 300,
+		sig_eps_sq = 0.5,
+		sig_eps_c_sq = 0.5,
+		guarantee_rank_condition = TRUE,
+		seed = NA
+	)
+	expect_s3_class(sim_grc, "FETWFE_simulated")
+	expect_equal(nrow(sim_grc$pdata), 300 * 13)
+})

--- a/tests/testthat/test-genassignments-retry-cap-436.R
+++ b/tests/testthat/test-genassignments-retry-cap-436.R
@@ -21,8 +21,9 @@
 #
 # PER DECISION LOG D8 THIS FILE CARRIES NO DRAW-COUNT PIN, unlike its
 # genCoefsCore() sibling. Replaying 1,000,000 rmultinom draws to pin the
-# boundary costs 0.85-1.32 s on every run of a 9-minute suite across six CI
-# jobs, and what it would buy is detection of a `>` vs `>=` off-by-one that
+# boundary costs a second-scale replay on every run of a 9-minute suite across
+# six CI jobs -- against 0.006 s for the genCoefsCore() pin -- and what it
+# would buy is detection of a `>` vs `>=` off-by-one that
 # moves the budget by one draw in a million and has no user-visible
 # consequence whatsoever. An ABSENT cap is caught by the timeout guard, and a
 # WRONG cap value by the exact literal `in 1000000 attempts`.
@@ -82,7 +83,9 @@ test_that("an infeasible guarantee_rank_condition panel errors instead of hangin
 
 	# N = (G + 1) * (d + 1) = 65 is the boundary simulateDataCore()'s own
 	# stopifnot() admits, and it is a MUCH harsher regime than the bar-1 floor:
-	# P = 2.7e-6 at G = 8, d = 4. This is also the first thing in the package to
+	# P = 3.0e-9 for THIS block's G = 12, d = 4, N = 65 (an earlier revision
+	# quoted 2.7e-6 here, which is G = 8, d = 4, N = 45 -- a different fixture
+	# and three orders of magnitude off). This is also the first thing in the package to
 	# exercise guarantee_rank_condition = TRUE inside genAssignments() at all.
 	set.seed(2)
 	e <- tryCatch(
@@ -113,7 +116,12 @@ test_that("an infeasible guarantee_rank_condition panel errors instead of hangin
 	#     a future grammar fix would silently delete -- note d = 0 under
 	#     guarantee_rank_condition = TRUE renders "at least 1 units".
 	expect_true(grepl("at least 5 units", msg_of(e), fixed = TRUE))
-	expect_true(grepl("about 25% is", msg_of(e), fixed = TRUE))
+	expect_true(grepl("25% more is usually enough", msg_of(e), fixed = TRUE))
+
+	# Pin that N and G render in the right ORDER. Nothing else in either cap
+	# file observes these two values, so transposing the sprintf() arguments
+	# was a mutation the whole suite missed.
+	expect_true(grepl("at N = 65 and G = 12", msg_of(e), fixed = TRUE))
 
 	# The `call. = FALSE` contract from #431 item 1.
 	expect_null(call_of(e))

--- a/tests/testthat/test-genassignments-retry-cap-436.R
+++ b/tests/testthat/test-genassignments-retry-cap-436.R
@@ -175,6 +175,10 @@ test_that("a comfortable panel returns promptly in both bar modes (#436)", {
 	expect_s3_class(sim_plain, "FETWFE_simulated")
 	expect_equal(nrow(sim_plain$pdata), 200 * 31)
 
+	# Re-armed because this block makes a SECOND call that a hang-mutation
+	# could stall: a fired elapsed limit disarms itself (measured; see the
+	# header of test-gencoefs-retry-cap-436.R).
+	setTimeLimit(elapsed = 60, transient = TRUE)
 	set.seed(5)
 	sim_grc <- simulateData(
 		.gar436_coefs_grc,

--- a/tests/testthat/test-genassignments-retry-cap-436.R
+++ b/tests/testthat/test-genassignments-retry-cap-436.R
@@ -80,21 +80,6 @@ test_that("an infeasible guarantee_rank_condition panel errors instead of hangin
 	setTimeLimit(elapsed = 60, transient = TRUE)
 	on.exit(setTimeLimit(), add = TRUE)
 
-	msg_of <- function(x) {
-		if (inherits(x, "condition")) {
-			conditionMessage(x)
-		} else {
-			paste0("<no error; returned ", class(x)[1], ">")
-		}
-	}
-	call_of <- function(x) {
-		if (inherits(x, "condition")) {
-			conditionCall(x)
-		} else {
-			quote(NO_ERROR_RAISED)
-		}
-	}
-
 	# N = (G + 1) * (d + 1) = 65 is the boundary simulateDataCore()'s own
 	# stopifnot() admits, and it is a MUCH harsher regime than the bar-1 floor:
 	# P = 2.7e-6 at G = 8, d = 4. This is also the first thing in the package to

--- a/tests/testthat/test-gencoefs-retry-cap-436.R
+++ b/tests/testthat/test-gencoefs-retry-cap-436.R
@@ -124,6 +124,14 @@ test_that("a workable density still returns with the cap in place (#436)", {
 	# not" control and NOTHING more -- it proves nothing about an off-by-one at
 	# the boundary, which is what the draw-count pin above is for. Seeded so it
 	# is reproducible.
+	#
+	# Guarded like every other block in this file even though no CAP mutation
+	# can hang it: a mutation to the DRAW rather than the cap (`prob = density`
+	# -> `prob = 0`) would spin here, and the file's whole purpose is keeping
+	# hang-mutants out of the suite. Two lines, zero cost on the green side.
+	setTimeLimit(elapsed = 60, transient = TRUE)
+	on.exit(setTimeLimit(), add = TRUE)
+
 	res <- genCoefsCore(
 		G = 3,
 		T = 5,

--- a/tests/testthat/test-gencoefs-retry-cap-436.R
+++ b/tests/testthat/test-gencoefs-retry-cap-436.R
@@ -66,21 +66,6 @@ test_that("the retry-cap error is identical from both doors and sets no call (#4
 	# Degrade to a readable value rather than raising, so a mutation that makes
 	# the call SUCCEED fails these assertions cleanly instead of aborting the
 	# block (same reasoning as test-gen-coefs-validator-429.R).
-	msg_of <- function(x) {
-		if (inherits(x, "condition")) {
-			conditionMessage(x)
-		} else {
-			paste0("<no error; returned ", class(x)[1], ">")
-		}
-	}
-	call_of <- function(x) {
-		if (inherits(x, "condition")) {
-			conditionCall(x)
-		} else {
-			quote(NO_ERROR_RAISED)
-		}
-	}
-
 	setTimeLimit(elapsed = 60, transient = TRUE)
 	e_core <- tryCatch(
 		genCoefsCore(G = 3, T = 5, d = 2, density = 1e-300, eff_size = 1),

--- a/tests/testthat/test-gencoefs-retry-cap-436.R
+++ b/tests/testthat/test-gencoefs-retry-cap-436.R
@@ -20,7 +20,11 @@
 #       back into the suite the exact pathology #436 exists to remove. 60 s is
 #       generous against a correct path measured at ~0.02 s, so runner jitter
 #       cannot false-positive it, and the on.exit() is required to stop the
-#       limit leaking into later blocks (measured).
+#       limit leaking into later blocks (measured). ONE setTimeLimit() CALL
+#       GUARDS EXACTLY ONE HANGING CALL: measured, a fired elapsed limit is
+#       disarmed, and the next long call in the same block runs unguarded to
+#       completion. Any block below with two calls that could hang therefore
+#       arms it twice.
 #
 #   (3) THE DRAW-COUNT PIN. `.apply_seed(NULL)` is a verified no-op on the RNG
 #       (it returns before touching it) and everything between it and the loop
@@ -49,7 +53,14 @@ test_that("a degenerate density errors instead of hanging (#436)", {
 })
 
 test_that("the retry-cap error is identical from both doors and sets no call (#436)", {
-	setTimeLimit(elapsed = 60, transient = TRUE)
+	# ONE setTimeLimit() GUARDS EXACTLY ONE HANGING CALL, so this block arms it
+	# twice -- once per door. Measured: inside a single top-level task (which is
+	# what a test_that() block is under devtools::test()), an elapsed limit
+	# fires at its deadline and is then DISARMED; a second long call in the same
+	# block runs unguarded to completion. Without the re-arm, a cap-removing
+	# mutation hangs this block forever on the second door, which is the exact
+	# failure mode the guard exists to prevent. The on.exit() still clears the
+	# limit at block end so it cannot leak into later blocks.
 	on.exit(setTimeLimit(), add = TRUE)
 
 	# Degrade to a readable value rather than raising, so a mutation that makes
@@ -70,10 +81,12 @@ test_that("the retry-cap error is identical from both doors and sets no call (#4
 		}
 	}
 
+	setTimeLimit(elapsed = 60, transient = TRUE)
 	e_core <- tryCatch(
 		genCoefsCore(G = 3, T = 5, d = 2, density = 1e-300, eff_size = 1),
 		error = function(e) e
 	)
+	setTimeLimit(elapsed = 60, transient = TRUE)
 	e_gc <- tryCatch(
 		genCoefs(G = 3, T = 5, d = 2, density = 1e-300, eff_size = 1),
 		error = function(e) e

--- a/tests/testthat/test-gencoefs-retry-cap-436.R
+++ b/tests/testthat/test-gencoefs-retry-cap-436.R
@@ -1,0 +1,140 @@
+# Issue #436: genCoefsCore()'s rejection-sampling loop over `density` had no
+# upper bound on its attempts. A legal-but-degenerate `density` (e.g. 1e-300,
+# which .validate_gen_coefs_scalars() accepts) made the call spin forever with
+# no message, no error, and an apparently frozen session. The loop is now
+# capped at 10,000 attempts and errors with an actionable message instead.
+#
+# THREE THINGS CARRY THE MUTATION POWER HERE, and each is written the way it is
+# because a weaker version was measured not to work:
+#
+#   (1) THE LITERAL IS `in 10000 attempts`, WITH fixed = TRUE. Not "10000":
+#       grepl("10000", "... in 100000 attempts ...", fixed = TRUE) is TRUE
+#       (measured), so a cap mutated to 100000L would survive it. Not
+#       "density" either -- the validator's own message for the SAME argument
+#       contains that word, so a mutation that made the validator reject
+#       1e-300 before the loop is entered would leave this green with the cap
+#       never exercised. That is issue #458's defect class.
+#
+#   (2) THE TIMEOUT GUARD. Without it, "cap removed", "counter never
+#       incremented" and "stop() unreachable" all HANG the suite -- putting
+#       back into the suite the exact pathology #436 exists to remove. 60 s is
+#       generous against a correct path measured at ~0.02 s, so runner jitter
+#       cannot false-positive it, and the on.exit() is required to stop the
+#       limit leaking into later blocks (measured).
+#
+#   (3) THE DRAW-COUNT PIN. `.apply_seed(NULL)` is a verified no-op on the RNG
+#       (it returns before touching it) and everything between it and the loop
+#       is RNG-free, so the ambient stream advances by exactly the loop's
+#       draws. That pins the cap VALUE, the off-by-one in `tries > max_tries`,
+#       AND that each retry is still `rbinom(n = p, size = 1, prob = density)`
+#       with its arguments unchanged -- 10,000 iterations of stream, where the
+#       #332 byte-identity guardrail in test-gencoefs-targeted-sparsity-332.R
+#       only ever exercises one, so it cannot see a retry-counter defect.
+#
+# THERE IS DELIBERATELY NO WALL-CLOCK ASSERTION. It cannot observe the
+# condition it would name -- if the cap is absent the call never returns, so
+# the timer never completes -- and a load-dependent assertion on a gating
+# six-job matrix whose measured job times swing 80% run to run is a flake
+# generator. The timing evidence lives in the ExecPlan instead.
+
+test_that("a degenerate density errors instead of hanging (#436)", {
+	setTimeLimit(elapsed = 60, transient = TRUE)
+	on.exit(setTimeLimit(), add = TRUE)
+
+	expect_error(
+		genCoefsCore(G = 3, T = 5, d = 2, density = 1e-300, eff_size = 1),
+		"in 10000 attempts",
+		fixed = TRUE
+	)
+})
+
+test_that("the retry-cap error is identical from both doors and sets no call (#436)", {
+	setTimeLimit(elapsed = 60, transient = TRUE)
+	on.exit(setTimeLimit(), add = TRUE)
+
+	# Degrade to a readable value rather than raising, so a mutation that makes
+	# the call SUCCEED fails these assertions cleanly instead of aborting the
+	# block (same reasoning as test-gen-coefs-validator-429.R).
+	msg_of <- function(x) {
+		if (inherits(x, "condition")) {
+			conditionMessage(x)
+		} else {
+			paste0("<no error; returned ", class(x)[1], ">")
+		}
+	}
+	call_of <- function(x) {
+		if (inherits(x, "condition")) {
+			conditionCall(x)
+		} else {
+			quote(NO_ERROR_RAISED)
+		}
+	}
+
+	e_core <- tryCatch(
+		genCoefsCore(G = 3, T = 5, d = 2, density = 1e-300, eff_size = 1),
+		error = function(e) e
+	)
+	e_gc <- tryCatch(
+		genCoefs(G = 3, T = 5, d = 2, density = 1e-300, eff_size = 1),
+		error = function(e) e
+	)
+
+	expect_true(grepl("in 10000 attempts", msg_of(e_core), fixed = TRUE))
+
+	# Door parity: one error reaches both public doors with IDENTICAL text.
+	# That is only true because the message names no function (Decision Log
+	# D5) -- `call. = FALSE` suppresses conditionCall(), so a genCoefsCore()
+	# prefix would tell a genCoefs() caller about a function they never
+	# called.
+	expect_identical(msg_of(e_gc), msg_of(e_core))
+
+	# The `call. = FALSE` contract from #431 item 1, which
+	# test-gen-coefs-validator-429.R pins on every one of its cells.
+	expect_null(call_of(e_core))
+	expect_null(call_of(e_gc))
+})
+
+test_that("the capped loop makes exactly 10,000 draws, no more and no fewer (#436)", {
+	setTimeLimit(elapsed = 60, transient = TRUE)
+	on.exit(setTimeLimit(), add = TRUE)
+
+	# p = getP(G = 3, T = 5, d = 2) = 50, and every retry draws
+	# rbinom(n = p, size = 1, prob = density). Comparing `.Random.seed` is an
+	# integer-state comparison, so none of the floating-point tolerance
+	# hazards apply.
+	seed_now <- function() get(".Random.seed", envir = globalenv())
+
+	set.seed(1)
+	invisible(tryCatch(
+		genCoefsCore(G = 3, T = 5, d = 2, density = 1e-300, eff_size = 1),
+		error = function(e) NULL
+	))
+	after <- seed_now()
+
+	set.seed(1)
+	for (i in seq_len(10000L)) {
+		invisible(rbinom(n = 50, size = 1, prob = 1e-300))
+	}
+	# Measured TRUE against exactly 10,000 reference draws, and FALSE against
+	# 9,999, 10,001 and the 10x mutant.
+	expect_identical(after, seed_now())
+})
+
+test_that("a workable density still returns with the cap in place (#436)", {
+	# density = 0.01 at p = 50 needs ~2.5 attempts, four orders of magnitude
+	# from the 10,000 budget. This is a "the cap does not fire when it should
+	# not" control and NOTHING more -- it proves nothing about an off-by-one at
+	# the boundary, which is what the draw-count pin above is for. Seeded so it
+	# is reproducible.
+	res <- genCoefsCore(
+		G = 3,
+		T = 5,
+		d = 2,
+		density = 0.01,
+		eff_size = 1,
+		seed = 1
+	)
+
+	expect_identical(names(res), c("beta", "theta"))
+	expect_true(sum(res$theta != 0) > 0)
+})


### PR DESCRIPTION

Two functions drew random values in a loop until a condition held, with no upper bound. Both are reachable from the documented API with arguments the package advertises as legal, and both then never returned — no message, no error, a session that looks frozen.

`genCoefsCore()` retries `rbinom(p, 1, density)` until a coefficient is nonzero. Expected attempts are `1 / (1 - (1 - density)^p)`, unbounded as `density → 0`, so `density = 1e-300` — which passes validation — spins forever. Now capped at 10,000 attempts.

`genAssignments()` retries a multinomial until every cohort clears its bar. Its callers assert only that the bar is *achievable*: at `N = G + 1` every group must take exactly one unit, probability `4.8e-13` at `G = 30`. Reachable as `simulateData(coefs, N = 31)` with `G = 30`, and at `N = (G+1)(d+1)` under `guarantee_rank_condition = TRUE`. Now capped at 1,000,000.

The caps differ deliberately: for `genCoefsCore()` a cap is effectively free, while for `genAssignments()` no safe cap exists — `E[draws]` grows super-exponentially in `G`, so the value is a latency choice. Each error names the arguments, the attempt count, and the way out.

Separately, `NA_real_`, `NA_integer_` and `NaN` slipped past `.validate_gen_coefs_scalars()` on all five scalars, giving R's `missing value where TRUE/FALSE needed`. Four reached a comparison evaluating to `NA`; `eff_size`, whose check makes no comparison, passed validation outright and died later in the coefficient assembly.

**One behavior regression, disclosed.** Near the smallest admissible sizes the retry cost is a smooth distribution, not a split between workable and hopeless — so bounding it cuts off the slowest successes too. Over ten seeds at `G = 14, T = 15, d = 1, N = 15`, the **default** mode with no rank-condition flag, `main` gave 10/10 at a median of 0.96 s; the branch gives 8/10. Raising `N` is the fix, and the error says so.

## Verification

`devtools::check(error_on = "note")` is clean: `Status: OK`, 0/0/0, not even the environmental timestamp NOTE. Suite 120 files / 997 blocks / 5,249 passing, `WARN 0`.

Adding a counter and an early `stop()` changes no draw — 616 configurations compared byte-for-byte against `main` on values and RNG state, 0 differences, 84 actually retrying. Mutation battery killed 14 of 15; the survivor is the conceded one-draw-in-a-million off-by-one.

## Follow-ups

Filed: #463 (next PR), #464, #465, #466, #467, #468. Nothing deferred without a disposition.

Closes #436
