### PR TITLE
test: make the cluster-floor guardrail run under `R CMD check`, and cover every site (#463)

### DIFF
--- a/tests/testthat/helper-namespace-inspect.R
+++ b/tests/testthat/helper-namespace-inspect.R
@@ -1,0 +1,117 @@
+# Package-agnostic primitives for guardrail tests that assert something about
+# the SHAPE of the package's own source code.
+#
+# WHY THIS FILE EXISTS. The reflex when writing a "does the source still do X?"
+# test is to `readLines()` an `R/*.R` file. That test runs on no automated
+# machine: under `R CMD check` -- which is what every CI job and every CRAN
+# machine runs -- the tests execute against the *installed* package, which has
+# no `R/` directory at all, so the file-existence guard fires and the whole
+# block skips. Issue #463 is exactly that failure: a guardrail that had been
+# green for months had never actually executed outside a source tree.
+#
+# The package NAMESPACE, by contrast, exists identically under
+# `devtools::load_all()` and under `test_check()` against an installed,
+# byte-compiled package: `body()` still returns the AST, and `deparse()` of
+# that AST is byte-identical between the two runners. So a guardrail that walks
+# the namespace runs everywhere, and it sees every function the package
+# defines -- including `@noRd` internals -- rather than whichever files someone
+# remembered to list.
+#
+# testthat sources every `helper-*.R` in `tests/testthat/` once, before any
+# `test-*.R` runs, under both runners, so these are in scope for every test
+# file with no `source()` call. The `.ns_` prefix keeps them from colliding
+# with the fixtures the other `helper-*.R` files put in the same environment.
+#
+# Everything here is package-agnostic on purpose; anything specific to one
+# guardrail's domain belongs in that guardrail's own test file.
+
+# Every function object in `pkg`'s namespace, as a name-sorted named list.
+# Non-function objects (the namespace bookkeeping environments, `load_all()`'s
+# injected `.__DEVTOOLS__`, package-level constants) are dropped.
+.ns_functions <- function(pkg = "fetwfe") {
+	ns <- asNamespace(pkg)
+	nms <- sort(ls(ns, all.names = TRUE))
+	objs <- mget(nms, envir = ns, inherits = FALSE)
+	objs[vapply(objs, is.function, logical(1))]
+}
+
+# The deparsed body of every namespace function, as a named list of character
+# vectors. `control` is pinned rather than left to the default so the rendering
+# stays deterministic across R versions; `useSource` is deliberately absent, so
+# comments never appear in the output even when a `srcref` is attached (which
+# it is under `options(keep.source.pkgs = TRUE)` plus `load_all()`). A function
+# with a `NULL` body contributes `character(0)`.
+.ns_deparsed_bodies <- function(pkg = "fetwfe") {
+	lapply(.ns_functions(pkg), function(f) {
+		if (is.null(body(f))) {
+			character(0)
+		} else {
+			deparse(body(f), control = c("keepInteger", "keepNA"))
+		}
+	})
+}
+
+# Depth-first walk over a parsed expression, calling `visit(node, ancestors)`
+# at every node. `ancestors` is a list ordered outermost-first and excludes the
+# node itself; `visit()`'s return value is ignored, so a visitor accumulates
+# with `<<-`.
+#
+# The child is tested and recursed on INLINE, never through a local. R
+# represents both an absent index (`x[, 1]`) and a defaulted-less formal with
+# its *empty symbol*, and binding that to a local makes the local behave as a
+# missing argument: the next mention of it raises
+# `argument "k" is missing, with no default` from a line that looks like an
+# ordinary recursive call. Testing `identical(kids[[i]], quote(expr = ))`
+# inline is safe; `k <- kids[[i]]` is not.
+.ns_walk_ast <- function(expr, visit, ancestors = list()) {
+	visit(expr, ancestors)
+	if (is.call(expr) || is.pairlist(expr) || is.expression(expr)) {
+		kids <- as.list(expr)
+		inner <- c(ancestors, list(expr))
+		for (i in seq_along(kids)) {
+			if (identical(kids[[i]], quote(expr = ))) {
+				next
+			}
+			.ns_walk_ast(kids[[i]], visit, inner)
+		}
+	}
+	invisible(NULL)
+}
+
+# Does the subtree rooted at `expr` mention any of the symbols named in `syms`
+# (a character vector)?
+.ns_subtree_has_symbol <- function(expr, syms) {
+	found <- FALSE
+	.ns_walk_ast(expr, function(node, ancestors) {
+		if (!found && is.symbol(node) && as.character(node) %in% syms) {
+			found <<- TRUE
+		}
+	})
+	found
+}
+
+# Is `expr` a call to any of the function names in `fn` (a character vector)?
+#
+# Resolves a namespace-qualified head. The head of `Matrix::crossprod(...)` is
+# itself a call -- ``::``(Matrix, crossprod) -- not a symbol, so the natural
+# `is.symbol(expr[[1]])` test silently declines to match it, and a
+# `pkg::op()` spelling escapes any guardrail built on this predicate. Measured:
+# that is exactly how a `Matrix::crossprod()` site slips past a structural
+# check while naming its operands literally.
+.ns_is_call_to <- function(expr, fn) {
+	if (!is.call(expr)) {
+		return(FALSE)
+	}
+	# Element 1 of a call is its function part and is never the empty symbol,
+	# so binding it here cannot hit the missing-argument trap above.
+	head <- expr[[1]]
+	if (
+		is.call(head) &&
+			length(head) == 3L &&
+			is.symbol(head[[1]]) &&
+			as.character(head[[1]]) %in% c("::", ":::")
+	) {
+		head <- head[[3]]
+	}
+	is.symbol(head) && as.character(head) %in% fn
+}

--- a/tests/testthat/helper-namespace-inspect.R
+++ b/tests/testthat/helper-namespace-inspect.R
@@ -103,15 +103,16 @@
 		return(FALSE)
 	}
 	# Element 1 of a call is its function part and is never the empty symbol,
-	# so binding it here cannot hit the missing-argument trap above.
-	head <- expr[[1]]
+	# so binding it here cannot hit the missing-argument trap above. Named
+	# `fn_head` rather than `head` so it does not shadow `utils::head()`.
+	fn_head <- expr[[1]]
 	if (
-		is.call(head) &&
-			length(head) == 3L &&
-			is.symbol(head[[1]]) &&
-			as.character(head[[1]]) %in% c("::", ":::")
+		is.call(fn_head) &&
+			length(fn_head) == 3L &&
+			is.symbol(fn_head[[1]]) &&
+			as.character(fn_head[[1]]) %in% c("::", ":::")
 	) {
-		head <- head[[3]]
+		fn_head <- fn_head[[3]]
 	}
-	is.symbol(head) && as.character(head) %in% fn
+	is.symbol(fn_head) && as.character(fn_head) %in% fn
 }

--- a/tests/testthat/test-cluster_floor.R
+++ b/tests/testthat/test-cluster_floor.R
@@ -29,7 +29,7 @@ library(fetwfe)
 #   only its diagonal, with a bare `pmax(diag(.), 0)` and no #139 diagnostic.
 #   It cannot route through `.floor_cluster_quad()`, which is scalar-only by
 #   contract: any input of length other than one is passed through unchanged.
-#   Extending the diagnostic to the matrix-valued floors is tracked separately.
+#   Extending the diagnostic to the matrix-valued floors is tracked as #470.
 #   The exemption is function-granular, so a future scalar form added inside
 #   that same function would inherit it silently.
 #
@@ -58,6 +58,34 @@ library(fetwfe)
 # never enters the expected set, so its removal the day after is invisible
 # forever. Exact equality forces the set to be updated at the moment of
 # addition, which is the only moment a human is looking.
+#
+# KNOWN BLIND SPOTS. These assertions are lexical, and a lexical guardrail has
+# a boundary. Recorded here because the block this one replaced shipped a
+# coverage claim it did not have -- "the five sites", and an `any(grepl())`
+# check advertised as catching duplicate labels, which it could not -- and
+# that is the failure mode #463 is. What escapes:
+#   * A NEW unfloored form in code that never spells `sandwich_full`, when the
+#     function it is added to is ALREADY in the expected sets. The realistic
+#     spelling is a general-purpose helper whose formal is named `S` or `M`,
+#     called from a function already listed -- the #344 consolidation shape.
+#     A1 cannot see it (`S` is not an alias; the alias walk resolves
+#     symbol-to-symbol assignment within one body only) and A6's set does not
+#     move. Adding such a helper as a NEW function does fire A6.
+#   * An alias built by anything other than symbol-to-symbol assignment
+#     INSIDE an already-listed function: `sw <- sandwich_full[keep, keep]`,
+#     a list element, `assign()`. As a new function these fire A6; in place
+#     they do not.
+#   * A scalar form added inside `.assemble_joint_cov_var1()`, which inherits
+#     that function's exemption. This is the function-granular limitation
+#     noted above, stated again because it is a false NEGATIVE, not a false
+#     positive.
+#   * Anything outside a function body: a formal's default expression, and
+#     the namespace's non-function objects. Measured 2026-08-27: none of them
+#     mentions `sandwich_full`.
+# Closing the first two needs dataflow across function boundaries, which is a
+# large amount of test machinery for a shape that does not occur in the tree.
+# The old guardrail was equally blind to all of them, so nothing regressed --
+# but a reader should not take this file for more than it is.
 # ------------------------------------------------------------------------------
 
 # --- Unit tests on the helper -------------------------------------------------
@@ -266,9 +294,9 @@ test_that(".floor_cluster_quad respects custom thresholds", {
 				)
 			}
 		})
-		for (q in quad_nodes) {
-			n_anc <- length(q$ancestors)
-			parent <- if (n_anc > 0L) q$ancestors[[n_anc]] else NULL
+		for (quad in quad_nodes) {
+			n_anc <- length(quad$ancestors)
+			parent <- if (n_anc > 0L) quad$ancestors[[n_anc]] else NULL
 			if (
 				!is.null(parent) &&
 					.ns_is_call_to(parent, .clf_quad_ops) &&
@@ -279,10 +307,10 @@ test_that(".floor_cluster_quad respects custom thresholds", {
 			sites[[length(sites) + 1L]] <- list(
 				fn = nm,
 				floored = .clf_any_ancestor(
-					q$ancestors,
+					quad$ancestors,
 					".floor_cluster_quad"
 				),
-				text = paste(deparse(q$node), collapse = " ")
+				text = paste(deparse(quad$node), collapse = " ")
 			)
 		}
 		for (cl in call_nodes) {
@@ -301,7 +329,8 @@ test_that(".floor_cluster_quad respects custom thresholds", {
 
 test_that("every cluster-sandwich floor routes through .floor_cluster_quad", {
 	bodies <- .ns_deparsed_bodies("fetwfe")
-	scanned <- .clf_scan(.ns_functions("fetwfe"))
+	fns <- .ns_functions("fetwfe")
+	scanned <- .clf_scan(fns)
 
 	# --- A1: the structural universal -------------------------------------
 	# Every collected cluster-sandwich quadratic form is floored in place,
@@ -309,6 +338,7 @@ test_that("every cluster-sandwich floor routes through .floor_cluster_quad", {
 	# containment: a listed site that has BECOME floored fails too, which is
 	# what stops the walk collapsing to nothing and satisfying the universal
 	# by finding no sites at all.
+	# A failure here may be a KNOWN FALSE-POSITIVE CLASS -- see the header.
 	expected_unfloored <- c(
 		# K x K covariance block; floors its diagonal with `pmax(diag(.), 0)`
 		# because `.floor_cluster_quad()` is scalar-only. See the header.
@@ -395,6 +425,7 @@ test_that("every cluster-sandwich floor routes through .floor_cluster_quad", {
 	# spelled, so it survives the aliasing and `crossprod` refactors that
 	# defeat a shape-based predicate, and it is what makes A1 non-vacuous --
 	# without it, a site that stops being DETECTED satisfies A1 by absence.
+	# A failure here may be a KNOWN FALSE-POSITIVE CLASS -- see the header.
 	expected_floor_call_fns <- c(
 		".compute_att_var1",
 		".event_study_etwfe_betwfe",
@@ -412,12 +443,19 @@ test_that("every cluster-sandwich floor routes through .floor_cluster_quad", {
 
 	# --- A6: the sandwich-mention inventory -------------------------------
 	# The set of namespace functions whose deparsed body mentions
-	# `sandwich_full`, again an exact set against a literal vector. This is
-	# the only assertion that catches a new unfloored site whose function
-	# does not name the matrix inside a quadratic-form node: the matrix
-	# arriving as a FORMAL from a caller (the consolidation shape #344
-	# already performed on this code), a `::`-qualified operator, the matrix
-	# reached through a list element, a submatrix alias, or `assign()`.
+	# `sandwich_full`, as an exact set against a literal vector. Its
+	# predicate is exactly that -- the literal string, anywhere in the body --
+	# which is what lets it survive the aliasing and `crossprod` refactors
+	# that defeat a shape-based check: a NEW function that reaches the matrix
+	# through a list element, a submatrix slice or `assign()`, or that
+	# receives it as a formal still SPELLED `sandwich_full`, lands in this set
+	# even though A1 cannot see the arithmetic. It also closes the coupling in
+	# the SHRINK direction: an already-listed function that stops spelling the
+	# symbol drops out and fails.
+	#
+	# What it does NOT do is the grow direction inside existing code -- see
+	# KNOWN BLIND SPOTS in the file header. (A `::`-qualified operator is
+	# caught by A1, not here; see `.ns_is_call_to()`.)
 	expected_sandwich_fns <- c(
 		".assemble_cluster_robust_sandwich",
 		".assemble_joint_cov_var1",
@@ -449,6 +487,30 @@ test_that("every cluster-sandwich floor routes through .floor_cluster_quad", {
 		"fn"
 	)))
 	expect_setequal(suppressed_fns, character(0))
+
+	# --- A7b: ... and none at the CALLER, one frame up --------------------
+	# A7 above scans the ancestors of the floor call within its own body, so
+	# `suppressWarnings(.compute_att_var1(...))` at the call site passes it
+	# while suppressing exactly the same diagnostic. That is the MORE likely
+	# edit of the two -- wrapping a whole internal call is easier to write
+	# than wrapping one inner expression. Measured: without this assertion
+	# that mutation leaves the suite fully green.
+	wrapped_callers <- character(0)
+	for (nm in names(fns)) {
+		fn_body <- body(fns[[nm]])
+		if (is.null(fn_body)) {
+			next
+		}
+		.ns_walk_ast(fn_body, function(node, ancestors) {
+			if (
+				.ns_is_call_to(node, .clf_suppressors) &&
+					.ns_subtree_has_symbol(node, expected_floor_call_fns)
+			) {
+				wrapped_callers <<- union(wrapped_callers, nm)
+			}
+		})
+	}
+	expect_setequal(sort(wrapped_callers), character(0))
 })
 
 test_that("no call site neuters .floor_cluster_quad's diagnostic contract", {

--- a/tests/testthat/test-cluster_floor.R
+++ b/tests/testthat/test-cluster_floor.R
@@ -320,7 +320,7 @@ test_that("every cluster-sandwich floor routes through .floor_cluster_quad", {
 		character(1),
 		"fn"
 	)))
-	expect_identical(unfloored, sort(expected_unfloored))
+	expect_setequal(unfloored, expected_unfloored)
 
 	# --- A2: per-site label coverage, exactly once ------------------------
 	# Anchored with the surrounding double quotes: `deparse()` renders string
@@ -352,9 +352,17 @@ test_that("every cluster-sandwich floor routes through .floor_cluster_quad", {
 		},
 		integer(1)
 	)
-	expected_counts <- rep(1L, length(expected_labels))
-	names(expected_counts) <- expected_labels
-	expect_identical(label_counts, expected_counts)
+	# `sprintf()` rather than `paste0()`: `paste0("x", character(0))` recycles
+	# the zero-length argument to `""` and returns `"x"`, so an empty offender
+	# list would render as one bogus entry and fail on a clean tree.
+	# `sprintf()` returns `character(0)` for zero-length inputs.
+	off <- label_counts != 1L
+	wrong_counts <- sprintf(
+		"%s (%d occurrences)",
+		expected_labels[off],
+		label_counts[off]
+	)
+	expect_setequal(wrong_counts, character(0))
 
 	# --- A3: the negative-direction guard ---------------------------------
 	# No bare `max(... sandwich_full ..., 0)` may remain. Scanned PER BODY,
@@ -371,7 +379,7 @@ test_that("every cluster-sandwich floor routes through .floor_cluster_quad", {
 		function(x) grepl(bare_max_re, paste(x, collapse = " "), perl = TRUE),
 		logical(1)
 	)]
-	expect_identical(bare_max_fns, character(0))
+	expect_setequal(bare_max_fns, character(0))
 
 	# --- A4: the floor-call inventory -------------------------------------
 	# The set of namespace functions that call `.floor_cluster_quad()`, as an
@@ -400,7 +408,7 @@ test_that("every cluster-sandwich floor routes through .floor_cluster_quad", {
 		character(1),
 		"fn"
 	)))
-	expect_identical(floor_call_fns, sort(expected_floor_call_fns))
+	expect_setequal(floor_call_fns, expected_floor_call_fns)
 
 	# --- A6: the sandwich-mention inventory -------------------------------
 	# The set of namespace functions whose deparsed body mentions
@@ -431,7 +439,7 @@ test_that("every cluster-sandwich floor routes through .floor_cluster_quad", {
 		function(x) any(grepl("sandwich_full", x, fixed = TRUE)),
 		logical(1)
 	)])
-	expect_identical(sandwich_fns, sort(expected_sandwich_fns))
+	expect_setequal(sandwich_fns, expected_sandwich_fns)
 
 	# --- A7: no condition suppression around a floor call -----------------
 	suppressed_fns <- sort(unique(vapply(
@@ -440,7 +448,7 @@ test_that("every cluster-sandwich floor routes through .floor_cluster_quad", {
 		character(1),
 		"fn"
 	)))
-	expect_identical(suppressed_fns, character(0))
+	expect_setequal(suppressed_fns, character(0))
 })
 
 test_that("no call site neuters .floor_cluster_quad's diagnostic contract", {
@@ -459,7 +467,7 @@ test_that("no call site neuters .floor_cluster_quad's diagnostic contract", {
 		function(fc) paste0(fc$fn, " (", fc$nargs, " args)"),
 		character(1)
 	)
-	expect_identical(sort(bad_arity), character(0))
+	expect_setequal(bad_arity, character(0))
 
 	# No namespace function other than the helper itself may mention either
 	# threshold: a NAMED per-call-site override is the other spelling of the
@@ -472,7 +480,7 @@ test_that("no call site neuters .floor_cluster_quad's diagnostic contract", {
 		},
 		logical(1)
 	)])
-	expect_identical(threshold_fns, ".floor_cluster_quad")
+	expect_setequal(threshold_fns, ".floor_cluster_quad")
 
 	# The helper's formals pinned by NAME, not by value. The unit tests above
 	# already catch every way of neutering the DEFAULTS, so a value pin would
@@ -480,8 +488,8 @@ test_that("no call site neuters .floor_cluster_quad's diagnostic contract", {
 	# `diagnose = TRUE`, passed `FALSE` at one site), which leaves the
 	# defaults untouched and so keeps those unit tests green.
 	expect_identical(
-		names(formals(fetwfe:::.floor_cluster_quad)),
-		c("q", "site", "err_threshold", "warn_threshold")
+		paste(names(formals(fetwfe:::.floor_cluster_quad)), collapse = ", "),
+		"q, site, err_threshold, warn_threshold"
 	)
 })
 

--- a/tests/testthat/test-cluster_floor.R
+++ b/tests/testthat/test-cluster_floor.R
@@ -301,7 +301,7 @@ test_that(".floor_cluster_quad respects custom thresholds", {
 
 test_that("every cluster-sandwich floor routes through .floor_cluster_quad", {
 	bodies <- .ns_deparsed_bodies("fetwfe")
-	scan <- .clf_scan(.ns_functions("fetwfe"))
+	scanned <- .clf_scan(.ns_functions("fetwfe"))
 
 	# --- A1: the structural universal -------------------------------------
 	# Every collected cluster-sandwich quadratic form is floored in place,
@@ -315,7 +315,7 @@ test_that("every cluster-sandwich floor routes through .floor_cluster_quad", {
 		".assemble_joint_cov_var1"
 	)
 	unfloored <- sort(unique(vapply(
-		Filter(function(s) !s$floored, scan$sites),
+		Filter(function(s) !s$floored, scanned$sites),
 		`[[`,
 		character(1),
 		"fn"
@@ -403,7 +403,7 @@ test_that("every cluster-sandwich floor routes through .floor_cluster_quad", {
 		"getCohortATTsFinal"
 	)
 	floor_call_fns <- sort(unique(vapply(
-		scan$floor_calls,
+		scanned$floor_calls,
 		`[[`,
 		character(1),
 		"fn"
@@ -443,7 +443,7 @@ test_that("every cluster-sandwich floor routes through .floor_cluster_quad", {
 
 	# --- A7: no condition suppression around a floor call -----------------
 	suppressed_fns <- sort(unique(vapply(
-		Filter(function(fc) fc$suppressed, scan$floor_calls),
+		Filter(function(fc) fc$suppressed, scanned$floor_calls),
 		`[[`,
 		character(1),
 		"fn"
@@ -453,7 +453,7 @@ test_that("every cluster-sandwich floor routes through .floor_cluster_quad", {
 
 test_that("no call site neuters .floor_cluster_quad's diagnostic contract", {
 	bodies <- .ns_deparsed_bodies("fetwfe")
-	scan <- .clf_scan(.ns_functions("fetwfe"))
+	scanned <- .clf_scan(.ns_functions("fetwfe"))
 
 	# Arity. Every call passes exactly two arguments. This is the
 	# load-bearing one: a per-call-site threshold override spelled
@@ -463,7 +463,7 @@ test_that("no call site neuters .floor_cluster_quad's diagnostic contract", {
 	# The arity rule rejects both spellings and does not depend on the
 	# parameters keeping their current names.
 	bad_arity <- vapply(
-		Filter(function(fc) fc$nargs != 2L, scan$floor_calls),
+		Filter(function(fc) fc$nargs != 2L, scanned$floor_calls),
 		function(fc) paste0(fc$fn, " (", fc$nargs, " args)"),
 		character(1)
 	)

--- a/tests/testthat/test-cluster_floor.R
+++ b/tests/testthat/test-cluster_floor.R
@@ -2,25 +2,62 @@ library(testthat)
 library(fetwfe)
 
 # ------------------------------------------------------------------------------
-# Tests for `.floor_cluster_quad()` and its integration at the five
-# cluster-sandwich quadratic-form floor sites (issue #139, version 1.11.2).
+# Tests for `.floor_cluster_quad()` (issue #139, version 1.11.2), and the
+# guardrail keeping every cluster-sandwich quadratic-form site routed through
+# it (issue #463).
 #
 # `.floor_cluster_quad()` layers a two-tier diagnostic on top of the
 # pre-existing `max(q, 0)` floor at each cluster-sandwich quadratic-form
 # site. The forms are PSD in exact arithmetic, so any negative value is
 # either FP-noise (silently clipped to 0) or a bug signal (warn / stop).
 #
-# The five sites:
-#   1. R/variance_machinery.R    getTeResultsOLS         (att_var_1)
-#   2. R/variance_machinery.R    getTeResults2           (att_var_1)
-#   3. R/variance_machinery.R    getCohortATTsFinal      (cohort_te_ses)
-#   4. R/event_study.R           .event_study_etwfe_betwfe (var_1_e)
-#   5. R/event_study.R           .event_study_fetwfe       (var_1_e)
+# The guardrail below states a PREDICATE, not a count and not a file list --
+# both of those went stale here once already. It walks the AST of every
+# function in the package NAMESPACE and asserts that every cluster-sandwich
+# quadratic form (a `%*%` / `crossprod()` / `tcrossprod()` node whose operands
+# reach the cluster-robust sandwich) sits lexically inside a
+# `.floor_cluster_quad()` call. Reading the namespace instead of `R/*.R` as
+# text is what makes it run under `R CMD check`, where the tests execute
+# against the *installed* package and there is no `R/` directory at all -- the
+# whole block used to skip there, which is every CI job and every CRAN
+# machine (#463).
 #
-# (PR #111 added 6 sites in 3 files; PR #118 consolidated
-#  getCohortATTsFinalOLS into getCohortATTsFinal, dropping the count to 5.
-#  Surprises & Discoveries in .plans/cluster-sandwich-floor-diagnostics-139
-#  documents the 6 -> 5 reduction.)
+# ONE DOCUMENTED EXCEPTION, asserted rather than tolerated (it is part of an
+# exact set, so this site silently becoming floored fails too):
+#   `.assemble_joint_cov_var1()` in R/variance_machinery.R builds a K x K
+#   covariance block `t(Psi_full) %*% sandwich_full %*% Psi_full` and floors
+#   only its diagonal, with a bare `pmax(diag(.), 0)` and no #139 diagnostic.
+#   It cannot route through `.floor_cluster_quad()`, which is scalar-only by
+#   contract: any input of length other than one is passed through unchanged.
+#   Extending the diagnostic to the matrix-valued floors is tracked separately.
+#   The exemption is function-granular, so a future scalar form added inside
+#   that same function would inherit it silently.
+#
+# On the per-site labels asserted below: `getTeResultsOLS/att_var_1` and
+# `getTeResults2/att_var_1` are two LABELS at one SITE. #344 merged those two
+# functions' floors into the shared `.compute_att_var1()`, and each caller
+# passes its own label through the `label` formal -- which is also why the
+# label assertion has no power at that site, and why the floor-call inventory
+# (A4) exists.
+#
+# KNOWN FALSE-POSITIVE CLASSES. Each is correct code that these assertions
+# reject on purpose; the resolution is always the same, a human looks and
+# either restores the expected shape or updates the literal expected set with
+# a reason:
+#   * A1 rejects a form hoisted into its own statement and floored on the next
+#     line -- the floor must be applied lexically AT the form. Following the
+#     value into a later floor call is dataflow analysis, deliberately not
+#     built.
+#   * A1 rejects renaming `sandwich_full` inside the exempt function, and
+#     rejects an alias later reassigned before an unrelated matrix product.
+#   * A4 rejects consolidating the floor call into a wrapper helper, and
+#     rejects a legitimately added, correctly floored site.
+#   * A6 rejects any consolidation refactor that moves sandwich-touching code
+#     between functions.
+# The last two are the design: under a subset rule a floor added tomorrow
+# never enters the expected set, so its removal the day after is invisible
+# forever. Exact equality forces the set to be updated at the moment of
+# addition, which is the only moment a human is looking.
 # ------------------------------------------------------------------------------
 
 # --- Unit tests on the helper -------------------------------------------------
@@ -120,102 +157,332 @@ test_that(".floor_cluster_quad respects custom thresholds", {
 })
 
 # --- Coverage / regression test ----------------------------------------------
-# Assert every cluster-sandwich quadratic-form site in the package code
-# routes through `.floor_cluster_quad`, catching a future revert to the bare
-# `max(., 0)` floor.
+# Assert every cluster-sandwich quadratic-form site in the package routes
+# through `.floor_cluster_quad`, catching a future revert to the bare
+# `max(., 0)` floor. See the file header for the predicate, the one documented
+# exception, and the known false-positive classes.
+#
+# The package-agnostic AST primitives (`.ns_*`) come from
+# helper-namespace-inspect.R, which testthat sources before this file under
+# both `devtools::test()` and `test_check()` inside `R CMD check`. Everything
+# below is specific to the cluster floor and deliberately stays here.
+
+# The matrix operators a quadratic form can be spelled with.
+.clf_quad_ops <- c("%*%", "crossprod", "tcrossprod")
+
+# Calls that swallow the #139 diagnostic if one wraps a floor call. Wrapping
+# the call in `suppressWarnings()` returns the site to pre-#139 behavior while
+# leaving every other assertion satisfied, and "this warning is noisy, wrap it"
+# is a one-line edit somebody makes without thinking about #139 at all.
+.clf_suppressors <- c(
+	"suppressWarnings",
+	"suppressMessages",
+	"try",
+	"tryCatch",
+	"withCallingHandlers"
+)
+
+# Is any ancestor node a call to one of `fn`?
+.clf_any_ancestor <- function(ancestors, fn) {
+	for (a in ancestors) {
+		if (.ns_is_call_to(a, fn)) {
+			return(TRUE)
+		}
+	}
+	FALSE
+}
+
+# The symbols inside one function body that hold the cluster-robust sandwich:
+# `sandwich_full` plus anything assigned directly from it, to a fixed point so
+# a chain `a <- sandwich_full; b <- a` is covered. Without this, a revert that
+# assigns the matrix to a local first is invisible -- no site is detected, so
+# the universal "every detected site is floored" is satisfied by finding
+# nothing.
+#
+# The set is MONOTONE: a symbol later reassigned to something else is never
+# removed, and an assignment inside a branch that never runs still counts. So
+# it can over-report a site and can never under-report one. That direction is
+# deliberate -- a false positive puts a human in the loop, a false negative is
+# a silently unfloored standard error. It is not dataflow analysis and does
+# not try to be.
+.clf_alias_symbols <- function(fn_body) {
+	aliases <- "sandwich_full"
+	repeat {
+		found <- aliases
+		.ns_walk_ast(fn_body, function(node, ancestors) {
+			if (
+				.ns_is_call_to(node, c("<-", "=", "<<-")) &&
+					length(node) == 3L &&
+					is.symbol(node[[2]]) &&
+					is.symbol(node[[3]]) &&
+					as.character(node[[3]]) %in% found
+			) {
+				found <<- union(found, as.character(node[[2]]))
+			}
+		})
+		if (setequal(found, aliases)) {
+			break
+		}
+		aliases <- found
+	}
+	aliases
+}
+
+# One pass over a namespace's functions, returning
+#   $sites        one entry per OUTERMOST cluster-sandwich quadratic form: the
+#                 owning function, whether a `.floor_cluster_quad()` call is
+#                 among its AST ancestors, and its deparsed text.
+#   $floor_calls  one entry per `.floor_cluster_quad()` call: the owning
+#                 function, its argument count, and whether a
+#                 condition-suppressing call is among ITS ancestors.
+#
+# "Outermost" drops the inner node of a chain: `t(a) %*% B %*% a` parses as
+# `(t(a) %*% B) %*% a`, so without it one form would be reported twice.
+.clf_scan <- function(fns) {
+	sites <- list()
+	floor_calls <- list()
+	for (nm in names(fns)) {
+		fn_body <- body(fns[[nm]])
+		if (is.null(fn_body)) {
+			next
+		}
+		aliases <- .clf_alias_symbols(fn_body)
+		quad_nodes <- list()
+		call_nodes <- list()
+		.ns_walk_ast(fn_body, function(node, ancestors) {
+			if (
+				.ns_is_call_to(node, .clf_quad_ops) &&
+					.ns_subtree_has_symbol(node, aliases)
+			) {
+				quad_nodes[[length(quad_nodes) + 1L]] <<- list(
+					node = node,
+					ancestors = ancestors
+				)
+			}
+			if (.ns_is_call_to(node, ".floor_cluster_quad")) {
+				call_nodes[[length(call_nodes) + 1L]] <<- list(
+					node = node,
+					ancestors = ancestors
+				)
+			}
+		})
+		for (q in quad_nodes) {
+			n_anc <- length(q$ancestors)
+			parent <- if (n_anc > 0L) q$ancestors[[n_anc]] else NULL
+			if (
+				!is.null(parent) &&
+					.ns_is_call_to(parent, .clf_quad_ops) &&
+					.ns_subtree_has_symbol(parent, aliases)
+			) {
+				next
+			}
+			sites[[length(sites) + 1L]] <- list(
+				fn = nm,
+				floored = .clf_any_ancestor(
+					q$ancestors,
+					".floor_cluster_quad"
+				),
+				text = paste(deparse(q$node), collapse = " ")
+			)
+		}
+		for (cl in call_nodes) {
+			floor_calls[[length(floor_calls) + 1L]] <- list(
+				fn = nm,
+				nargs = length(cl$node) - 1L,
+				suppressed = .clf_any_ancestor(
+					cl$ancestors,
+					.clf_suppressors
+				)
+			)
+		}
+	}
+	list(sites = sites, floor_calls = floor_calls)
+}
 
 test_that("every cluster-sandwich floor routes through .floor_cluster_quad", {
-	pkg_root <- system.file(package = "fetwfe")
-	# When the package is loaded via devtools::load_all(), the installed
-	# `system.file()` may return the install dir (no R/ source). Prefer the
-	# source tree if it is present (the test repo root).
-	src_root <- normalizePath(file.path(testthat::test_path(), "..", ".."))
-	if (
-		dir.exists(file.path(src_root, "R")) &&
-			file.exists(file.path(src_root, "R", "variance_machinery.R"))
-	) {
-		root <- src_root
-	} else {
-		root <- pkg_root
-	}
+	bodies <- .ns_deparsed_bodies("fetwfe")
+	scan <- .clf_scan(.ns_functions("fetwfe"))
 
-	files <- c("R/variance_machinery.R", "R/event_study.R")
-	# Count `.floor_cluster_quad(` call sites across both files, skipping
-	# comment lines (so a helper-name mention in a site's explanatory comment
-	# does not double-count). There are 4 call sites: the shared
-	# `.compute_att_var1()` (#344; invoked by both getTeResultsOLS() and
-	# getTeResults2(), each passing its own per-site label), getCohortATTsFinal(),
-	# and the two event-study workers. The 5 labeled computations -- two of which
-	# now share `.compute_att_var1()` -- are verified individually below.
-	call_count <- 0L
-	for (f in files) {
-		path <- file.path(root, f)
-		skip_if_not(
-			file.exists(path),
-			paste("source file not in test bundle:", f)
-		)
-		src <- readLines(path, warn = FALSE)
-		non_comment <- src[!grepl("^\\s*#", src)]
-		call_count <- call_count +
-			sum(grepl(".floor_cluster_quad(", non_comment, fixed = TRUE))
-	}
-	expect_equal(call_count, 4L)
+	# --- A1: the structural universal -------------------------------------
+	# Every collected cluster-sandwich quadratic form is floored in place,
+	# except the one documented matrix-valued site. EXACT set equality, not
+	# containment: a listed site that has BECOME floored fails too, which is
+	# what stops the walk collapsing to nothing and satisfying the universal
+	# by finding no sites at all.
+	expected_unfloored <- c(
+		# K x K covariance block; floors its diagonal with `pmax(diag(.), 0)`
+		# because `.floor_cluster_quad()` is scalar-only. See the header.
+		".assemble_joint_cov_var1"
+	)
+	unfloored <- sort(unique(vapply(
+		Filter(function(s) !s$floored, scan$sites),
+		`[[`,
+		character(1),
+		"fn"
+	)))
+	expect_identical(unfloored, sort(expected_unfloored))
 
-	# Per-site label coverage: each site uses its expected per-site label.
-	# This catches a future copy-paste regression where two sites end up
-	# with the same label.
+	# --- A2: per-site label coverage, exactly once ------------------------
+	# Anchored with the surrounding double quotes: `deparse()` renders string
+	# literals including their quotes, so an unanchored
+	# "cohort_time_atts/var_1" would also match a future
+	# "cohort_time_atts/var_12". Counted over OCCURRENCES with `gregexpr()`
+	# rather than over elements containing a match -- `sum(grepl(...))` scores
+	# two calls sharing one deparsed line as one and passes, which is exactly
+	# the copy-paste case this assertion advertises catching. `fixed = TRUE`
+	# throughout, stated rather than relied upon.
 	expected_labels <- c(
 		"getTeResultsOLS/att_var_1",
 		"getTeResults2/att_var_1",
 		"getCohortATTsFinal/cohort_te_se",
 		"event_study_etwfe_betwfe/var_1_e",
-		"event_study_fetwfe/var_1_e"
+		"event_study_fetwfe/var_1_e",
+		"cohort_time_atts/var_1"
 	)
-	src_all <- character(0)
-	for (f in files) {
-		path <- file.path(root, f)
-		if (file.exists(path)) {
-			src_all <- c(src_all, readLines(path, warn = FALSE))
-		}
-	}
-	for (lbl in expected_labels) {
-		expect_true(
-			any(grepl(lbl, src_all, fixed = TRUE)),
-			info = paste("missing site label:", lbl)
-		)
-	}
+	all_body_text <- paste(unlist(bodies), collapse = " ")
+	label_counts <- vapply(
+		expected_labels,
+		function(lbl) {
+			hits <- gregexpr(
+				paste0('"', lbl, '"'),
+				all_body_text,
+				fixed = TRUE
+			)[[1]]
+			if (hits[[1]] == -1L) 0L else length(hits)
+		},
+		integer(1)
+	)
+	expected_counts <- rep(1L, length(expected_labels))
+	names(expected_counts) <- expected_labels
+	expect_identical(label_counts, expected_counts)
 
-	# Negative-direction guard: no bare `max(..., 0)` floor remains around a
-	# `sandwich_full` quadratic form. The historical bare-max idiom from PR
-	# #111 was `<lhs> <- max(... sandwich_full %*% ..., 0)` (single-line);
-	# the wired-up helper at every cluster-sandwich site uses
-	# `.floor_cluster_quad(...)` instead, so any `max(...sandwich_full...,0)`
-	# match indicates a partial revert / regression. We scan a space-joined
-	# concatenation (with comments stripped) so the check is robust to a
-	# future multi-line reformat and to the explanatory comments in
-	# `R/cluster_floor.R` that name the legacy pattern.
-	bare_max_on_sandwich <- 0L
-	for (f in files) {
-		path <- file.path(root, f)
-		if (!file.exists(path)) {
-			next
-		}
-		src <- readLines(path, warn = FALSE)
-		# Strip comments so a comment that names the legacy `max(..., 0)`
-		# idiom does not false-positive.
-		src_no_comment <- sub("#.*$", "", src)
-		combined <- paste(src_no_comment, collapse = " ")
-		# Bounded non-greedy: `max(<up to 300 chars with sandwich_full><up
-		# to 200 chars>, 0)`. The bounded counts avoid catastrophic
-		# regex backtracking on a large concatenated source.
-		re <- "max\\(.{0,300}sandwich_full.{0,200}?,\\s*0\\)"
-		matches <- regmatches(
-			combined,
-			gregexpr(re, combined, perl = TRUE)
-		)[[1]]
-		bare_max_on_sandwich <- bare_max_on_sandwich + length(matches)
-	}
-	expect_equal(bare_max_on_sandwich, 0L)
+	# --- A3: the negative-direction guard ---------------------------------
+	# No bare `max(... sandwich_full ..., 0)` may remain. Scanned PER BODY,
+	# not over a concatenation of all of them -- that is a change of meaning,
+	# not a port of the old file-text scan. The regex has a bounded reach in
+	# characters, so joining every body makes adjacency an artifact of
+	# alphabetical name order and a `max(` in one function can pair with a
+	# `sandwich_full` in the next, which both fakes detections and can go red
+	# on a correct tree. Per-body scanning also lets the failure name the
+	# offending function.
+	bare_max_re <- "max\\(.{0,300}sandwich_full.{0,200}?,\\s*0\\)"
+	bare_max_fns <- names(bodies)[vapply(
+		bodies,
+		function(x) grepl(bare_max_re, paste(x, collapse = " "), perl = TRUE),
+		logical(1)
+	)]
+	expect_identical(bare_max_fns, character(0))
+
+	# --- A4: the floor-call inventory -------------------------------------
+	# The set of namespace functions that call `.floor_cluster_quad()`, as an
+	# EXACT set against a LITERAL expected vector.
+	#
+	# The expectation is written out here on purpose. An expectation
+	# re-derived from the namespace is `setequal(x, x)` and passes every
+	# mutation, including a bare revert of the floor at any site. What went
+	# stale in #463 was the hand-maintained FILE LIST that produced the
+	# OBSERVATION -- and the observation is what is namespace-derived below.
+	#
+	# This is the absolute pin: it does not care how the arithmetic is
+	# spelled, so it survives the aliasing and `crossprod` refactors that
+	# defeat a shape-based predicate, and it is what makes A1 non-vacuous --
+	# without it, a site that stops being DETECTED satisfies A1 by absence.
+	expected_floor_call_fns <- c(
+		".compute_att_var1",
+		".event_study_etwfe_betwfe",
+		".event_study_fetwfe",
+		"cohortTimeATTs",
+		"getCohortATTsFinal"
+	)
+	floor_call_fns <- sort(unique(vapply(
+		scan$floor_calls,
+		`[[`,
+		character(1),
+		"fn"
+	)))
+	expect_identical(floor_call_fns, sort(expected_floor_call_fns))
+
+	# --- A6: the sandwich-mention inventory -------------------------------
+	# The set of namespace functions whose deparsed body mentions
+	# `sandwich_full`, again an exact set against a literal vector. This is
+	# the only assertion that catches a new unfloored site whose function
+	# does not name the matrix inside a quadratic-form node: the matrix
+	# arriving as a FORMAL from a caller (the consolidation shape #344
+	# already performed on this code), a `::`-qualified operator, the matrix
+	# reached through a list element, a submatrix alias, or `assign()`.
+	expected_sandwich_fns <- c(
+		".assemble_cluster_robust_sandwich",
+		".assemble_joint_cov_var1",
+		".compute_att_var1",
+		".event_study_etwfe_betwfe",
+		".event_study_fetwfe",
+		".ols_estimator_core",
+		".recompute_gram_and_sandwich",
+		".simultaneous_cis_impl",
+		"betwfe_core",
+		"cohortTimeATTs",
+		"fetwfe_core",
+		"getCohortATTsFinal",
+		"getTeResults2",
+		"getTeResultsOLS"
+	)
+	sandwich_fns <- sort(names(bodies)[vapply(
+		bodies,
+		function(x) any(grepl("sandwich_full", x, fixed = TRUE)),
+		logical(1)
+	)])
+	expect_identical(sandwich_fns, sort(expected_sandwich_fns))
+
+	# --- A7: no condition suppression around a floor call -----------------
+	suppressed_fns <- sort(unique(vapply(
+		Filter(function(fc) fc$suppressed, scan$floor_calls),
+		`[[`,
+		character(1),
+		"fn"
+	)))
+	expect_identical(suppressed_fns, character(0))
+})
+
+test_that("no call site neuters .floor_cluster_quad's diagnostic contract", {
+	bodies <- .ns_deparsed_bodies("fetwfe")
+	scan <- .clf_scan(.ns_functions("fetwfe"))
+
+	# Arity. Every call passes exactly two arguments. This is the
+	# load-bearing one: a per-call-site threshold override spelled
+	# POSITIONALLY -- `.floor_cluster_quad(form, "label", -Inf, -Inf)` --
+	# mentions no parameter name, so the scan below cannot see it, and it
+	# returns the site to a silent `max(q, 0)` with the whole suite green.
+	# The arity rule rejects both spellings and does not depend on the
+	# parameters keeping their current names.
+	bad_arity <- vapply(
+		Filter(function(fc) fc$nargs != 2L, scan$floor_calls),
+		function(fc) paste0(fc$fn, " (", fc$nargs, " args)"),
+		character(1)
+	)
+	expect_identical(sort(bad_arity), character(0))
+
+	# No namespace function other than the helper itself may mention either
+	# threshold: a NAMED per-call-site override is the other spelling of the
+	# same edit.
+	threshold_fns <- sort(names(bodies)[vapply(
+		bodies,
+		function(x) {
+			any(grepl("err_threshold", x, fixed = TRUE)) ||
+				any(grepl("warn_threshold", x, fixed = TRUE))
+		},
+		logical(1)
+	)])
+	expect_identical(threshold_fns, ".floor_cluster_quad")
+
+	# The helper's formals pinned by NAME, not by value. The unit tests above
+	# already catch every way of neutering the DEFAULTS, so a value pin would
+	# add nothing; the name pin is what catches a new opt-out formal (say
+	# `diagnose = TRUE`, passed `FALSE` at one site), which leaves the
+	# defaults untouched and so keeps those unit tests green.
+	expect_identical(
+		names(formals(fetwfe:::.floor_cluster_quad)),
+		c("q", "site", "err_threshold", "warn_threshold")
+	)
 })
 
 # --- Integration smoke test --------------------------------------------------


### PR DESCRIPTION

Resolves #463. The guardrail asserting that every cluster-sandwich quadratic form routes
through `.floor_cluster_quad()` read `R/*.R` **as text**, falling back to
`system.file(package = "fetwfe")` — which for an installed package has no `R/` — so under
`R CMD check` it hit `skip_if_not()` and skipped. That is the runner all six CI jobs and
every CRAN machine use, so it ran on none of them; and its hand-maintained two-file list
never included `R/cohort_time_atts.R`, so even locally a revert at `cohortTimeATTs()` was
invisible. It now walks the **package namespace** with `body()` / `deparse()`, which exists
identically under both runners, and states a predicate instead of a file list and a count.
Test-only: nothing under `R/` changes, so no `NEWS.md` bullet and no version bump.

The AST primitives live in a new shared `tests/testthat/helper-namespace-inspect.R`, so the
next guardrail reaches for the namespace rather than re-inventing the source-text read that
caused this.

## Worth your attention

The assertion set is larger than the issue proposed, because each addition exists to catch a
mutation that defeated the smaller set. The first draft — detect `%*%` expressions naming
`sandwich_full`, assert each is floored — measured **weaker than the guardrail it replaces**:
a one-line `sw <- sandwich_full` makes the site undetectable, so the universal is satisfied
by finding nothing, and at `.compute_att_var1()` (the overall-ATT standard error) the label
check has no power either, since that site's labels live in its callers. The block now also
pins the set of functions that *call* the floor and the set that *mention* the sandwich, an
arity rule, and ancestor checks for `suppressWarnings()` at both the call and its caller.
Four of those are each the only assertion catching one shape.

Three consequences before you merge. Some **correct** refactors will now go red on purpose —
consolidating the floor into a wrapper, adding a new correctly-floored site, moving
sandwich-touching code between functions — because the expected sets are exact rather than
subsets. The sandwich-mention set changed on four PRs in the last 120 `R/` commits, all
consolidation refactors, which is the churn that buys it. And the checks are lexical, so
they have a boundary: an unfloored form added *inside an already-listed function* through a
name they cannot see — a helper whose formal is `S`, a submatrix slice — still passes. The
file header documents both directions, false positives and false negatives, because the
guardrail this replaces shipped a coverage claim it did not have and that is the failure
#463 is. Nothing regressed: the old block was equally blind to all of them, measured.

Gate clean; `document()`'s 14 unresolved-`\link{}` warnings are unchanged from #468.

## Out of scope (deferred follow-ups)

- **Matrix-valued floors get no #139 diagnostic** — the `pmax(diag(.), 0)` floors reachable
  from a cluster-sandwich covariance still clamp silently, and `.floor_cluster_quad()` is
  scalar-only by contract so it cannot be dropped in. `.assemble_joint_cov_var1()` is
  carried as a documented, asserted exception here. Filed as #470.
- **Pinning `.floor_cluster_quad()`'s threshold *values*** — dropped: the helper's own unit
  tests already fail on every way of neutering the defaults, so a value pin adds nothing.
  The formal *names* are pinned, which is what catches a new opt-out argument.
